### PR TITLE
Fix SEO editor asset loading in block editor

### DIFF
--- a/admin/class-gm2-seo-admin.php
+++ b/admin/class-gm2-seo-admin.php
@@ -862,14 +862,11 @@ class Gm2_SEO_Admin {
     }
 
     public function enqueue_editor_scripts($hook = null) {
-        if ($hook !== null && $hook !== 'post.php' && $hook !== 'post-new.php') {
-            return;
-        }
 
         /*
          * $pagenow is not always reliable inside the block editor iframe.
-         * Rely only on the passed $hook parameter and post type checks below
-         * so the tab assets load in both classic and block editors.
+         * Determine the post type directly so the tab assets load in both
+         * classic and block editors even when Elementor adjusts the screen.
          */
 
         $typenow = '';


### PR DESCRIPTION
## Summary
- make `enqueue_editor_scripts()` run without page checks so it fires in block editor even with Elementor

## Testing
- `php -l admin/class-gm2-seo-admin.php`
- `phpunit` *(fails: missing WordPress test library)*

------
https://chatgpt.com/codex/tasks/task_e_686c0ddba2e08327bde9fdba9280b0d7