### PR TITLE
Add redirect integration test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
   "type": "project",
   "require-dev": {
     "phpunit/phpunit": "^9",
-    "wp-phpunit/wp-phpunit": "^6"
+    "wp-phpunit/wp-phpunit": "^6",
+    "yoast/phpunit-polyfills": "^4.0"
   },
   "scripts": {
     "test": "vendor/bin/phpunit"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e702ff8ef0c2759c55cdb6fb5dcef8e4",
+    "content-hash": "a5d6528e5046f8a525cf1536ea42f2fd",
     "packages": [],
     "packages-dev": [
         {
@@ -1803,6 +1803,69 @@
                 "source": "https://github.com/wp-phpunit/wp-phpunit"
             },
             "time": "2025-04-16T01:40:54+00:00"
+        },
+        {
+            "name": "yoast/phpunit-polyfills",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/134921bfca9b02d8f374c48381451da1d98402f9",
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0 || ^11.0 || ^12.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "yoast/yoastcs": "^3.1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "phpunitpolyfills-autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
+                }
+            ],
+            "description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
+            "homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
+            "keywords": [
+                "phpunit",
+                "polyfill",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
+                "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
+                "source": "https://github.com/Yoast/PHPUnit-Polyfills"
+            },
+            "time": "2025-02-09T18:58:54+00:00"
         }
     ],
     "aliases": [],

--- a/tests/test-redirect.php
+++ b/tests/test-redirect.php
@@ -22,5 +22,37 @@ class RedirectTest extends WP_UnitTestCase {
         }
         remove_all_filters('wp_redirect');
     }
+
+    public function test_visit_old_url_triggers_redirect() {
+        update_option('gm2_redirects', [
+            [
+                'source' => '/legacy',
+                'target' => '/new-destination',
+                'type'   => 302,
+            ]
+        ]);
+
+        $seo = new Gm2_SEO_Public();
+        $seo->run();
+
+        $this->assertSame(0, has_action('template_redirect', [$seo, 'maybe_apply_redirects']));
+
+        $captured = [];
+        add_filter('wp_redirect', function($location, $status) use (&$captured) {
+            $captured = [$location, $status];
+            throw new Exception('redirect');
+        }, 10, 2);
+
+        $this->go_to(home_url('/legacy'));
+        try {
+            do_action('template_redirect');
+        } catch (Exception $e) {
+            // swallow redirect exception
+        }
+        remove_all_filters('wp_redirect');
+
+        $this->assertSame('/new-destination', $captured[0]);
+        $this->assertSame(302, $captured[1]);
+    }
 }
 

--- a/tests/test-schema.php
+++ b/tests/test-schema.php
@@ -4,7 +4,7 @@ class SchemaOutputTest extends WP_UnitTestCase {
         parent::setUp();
         // Stub WooCommerce environment if needed
         if (!class_exists('WooCommerce')) {
-            class WooCommerce {}
+            eval('class WooCommerce {}');
         }
         if (!function_exists('is_product')) {
             function is_product() {
@@ -12,14 +12,14 @@ class SchemaOutputTest extends WP_UnitTestCase {
             }
         }
         if (!class_exists('WC_Product_Stub')) {
-            class WC_Product_Stub {
+            eval('class WC_Product_Stub {
                 public function get_image_id() { return 0; }
-                public function get_description() { return 'Sample description'; }
-                public function get_sku() { return 'SKU'; }
-                public function get_price() { return '10'; }
+                public function get_description() { return "Sample description"; }
+                public function get_sku() { return "SKU"; }
+                public function get_price() { return "10"; }
                 public function is_in_stock() { return true; }
                 public function get_average_rating() { return 4; }
-            }
+            }');
         }
         if (!function_exists('wc_get_product')) {
             function wc_get_product($id) {


### PR DESCRIPTION
## Summary
- capture redirect priority and exit logic
- add redirect integration test
- install yoast/phpunit-polyfills for WP test suite compatibility
- avoid nested class declarations in schema test

## Testing
- `composer run test` *(fails: 6 failures, 3 risky tests)*

------
https://chatgpt.com/codex/tasks/task_e_6868805e0b1c8327912e46873b70780c