### PR TITLE
Add PHPUnit CI workflow

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,0 +1,52 @@
+name: PHPUnit
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version: ['7.4', '8.1']
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: wordpress
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping --silent" \
+          --health-interval=10s \
+          --health-timeout=5s \
+          --health-retries=3
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: none
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y subversion mysql-client
+
+      - name: Install Composer dependencies
+        run: composer install --prefer-dist --no-progress --no-suggest
+
+      - name: Install WordPress test suite
+        env:
+          DB_NAME: wordpress
+          DB_USER: root
+          DB_PASS: root
+          DB_HOST: 127.0.0.1
+          WP_VERSION: latest
+        run: bash bin/install-wp-tests.sh $DB_NAME $DB_USER $DB_PASS $DB_HOST $WP_VERSION
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit


### PR DESCRIPTION
## Summary
- run PHPUnit tests in GitHub Actions

## Testing
- `composer run test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_68532c0387048327a4bd3c6c27fef590