### PR TITLE
Switch tariff IDs to UUIDs

### DIFF
--- a/admin/class-gm2-admin.php
+++ b/admin/class-gm2-admin.php
@@ -114,7 +114,7 @@ class Gm2_Admin {
             ];
 
             if (!empty($_POST['tariff_id'])) {
-                $manager->update_tariff(intval($_POST['tariff_id']), $data);
+                $manager->update_tariff(sanitize_text_field($_POST['tariff_id']), $data);
             } else {
                 $manager->add_tariff($data);
             }
@@ -128,13 +128,13 @@ class Gm2_Admin {
         $tariff = false;
         if (!empty($_GET['id'])) {
             $manager = new Gm2_Tariff_Manager();
-            $tariff  = $manager->get_tariff(intval($_GET['id']));
+            $tariff  = $manager->get_tariff(sanitize_text_field($_GET['id']));
         }
 
         $name       = $tariff ? esc_attr($tariff['name']) : '';
         $percentage = $tariff ? esc_attr($tariff['percentage']) : '';
         $status     = $tariff ? $tariff['status'] : 'enabled';
-        $id_field   = $tariff ? '<input type="hidden" name="tariff_id" value="' . intval($tariff['id']) . '" />' : '';
+        $id_field   = $tariff ? '<input type="hidden" name="tariff_id" value="' . esc_attr($tariff['id']) . '" />' : '';
 
         echo '<div class="wrap"><h1>Edit Tariff</h1>';
         echo '<form method="post">';
@@ -153,8 +153,9 @@ class Gm2_Admin {
         $manager = new Gm2_Tariff_Manager();
 
         if (!empty($_GET['action']) && $_GET['action'] === 'delete' && !empty($_GET['id'])) {
-            check_admin_referer('gm2_delete_tariff_' . intval($_GET['id']));
-            $manager->delete_tariff(intval($_GET['id']));
+            $id = sanitize_text_field($_GET['id']);
+            check_admin_referer('gm2_delete_tariff_' . $id);
+            $manager->delete_tariff($id);
             echo '<div class="updated"><p>Tariff deleted.</p></div>';
         }
 

--- a/includes/class-gm2-tariff-manager.php
+++ b/includes/class-gm2-tariff-manager.php
@@ -27,9 +27,16 @@ class Gm2_Tariff_Manager {
 
     public function add_tariff($data) {
         $tariffs = $this->get_tariffs();
-        $data['id'] = time();
+
+        if (function_exists('wp_generate_uuid4')) {
+            $data['id'] = wp_generate_uuid4();
+        } else {
+            $data['id'] = uniqid('', true);
+        }
+
         $tariffs[] = $data;
         update_option($this->option_name, $tariffs);
+
         return $data['id'];
     }
 


### PR DESCRIPTION
## Summary
- generate UUIDs for new tariff IDs instead of timestamps
- sanitize ID values when handling form submissions and deletions

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853512618008327ae723c6a1c0976d2