### PR TITLE
Add minify tests and usage instructions

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -17,7 +17,13 @@ A powerful suite of WordPress enhancements including admin tools, frontend optim
 
 == Caching ==
 Enable HTML, CSS, and JavaScript minification from the SEO &gt; Performance
-screen. For full page caching, hook into the `gm2_set_cache_headers` action
+screen. To enable these options:
+
+1. Navigate to **SEO → Performance** in your WordPress admin area.
+2. Check **Minify HTML**, **Minify CSS**, and **Minify JS** as desired.
+3. Click **Save Settings**.
+
+For full page caching, hook into the `gm2_set_cache_headers` action
 to configure headers or integrate your preferred caching plugin.
 
 == Image Optimization ==

--- a/tests/test-minify.php
+++ b/tests/test-minify.php
@@ -1,0 +1,57 @@
+<?php
+class MinifyTest extends WP_UnitTestCase {
+    private $seo;
+
+    public function setUp(): void {
+        parent::setUp();
+        $this->seo = new Gm2_SEO_Public();
+    }
+
+    public function tearDown(): void {
+        while (ob_get_level()) { ob_end_clean(); }
+        delete_option('gm2_minify_html');
+        delete_option('gm2_minify_css');
+        delete_option('gm2_minify_js');
+        parent::tearDown();
+    }
+
+    public function test_maybe_buffer_output_starts_buffer_when_enabled() {
+        update_option('gm2_minify_html', '1');
+        $this->seo->maybe_buffer_output();
+        $this->assertGreaterThan(0, ob_get_level());
+    }
+
+    public function test_maybe_buffer_output_does_nothing_when_disabled() {
+        update_option('gm2_minify_html', '0');
+        $this->seo->maybe_buffer_output();
+        $this->assertSame(0, ob_get_level());
+    }
+
+    public function test_minify_output_respects_html_option() {
+        $html = "<div>  A  </div>";
+        update_option('gm2_minify_html', '1');
+        $result = $this->seo->minify_output($html);
+        $this->assertSame('<div> A </div>', $result);
+    }
+
+    public function test_minify_output_skips_when_disabled() {
+        $html = "<div>  A  </div>";
+        update_option('gm2_minify_html', '0');
+        $result = $this->seo->minify_output($html);
+        $this->assertSame($html, $result);
+    }
+
+    public function test_minify_output_respects_css_option() {
+        $html = '<style>\n  body { color: red; }\n</style>';
+        update_option('gm2_minify_css', '1');
+        $result = $this->seo->minify_output($html);
+        $this->assertSame('<style>body { color: red; }</style>', $result);
+    }
+
+    public function test_minify_output_respects_js_option() {
+        $html = '<script>\n  var x = 1;\n</script>';
+        update_option('gm2_minify_js', '1');
+        $result = $this->seo->minify_output($html);
+        $this->assertSame('<script>var x = 1;</script>', $result);
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for SEO minification buffer logic
- document how to enable minification options in the Performance tab

## Testing
- `composer test` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_68687cde14588327a5d3cf7a2efa7b99