### PR TITLE
Add uninstall cleanup

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,25 @@
+<?php
+// If uninstall not called from WordPress, exit.
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+    exit();
+}
+
+// List of options to remove.
+$option_names = array(
+    'gm2_suite_settings',
+    'gm2_suite_version',
+);
+
+foreach ( $option_names as $option ) {
+    if ( is_multisite() ) {
+        delete_site_option( $option );
+    }
+
+    delete_option( $option );
+}
+
+// Example table cleanup.
+global $wpdb;
+$table_name = $wpdb->prefix . 'gm2_suite_data';
+$wpdb->query( "DROP TABLE IF EXISTS {$table_name}" );
+


### PR DESCRIPTION
## Summary
- clean up options and tables in `uninstall.php`
- check for `WP_UNINSTALL_PLUGIN` before running cleanup

## Testing
- `composer install`
- `composer test` *(fails: displays PHPUnit usage)*

------
https://chatgpt.com/codex/tasks/task_e_68532da489a08327aa0e655d199882d4