### PR TITLE
Fix escaping for admin action URLs

### DIFF
--- a/admin/class-gm2-admin.php
+++ b/admin/class-gm2-admin.php
@@ -197,7 +197,7 @@ class Gm2_Admin {
                 echo '<td>' . esc_html($tariff['name']) . '</td>';
                 echo '<td>' . esc_html($tariff['percentage']) . '%</td>';
                 echo '<td>' . esc_html(ucfirst($tariff['status'])) . '</td>';
-                echo '<td><a href="' . $edit_url . '">View</a> | <a href="' . $edit_url . '">Edit</a> | <a href="' . $delete_url . '" onclick="return confirm(\'Are you sure?\');">Delete</a></td>';
+                echo '<td><a href="' . esc_url( $edit_url ) . '">View</a> | <a href="' . esc_url( $edit_url ) . '">Edit</a> | <a href="' . esc_url( $delete_url ) . '" onclick="return confirm(\'Are you sure?\');">Delete</a></td>';
                 echo '</tr>';
             }
         } else {


### PR DESCRIPTION
## Summary
- sanitize edit and delete URLs in tariff table rows

## Testing
- `php -l admin/class-gm2-admin.php`
- `phpunit` *(fails: displays usage due to missing config)*

------
https://chatgpt.com/codex/tasks/task_e_6853650028bc8327a1936539f5542e23