### PR TITLE
Add breadcrumbs shortcode test and docs

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -15,6 +15,11 @@ A powerful suite of WordPress enhancements including admin tools, frontend optim
 2. Activate the plugin through the 'Plugins' screen in WordPress.
 3. Use the Gm2 Suite menu in the admin sidebar to configure settings.
 
+== Breadcrumbs ==
+Display a breadcrumb trail anywhere using the `[gm2_breadcrumbs]` shortcode. The output
+is an ordered list wrapped in a `<nav>` element with accompanying JSON-LD for search engines.
+You can enable automatic breadcrumbs in the footer from **SEO → Schema**.
+
 == Caching ==
 Enable HTML, CSS, and JavaScript minification from the SEO &gt; Performance
 screen. To enable these options:

--- a/tests/test-breadcrumbs.php
+++ b/tests/test-breadcrumbs.php
@@ -18,4 +18,26 @@ class BreadcrumbsTest extends WP_UnitTestCase {
         $seo->run();
         $this->assertNotFalse( has_action('wp_footer', [$seo, 'output_breadcrumbs']) );
     }
+
+    public function test_shortcode_outputs_ordered_list_with_json_ld() {
+        $post_id = self::factory()->post->create([
+            'post_title'   => 'Sample',
+            'post_content' => 'Content',
+        ]);
+        $seo = new Gm2_SEO_Public();
+        $this->go_to(get_permalink($post_id));
+        setup_postdata(get_post($post_id));
+
+        $output = $seo->gm2_breadcrumbs_shortcode();
+
+        $this->assertStringContainsString('<ol>', $output);
+        $this->assertStringContainsString('</ol>', $output);
+        $this->assertStringContainsString('<script type="application/ld+json">', $output);
+
+        preg_match('/<script type="application\/ld\+json">(.*?)<\/script>/', $output, $m);
+        $json = $m[1] ?? '';
+        $data = json_decode($json, true);
+        $this->assertIsArray($data);
+        $this->assertSame('BreadcrumbList', $data['@type']);
+    }
 }


### PR DESCRIPTION
## Summary
- test breadcrumbs shortcode output
- document breadcrumbs shortcode usage in readme

## Testing
- `composer test` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686884de5fd08327b7aff2f1bcd8c607