### PR TITLE
Fix duplicate canonical tags

### DIFF
--- a/public/class-gm2-seo-public.php
+++ b/public/class-gm2-seo-public.php
@@ -226,8 +226,10 @@ class Gm2_SEO_Public {
         $robots[]    = ($data['nofollow'] === '1') ? 'nofollow' : 'follow';
         $canonical   = $data['canonical'];
 
-        // Output the canonical link tag first.
-        $this->output_canonical_url();
+        // Output the canonical link tag first if it isn't already hooked.
+        if (!has_action('wp_head', [$this, 'output_canonical_url'])) {
+            $this->output_canonical_url();
+        }
 
         if (!current_theme_supports('title-tag')) {
             echo '<title>' . esc_html($title) . "</title>\n";


### PR DESCRIPTION
## Summary
- avoid outputting duplicate canonical URLs by checking if `output_canonical_url` is already hooked

## Testing
- `composer run test` *(fails: missing WordPress testing suite)*

------
https://chatgpt.com/codex/tasks/task_e_68688a57db108327a46abd4b5def577b