### PR TITLE
Respect title-tag support

### DIFF
--- a/public/class-gm2-seo-public.php
+++ b/public/class-gm2-seo-public.php
@@ -203,7 +203,9 @@ class Gm2_SEO_Public {
         $robots[]    = ($data['nofollow'] === '1') ? 'nofollow' : 'follow';
         $canonical   = $data['canonical'];
 
-        echo '<title>' . esc_html($title) . "</title>\n";
+        if (!wp_get_theme_support('title-tag')) {
+            echo '<title>' . esc_html($title) . "</title>\n";
+        }
         echo '<meta name="description" content="' . esc_attr($description) . '" />' . "\n";
         echo '<meta name="robots" content="' . esc_attr(implode(',', $robots)) . '" />' . "\n";
 

--- a/tests/test-meta-tags.php
+++ b/tests/test-meta-tags.php
@@ -1,6 +1,6 @@
 <?php
 class MetaTagsTest extends WP_UnitTestCase {
-    public function test_output_meta_tags_for_post() {
+    public function test_output_meta_tags_for_post_without_title_support() {
         $post_id = self::factory()->post->create([
             'post_title'   => 'Sample',
             'post_content' => 'Content',
@@ -10,10 +10,30 @@ class MetaTagsTest extends WP_UnitTestCase {
         $seo = new Gm2_SEO_Public();
         $this->go_to(get_permalink($post_id));
         setup_postdata(get_post($post_id));
+        remove_theme_support('title-tag');
         ob_start();
         $seo->output_meta_tags();
         $output = ob_get_clean();
         $this->assertStringContainsString('<title>Custom Title</title>', $output);
+        $this->assertStringContainsString('content="Custom Description"', $output);
+        add_theme_support('title-tag');
+    }
+
+    public function test_output_meta_tags_for_post_with_title_support() {
+        $post_id = self::factory()->post->create([
+            'post_title'   => 'Sample',
+            'post_content' => 'Content',
+        ]);
+        update_post_meta($post_id, '_gm2_title', 'Custom Title');
+        update_post_meta($post_id, '_gm2_description', 'Custom Description');
+        $seo = new Gm2_SEO_Public();
+        $this->go_to(get_permalink($post_id));
+        setup_postdata(get_post($post_id));
+        add_theme_support('title-tag');
+        ob_start();
+        $seo->output_meta_tags();
+        $output = ob_get_clean();
+        $this->assertStringNotContainsString('<title>Custom Title</title>', $output);
         $this->assertStringContainsString('content="Custom Description"', $output);
     }
 }


### PR DESCRIPTION
## Summary
- avoid echoing `<title>` if the theme already supports the `title-tag` feature
- expand meta tag tests to cover cases with and without `title-tag` support

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68685b34c9308327a0e4285e9f7121e1