### PR TITLE
Enforce tariff percentage range

### DIFF
--- a/admin/class-gm2-admin.php
+++ b/admin/class-gm2-admin.php
@@ -48,11 +48,15 @@ class Gm2_Admin {
 
         $percentage_raw = $_POST['tariff_percentage'] ?? '';
 
-        if (!is_numeric($percentage_raw) || floatval($percentage_raw) < 0) {
-            wp_send_json_error('Tariff percentage must be a non-negative number');
+        if (!is_numeric($percentage_raw)) {
+            wp_send_json_error('Tariff percentage must be a number');
         }
 
         $percentage = floatval($percentage_raw);
+
+        if ($percentage < 0 || $percentage > 100) {
+            wp_send_json_error('Tariff percentage must be between 0 and 100');
+        }
         $status = ($_POST['tariff_status'] ?? '') === 'enabled' ? 'enabled' : 'disabled';
 
         $manager = new Gm2_Tariff_Manager();


### PR DESCRIPTION
## Summary
- validate that tariff percentage values are between 0 and 100

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685366b0d5c88327a75f643f58966b5e