### PR TITLE
Add SEO meta tests for products and brand terms

### DIFF
--- a/public/class-gm2-seo-public.php
+++ b/public/class-gm2-seo-public.php
@@ -138,6 +138,21 @@ class Gm2_SEO_Public {
         return $breadcrumbs;
     }
 
+    /**
+     * Retrieve SEO metadata for the current query.
+     *
+     * For singular screens this pulls post meta which includes custom post
+     * types such as `product`. When viewing taxonomy archives term meta is
+     * used, covering taxonomies like `product_cat` and `brand`.
+     *
+     * @return array{
+     *     title:string,
+     *     description:string,
+     *     noindex:string,
+     *     nofollow:string,
+     *     canonical:string
+     * }
+     */
     private function get_seo_meta() {
         $title       = '';
         $description = '';

--- a/tests/test-meta-tags.php
+++ b/tests/test-meta-tags.php
@@ -36,5 +36,47 @@ class MetaTagsTest extends WP_UnitTestCase {
         $this->assertStringNotContainsString('<title>Custom Title</title>', $output);
         $this->assertStringContainsString('content="Custom Description"', $output);
     }
+
+    public function test_output_meta_tags_for_product_post() {
+        register_post_type('product');
+        $post_id = self::factory()->post->create([
+            'post_type'    => 'product',
+            'post_title'   => 'Product Sample',
+            'post_content' => 'Content',
+        ]);
+        update_post_meta($post_id, '_gm2_title', 'Product Title');
+        update_post_meta($post_id, '_gm2_description', 'Product Description');
+
+        $seo = new Gm2_SEO_Public();
+        $this->go_to(get_permalink($post_id));
+        setup_postdata(get_post($post_id));
+        ob_start();
+        $seo->output_meta_tags();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('<meta property="og:title" content="Product Title"', $output);
+        $this->assertStringContainsString('<meta name="twitter:title" content="Product Title"', $output);
+        $this->assertStringContainsString('content="Product Description"', $output);
+    }
+
+    public function test_output_meta_tags_for_brand_term() {
+        register_taxonomy('brand', 'post');
+        $term_id = self::factory()->term->create([
+            'taxonomy' => 'brand',
+            'name'     => 'Brand One',
+        ]);
+        update_term_meta($term_id, '_gm2_title', 'Brand Title');
+        update_term_meta($term_id, '_gm2_description', 'Brand Description');
+
+        $seo = new Gm2_SEO_Public();
+        $this->go_to(get_term_link($term_id, 'brand'));
+        ob_start();
+        $seo->output_meta_tags();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('<meta property="og:title" content="Brand Title"', $output);
+        $this->assertStringContainsString('<meta name="twitter:title" content="Brand Title"', $output);
+        $this->assertStringContainsString('content="Brand Description"', $output);
+    }
 }
 


### PR DESCRIPTION
## Summary
- document meta fetching for WooCommerce content
- test open graph and twitter meta tags for products and brand archive pages

## Testing
- `composer test` *(fails: `/tmp/wordpress-tests-lib` missing)*

------
https://chatgpt.com/codex/tasks/task_e_686869480fc88327b1d01d2d01cf66a6