### PR TITLE
Validate tariff percentage on Ajax add

### DIFF
--- a/admin/class-gm2-admin.php
+++ b/admin/class-gm2-admin.php
@@ -41,9 +41,15 @@ class Gm2_Admin {
 
         check_ajax_referer('gm2_add_tariff');
 
-        $name       = sanitize_text_field($_POST['tariff_name'] ?? '');
-        $percentage = floatval($_POST['tariff_percentage'] ?? 0);
-        $status     = ($_POST['tariff_status'] ?? '') === 'enabled' ? 'enabled' : 'disabled';
+        $name = sanitize_text_field($_POST['tariff_name'] ?? '');
+        $percentage_raw = $_POST['tariff_percentage'] ?? '';
+
+        if (!is_numeric($percentage_raw) || floatval($percentage_raw) < 0) {
+            wp_send_json_error('Tariff percentage must be a non-negative number');
+        }
+
+        $percentage = floatval($percentage_raw);
+        $status = ($_POST['tariff_status'] ?? '') === 'enabled' ? 'enabled' : 'disabled';
 
         $manager = new Gm2_Tariff_Manager();
         $id      = $manager->add_tariff([

--- a/admin/js/gm2-tariff.js
+++ b/admin/js/gm2-tariff.js
@@ -20,7 +20,8 @@ jQuery(function($){
                 $('#gm2-tariff-table tbody').append(row);
                 $('#gm2-add-tariff-form')[0].reset();
             } else {
-                alert(response.data || 'Error');
+                var msg = response.data && response.data.message ? response.data.message : response.data;
+                alert(msg || 'Error');
             }
         });
     });


### PR DESCRIPTION
## Summary
- validate `tariff_percentage` in `ajax_add_tariff`
- expose error messages from the API in the admin UI

## Testing
- `composer install` *(fails: command not found)*
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853572f640083278234b40e8c52b96f