### PR TITLE
Fix plugin activation dependencies

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -20,6 +20,8 @@ define('GM2_PLUGIN_URL', plugin_dir_url(__FILE__));
 
 // Include required files
 require_once GM2_PLUGIN_DIR . 'includes/class-gm2-loader.php';
+require_once GM2_PLUGIN_DIR . 'public/class-gm2-seo-public.php';
+require_once GM2_PLUGIN_DIR . 'includes/class-gm2-sitemap.php';
 
 function gm2_activate_plugin() {
     $public = new Gm2_SEO_Public();


### PR DESCRIPTION
## Summary
- include required files before activation hook runs

## Testing
- `composer install --no-interaction` *(fails: command not found)*
- `phpunit` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_686c2ba15ad4832785e9e6eff25d067a