### PR TITLE
Add image compression support

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -20,6 +20,10 @@ Enable HTML, CSS, and JavaScript minification from the SEO &gt; Performance
 screen. For full page caching, hook into the `gm2_set_cache_headers` action
 to configure headers or integrate your preferred caching plugin.
 
+== Image Optimization ==
+Enter your compression API key and enable the service from the SEO &gt; Performance screen.
+When enabled, uploaded images are sent to the API and replaced with the optimized result.
+
 == Changelog ==
 = 1.4.0 =
 * Basic HTML/CSS/JS minification options and hooks for caching.


### PR DESCRIPTION
## Summary
- add option to enable image compression via external service
- process uploaded images through API when enabled
- document API usage in readme

## Testing
- `composer run test` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php) failed)*

------
https://chatgpt.com/codex/tasks/task_e_68687070c4e48327ae8a8ec9186c52a6