### PR TITLE
Fix tab assets for classic editor

### DIFF
--- a/admin/class-gm2-seo-admin.php
+++ b/admin/class-gm2-seo-admin.php
@@ -9,6 +9,7 @@ class Gm2_SEO_Admin {
         add_action('add_meta_boxes', [$this, 'register_meta_boxes']);
         add_action('save_post', [$this, 'save_post_meta']);
         add_action('enqueue_block_editor_assets', [$this, 'enqueue_editor_scripts']);
+        add_action('admin_enqueue_scripts', [$this, 'enqueue_classic_editor_scripts']);
         add_action('admin_enqueue_scripts', [$this, 'enqueue_taxonomy_scripts']);
         add_action('admin_init', [$this, 'register_settings']);
         add_action('admin_post_gm2_sitemap_settings', [$this, 'handle_sitemap_form']);
@@ -822,6 +823,34 @@ class Gm2_SEO_Admin {
                 'postType' => $typenow,
                 'nonce' => wp_create_nonce('gm2_check_rules'),
             ]
+        );
+    }
+
+    public function enqueue_classic_editor_scripts($hook) {
+        if ($hook !== 'post.php' && $hook !== 'post-new.php') {
+            return;
+        }
+        $screen = get_current_screen();
+        if (!$screen || $screen->base !== 'post') {
+            return;
+        }
+        $typenow = $screen->post_type;
+        if (!in_array($typenow, $this->get_supported_post_types(), true)) {
+            return;
+        }
+
+        wp_enqueue_script(
+            'gm2-seo-tabs',
+            GM2_PLUGIN_URL . 'admin/js/gm2-seo.js',
+            ['jquery'],
+            GM2_VERSION,
+            true
+        );
+        wp_enqueue_style(
+            'gm2-seo-style',
+            GM2_PLUGIN_URL . 'admin/css/gm2-seo.css',
+            [],
+            GM2_VERSION
         );
     }
 


### PR DESCRIPTION
## Summary
- load tab JS/CSS when using the classic editor
- add helper `enqueue_classic_editor_scripts`

## Testing
- `composer run test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_68682cc68a5c83278c40deac154fe094