### PR TITLE
Add Google OAuth connect page

### DIFF
--- a/admin/class-gm2-seo-admin.php
+++ b/admin/class-gm2-seo-admin.php
@@ -87,6 +87,15 @@ class Gm2_SEO_Admin {
             'gm2-seo',
             [$this, 'display_dashboard']
         );
+
+        add_submenu_page(
+            'gm2',
+            'Connect Google Account',
+            'Connect Google Account',
+            'manage_options',
+            'gm2-google-connect',
+            [$this, 'display_google_connect_page']
+        );
     }
 
     public function register_settings() {
@@ -151,36 +160,8 @@ class Gm2_SEO_Admin {
             'gm2_seo',
             'gm2_seo_main'
         );
-        add_settings_field(
-            'gm2_gads_client_id',
-            'Google Ads Client ID',
-            function () {
-                $value = get_option('gm2_gads_client_id', '');
-                echo '<input type="text" name="gm2_gads_client_id" value="' . esc_attr($value) . '" class="regular-text" />';
-            },
-            'gm2_seo',
-            'gm2_seo_main'
-        );
-        add_settings_field(
-            'gm2_gads_client_secret',
-            'Google Ads Client Secret',
-            function () {
-                $value = get_option('gm2_gads_client_secret', '');
-                echo '<input type="password" name="gm2_gads_client_secret" value="' . esc_attr($value) . '" class="regular-text" />';
-            },
-            'gm2_seo',
-            'gm2_seo_main'
-        );
-        add_settings_field(
-            'gm2_gads_refresh_token',
-            'Google Ads Refresh Token',
-            function () {
-                $value = get_option('gm2_gads_refresh_token', '');
-                echo '<input type="text" name="gm2_gads_refresh_token" value="' . esc_attr($value) . '" class="regular-text" />';
-            },
-            'gm2_seo',
-            'gm2_seo_main'
-        );
+        // Client ID, secret and refresh token fields are now managed via OAuth
+        // and hidden from the settings screen to avoid manual entry.
         add_settings_field(
             'gm2_gads_customer_id',
             'Google Ads Customer ID',
@@ -397,6 +378,28 @@ class Gm2_SEO_Admin {
             echo '</form>';
         }
 
+        echo '</div>';
+    }
+
+    public function display_google_connect_page() {
+        $oauth = apply_filters('gm2_google_oauth_instance', new Gm2_Google_OAuth());
+
+        $notice = '';
+        if (isset($_GET['code'])) {
+            if ($oauth->handle_callback()) {
+                $notice = '<div class="updated notice"><p>Google account connected.</p></div>';
+            }
+        }
+
+        echo '<div class="wrap">';
+        echo '<h1>Connect Google Account</h1>';
+        echo $notice;
+        if (!$oauth->is_connected()) {
+            $url = esc_url($oauth->get_auth_url());
+            echo '<a href="' . $url . '" class="button button-primary">Connect Google</a>';
+        } else {
+            echo '<p>Google account connected.</p>';
+        }
         echo '</div>';
     }
 

--- a/includes/class-gm2-google-oauth.php
+++ b/includes/class-gm2-google-oauth.php
@@ -40,6 +40,17 @@ class Gm2_Google_OAuth {
         return (bool) get_option('gm2_google_refresh_token');
     }
 
+    public function get_access_token() {
+        $token = $this->client->getAccessToken();
+        if (!$token || $this->client->isAccessTokenExpired()) {
+            $refresh = get_option('gm2_google_refresh_token');
+            if ($refresh) {
+                $token = $this->client->fetchAccessTokenWithRefreshToken($refresh);
+            }
+        }
+        return $token['access_token'] ?? '';
+    }
+
     public function get_auth_url() {
         return $this->client->createAuthUrl();
     }

--- a/readme.txt
+++ b/readme.txt
@@ -13,7 +13,8 @@ A powerful suite of WordPress enhancements including admin tools, frontend optim
 == Installation ==
 1. Upload the plugin files to the `/wp-content/plugins/gm2-wordpress-suite` directory.
 2. Activate the plugin through the 'Plugins' screen in WordPress.
-3. Use the Gm2 Suite menu in the admin sidebar to configure settings.
+3. Use the Gm2 Suite menu in the admin sidebar to configure settings. Visit
+   **SEO → Connect Google Account** to authorize your Google account.
 
 == Breadcrumbs ==
 Display a breadcrumb trail anywhere using the `[gm2_breadcrumbs]` shortcode. The output
@@ -32,7 +33,7 @@ For full page caching, hook into the `gm2_set_cache_headers` action
 to configure headers or integrate your preferred caching plugin.
 
 == Keyword Research ==
-Enter your Google Ads credentials in **SEO → General** and use the
+Connect your Google account from **SEO → Connect Google Account** and use the
 **Keyword Research** tab to generate ideas via the Google Keyword Planner.
 
 == Image Optimization ==

--- a/tests/test-connect-page.php
+++ b/tests/test-connect-page.php
@@ -1,0 +1,44 @@
+<?php
+class GoogleConnectPageTest extends WP_UnitTestCase {
+    public function tearDown(): void {
+        delete_option('gm2_google_refresh_token');
+        remove_all_filters('gm2_google_oauth_instance');
+        parent::tearDown();
+    }
+
+    public function test_connect_page_shows_login_when_no_token() {
+        delete_option('gm2_google_refresh_token');
+        add_filter('gm2_google_oauth_instance', function() {
+            return new class {
+                public function is_connected() { return false; }
+                public function get_auth_url() { return 'https://accounts.google.com/mock'; }
+                public function handle_callback() { return false; }
+            };
+        });
+        $admin = new Gm2_SEO_Admin();
+        ob_start();
+        $admin->display_google_connect_page();
+        $output = ob_get_clean();
+        $this->assertStringContainsString('accounts.google.com', $output);
+    }
+
+    public function test_connect_page_callback_saves_token() {
+        delete_option('gm2_google_refresh_token');
+        $_GET['code'] = 'abc';
+        add_filter('gm2_google_oauth_instance', function() {
+            return new class {
+                public function is_connected() { return false; }
+                public function get_auth_url() { return ''; }
+                public function handle_callback() {
+                    update_option('gm2_google_refresh_token', 'saved');
+                    return true;
+                }
+            };
+        });
+        $admin = new Gm2_SEO_Admin();
+        ob_start();
+        $admin->display_google_connect_page();
+        ob_end_clean();
+        $this->assertSame('saved', get_option('gm2_google_refresh_token'));
+    }
+}


### PR DESCRIPTION
## Summary
- add Connect Google Account admin page
- hide manual Ads token fields from SEO settings
- expose access token getter
- use OAuth token in keyword planner
- document OAuth connection
- cover connect page in unit tests

## Testing
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686c159640b883279b621b235c2ff4ce