### PR TITLE
Update robots meta handling

### DIFF
--- a/public/class-gm2-seo-public.php
+++ b/public/class-gm2-seo-public.php
@@ -226,6 +226,9 @@ class Gm2_SEO_Public {
         $robots[]    = ($data['nofollow'] === '1') ? 'nofollow' : 'follow';
         $canonical   = $data['canonical'];
 
+        // Output the canonical link tag first.
+        $this->output_canonical_url();
+
         if (!current_theme_supports('title-tag')) {
             echo '<title>' . esc_html($title) . "</title>\n";
         }

--- a/tests/test-meta-tags.php
+++ b/tests/test-meta-tags.php
@@ -78,5 +78,25 @@ class MetaTagsTest extends WP_UnitTestCase {
         $this->assertStringContainsString('<meta name="twitter:title" content="Brand Title"', $output);
         $this->assertStringContainsString('content="Brand Description"', $output);
     }
+
+    public function test_noindex_nofollow_outputs_correct_robots_meta() {
+        $post_id = self::factory()->post->create([
+            'post_title'   => 'Sample',
+            'post_content' => 'Content',
+        ]);
+        update_post_meta($post_id, '_gm2_noindex', '1');
+        update_post_meta($post_id, '_gm2_nofollow', '1');
+        update_post_meta($post_id, '_gm2_canonical', 'https://example.com/canonical');
+
+        $seo = new Gm2_SEO_Public();
+        $this->go_to(get_permalink($post_id));
+        setup_postdata(get_post($post_id));
+        ob_start();
+        $seo->output_meta_tags();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('<meta name="robots" content="noindex,nofollow"', $output);
+        $this->assertStringContainsString('<link rel="canonical" href="https://example.com/canonical" />', $output);
+    }
 }
 


### PR DESCRIPTION
## Summary
- call `output_canonical_url()` inside `output_meta_tags`
- test canonical link and robots directive output when a post is set to noindex/nofollow

## Testing
- `vendor/bin/phpunit` *(fails: wordpress-tests-lib missing)*

------
https://chatgpt.com/codex/tasks/task_e_68686ca1a23483279d0807a2c51ddf43