### PR TITLE
Enable content analysis script for products

### DIFF
--- a/admin/class-gm2-seo-admin.php
+++ b/admin/class-gm2-seo-admin.php
@@ -632,7 +632,7 @@ class Gm2_SEO_Admin {
         if (!in_array($hook, ['post.php', 'post-new.php'], true)) {
             return;
         }
-        if (!in_array($typenow, $this->get_supported_post_types(), true)) {
+        if (!in_array($typenow, ['post', 'product'], true)) {
             return;
         }
 

--- a/tests/ContentAnalysisTest.php
+++ b/tests/ContentAnalysisTest.php
@@ -1,0 +1,31 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class ContentAnalysisTest extends TestCase {
+    public function test_analyze_content_js() {
+        $content = '<p>Hello world.</p> Hello again!';
+        $js = <<<'JS'
+const fs = require('fs');
+const filePath = process.argv[3];
+let code = fs.readFileSync(filePath, 'utf8');
+const start = code.indexOf('function countSyllables');
+const end = code.indexOf('function analyzeFocusKeywords');
+let snippet = code.substring(start, end);
+function jQuery(){return {_html:'',html:function(c){this._html=c;return this;},text:function(){return this._html.replace(/<[^>]*>/g,'');}};}
+const vm = require('vm');
+const context = {jQuery:jQuery, $: jQuery};
+vm.createContext(context);
+vm.runInContext(snippet + '; exports={analyzeContent};', context);
+const result = context.exports.analyzeContent(process.argv[2]);
+console.log(JSON.stringify({topWord: result.topWord, readability: result.readability}));
+JS;
+        $tmp = tempnam(sys_get_temp_dir(), 'js');
+        file_put_contents($tmp, $js);
+        $filePath = realpath(__DIR__ . '/../admin/js/gm2-content-analysis.js');
+        $output = shell_exec('node ' . escapeshellarg($tmp) . ' ' . escapeshellarg($content) . ' ' . escapeshellarg($filePath));
+        unlink($tmp);
+        $data = json_decode(trim($output), true);
+        $this->assertSame('hello', $data['topWord']);
+        $this->assertGreaterThan(0, $data['readability']);
+    }
+}


### PR DESCRIPTION
## Summary
- load `gm2-content-analysis.js` on post and product editors
- add unit test for JS content analysis

## Testing
- `vendor/bin/phpunit --no-configuration --bootstrap vendor/autoload.php tests/ContentAnalysisTest.php`
- `composer test` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68687e40834c8327b6af0f9608d1afa2