### PR TITLE
Improve Elementor loading hook

### DIFF
--- a/includes/class-gm2-loader.php
+++ b/includes/class-gm2-loader.php
@@ -36,6 +36,14 @@ class Gm2_Loader {
         $seo_public = new Gm2_SEO_Public();
         $seo_public->run();
 
+        if (did_action('elementor/loaded')) {
+            $this->init_elementor_seo();
+        } else {
+            add_action('elementor/loaded', [$this, 'init_elementor_seo']);
+        }
+    }
+
+    public function init_elementor_seo() {
         if (class_exists('Elementor\\Plugin')) {
             new Gm2_Elementor_SEO();
         }


### PR DESCRIPTION
## Summary
- load Gm2_Elementor_SEO after Elementor loads regardless of plugin order

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686c1ad86c508327ace667f89a1fbbf0