### PR TITLE
Integrate SEO meta tabs with Elementor editor

### DIFF
--- a/admin/class-gm2-elementor.php
+++ b/admin/class-gm2-elementor.php
@@ -1,0 +1,47 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Gm2_Elementor {
+    private $seo_admin;
+
+    public function __construct($seo_admin) {
+        $this->seo_admin = $seo_admin;
+        add_action('elementor/editor/after_enqueue_styles', [$this, 'enqueue_editor_assets']);
+        add_action('elementor/editor/footer', [$this, 'render_meta_box']);
+        add_action('elementor/document/after_save', [$this, 'save_meta'], 10, 2);
+    }
+
+    public function enqueue_editor_assets() {
+        wp_enqueue_script(
+            'gm2-seo-tabs',
+            GM2_PLUGIN_URL . 'admin/js/gm2-seo.js',
+            ['jquery'],
+            GM2_VERSION,
+            true
+        );
+        wp_enqueue_style(
+            'gm2-seo-style',
+            GM2_PLUGIN_URL . 'admin/css/gm2-seo.css',
+            [],
+            GM2_VERSION
+        );
+    }
+
+    public function render_meta_box() {
+        global $post;
+        if ($post) {
+            $this->seo_admin->render_seo_tabs_meta_box($post);
+        }
+    }
+
+    public function save_meta($document) {
+        if (is_object($document) && method_exists($document, 'get_main_id')) {
+            $post_id = $document->get_main_id();
+        } else {
+            $post_id = intval($document);
+        }
+        $this->seo_admin->save_post_meta($post_id);
+    }
+}

--- a/admin/class-gm2-seo-admin.php
+++ b/admin/class-gm2-seo-admin.php
@@ -38,6 +38,11 @@ class Gm2_SEO_Admin {
             add_action("edited_{$tax}", [$this, 'maybe_generate_sitemap'], 10, 0);
             add_action("delete_{$tax}", [$this, 'maybe_generate_sitemap'], 10, 0);
         }
+
+        if (did_action('elementor/loaded')) {
+            require_once GM2_PLUGIN_DIR . 'admin/class-gm2-elementor.php';
+            new Gm2_Elementor($this);
+        }
     }
 
     public function maybe_generate_sitemap($new_status = null, $old_status = null, $post = null) {


### PR DESCRIPTION
## Summary
- add `Gm2_Elementor` class for Elementor integration
- load Elementor assets/hooks when Elementor is loaded

## Testing
- `composer test` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php) failed)*

------
https://chatgpt.com/codex/tasks/task_e_686c0bdd74688327b0f188d2c0a57b63