### PR TITLE
Check get_term_link error

### DIFF
--- a/public/class-gm2-seo-public.php
+++ b/public/class-gm2-seo-public.php
@@ -178,7 +178,8 @@ class Gm2_SEO_Public {
             if (is_singular()) {
                 $canonical = get_permalink();
             } elseif (is_category() || is_tag() || is_tax()) {
-                $canonical = get_term_link(get_queried_object());
+                $term_link = get_term_link(get_queried_object());
+                $canonical = !is_wp_error($term_link) ? $term_link : home_url();
             } else {
                 $canonical = home_url();
             }


### PR DESCRIPTION
## Summary
- guard against WP_Error when resolving canonical URLs for terms

## Testing
- `composer test` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68685a74160c8327ac60bb98fee757a1