### PR TITLE
Improve WP_TESTS_DIR instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,14 +30,15 @@ The PHPUnit tests depend on the WordPress testing suite. The installation script
 svn co https://develop.svn.wordpress.org/trunk/tests/phpunit $WP_TESTS_DIR
 ```
 
-Set the `WP_TESTS_DIR` environment variable to the directory where the suite resides. PHPUnit tests cannot run without this directory.
+Set the `WP_TESTS_DIR` environment variable to the directory where the suite resides. PHPUnit tests cannot run without this directory. If the variable is not set, `tests/bootstrap.php` falls back to `/tmp/wordpress-tests-lib`.
 
 ## Running Tests
 
-After the dependencies and test suite are installed, run:
+After the dependencies and test suite are installed, run the tests. Ensure that
+`WP_TESTS_DIR` points to the installed suite, for example:
 
 ```bash
-composer run test
+WP_TESTS_DIR=/path/to/wordpress-tests-lib composer run test
 ```
 
-This will execute the PHPUnit tests located in the `tests/` directory.
+This command executes the PHPUnit tests located in the `tests/` directory.


### PR DESCRIPTION
## Summary
- clarify that WP_TESTS_DIR must point to the installed WordPress test suite
- mention default `/tmp/wordpress-tests-lib` path used in tests/bootstrap.php
- provide example command showing how to set WP_TESTS_DIR when running tests

## Testing
- `composer run test` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686c3c41d81c832796ff8da07620bd62