### PR TITLE
Refresh sitemap on taxonomy updates

### DIFF
--- a/admin/class-gm2-seo-admin.php
+++ b/admin/class-gm2-seo-admin.php
@@ -27,13 +27,18 @@ class Gm2_SEO_Admin {
             add_action("{$tax}_edit_form_fields", [$this, 'render_taxonomy_meta_box']);
             add_action("create_{$tax}", [$this, 'save_taxonomy_meta']);
             add_action("edited_{$tax}", [$this, 'save_taxonomy_meta']);
-            add_action("created_{$tax}", 'gm2_generate_sitemap');
-            add_action("edited_{$tax}", 'gm2_generate_sitemap');
-            add_action("delete_{$tax}", 'gm2_generate_sitemap');
+            add_action("created_{$tax}", [$this, 'maybe_generate_sitemap'], 10, 0);
+            add_action("edited_{$tax}", [$this, 'maybe_generate_sitemap'], 10, 0);
+            add_action("delete_{$tax}", [$this, 'maybe_generate_sitemap'], 10, 0);
         }
     }
 
-    public function maybe_generate_sitemap($new_status, $old_status, $post) {
+    public function maybe_generate_sitemap($new_status = null, $old_status = null, $post = null) {
+        if (is_null($new_status) && is_null($old_status)) {
+            gm2_generate_sitemap();
+            return;
+        }
+
         if ($new_status === 'publish' || $old_status === 'publish') {
             gm2_generate_sitemap();
         }

--- a/tests/test-sitemap.php
+++ b/tests/test-sitemap.php
@@ -10,5 +10,30 @@ class SitemapTest extends WP_UnitTestCase {
         $this->assertStringContainsString('<urlset', $content);
         $this->assertStringContainsString(get_permalink($post_id), $content);
     }
+
+    public function test_product_and_category_in_sitemap() {
+        register_post_type('product');
+        register_taxonomy('product_cat', 'product');
+
+        $term_id = self::factory()->term->create([
+            'taxonomy' => 'product_cat',
+            'name'     => 'Category One',
+        ]);
+
+        $post_id = self::factory()->post->create([
+            'post_type' => 'product',
+            'post_title' => 'Product',
+            'post_status' => 'publish',
+        ]);
+
+        wp_set_object_terms($post_id, [$term_id], 'product_cat');
+
+        $sitemap = new Gm2_Sitemap();
+        $sitemap->generate();
+        $content = file_get_contents(ABSPATH . 'sitemap.xml');
+
+        $this->assertStringContainsString(get_permalink($post_id), $content);
+        $this->assertStringContainsString(get_term_link($term_id, 'product_cat'), $content);
+    }
 }
 


### PR DESCRIPTION
## Summary
- hook `maybe_generate_sitemap()` to taxonomy events
- allow `maybe_generate_sitemap()` to run with no arguments
- test that product posts and categories appear in the sitemap

## Testing
- `./vendor/bin/phpunit --configuration phpunit.xml` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68686a51312883279b66f259cf6fdc09