### PR TITLE
Fix enqueue_editor_scripts assets loading

### DIFF
--- a/admin/class-gm2-seo-admin.php
+++ b/admin/class-gm2-seo-admin.php
@@ -787,34 +787,28 @@ class Gm2_SEO_Admin {
             return;
         }
 
-        if (!wp_script_is('gm2-content-analysis', 'enqueued')) {
-            wp_enqueue_script(
-                'gm2-content-analysis',
-                GM2_PLUGIN_URL . 'admin/js/gm2-content-analysis.js',
-                ['jquery', 'wp-data'],
-                GM2_VERSION,
-                true
-            );
-        }
+        wp_enqueue_script(
+            'gm2-content-analysis',
+            GM2_PLUGIN_URL . 'admin/js/gm2-content-analysis.js',
+            ['jquery', 'wp-data'],
+            GM2_VERSION,
+            true
+        );
 
-        if (!wp_script_is('gm2-seo-tabs', 'enqueued')) {
-            wp_enqueue_script(
-                'gm2-seo-tabs',
-                GM2_PLUGIN_URL . 'admin/js/gm2-seo.js',
-                ['jquery'],
-                GM2_VERSION,
-                true
-            );
-        }
+        wp_enqueue_script(
+            'gm2-seo-tabs',
+            GM2_PLUGIN_URL . 'admin/js/gm2-seo.js',
+            ['jquery'],
+            GM2_VERSION,
+            true
+        );
 
-        if (!wp_style_is('gm2-seo-style', 'enqueued')) {
-            wp_enqueue_style(
-                'gm2-seo-style',
-                GM2_PLUGIN_URL . 'admin/css/gm2-seo.css',
-                [],
-                GM2_VERSION
-            );
-        }
+        wp_enqueue_style(
+            'gm2-seo-style',
+            GM2_PLUGIN_URL . 'admin/css/gm2-seo.css',
+            [],
+            GM2_VERSION
+        );
 
         $current = isset($_GET['post']) ? absint($_GET['post']) : 0;
         $posts    = get_posts([


### PR DESCRIPTION
## Summary
- ensure SEO editor scripts/styles always enqueue

## Testing
- `composer run test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c051ad51883278fd27bc436bb90a6