### PR TITLE
Fix duplicate ID in content analysis section

### DIFF
--- a/admin/class-gm2-seo-admin.php
+++ b/admin/class-gm2-seo-admin.php
@@ -793,7 +793,7 @@ class Gm2_SEO_Admin {
             echo '<li><span class="dashicons dashicons-no"></span> ' . esc_html($text) . '</li>';
         }
         echo '</ul>';
-        echo '<div id="gm2-content-analysis">';
+        echo '<div id="gm2-content-analysis-data">';
         echo '<p>Word Count: <span id="gm2-content-analysis-word-count">0</span></p>';
         echo '<p>Top Keyword: <span id="gm2-content-analysis-keyword"></span></p>';
         echo '<p>Keyword Density: <span id="gm2-content-analysis-density">0</span>%</p>';


### PR DESCRIPTION
## Summary
- use a unique ID for the inner content analysis container

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6868bbc0ecd08327b580b8d86ec4192c