### PR TITLE
Improve content rules parsing

### DIFF
--- a/admin/js/gm2-content-analysis.js
+++ b/admin/js/gm2-content-analysis.js
@@ -51,23 +51,24 @@
     }
 
     function applyRuleResults(results){
-        const keys = ['title','description','focus','content'];
-        $('.gm2-analysis-rules li').each(function(i){
-            const pass = results[keys[i]];
-            if(typeof pass === 'undefined') return;
+        $('.gm2-analysis-rules li').each(function(){
+            const key = $(this).data('rule');
+            if(!key || typeof results[key] === 'undefined') return;
+            const pass = results[key];
             $(this).toggleClass('pass', pass).toggleClass('fail', !pass)
                 .find('.dashicons').removeClass('dashicons-no dashicons-yes')
                 .addClass(pass ? 'dashicons-yes' : 'dashicons-no');
         });
     }
 
-    function checkRules(content, title, description, focus){
+    function checkRules(content, title, description, focus, postType){
         $.post(ajaxurl, {
             action: 'gm2_check_rules',
             content: content,
             title: title,
             description: description,
-            focus: focus
+            focus: focus,
+            post_type: postType
         }, function(resp){
             if(resp && resp.success){
                 applyRuleResults(resp.data);
@@ -107,7 +108,8 @@
             $('<li>').append($('<a>').attr('href', p.link).text(p.title)).appendTo(list);
         });
 
-        checkRules(content, $('#gm2_seo_title').val() || '', $('#gm2_seo_description').val() || '', kwInput);
+        const ptype = window.gm2ContentAnalysisData ? window.gm2ContentAnalysisData.postType : '';
+        checkRules(content, $('#gm2_seo_title').val() || '', $('#gm2_seo_description').val() || '', kwInput, ptype);
     }
 
     $(document).ready(function(){

--- a/tests/test-content-rules.php
+++ b/tests/test-content-rules.php
@@ -39,10 +39,10 @@ class ContentRulesAjaxTest extends WP_Ajax_UnitTestCase {
         }
         $resp = json_decode($this->_last_response, true);
         $this->assertTrue($resp['success']);
-        $this->assertTrue($resp['data']['title']);
-        $this->assertTrue($resp['data']['description']);
-        $this->assertFalse($resp['data']['focus']);
-        $this->assertFalse($resp['data']['content']);
+        $this->assertTrue($resp['data']['title-length-between-30-and-60-characters']);
+        $this->assertTrue($resp['data']['description-length-between-50-and-160-characters']);
+        $this->assertFalse($resp['data']['at-least-one-focus-keyword']);
+        $this->assertFalse($resp['data']['content-has-at-least-300-words']);
     }
 }
 ?>


### PR DESCRIPTION
## Summary
- parse saved content rules instead of using hardcoded ones
- localize post type in analysis data and send in AJAX
- key rule results by rule slug
- update JS to handle keyed results via data-rule attributes
- adjust unit tests for new structure

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: no such file)*

------
https://chatgpt.com/codex/tasks/task_e_6868be43a5988327a9e1407774c377ac