### PR TITLE
Ensure vendor autoload is loaded

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -23,12 +23,13 @@ if (file_exists(GM2_PLUGIN_DIR . 'vendor/autoload.php')) {
 } else {
     if (!function_exists('gm2_missing_autoload_notice')) {
         function gm2_missing_autoload_notice() {
-            echo '<div class="notice notice-warning"><p>' .
-                esc_html__('Gm2 WordPress Suite: missing Composer autoload. Please run "composer install" or include the vendor directory.', 'gm2-wordpress-suite') .
+            echo '<div class="notice notice-error"><p>' .
+                esc_html__('Gm2 WordPress Suite requires its Composer dependencies. Please run "composer install".', 'gm2-wordpress-suite') .
                 '</p></div>';
         }
     }
     add_action('admin_notices', 'gm2_missing_autoload_notice');
+    return;
 }
 
 // Include required files

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,6 +4,10 @@ if (!$_tests_dir) {
     $_tests_dir = '/tmp/wordpress-tests-lib';
 }
 require_once $_tests_dir . '/includes/functions.php';
+$vendor_autoload = dirname(__DIR__) . '/vendor/autoload.php';
+if (file_exists($vendor_autoload)) {
+    require_once $vendor_autoload;
+}
 function _manually_load_plugin() {
     require dirname(__DIR__) . '/gm2-wordpress-suite.php';
 }


### PR DESCRIPTION
## Summary
- check for Composer autoload before including plugin files
- bail out with admin notice when dependencies are missing
- load autoload in test bootstrap

## Testing
- `composer install --no-interaction --prefer-dist`
- `composer test` *(fails: wordpress-tests-lib missing)*

------
https://chatgpt.com/codex/tasks/task_e_686c3ada08d08327a5c216d26d46a42f