### PR TITLE
Add nonce verification for rules check

### DIFF
--- a/admin/class-gm2-seo-admin.php
+++ b/admin/class-gm2-seo-admin.php
@@ -661,6 +661,7 @@ class Gm2_SEO_Admin {
     }
 
     public function ajax_check_rules() {
+        check_ajax_referer('gm2_check_rules');
         if (!current_user_can('edit_posts')) {
             wp_send_json_error('permission denied', 403);
         }
@@ -772,6 +773,7 @@ class Gm2_SEO_Admin {
                 'posts' => $list,
                 'rules' => $current_rules,
                 'postType' => $typenow,
+                'nonce' => wp_create_nonce('gm2_check_rules'),
             ]
         );
     }

--- a/admin/js/gm2-content-analysis.js
+++ b/admin/js/gm2-content-analysis.js
@@ -68,7 +68,8 @@
             title: title,
             description: description,
             focus: focus,
-            post_type: postType
+            post_type: postType,
+            _ajax_nonce: window.gm2ContentAnalysisData ? window.gm2ContentAnalysisData.nonce : ''
         }, function(resp){
             if(resp && resp.success){
                 applyRuleResults(resp.data);

--- a/tests/test-content-rules.php
+++ b/tests/test-content-rules.php
@@ -11,6 +11,8 @@ class ContentRulesAjaxTest extends WP_Ajax_UnitTestCase {
         $_POST['description'] = str_repeat('D', 80);
         $_POST['focus'] = 'keyword';
         $_POST['content'] = str_repeat('word ', 300);
+        $_POST['_ajax_nonce'] = wp_create_nonce('gm2_check_rules');
+        $_REQUEST['_ajax_nonce'] = $_POST['_ajax_nonce'];
         try {
             $this->_handleAjax('gm2_check_rules');
         } catch (WPAjaxDieContinueException $e) {
@@ -33,6 +35,8 @@ class ContentRulesAjaxTest extends WP_Ajax_UnitTestCase {
         $_POST['description'] = str_repeat('D', 80);
         $_POST['focus'] = '';
         $_POST['content'] = str_repeat('word ', 50);
+        $_POST['_ajax_nonce'] = wp_create_nonce('gm2_check_rules');
+        $_REQUEST['_ajax_nonce'] = $_POST['_ajax_nonce'];
         try {
             $this->_handleAjax('gm2_check_rules');
         } catch (WPAjaxDieContinueException $e) {


### PR DESCRIPTION
## Summary
- generate nonce in `enqueue_editor_scripts`
- send nonce with rule check requests
- verify nonce in `ajax_check_rules`
- update Ajax tests for nonce

## Testing
- `vendor/bin/phpunit` *(fails: Error in bootstrap script)*

------
https://chatgpt.com/codex/tasks/task_e_6868bf6592588327a9a379ad1e24d9fd