### PR TITLE
Add SEO meta functionality

### DIFF
--- a/admin/class-gm2-seo-admin.php
+++ b/admin/class-gm2-seo-admin.php
@@ -7,6 +7,37 @@ class Gm2_SEO_Admin {
     public function run() {
         add_action('admin_menu', [$this, 'add_settings_pages']);
         add_action('add_meta_boxes', [$this, 'register_meta_boxes']);
+        add_action('save_post', [$this, 'save_post_meta']);
+
+        $taxonomies = $this->get_supported_taxonomies();
+        foreach ($taxonomies as $tax) {
+            add_action("{$tax}_add_form_fields", [$this, 'render_taxonomy_meta_box']);
+            add_action("{$tax}_edit_form_fields", [$this, 'render_taxonomy_meta_box']);
+            add_action("create_{$tax}", [$this, 'save_taxonomy_meta']);
+            add_action("edited_{$tax}", [$this, 'save_taxonomy_meta']);
+        }
+    }
+
+    private function get_supported_post_types() {
+        $types = ['post', 'page'];
+        if (post_type_exists('product')) {
+            $types[] = 'product';
+        }
+        return $types;
+    }
+
+    private function get_supported_taxonomies() {
+        $taxonomies = ['category'];
+        if (taxonomy_exists('product_cat')) {
+            $taxonomies[] = 'product_cat';
+        }
+        if (taxonomy_exists('brand')) {
+            $taxonomies[] = 'brand';
+        }
+        if (taxonomy_exists('product_brand')) {
+            $taxonomies[] = 'product_brand';
+        }
+        return $taxonomies;
     }
 
     public function add_settings_pages() {
@@ -77,39 +108,69 @@ class Gm2_SEO_Admin {
     }
 
     public function register_meta_boxes() {
-        add_meta_box(
-            'gm2_seo_post_meta',
-            'SEO Settings',
-            [$this, 'render_post_meta_box'],
-            'post',
-            'normal',
-            'high'
-        );
-
-        if (post_type_exists('product')) {
+        foreach ($this->get_supported_post_types() as $type) {
             add_meta_box(
-                'gm2_seo_product_meta',
+                'gm2_seo_' . $type . '_meta',
                 'SEO Settings',
-                [$this, 'render_product_meta_box'],
-                'product',
+                [$this, 'render_post_meta_box'],
+                $type,
                 'normal',
                 'high'
             );
         }
-
-        add_action('category_add_form_fields', [$this, 'render_taxonomy_meta_box']);
-        add_action('category_edit_form_fields', [$this, 'render_taxonomy_meta_box']);
     }
 
     public function render_post_meta_box($post) {
-        echo '<p>Post SEO options go here.</p>';
-    }
-
-    public function render_product_meta_box($post) {
-        echo '<p>Product SEO options go here.</p>';
+        $title       = get_post_meta($post->ID, '_gm2_title', true);
+        $description = get_post_meta($post->ID, '_gm2_description', true);
+        wp_nonce_field('gm2_save_seo_meta', 'gm2_seo_nonce');
+        echo '<p><label for="gm2_seo_title">SEO Title</label>';
+        echo '<input type="text" id="gm2_seo_title" name="gm2_seo_title" value="' . esc_attr($title) . '" class="widefat" /></p>';
+        echo '<p><label for="gm2_seo_description">SEO Description</label>';
+        echo '<textarea id="gm2_seo_description" name="gm2_seo_description" class="widefat" rows="3">' . esc_textarea($description) . '</textarea></p>';
     }
 
     public function render_taxonomy_meta_box($term) {
-        echo '<div class="form-field"><label>SEO Title</label><input type="text" name="gm2_seo_title" value="" /></div>';
+        $title = '';
+        $description = '';
+        if (is_object($term)) {
+            $title       = get_term_meta($term->term_id, '_gm2_title', true);
+            $description = get_term_meta($term->term_id, '_gm2_description', true);
+        }
+        wp_nonce_field('gm2_save_seo_meta', 'gm2_seo_nonce');
+
+        if (is_object($term)) {
+            echo '<tr class="form-field"><th scope="row"><label for="gm2_seo_title">SEO Title</label></th><td><input name="gm2_seo_title" id="gm2_seo_title" type="text" value="' . esc_attr($title) . '" class="regular-text" /></td></tr>';
+            echo '<tr class="form-field"><th scope="row"><label for="gm2_seo_description">SEO Description</label></th><td><textarea name="gm2_seo_description" id="gm2_seo_description" rows="5" class="large-text">' . esc_textarea($description) . '</textarea></td></tr>';
+        } else {
+            echo '<div class="form-field"><label for="gm2_seo_title">SEO Title</label><input type="text" name="gm2_seo_title" id="gm2_seo_title" value="" /></div>';
+            echo '<div class="form-field"><label for="gm2_seo_description">SEO Description</label><textarea name="gm2_seo_description" id="gm2_seo_description" rows="5"></textarea></div>';
+        }
+    }
+
+    public function save_post_meta($post_id) {
+        if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
+            return;
+        }
+        if (!isset($_POST['gm2_seo_nonce']) || !wp_verify_nonce($_POST['gm2_seo_nonce'], 'gm2_save_seo_meta')) {
+            return;
+        }
+        if (!current_user_can('edit_post', $post_id)) {
+            return;
+        }
+        $title       = isset($_POST['gm2_seo_title']) ? sanitize_text_field($_POST['gm2_seo_title']) : '';
+        $description = isset($_POST['gm2_seo_description']) ? sanitize_textarea_field($_POST['gm2_seo_description']) : '';
+        update_post_meta($post_id, '_gm2_title', $title);
+        update_post_meta($post_id, '_gm2_description', $description);
+    }
+
+    public function save_taxonomy_meta($term_id) {
+        if (!isset($_POST['gm2_seo_nonce']) || !wp_verify_nonce($_POST['gm2_seo_nonce'], 'gm2_save_seo_meta')) {
+            return;
+        }
+        $title       = isset($_POST['gm2_seo_title']) ? sanitize_text_field($_POST['gm2_seo_title']) : '';
+        $description = isset($_POST['gm2_seo_description']) ? sanitize_textarea_field($_POST['gm2_seo_description']) : '';
+        update_term_meta($term_id, '_gm2_title', $title);
+        update_term_meta($term_id, '_gm2_description', $description);
     }
 }

--- a/public/class-gm2-seo-public.php
+++ b/public/class-gm2-seo-public.php
@@ -11,8 +11,54 @@ class Gm2_SEO_Public {
         add_action('wp_footer', [$this, 'output_breadcrumbs']);
     }
 
+    private function get_seo_meta() {
+        $title       = '';
+        $description = '';
+
+        if (is_singular()) {
+            $post_id    = get_queried_object_id();
+            $title       = get_post_meta($post_id, '_gm2_title', true);
+            $description = get_post_meta($post_id, '_gm2_description', true);
+        } elseif (is_category() || is_tag() || is_tax()) {
+            $term = get_queried_object();
+            if ($term && isset($term->term_id)) {
+                $title       = get_term_meta($term->term_id, '_gm2_title', true);
+                $description = get_term_meta($term->term_id, '_gm2_description', true);
+            }
+        }
+
+        if (!$title) {
+            $title = wp_get_document_title();
+        }
+        if (!$description) {
+            $description = get_bloginfo('description');
+        }
+
+        return [
+            'title'       => $title,
+            'description' => $description,
+        ];
+    }
+
     public function output_meta_tags() {
-        echo "<!-- SEO meta tags placeholder -->\n";
+        $data = $this->get_seo_meta();
+        $title = $data['title'];
+        $description = $data['description'];
+
+        echo '<title>' . esc_html($title) . "</title>\n";
+        echo '<meta name="description" content="' . esc_attr($description) . '" />' . "\n";
+
+        $url  = is_singular() ? get_permalink() : (is_category() || is_tag() || is_tax() ? get_term_link(get_queried_object()) : home_url());
+        $type = is_singular() ? 'article' : 'website';
+
+        echo '<meta property="og:title" content="' . esc_attr($title) . '" />' . "\n";
+        echo '<meta property="og:description" content="' . esc_attr($description) . '" />' . "\n";
+        echo '<meta property="og:url" content="' . esc_url($url) . '" />' . "\n";
+        echo '<meta property="og:type" content="' . esc_attr($type) . '" />' . "\n";
+
+        echo '<meta name="twitter:card" content="summary" />' . "\n";
+        echo '<meta name="twitter:title" content="' . esc_attr($title) . '" />' . "\n";
+        echo '<meta name="twitter:description" content="' . esc_attr($description) . '" />' . "\n";
     }
 
     public function output_structured_data() {


### PR DESCRIPTION
## Summary
- register SEO meta boxes for posts, pages, products and taxonomies
- save custom title and description on save hooks
- output `<title>` and meta description along with Open Graph and Twitter tags in the frontend

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit --version` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686833b684708327bb193daec9d9ca93