### PR TITLE
Add composer autoload check and document vendor install

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,10 @@ This project includes a PHPUnit test suite that relies on the WordPress test lib
    composer install
    ```
 
+   This command installs packages under the `vendor/` directory. On production
+   systems you can run `composer install --no-dev` to omit development-only
+   packages.
+
 2. Set up the WordPress testing suite. This script installs WordPress and configures the test environment:
 
    ```bash

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -18,9 +18,8 @@ define('GM2_VERSION', '1.5.0');
 define('GM2_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('GM2_PLUGIN_URL', plugin_dir_url(__FILE__));
 
-$autoload = GM2_PLUGIN_DIR . 'vendor/autoload.php';
-if (file_exists($autoload)) {
-    require_once $autoload;
+if (file_exists(GM2_PLUGIN_DIR . 'vendor/autoload.php')) {
+    require GM2_PLUGIN_DIR . 'vendor/autoload.php';
 } else {
     if (!function_exists('gm2_missing_autoload_notice')) {
         function gm2_missing_autoload_notice() {

--- a/readme.txt
+++ b/readme.txt
@@ -15,6 +15,9 @@ A powerful suite of WordPress enhancements including admin tools, frontend optim
 2. Activate the plugin through the 'Plugins' screen in WordPress.
 3. Use the Gm2 Suite menu in the admin sidebar to configure settings. Visit
    **SEO → Connect Google Account** to authorize your Google account.
+4. Run `composer install` to install development dependencies. For a production
+   environment, use `composer install --no-dev`. The libraries will be placed
+   in the `vendor/` directory.
 
 == Breadcrumbs ==
 Display a breadcrumb trail anywhere using the `[gm2_breadcrumbs]` shortcode. The output


### PR DESCRIPTION
## Summary
- load `vendor/autoload.php` when available
- clarify how Composer installs dependencies to `vendor/`

## Testing
- `composer run test` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686c36a030ac83279e26953cefd8f29c