### PR TITLE
Add tariff management feature

### DIFF
--- a/admin/class-gm2-admin.php
+++ b/admin/class-gm2-admin.php
@@ -12,16 +12,109 @@ class Gm2_Admin {
 
     public function add_admin_menu() {
         add_menu_page(
-            'Gm2 Suite',
-            'Gm2 Suite',
+            'Gm2',
+            'Gm2',
             'manage_options',
-            'gm2-suite',
-            [$this, 'display_admin_page'],
+            'gm2',
+            [$this, 'display_dashboard'],
             'dashicons-admin-generic'
+        );
+
+        add_submenu_page(
+            'gm2',
+            'Tariff',
+            'Tariff',
+            'manage_options',
+            'gm2-tariff',
+            [$this, 'display_tariff_page']
+        );
+
+        add_submenu_page(
+            'gm2',
+            'Add Tariff',
+            'Add Tariff',
+            'manage_options',
+            'gm2-add-tariff',
+            [$this, 'display_add_tariff_page']
         );
     }
 
-    public function display_admin_page() {
-        echo '<div class="wrap"><h1>Gm2 WordPress Suite</h1><p>Welcome to the admin interface!</p></div>';
+    public function display_dashboard() {
+        echo '<div class="wrap"><h1>Gm2 Suite</h1><p>Welcome to the admin interface!</p></div>';
+    }
+
+    private function handle_form_submission() {
+        if (!empty($_POST['gm2_tariff_nonce']) && wp_verify_nonce($_POST['gm2_tariff_nonce'], 'gm2_save_tariff')) {
+            $manager = new Gm2_Tariff_Manager();
+            $data    = [
+                'name'       => sanitize_text_field($_POST['tariff_name']),
+                'percentage' => floatval($_POST['tariff_percentage']),
+                'status'     => isset($_POST['tariff_status']) ? 'enabled' : 'disabled',
+            ];
+
+            if (!empty($_POST['tariff_id'])) {
+                $manager->update_tariff(intval($_POST['tariff_id']), $data);
+            } else {
+                $manager->add_tariff($data);
+            }
+            echo '<div class="updated"><p>Tariff saved.</p></div>';
+        }
+    }
+
+    public function display_add_tariff_page() {
+        $this->handle_form_submission();
+
+        $tariff = false;
+        if (!empty($_GET['id'])) {
+            $manager = new Gm2_Tariff_Manager();
+            $tariff  = $manager->get_tariff(intval($_GET['id']));
+        }
+
+        $name       = $tariff ? esc_attr($tariff['name']) : '';
+        $percentage = $tariff ? esc_attr($tariff['percentage']) : '';
+        $status     = $tariff ? $tariff['status'] : 'enabled';
+        $id_field   = $tariff ? '<input type="hidden" name="tariff_id" value="' . intval($tariff['id']) . '" />' : '';
+
+        echo '<div class="wrap"><h1>Add Tariff</h1>';
+        echo '<form method="post">';
+        wp_nonce_field('gm2_save_tariff', 'gm2_tariff_nonce');
+        echo $id_field;
+        echo '<table class="form-table"><tbody>';
+        echo '<tr><th scope="row"><label for="tariff_name">Name</label></th><td><input name="tariff_name" type="text" id="tariff_name" value="' . $name . '" class="regular-text" required></td></tr>';
+        echo '<tr><th scope="row"><label for="tariff_percentage">Percentage</label></th><td><input name="tariff_percentage" type="number" step="0.01" id="tariff_percentage" value="' . $percentage . '" class="regular-text" required></td></tr>';
+        echo '<tr><th scope="row">Status</th><td><label><input type="checkbox" name="tariff_status"' . checked($status, 'enabled', false) . '> Enabled</label></td></tr>';
+        echo '</tbody></table>';
+        submit_button('Save Tariff');
+        echo '</form></div>';
+    }
+
+    public function display_tariff_page() {
+        $manager = new Gm2_Tariff_Manager();
+
+        if (!empty($_GET['action']) && $_GET['action'] === 'delete' && !empty($_GET['id'])) {
+            check_admin_referer('gm2_delete_tariff_' . intval($_GET['id']));
+            $manager->delete_tariff(intval($_GET['id']));
+            echo '<div class="updated"><p>Tariff deleted.</p></div>';
+        }
+
+        $tariffs = $manager->get_tariffs();
+
+        echo '<div class="wrap"><h1>Tariffs</h1>';
+        echo '<table class="widefat"><thead><tr><th>Name</th><th>Percentage</th><th>Status</th><th>Actions</th></tr></thead><tbody>';
+        if ($tariffs) {
+            foreach ($tariffs as $tariff) {
+                $delete_url = wp_nonce_url(admin_url('admin.php?page=gm2-tariff&action=delete&id=' . $tariff['id']), 'gm2_delete_tariff_' . $tariff['id']);
+                $edit_url   = admin_url('admin.php?page=gm2-add-tariff&id=' . $tariff['id']);
+                echo '<tr>';
+                echo '<td>' . esc_html($tariff['name']) . '</td>';
+                echo '<td>' . esc_html($tariff['percentage']) . '%</td>';
+                echo '<td>' . esc_html(ucfirst($tariff['status'])) . '</td>';
+                echo '<td><a href="' . $edit_url . '">View</a> | <a href="' . $edit_url . '">Edit</a> | <a href="' . $delete_url . '" onclick="return confirm(\'Are you sure?\');">Delete</a></td>';
+                echo '</tr>';
+            }
+        } else {
+            echo '<tr><td colspan="4">No tariffs found.</td></tr>';
+        }
+        echo '</tbody></table></div>';
     }
 }

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Gm2 WordPress Suite
  * Description:       A powerful suite of tools and features for WordPress, by Gm2.
- * Version:           1.0.0
+ * Version:           1.1.0
  * Author:            Your Name or Team Gm2
  * Author URI:        https://yourwebsite.com
  * License:           GPL-2.0+
@@ -14,7 +14,7 @@
 defined('ABSPATH') or die('No script kiddies please!');
 
 // Define constants
-define('GM2_VERSION', '1.0.0');
+define('GM2_VERSION', '1.1.0');
 define('GM2_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('GM2_PLUGIN_URL', plugin_dir_url(__FILE__));
 

--- a/includes/class-gm2-loader.php
+++ b/includes/class-gm2-loader.php
@@ -14,6 +14,7 @@ class Gm2_Loader {
     private function load_dependencies() {
         require_once GM2_PLUGIN_DIR . 'admin/class-gm2-admin.php';
         require_once GM2_PLUGIN_DIR . 'public/class-gm2-public.php';
+        require_once GM2_PLUGIN_DIR . 'includes/class-gm2-tariff-manager.php';
     }
 
     public function run() {

--- a/includes/class-gm2-tariff-manager.php
+++ b/includes/class-gm2-tariff-manager.php
@@ -1,0 +1,55 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Gm2_Tariff_Manager {
+
+    private $option_name = 'gm2_tariffs';
+
+    public function get_tariffs() {
+        $tariffs = get_option($this->option_name, []);
+        if (!is_array($tariffs)) {
+            $tariffs = [];
+        }
+        return $tariffs;
+    }
+
+    public function get_tariff($id) {
+        $tariffs = $this->get_tariffs();
+        foreach ($tariffs as $tariff) {
+            if ($tariff['id'] == $id) {
+                return $tariff;
+            }
+        }
+        return false;
+    }
+
+    public function add_tariff($data) {
+        $tariffs = $this->get_tariffs();
+        $data['id'] = time();
+        $tariffs[] = $data;
+        update_option($this->option_name, $tariffs);
+        return $data['id'];
+    }
+
+    public function update_tariff($id, $data) {
+        $tariffs = $this->get_tariffs();
+        foreach ($tariffs as &$tariff) {
+            if ($tariff['id'] == $id) {
+                $data['id'] = $id;
+                $tariff = array_merge($tariff, $data);
+                break;
+            }
+        }
+        update_option($this->option_name, $tariffs);
+    }
+
+    public function delete_tariff($id) {
+        $tariffs = $this->get_tariffs();
+        $tariffs = array_filter($tariffs, function($t) use ($id) {
+            return $t['id'] != $id;
+        });
+        update_option($this->option_name, array_values($tariffs));
+    }
+}

--- a/public/class-gm2-public.php
+++ b/public/class-gm2-public.php
@@ -8,10 +8,33 @@ class Gm2_Public {
 
     public function run() {
         add_action('wp_enqueue_scripts', [$this, 'enqueue_scripts']);
+        add_action('woocommerce_cart_calculate_fees', [$this, 'add_tariff_fees']);
     }
 
     public function enqueue_scripts() {
         wp_enqueue_style('gm2-public-style', GM2_PLUGIN_URL . 'public/css/gm2-public.css');
         wp_enqueue_script('gm2-public-script', GM2_PLUGIN_URL . 'public/js/gm2-public.js', [], false, true);
+    }
+
+    public function add_tariff_fees($cart) {
+        if (is_admin() && !defined('DOING_AJAX')) {
+            return;
+        }
+
+        if (!class_exists('WooCommerce')) {
+            return;
+        }
+
+        $manager = new Gm2_Tariff_Manager();
+        $tariffs = $manager->get_tariffs();
+
+        if ($tariffs) {
+            foreach ($tariffs as $tariff) {
+                if ($tariff['status'] === 'enabled') {
+                    $amount = $cart->get_subtotal() * ($tariff['percentage'] / 100);
+                    $cart->add_fee($tariff['name'], $amount, false);
+                }
+            }
+        }
     }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: gm2team
 Tags: admin, tools, suite, performance
 Requires at least: 5.6
 Tested up to: 6.5
-Stable tag: 1.0.0
+Stable tag: 1.1.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -16,6 +16,8 @@ A powerful suite of WordPress enhancements including admin tools, frontend optim
 3. Use the Gm2 Suite menu in the admin sidebar to configure settings.
 
 == Changelog ==
+= 1.1.0 =
+* Added Tariff management and WooCommerce checkout integration.
 = 1.0.0 =
 * Initial release.
 


### PR DESCRIPTION
## Summary
- add tariff manager class for storing tariffs
- create admin pages to add/list tariffs
- integrate tariff fees with WooCommerce checkout
- bump plugin version to 1.1.0 and update docs

## Testing
- `composer run test` *(fails: composer not found)*
- `phpunit -v` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_685339c7a47c8327aa859ae985cade08