### PR TITLE
Fix content analysis script loading for pages

### DIFF
--- a/admin/class-gm2-seo-admin.php
+++ b/admin/class-gm2-seo-admin.php
@@ -688,7 +688,7 @@ class Gm2_SEO_Admin {
         if (!in_array($hook, ['post.php', 'post-new.php'], true)) {
             return;
         }
-        if (!in_array($typenow, ['post', 'product'], true)) {
+        if (!in_array($typenow, $this->get_supported_post_types(), true)) {
             return;
         }
 


### PR DESCRIPTION
## Summary
- load JS for all supported post types in `enqueue_editor_scripts`

## Testing
- `composer test` *(fails: WordPress test suite missing)*

------
https://chatgpt.com/codex/tasks/task_e_6868b962b77483278a463be801562b97