### PR TITLE
Fix editor asset enqueue method

### DIFF
--- a/admin/class-gm2-seo-admin.php
+++ b/admin/class-gm2-seo-admin.php
@@ -761,8 +761,8 @@ class Gm2_SEO_Admin {
         wp_send_json_success($results);
     }
 
-    public function enqueue_editor_scripts($hook = '') {
-        if ($hook && $hook !== 'post.php' && $hook !== 'post-new.php') {
+    public function enqueue_editor_scripts($hook = null) {
+        if ($hook !== null && $hook !== 'post.php' && $hook !== 'post-new.php') {
             return;
         }
         if (isset($_GET['post_type'])) {


### PR DESCRIPTION
## Summary
- ensure enqueue_editor_scripts can handle null hook argument
- prepare SEO admin to enqueue scripts in both the block and classic editors

## Testing
- `phpunit -c phpunit.xml` *(fails: cannot download WordPress test suite)*

------
https://chatgpt.com/codex/tasks/task_e_686bddb19bdc8327a40f81a5bb206148