### PR TITLE
Fix tariff nonce usage

### DIFF
--- a/admin/js/gm2-tariff.js
+++ b/admin/js/gm2-tariff.js
@@ -3,7 +3,7 @@ jQuery(function($){
         e.preventDefault();
         var data = {
             action: 'gm2_add_tariff',
-            _ajax_nonce: $('#gm2_add_tariff_nonce').val(),
+            _ajax_nonce: gm2Tariff.nonce,
             tariff_name: $('#tariff_name').val(),
             tariff_percentage: $('#tariff_percentage').val(),
             tariff_status: $('#tariff_status').is(':checked') ? 'enabled' : 'disabled'


### PR DESCRIPTION
## Summary
- load the AJAX nonce from the localized `gm2Tariff` object

## Testing
- `composer install` *(fails: phpunit requires ext-dom)*
- `vendor/bin/phpunit tests/test-sample.php` *(fails: WP_UnitTestCase not found)*

------
https://chatgpt.com/codex/tasks/task_e_68535031ea0883279a452d22aa533abf