### PR TITLE
Fix title tag support check

### DIFF
--- a/public/class-gm2-seo-public.php
+++ b/public/class-gm2-seo-public.php
@@ -211,7 +211,7 @@ class Gm2_SEO_Public {
         $robots[]    = ($data['nofollow'] === '1') ? 'nofollow' : 'follow';
         $canonical   = $data['canonical'];
 
-        if (!wp_get_theme_support('title-tag')) {
+        if (!current_theme_supports('title-tag')) {
             echo '<title>' . esc_html($title) . "</title>\n";
         }
         echo '<meta name="description" content="' . esc_attr($description) . '" />' . "\n";


### PR DESCRIPTION
## Summary
- ensure SEO output uses `current_theme_supports('title-tag')`

## Testing
- `composer run test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_686862b7fdfc8327b6b2f9637faf3793