### PR TITLE
Add plugin build script and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Build Release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          coverage: none
+      - name: Build plugin
+        run: bash bin/build-plugin.sh
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v1
+        with:
+          files: gm2-wordpress-suite.zip

--- a/bin/build-plugin.sh
+++ b/bin/build-plugin.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+PLUGIN_SLUG="gm2-wordpress-suite"
+ZIP_FILE="${PLUGIN_SLUG}.zip"
+
+cd "$ROOT_DIR"
+
+# Install production dependencies
+composer install --no-dev --optimize-autoloader
+
+# Remove any existing archive
+rm -f "$ZIP_FILE"
+
+STAGING_DIR="$(mktemp -d)"
+
+# Copy plugin files to staging directory
+rsync -a \
+  --exclude='.git*' \
+  --exclude='.github' \
+  --exclude='bin/*' \
+  --exclude='tests*' \
+  --exclude='phpunit.xml' \
+  "$ROOT_DIR/" "$STAGING_DIR/$PLUGIN_SLUG/"
+
+# Create zip archive
+(cd "$STAGING_DIR" && zip -r "$ROOT_DIR/$ZIP_FILE" "$PLUGIN_SLUG")
+
+# Cleanup
+rm -rf "$STAGING_DIR"
+
+echo "Created $ZIP_FILE"


### PR DESCRIPTION
## Summary
- add `bin/build-plugin.sh` to package the plugin
- create release workflow to build and upload plugin zip on release creation

## Testing
- `composer run test` *(fails: WordPress test suite missing)*
- `bash bin/build-plugin.sh`

------
https://chatgpt.com/codex/tasks/task_e_686c3821066c83278b787be1cbdead94