### PR TITLE
Improve tariff error handling

### DIFF
--- a/admin/class-gm2-admin.php
+++ b/admin/class-gm2-admin.php
@@ -42,6 +42,10 @@ class Gm2_Admin {
         check_ajax_referer('gm2_add_tariff');
 
         $name = sanitize_text_field($_POST['tariff_name'] ?? '');
+        if ($name === '') {
+            wp_send_json_error('Tariff name is required');
+        }
+
         $percentage_raw = $_POST['tariff_percentage'] ?? '';
 
         if (!is_numeric($percentage_raw) || floatval($percentage_raw) < 0) {

--- a/admin/js/gm2-tariff.js
+++ b/admin/js/gm2-tariff.js
@@ -1,5 +1,16 @@
 jQuery(function($){
-    $('#gm2-add-tariff-form').on('submit', function(e){
+    var $form = $('#gm2-add-tariff-form');
+    if (!$form.length) {
+        return;
+    }
+
+    var $error = $('#gm2-tariff-error');
+    if (!$error.length) {
+        $error = $('<div id="gm2-tariff-error" class="notice notice-error" style="display:none;"></div>');
+        $form.before($error);
+    }
+
+    $form.on('submit', function(e){
         e.preventDefault();
         var data = {
             action: 'gm2_add_tariff',
@@ -9,7 +20,7 @@ jQuery(function($){
             tariff_status: $('#tariff_status').is(':checked') ? 'enabled' : 'disabled'
         };
         $.post(gm2Tariff.ajax_url, data, function(response){
-            if(response.success){
+            if (response.success) {
                 var t = response.data;
                 var row = '<tr>'+
                     '<td>'+t.name+'</td>'+
@@ -18,10 +29,11 @@ jQuery(function($){
                     '<td><a href="'+t.edit_url+'">View</a> | <a href="'+t.edit_url+'">Edit</a> | <a href="'+t.delete_url+'" onclick="return confirm(\'Are you sure?\');">Delete</a></td>'+
                 '</tr>';
                 $('#gm2-tariff-table tbody').append(row);
-                $('#gm2-add-tariff-form')[0].reset();
+                $form[0].reset();
+                $error.hide().text('');
             } else {
                 var msg = response.data && response.data.message ? response.data.message : response.data;
-                alert(msg || 'Error');
+                $error.text(msg || 'Error').show();
             }
         });
     });


### PR DESCRIPTION
## Summary
- inject a dedicated error container in `gm2-tariff.js`
- display ajax errors in that container rather than using `alert`
- validate tariff name in `ajax_add_tariff` and return an error if empty

## Testing
- `composer test` *(fails: composer not found)*
- `vendor/bin/phpunit` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68535935b00c8327b1a990c604e634c5