### PR TITLE
Add focus keywords feature with density analysis

### DIFF
--- a/admin/class-gm2-seo-admin.php
+++ b/admin/class-gm2-seo-admin.php
@@ -302,16 +302,19 @@ class Gm2_SEO_Admin {
     }
 
     public function render_post_meta_box($post) {
-        $title       = get_post_meta($post->ID, '_gm2_title', true);
-        $description = get_post_meta($post->ID, '_gm2_description', true);
-        $noindex     = get_post_meta($post->ID, '_gm2_noindex', true);
-        $nofollow    = get_post_meta($post->ID, '_gm2_nofollow', true);
-        $canonical   = get_post_meta($post->ID, '_gm2_canonical', true);
+        $title          = get_post_meta($post->ID, '_gm2_title', true);
+        $description    = get_post_meta($post->ID, '_gm2_description', true);
+        $noindex        = get_post_meta($post->ID, '_gm2_noindex', true);
+        $nofollow       = get_post_meta($post->ID, '_gm2_nofollow', true);
+        $canonical      = get_post_meta($post->ID, '_gm2_canonical', true);
+        $focus_keywords = get_post_meta($post->ID, '_gm2_focus_keywords', true);
         wp_nonce_field('gm2_save_seo_meta', 'gm2_seo_nonce');
         echo '<p><label for="gm2_seo_title">SEO Title</label>';
         echo '<input type="text" id="gm2_seo_title" name="gm2_seo_title" value="' . esc_attr($title) . '" class="widefat" /></p>';
         echo '<p><label for="gm2_seo_description">SEO Description</label>';
         echo '<textarea id="gm2_seo_description" name="gm2_seo_description" class="widefat" rows="3">' . esc_textarea($description) . '</textarea></p>';
+        echo '<p><label for="gm2_focus_keywords">Focus Keywords (comma separated)</label>';
+        echo '<input type="text" id="gm2_focus_keywords" name="gm2_focus_keywords" value="' . esc_attr($focus_keywords) . '" class="widefat" /></p>';
         echo '<p><label><input type="checkbox" name="gm2_noindex" value="1" ' . checked($noindex, '1', false) . '> noindex</label></p>';
         echo '<p><label><input type="checkbox" name="gm2_nofollow" value="1" ' . checked($nofollow, '1', false) . '> nofollow</label></p>';
         echo '<p><label for="gm2_canonical_url">Canonical URL</label>';
@@ -323,13 +326,15 @@ class Gm2_SEO_Admin {
         $description = '';
         $noindex = '';
         $nofollow = '';
-        $canonical = '';
+        $canonical      = '';
+        $focus_keywords = '';
         if (is_object($term)) {
             $title       = get_term_meta($term->term_id, '_gm2_title', true);
             $description = get_term_meta($term->term_id, '_gm2_description', true);
             $noindex     = get_term_meta($term->term_id, '_gm2_noindex', true);
             $nofollow    = get_term_meta($term->term_id, '_gm2_nofollow', true);
             $canonical   = get_term_meta($term->term_id, '_gm2_canonical', true);
+            $focus_keywords = get_term_meta($term->term_id, '_gm2_focus_keywords', true);
         }
         wp_nonce_field('gm2_save_seo_meta', 'gm2_seo_nonce');
 
@@ -338,12 +343,14 @@ class Gm2_SEO_Admin {
             echo '<tr class="form-field"><th scope="row"><label for="gm2_seo_description">SEO Description</label></th><td><textarea name="gm2_seo_description" id="gm2_seo_description" rows="5" class="large-text">' . esc_textarea($description) . '</textarea></td></tr>';
             echo '<tr class="form-field"><th scope="row">Robots</th><td><label><input type="checkbox" name="gm2_noindex" value="1" ' . checked($noindex, '1', false) . '> noindex</label><br/><label><input type="checkbox" name="gm2_nofollow" value="1" ' . checked($nofollow, '1', false) . '> nofollow</label></td></tr>';
             echo '<tr class="form-field"><th scope="row"><label for="gm2_canonical_url">Canonical URL</label></th><td><input name="gm2_canonical_url" id="gm2_canonical_url" type="url" value="' . esc_attr($canonical) . '" class="regular-text" /></td></tr>';
+            echo '<tr class="form-field"><th scope="row"><label for="gm2_focus_keywords">Focus Keywords (comma separated)</label></th><td><input name="gm2_focus_keywords" id="gm2_focus_keywords" type="text" value="' . esc_attr($focus_keywords) . '" class="regular-text" /></td></tr>';
         } else {
             echo '<div class="form-field"><label for="gm2_seo_title">SEO Title</label><input type="text" name="gm2_seo_title" id="gm2_seo_title" value="" /></div>';
             echo '<div class="form-field"><label for="gm2_seo_description">SEO Description</label><textarea name="gm2_seo_description" id="gm2_seo_description" rows="5"></textarea></div>';
             echo '<div class="form-field"><label><input type="checkbox" name="gm2_noindex" value="1"> noindex</label></div>';
             echo '<div class="form-field"><label><input type="checkbox" name="gm2_nofollow" value="1"> nofollow</label></div>';
             echo '<div class="form-field"><label for="gm2_canonical_url">Canonical URL</label><input type="url" name="gm2_canonical_url" id="gm2_canonical_url" /></div>';
+            echo '<div class="form-field"><label for="gm2_focus_keywords">Focus Keywords (comma separated)</label><input type="text" name="gm2_focus_keywords" id="gm2_focus_keywords" /></div>';
         }
     }
 
@@ -361,12 +368,14 @@ class Gm2_SEO_Admin {
         $description = isset($_POST['gm2_seo_description']) ? sanitize_textarea_field($_POST['gm2_seo_description']) : '';
         $noindex     = isset($_POST['gm2_noindex']) ? '1' : '0';
         $nofollow    = isset($_POST['gm2_nofollow']) ? '1' : '0';
-        $canonical   = isset($_POST['gm2_canonical_url']) ? esc_url_raw($_POST['gm2_canonical_url']) : '';
+        $canonical      = isset($_POST['gm2_canonical_url']) ? esc_url_raw($_POST['gm2_canonical_url']) : '';
+        $focus_keywords = isset($_POST['gm2_focus_keywords']) ? sanitize_text_field($_POST['gm2_focus_keywords']) : '';
         update_post_meta($post_id, '_gm2_title', $title);
         update_post_meta($post_id, '_gm2_description', $description);
         update_post_meta($post_id, '_gm2_noindex', $noindex);
         update_post_meta($post_id, '_gm2_nofollow', $nofollow);
         update_post_meta($post_id, '_gm2_canonical', $canonical);
+        update_post_meta($post_id, '_gm2_focus_keywords', $focus_keywords);
     }
 
     public function save_taxonomy_meta($term_id) {
@@ -377,12 +386,14 @@ class Gm2_SEO_Admin {
         $description = isset($_POST['gm2_seo_description']) ? sanitize_textarea_field($_POST['gm2_seo_description']) : '';
         $noindex     = isset($_POST['gm2_noindex']) ? '1' : '0';
         $nofollow    = isset($_POST['gm2_nofollow']) ? '1' : '0';
-        $canonical   = isset($_POST['gm2_canonical_url']) ? esc_url_raw($_POST['gm2_canonical_url']) : '';
+        $canonical      = isset($_POST['gm2_canonical_url']) ? esc_url_raw($_POST['gm2_canonical_url']) : '';
+        $focus_keywords = isset($_POST['gm2_focus_keywords']) ? sanitize_text_field($_POST['gm2_focus_keywords']) : '';
         update_term_meta($term_id, '_gm2_title', $title);
         update_term_meta($term_id, '_gm2_description', $description);
         update_term_meta($term_id, '_gm2_noindex', $noindex);
         update_term_meta($term_id, '_gm2_nofollow', $nofollow);
         update_term_meta($term_id, '_gm2_canonical', $canonical);
+        update_term_meta($term_id, '_gm2_focus_keywords', $focus_keywords);
     }
 
     public function handle_sitemap_form() {
@@ -610,6 +621,7 @@ class Gm2_SEO_Admin {
         echo '<p>Word Count: <span id="gm2-content-analysis-word-count">0</span></p>';
         echo '<p>Top Keyword: <span id="gm2-content-analysis-keyword"></span></p>';
         echo '<p>Keyword Density: <span id="gm2-content-analysis-density">0</span>%</p>';
+        echo '<p>Focus Keyword Density:</p><ul id="gm2-focus-keyword-density"></ul>';
         echo '<p>Readability: <span id="gm2-content-analysis-readability">0</span></p>';
         echo '<p>Suggested Links:</p><ul id="gm2-content-analysis-links"></ul>';
         echo '</div>';

--- a/admin/js/gm2-content-analysis.js
+++ b/admin/js/gm2-content-analysis.js
@@ -31,17 +31,40 @@
         const readability = (sentences.length && wordCount) ?
             206.835 - 1.015*(wordCount/sentences.length) - 84.6*(syllables/wordCount)
             : 0;
-        return {wordCount, topWord, density, readability, words: words.map(function(w){return w.toLowerCase();})};
+        return {wordCount, topWord, density, readability, words: words.map(function(w){return w.toLowerCase();}), text};
+    }
+
+    function analyzeFocusKeywords(text, wordCount, keywords){
+        const lower = text.toLowerCase();
+        const result = {};
+        keywords.forEach(function(k){
+            const key = k.trim().toLowerCase();
+            if(!key) return;
+            const wordLen = key.split(/\s+/).filter(Boolean).length;
+            const regex = new RegExp(key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g');
+            const matches = lower.match(regex);
+            const count = matches ? matches.length : 0;
+            const density = wordCount ? ((count * wordLen) / wordCount * 100).toFixed(2) : '0';
+            result[key] = density;
+        });
+        return result;
     }
 
     function update(){
         if(typeof wp === 'undefined' || !wp.data) return;
         const content = wp.data.select('core/editor').getEditedPostContent();
         const data = analyzeContent(content);
+        const kwInput = $('#gm2_focus_keywords').val() || '';
+        const keywords = kwInput.split(',');
+        const densities = analyzeFocusKeywords(data.text, data.wordCount, keywords);
         $('#gm2-content-analysis-word-count').text(data.wordCount);
         $('#gm2-content-analysis-keyword').text(data.topWord);
         $('#gm2-content-analysis-density').text(data.density);
         $('#gm2-content-analysis-readability').text(data.readability.toFixed(2));
+        const kwList = $('#gm2-focus-keyword-density').empty();
+        Object.keys(densities).forEach(function(k){
+            $('<li>').text(k + ': ' + densities[k] + '%').appendTo(kwList);
+        });
         const used = new Set(data.words);
         const suggestions = [];
         if(window.gm2ContentAnalysisData){
@@ -65,5 +88,6 @@
         if(typeof wp !== 'undefined' && wp.data){
             wp.data.subscribe(update);
         }
+        $(document).on('input', '#gm2_focus_keywords', update);
     });
 })(jQuery);


### PR DESCRIPTION
## Summary
- add Focus Keywords field to SEO meta box for posts & taxonomies
- store the keywords metadata
- show focus keyword density results in content analysis box
- extend JS to compute density for each focus keyword

## Testing
- `composer test` *(fails: PHPUnit requires unavailable PHP extensions)*

------
https://chatgpt.com/codex/tasks/task_e_6868682242448327a5872d5c1fbd79aa