### PR TITLE
Add wp_head tracking tests

### DIFF
--- a/tests/test-ga-search-console.php
+++ b/tests/test-ga-search-console.php
@@ -1,0 +1,32 @@
+<?php
+class GaAndSearchConsoleTest extends WP_UnitTestCase {
+    private $seo;
+    public function setUp(): void {
+        parent::setUp();
+        remove_all_actions('wp_head');
+        $this->seo = new Gm2_SEO_Public();
+    }
+    public function tearDown(): void {
+        remove_all_actions('wp_head');
+        delete_option('gm2_ga_measurement_id');
+        delete_option('gm2_search_console_verification');
+        parent::tearDown();
+    }
+    public function test_ga_tracking_code_added_to_wp_head() {
+        update_option('gm2_ga_measurement_id', 'G-123456');
+        $this->seo->run();
+        ob_start();
+        do_action('wp_head');
+        $output = ob_get_clean();
+        $this->assertStringContainsString('https://www.googletagmanager.com/gtag/js?id=G-123456', $output);
+    }
+    public function test_search_console_meta_added_to_wp_head() {
+        update_option('gm2_search_console_verification', 'verify-me');
+        $this->seo->run();
+        ob_start();
+        do_action('wp_head');
+        $output = ob_get_clean();
+        $this->assertStringContainsString('<meta name="google-site-verification" content="verify-me"', $output);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add tests ensuring GA and Search Console tags output in `wp_head`

## Testing
- `vendor/bin/phpunit --filter GaAndSearchConsoleTest`
- `vendor/bin/phpunit` *(fails: 6 failed, 3 risky)*

------
https://chatgpt.com/codex/tasks/task_e_6868827739b0832789d86143dde700a7