### PR TITLE
Init default content rules

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -26,6 +26,8 @@ function gm2_activate_plugin() {
     $public->add_sitemap_rewrite();
     flush_rewrite_rules();
     gm2_generate_sitemap();
+
+    gm2_initialize_content_rules();
 }
 register_activation_hook(__FILE__, 'gm2_activate_plugin');
 
@@ -33,6 +35,49 @@ function gm2_deactivate_plugin() {
     flush_rewrite_rules();
 }
 register_deactivation_hook(__FILE__, 'gm2_deactivate_plugin');
+
+function gm2_initialize_content_rules() {
+    $existing = get_option('gm2_content_rules', null);
+    if ($existing !== null && $existing !== false && !empty($existing)) {
+        return;
+    }
+
+    $rules = [];
+
+    $posts = ['post', 'page'];
+    if (post_type_exists('product')) {
+        $posts[] = 'product';
+    }
+    $post_defaults = [
+        'Title length between 30 and 60 characters',
+        'Description length between 50 and 160 characters',
+        'At least one focus keyword',
+        'Content has at least 300 words',
+    ];
+    foreach ($posts as $pt) {
+        $rules['post_' . $pt] = implode("\n", $post_defaults);
+    }
+
+    $taxonomies = ['category'];
+    if (taxonomy_exists('product_cat')) {
+        $taxonomies[] = 'product_cat';
+    }
+    if (taxonomy_exists('brand')) {
+        $taxonomies[] = 'brand';
+    }
+    if (taxonomy_exists('product_brand')) {
+        $taxonomies[] = 'product_brand';
+    }
+    $tax_defaults = [
+        'Title length between 30 and 60 characters',
+        'Description length between 50 and 160 characters',
+    ];
+    foreach ($taxonomies as $tax) {
+        $rules['tax_' . $tax] = implode("\n", $tax_defaults);
+    }
+
+    add_option('gm2_content_rules', $rules);
+}
 
 // Initialize plugin
 function gm2_init_plugin() {


### PR DESCRIPTION
## Summary
- initialize recommended content rules for posts and taxonomies when the plugin is activated

## Testing
- `composer run test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6868b4811e288327a690c5087b89d895