### PR TITLE
Add PHPUnit config and tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,11 @@
 {
-    "name": "gm2/wordpress-suite",
-    "type": "project",
-    "require-dev": {
-        "phpunit/phpunit": "^9",
-        "wp-phpunit/wp-phpunit": "^6"
-    },
-    "scripts": {
-        "test": "phpunit"
-    }
+  "name": "gm2/wordpress-suite",
+  "type": "project",
+  "require-dev": {
+    "phpunit/phpunit": "^9",
+    "wp-phpunit/wp-phpunit": "^6"
+  },
+  "scripts": {
+    "test": "vendor/bin/phpunit"
+  }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="Plugin Test Suite">
+            <directory suffix=".php">./tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,12 @@
+<?php
+$_tests_dir = getenv('WP_TESTS_DIR');
+if (!$_tests_dir) {
+    $_tests_dir = '/tmp/wordpress-tests-lib';
+}
+require_once $_tests_dir . '/includes/functions.php';
+function _manually_load_plugin() {
+    require dirname(__DIR__) . '/gm2-wordpress-suite.php';
+}
+tests_add_filter('muplugins_loaded', '_manually_load_plugin');
+require $_tests_dir . '/includes/bootstrap.php';
+

--- a/tests/test-meta-tags.php
+++ b/tests/test-meta-tags.php
@@ -1,0 +1,20 @@
+<?php
+class MetaTagsTest extends WP_UnitTestCase {
+    public function test_output_meta_tags_for_post() {
+        $post_id = self::factory()->post->create([
+            'post_title'   => 'Sample',
+            'post_content' => 'Content',
+        ]);
+        update_post_meta($post_id, '_gm2_title', 'Custom Title');
+        update_post_meta($post_id, '_gm2_description', 'Custom Description');
+        $seo = new Gm2_SEO_Public();
+        $this->go_to(get_permalink($post_id));
+        setup_postdata(get_post($post_id));
+        ob_start();
+        $seo->output_meta_tags();
+        $output = ob_get_clean();
+        $this->assertStringContainsString('<title>Custom Title</title>', $output);
+        $this->assertStringContainsString('content="Custom Description"', $output);
+    }
+}
+

--- a/tests/test-redirect.php
+++ b/tests/test-redirect.php
@@ -1,0 +1,26 @@
+<?php
+class RedirectTest extends WP_UnitTestCase {
+    public function test_maybe_apply_redirects_when_source_exists() {
+        update_option('gm2_redirects', [
+            [
+                'source' => '/old-page',
+                'target' => '/new-page',
+                'type'   => 301,
+            ]
+        ]);
+        $seo = new Gm2_SEO_Public();
+        $_SERVER['REQUEST_URI'] = '/old-page';
+        add_filter('wp_redirect', function($location, $status) {
+            $this->assertSame('/new-page', $location);
+            $this->assertSame(301, $status);
+            return $location;
+        }, 10, 2);
+        try {
+            $seo->maybe_apply_redirects();
+        } catch (Exception $e) {
+            // ignore
+        }
+        remove_all_filters('wp_redirect');
+    }
+}
+

--- a/tests/test-sitemap.php
+++ b/tests/test-sitemap.php
@@ -1,0 +1,14 @@
+<?php
+class SitemapTest extends WP_UnitTestCase {
+    public function test_generate_sitemap_creates_file() {
+        $post_id = self::factory()->post->create();
+        $sitemap = new Gm2_Sitemap();
+        $sitemap->generate();
+        $file = ABSPATH . 'sitemap.xml';
+        $this->assertFileExists($file);
+        $content = file_get_contents($file);
+        $this->assertStringContainsString('<urlset', $content);
+        $this->assertStringContainsString(get_permalink($post_id), $content);
+    }
+}
+


### PR DESCRIPTION
## Summary
- configure PHPUnit with a bootstrap file
- add unit tests for meta tags, sitemap generation, and redirect logic
- adjust Composer test script to run vendor phpunit

## Testing
- `composer test` *(fails: Error in bootstrap script: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_686851c1d80483279b6340d692be5107