### PR TITLE
Store path-only in 404 log

### DIFF
--- a/public/class-gm2-seo-public.php
+++ b/public/class-gm2-seo-public.php
@@ -68,7 +68,7 @@ class Gm2_SEO_Public {
     public function log_404_url() {
         if (is_404()) {
             $logs  = get_option('gm2_404_logs', []);
-            $path  = untrailingslashit($_SERVER['REQUEST_URI']);
+            $path  = untrailingslashit(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH));
             if (!in_array($path, $logs, true)) {
                 $logs[] = $path;
                 if (count($logs) > 100) {


### PR DESCRIPTION
## Summary
- trim `$_SERVER['REQUEST_URI']` to the path before logging 404 URLs

## Testing
- `composer test` *(fails: missing `wordpress-tests-lib`)*

------
https://chatgpt.com/codex/tasks/task_e_68688b5f7c248327aaa0af8c7a98ef70