### PR TITLE
Enhance tariff admin feedback

### DIFF
--- a/admin/class-gm2-admin.php
+++ b/admin/class-gm2-admin.php
@@ -172,6 +172,7 @@ class Gm2_Admin {
         echo '<hr class="wp-header-end">';
 
         echo '<h2>Add Tariff</h2>';
+        echo '<div class="notice notice-success hidden" id="gm2-tariff-msg"></div>';
         echo '<form id="gm2-add-tariff-form">';
         wp_nonce_field('gm2_add_tariff', 'gm2_add_tariff_nonce');
         echo '<table class="form-table"><tbody>';

--- a/admin/js/gm2-tariff.js
+++ b/admin/js/gm2-tariff.js
@@ -1,6 +1,14 @@
 jQuery(function($){
-    $('#gm2-add-tariff-form').on('submit', function(e){
+    var $form = $('#gm2-add-tariff-form');
+    var $msg  = $('#gm2-tariff-msg');
+
+    $form.on('submit', function(e){
         e.preventDefault();
+
+        var $submit = $form.find('input[type="submit"]');
+        $submit.prop('disabled', true);
+        $msg.addClass('hidden').removeClass('notice-error notice-success').empty();
+
         var data = {
             action: 'gm2_add_tariff',
             _ajax_nonce: gm2Tariff.nonce,
@@ -8,21 +16,33 @@ jQuery(function($){
             tariff_percentage: $('#tariff_percentage').val(),
             tariff_status: $('#tariff_status').is(':checked') ? 'enabled' : 'disabled'
         };
-        $.post(gm2Tariff.ajax_url, data, function(response){
-            if(response.success){
-                var t = response.data;
-                var row = '<tr>'+
-                    '<td>'+t.name+'</td>'+
-                    '<td>'+t.percentage+'%</td>'+
-                    '<td>'+t.status.charAt(0).toUpperCase()+t.status.slice(1)+'</td>'+
-                    '<td><a href="'+t.edit_url+'">View</a> | <a href="'+t.edit_url+'">Edit</a> | <a href="'+t.delete_url+'" onclick="return confirm(\'Are you sure?\');">Delete</a></td>'+
-                '</tr>';
-                $('#gm2-tariff-table tbody').append(row);
-                $('#gm2-add-tariff-form')[0].reset();
-            } else {
-                var msg = response.data && response.data.message ? response.data.message : response.data;
-                alert(msg || 'Error');
-            }
-        });
+
+        $.post(gm2Tariff.ajax_url, data)
+            .done(function(response){
+                if(response.success){
+                    var t = response.data;
+                    var row = '<tr>'+
+                        '<td>'+t.name+'</td>'+
+                        '<td>'+t.percentage+'%</td>'+
+                        '<td>'+t.status.charAt(0).toUpperCase()+t.status.slice(1)+'</td>'+
+                        '<td><a href="'+t.edit_url+'">View</a> | <a href="'+t.edit_url+'">Edit</a> | <a href="'+t.delete_url+'" onclick="return confirm(\'Are you sure?\');">Delete</a></td>'+
+                    '</tr>';
+                    $('#gm2-tariff-table tbody').append(row);
+                    $form[0].reset();
+                    $msg.text('Tariff added.').addClass('notice-success').removeClass('hidden');
+                } else {
+                    var msg = response.data && response.data.message ? response.data.message : (response.data || 'Error');
+                    $msg.text(msg).addClass('notice-error').removeClass('hidden');
+                }
+            })
+            .fail(function(){
+                $msg.text('Request failed.').addClass('notice-error').removeClass('hidden');
+            })
+            .always(function(){
+                $submit.prop('disabled', false);
+                if($msg.length){
+                    $('html, body').animate({scrollTop: $msg.offset().top}, 300);
+                }
+            });
     });
 });


### PR DESCRIPTION
## Summary
- show success notification placeholder on Tariff page
- disable Add Tariff submit button during request
- display success/error messages after adding tariffs

## Testing
- `composer test` *(fails: PHPUnit expects WordPress environment)*

------
https://chatgpt.com/codex/tasks/task_e_685362ec26dc8327b44e964ce5ad414f