### PR TITLE
Add gm2_show_footer_breadcrumbs option

### DIFF
--- a/admin/class-gm2-seo-admin.php
+++ b/admin/class-gm2-seo-admin.php
@@ -170,6 +170,7 @@ class Gm2_SEO_Admin {
         $brand      = get_option('gm2_schema_brand', '1');
         $breadcrumbs = get_option('gm2_schema_breadcrumbs', '1');
         $review     = get_option('gm2_schema_review', '1');
+        $footer_bc  = get_option('gm2_show_footer_breadcrumbs', '1');
 
         echo '<div class="wrap"><h1>Structured Data</h1>';
         if (!empty($_GET['updated'])) {
@@ -182,6 +183,7 @@ class Gm2_SEO_Admin {
         echo '<tr><th scope="row">Product Schema</th><td><input type="checkbox" name="gm2_schema_product" value="1" ' . checked($product, '1', false) . '></td></tr>';
         echo '<tr><th scope="row">Brand Schema</th><td><input type="checkbox" name="gm2_schema_brand" value="1" ' . checked($brand, '1', false) . '></td></tr>';
         echo '<tr><th scope="row">Breadcrumb Schema</th><td><input type="checkbox" name="gm2_schema_breadcrumbs" value="1" ' . checked($breadcrumbs, '1', false) . '></td></tr>';
+        echo '<tr><th scope="row">Show Breadcrumbs in Footer</th><td><input type="checkbox" name="gm2_show_footer_breadcrumbs" value="1" ' . checked($footer_bc, '1', false) . '></td></tr>';
         echo '<tr><th scope="row">Review Schema</th><td><input type="checkbox" name="gm2_schema_review" value="1" ' . checked($review, '1', false) . '></td></tr>';
         echo '</tbody></table>';
         submit_button('Save Settings');
@@ -438,6 +440,9 @@ class Gm2_SEO_Admin {
 
         $breadcrumbs = isset($_POST['gm2_schema_breadcrumbs']) ? '1' : '0';
         update_option('gm2_schema_breadcrumbs', $breadcrumbs);
+
+        $footer_bc = isset($_POST['gm2_show_footer_breadcrumbs']) ? '1' : '0';
+        update_option('gm2_show_footer_breadcrumbs', $footer_bc);
 
         $review     = isset($_POST['gm2_schema_review']) ? '1' : '0';
         update_option('gm2_schema_review', $review);

--- a/public/class-gm2-seo-public.php
+++ b/public/class-gm2-seo-public.php
@@ -18,7 +18,9 @@ class Gm2_SEO_Public {
         add_action('wp_head', [$this, 'output_brand_schema'], 20);
         add_action('wp_head', [$this, 'output_breadcrumb_schema'], 20);
         add_action('wp_head', [$this, 'output_review_schema'], 20);
-        add_action('wp_footer', [$this, 'output_breadcrumbs']);
+        if (get_option('gm2_show_footer_breadcrumbs', '1') === '1') {
+            add_action('wp_footer', [$this, 'output_breadcrumbs']);
+        }
         add_shortcode('gm2_breadcrumbs', [$this, 'gm2_breadcrumbs_shortcode']);
         add_action('init', [$this, 'register_breadcrumb_block']);
 

--- a/tests/test-breadcrumbs.php
+++ b/tests/test-breadcrumbs.php
@@ -1,0 +1,21 @@
+<?php
+class BreadcrumbsTest extends WP_UnitTestCase {
+    public function setUp(): void {
+        parent::setUp();
+        remove_all_actions('wp_footer');
+    }
+
+    public function test_footer_breadcrumbs_disabled() {
+        update_option('gm2_show_footer_breadcrumbs', '0');
+        $seo = new Gm2_SEO_Public();
+        $seo->run();
+        $this->assertFalse( has_action('wp_footer', [$seo, 'output_breadcrumbs']) );
+    }
+
+    public function test_footer_breadcrumbs_enabled() {
+        update_option('gm2_show_footer_breadcrumbs', '1');
+        $seo = new Gm2_SEO_Public();
+        $seo->run();
+        $this->assertNotFalse( has_action('wp_footer', [$seo, 'output_breadcrumbs']) );
+    }
+}


### PR DESCRIPTION
## Summary
- add `gm2_show_footer_breadcrumbs` option
- display checkbox in Structured Data settings
- hook breadcrumbs on `wp_footer` only when enabled
- add tests for the new behaviour

## Testing
- `composer test` *(fails: require WordPress testing framework)*

------
https://chatgpt.com/codex/tasks/task_e_68685c2dc58083278cc7825a744c33d1