### PR TITLE
Add GA and Search Console options

### DIFF
--- a/admin/class-gm2-seo-admin.php
+++ b/admin/class-gm2-seo-admin.php
@@ -9,6 +9,7 @@ class Gm2_SEO_Admin {
         add_action('add_meta_boxes', [$this, 'register_meta_boxes']);
         add_action('save_post', [$this, 'save_post_meta']);
         add_action('admin_enqueue_scripts', [$this, 'enqueue_editor_scripts']);
+        add_action('admin_init', [$this, 'register_settings']);
         add_action('admin_post_gm2_sitemap_settings', [$this, 'handle_sitemap_form']);
         add_action('admin_post_gm2_meta_tags_settings', [$this, 'handle_meta_tags_form']);
         add_action('admin_post_gm2_schema_settings', [$this, 'handle_schema_form']);
@@ -110,8 +111,51 @@ class Gm2_SEO_Admin {
         );
     }
 
+    public function register_settings() {
+        register_setting('gm2_seo_options', 'gm2_ga_measurement_id', [
+            'sanitize_callback' => 'sanitize_text_field',
+        ]);
+        register_setting('gm2_seo_options', 'gm2_search_console_verification', [
+            'sanitize_callback' => 'sanitize_text_field',
+        ]);
+
+        add_settings_section(
+            'gm2_seo_main',
+            '',
+            '__return_false',
+            'gm2_seo'
+        );
+
+        add_settings_field(
+            'gm2_ga_measurement_id',
+            'Google Analytics Measurement ID',
+            function () {
+                $value = get_option('gm2_ga_measurement_id', '');
+                echo '<input type="text" name="gm2_ga_measurement_id" value="' . esc_attr($value) . '" class="regular-text" />';
+            },
+            'gm2_seo',
+            'gm2_seo_main'
+        );
+
+        add_settings_field(
+            'gm2_search_console_verification',
+            'Search Console Verification Code',
+            function () {
+                $value = get_option('gm2_search_console_verification', '');
+                echo '<input type="text" name="gm2_search_console_verification" value="' . esc_attr($value) . '" class="regular-text" />';
+            },
+            'gm2_seo',
+            'gm2_seo_main'
+        );
+    }
+
     public function display_dashboard() {
-        echo '<div class="wrap"><h1>SEO Settings</h1></div>';
+        echo '<div class="wrap"><h1>SEO Settings</h1>';
+        echo '<form method="post" action="options.php">';
+        settings_fields('gm2_seo_options');
+        do_settings_sections('gm2_seo');
+        submit_button();
+        echo '</form></div>';
     }
 
     public function display_meta_tags_page() {

--- a/public/class-gm2-seo-public.php
+++ b/public/class-gm2-seo-public.php
@@ -12,6 +12,8 @@ class Gm2_SEO_Public {
         add_action('template_redirect', [$this, 'log_404_url'], 99);
         add_action('wp_head', [$this, 'output_canonical_url'], 5);
         add_action('wp_head', [$this, 'output_meta_tags']);
+        add_action('wp_head', [$this, 'output_search_console_meta']);
+        add_action('wp_head', [$this, 'output_ga_tracking_code']);
         add_action('wp_head', [$this, 'output_product_schema'], 20);
         add_action('wp_head', [$this, 'output_brand_schema'], 20);
         add_action('wp_head', [$this, 'output_breadcrumb_schema'], 20);
@@ -402,6 +404,21 @@ class Gm2_SEO_Public {
         $canonical = $data['canonical'];
         if ($canonical) {
             echo '<link rel="canonical" href="' . esc_url($canonical) . '" />' . "\n";
+        }
+    }
+
+    public function output_search_console_meta() {
+        $code = get_option('gm2_search_console_verification', '');
+        if ($code) {
+            echo '<meta name="google-site-verification" content="' . esc_attr($code) . '" />' . "\n";
+        }
+    }
+
+    public function output_ga_tracking_code() {
+        $id = trim(get_option('gm2_ga_measurement_id', ''));
+        if ($id) {
+            echo '<script async src="https://www.googletagmanager.com/gtag/js?id=' . esc_attr($id) . '"></script>' . "\n";
+            echo '<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag(\'js\', new Date());gtag(\'config\', \'' . esc_js($id) . '\');</script>' . "\n";
         }
     }
 }


### PR DESCRIPTION
## Summary
- add Google Analytics & Search Console options to SEO admin page
- output analytics tracking code and verification meta tag in public SEO class

## Testing
- `composer test` *(fails: displays phpunit usage)*

------
https://chatgpt.com/codex/tasks/task_e_68684f23734c8327a5a698b44bc21595