### PR TITLE
Add breadcrumb shortcode and block

### DIFF
--- a/public/js/breadcrumb-block.js
+++ b/public/js/breadcrumb-block.js
@@ -1,0 +1,15 @@
+( function( blocks, element ) {
+    var el = element.createElement;
+    blocks.registerBlockType( 'gm2/breadcrumbs', {
+        title: 'GM2 Breadcrumbs',
+        icon: 'menu',
+        category: 'widgets',
+        edit: function() {
+            return el( 'p', null, 'GM2 Breadcrumbs' );
+        },
+        save: function() {
+            return null;
+        }
+    } );
+} )( window.wp.blocks, window.wp.element );
+


### PR DESCRIPTION
## Summary
- add `gm2_breadcrumbs` shortcode to output breadcrumbs and JSON-LD
- provide dynamic `gm2/breadcrumbs` block for Gutenberg that renders the shortcode
- hook new shortcode and block in `Gm2_SEO_Public`

## Testing
- `php -l public/class-gm2-seo-public.php`
- `php -l public/js/breadcrumb-block.js`
- `phpunit tests/test-sample.php` *(fails: WP_UnitTestCase not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868442fe57c8327978103bab81e7863