### PR TITLE
Inline Tariff Form with AJAX

### DIFF
--- a/admin/class-gm2-admin.php
+++ b/admin/class-gm2-admin.php
@@ -8,6 +8,64 @@ class Gm2_Admin {
 
     public function run() {
         add_action('admin_menu', [$this, 'add_admin_menu']);
+        add_action('admin_enqueue_scripts', [$this, 'enqueue_admin_scripts']);
+        add_action('wp_ajax_gm2_add_tariff', [$this, 'ajax_add_tariff']);
+        add_action('wp_ajax_nopriv_gm2_add_tariff', [$this, 'ajax_add_tariff']);
+    }
+
+    public function enqueue_admin_scripts($hook) {
+        if ($hook !== 'gm2_page_gm2-tariff') {
+            return;
+        }
+        wp_enqueue_script(
+            'gm2-tariff',
+            GM2_PLUGIN_URL . 'admin/js/gm2-tariff.js',
+            ['jquery'],
+            GM2_VERSION,
+            true
+        );
+        wp_localize_script(
+            'gm2-tariff',
+            'gm2Tariff',
+            [
+                'nonce'    => wp_create_nonce('gm2_add_tariff'),
+                'ajax_url' => admin_url('admin-ajax.php'),
+            ]
+        );
+    }
+
+    public function ajax_add_tariff() {
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error('Permission denied');
+        }
+
+        check_ajax_referer('gm2_add_tariff');
+
+        $name       = sanitize_text_field($_POST['tariff_name'] ?? '');
+        $percentage = floatval($_POST['tariff_percentage'] ?? 0);
+        $status     = ($_POST['tariff_status'] ?? '') === 'enabled' ? 'enabled' : 'disabled';
+
+        $manager = new Gm2_Tariff_Manager();
+        $id      = $manager->add_tariff([
+            'name'       => $name,
+            'percentage' => $percentage,
+            'status'     => $status,
+        ]);
+
+        $delete_url = wp_nonce_url(
+            admin_url('admin.php?page=gm2-tariff&action=delete&id=' . $id),
+            'gm2_delete_tariff_' . $id
+        );
+        $edit_url = admin_url('admin.php?page=gm2-add-tariff&id=' . $id);
+
+        wp_send_json_success([
+            'id'         => $id,
+            'name'       => $name,
+            'percentage' => $percentage,
+            'status'     => $status,
+            'delete_url' => $delete_url,
+            'edit_url'   => $edit_url,
+        ]);
     }
 
     public function add_admin_menu() {
@@ -29,10 +87,13 @@ class Gm2_Admin {
             [$this, 'display_tariff_page']
         );
 
+        // The add tariff form is now part of the Tariff page. The following
+        // submenu is kept for editing existing tariffs but hidden from the
+        // menu by setting the parent slug to null.
         add_submenu_page(
-            'gm2-tariff',
-            'Add Tariff',
-            'Add Tariff',
+            null,
+            'Edit Tariff',
+            'Edit Tariff',
             'manage_options',
             'gm2-add-tariff',
             [$this, 'display_add_tariff_page']
@@ -75,7 +136,7 @@ class Gm2_Admin {
         $status     = $tariff ? $tariff['status'] : 'enabled';
         $id_field   = $tariff ? '<input type="hidden" name="tariff_id" value="' . intval($tariff['id']) . '" />' : '';
 
-        echo '<div class="wrap"><h1>Add Tariff</h1>';
+        echo '<div class="wrap"><h1>Edit Tariff</h1>';
         echo '<form method="post">';
         wp_nonce_field('gm2_save_tariff', 'gm2_tariff_nonce');
         echo $id_field;
@@ -99,11 +160,23 @@ class Gm2_Admin {
 
         $tariffs = $manager->get_tariffs();
 
-        $add_url = admin_url('admin.php?page=gm2-add-tariff');
-        echo '<div class="wrap"><h1 class="wp-heading-inline">Tariffs</h1>';
-        echo ' <a href="' . esc_url($add_url) . '" class="page-title-action">Add Tariff</a>';
+        echo '<div class="wrap">';
+        echo '<h1 class="wp-heading-inline">Tariffs</h1>';
         echo '<hr class="wp-header-end">';
-        echo '<table class="widefat"><thead><tr><th>Name</th><th>Percentage</th><th>Status</th><th>Actions</th></tr></thead><tbody>';
+
+        echo '<h2>Add Tariff</h2>';
+        echo '<form id="gm2-add-tariff-form">';
+        wp_nonce_field('gm2_add_tariff', 'gm2_add_tariff_nonce');
+        echo '<table class="form-table"><tbody>';
+        echo '<tr><th scope="row"><label for="tariff_name">Name</label></th><td><input name="tariff_name" type="text" id="tariff_name" class="regular-text" required></td></tr>';
+        echo '<tr><th scope="row"><label for="tariff_percentage">Percentage</label></th><td><input name="tariff_percentage" type="number" step="0.01" id="tariff_percentage" class="regular-text" required></td></tr>';
+        echo '<tr><th scope="row">Status</th><td><label><input type="checkbox" name="tariff_status" id="tariff_status" checked> Enabled</label></td></tr>';
+        echo '</tbody></table>';
+        submit_button('Add Tariff');
+        echo '</form>';
+
+        echo '<h2>Existing Tariffs</h2>';
+        echo '<table class="widefat" id="gm2-tariff-table"><thead><tr><th>Name</th><th>Percentage</th><th>Status</th><th>Actions</th></tr></thead><tbody>';
         if ($tariffs) {
             foreach ($tariffs as $tariff) {
                 $delete_url = wp_nonce_url(admin_url('admin.php?page=gm2-tariff&action=delete&id=' . $tariff['id']), 'gm2_delete_tariff_' . $tariff['id']);

--- a/admin/js/gm2-tariff.js
+++ b/admin/js/gm2-tariff.js
@@ -1,0 +1,27 @@
+jQuery(function($){
+    $('#gm2-add-tariff-form').on('submit', function(e){
+        e.preventDefault();
+        var data = {
+            action: 'gm2_add_tariff',
+            _ajax_nonce: $('#gm2_add_tariff_nonce').val(),
+            tariff_name: $('#tariff_name').val(),
+            tariff_percentage: $('#tariff_percentage').val(),
+            tariff_status: $('#tariff_status').is(':checked') ? 'enabled' : 'disabled'
+        };
+        $.post(gm2Tariff.ajax_url, data, function(response){
+            if(response.success){
+                var t = response.data;
+                var row = '<tr>'+
+                    '<td>'+t.name+'</td>'+
+                    '<td>'+t.percentage+'%</td>'+
+                    '<td>'+t.status.charAt(0).toUpperCase()+t.status.slice(1)+'</td>'+
+                    '<td><a href="'+t.edit_url+'">View</a> | <a href="'+t.edit_url+'">Edit</a> | <a href="'+t.delete_url+'" onclick="return confirm(\'Are you sure?\');">Delete</a></td>'+
+                '</tr>';
+                $('#gm2-tariff-table tbody').append(row);
+                $('#gm2-add-tariff-form')[0].reset();
+            } else {
+                alert(response.data || 'Error');
+            }
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- show a tariff creation form on the main Tariff admin page
- add script to submit tariffs via AJAX and update the table dynamically
- enqueue the new script only on the Tariff page
- provide AJAX handlers for creating tariffs
- hide the old Add Tariff submenu and repurpose it for editing

## Testing
- `composer install` *(fails: command not found)*
- `composer run test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68534876c7248327b479463774208cbf