### PR TITLE
Add advanced SEO meta controls

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Gm2 WordPress Suite
  * Description:       A powerful suite of tools and features for WordPress, by Gm2.
- * Version:           1.1.0
+ * Version:           1.2.0
  * Author:            Your Name or Team Gm2
  * Author URI:        https://yourwebsite.com
  * License:           GPL-2.0+
@@ -14,7 +14,7 @@
 defined('ABSPATH') or die('No script kiddies please!');
 
 // Define constants
-define('GM2_VERSION', '1.1.0');
+define('GM2_VERSION', '1.2.0');
 define('GM2_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('GM2_PLUGIN_URL', plugin_dir_url(__FILE__));
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: gm2team
 Tags: admin, tools, suite, performance
 Requires at least: 5.6
 Tested up to: 6.5
-Stable tag: 1.1.0
+Stable tag: 1.2.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -16,6 +16,9 @@ A powerful suite of WordPress enhancements including admin tools, frontend optim
 3. Use the Gm2 Suite menu in the admin sidebar to configure settings.
 
 == Changelog ==
+= 1.2.0 =
+* Added robots and canonical controls in meta boxes.
+* Optional settings to noindex product variants and out-of-stock items.
 = 1.1.0 =
 * Added Tariff management and WooCommerce checkout integration.
 = 1.0.0 =


### PR DESCRIPTION
## Summary
- add index/follow options and canonical URL fields in meta boxes
- inject robots meta and canonical link based on saved settings
- add bulk meta-tag settings to noindex WooCommerce variants or out-of-stock products
- bump plugin version to 1.2.0

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686836bc34d083279b22695ddbf1a41f