### PR TITLE
Improve autoload notice

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -22,18 +22,43 @@ use Gm2\Gm2_Loader;
 use Gm2\Gm2_SEO_Public;
 use Gm2\Gm2_Sitemap;
 
+if (!function_exists('gm2_try_composer_install')) {
+    function gm2_try_composer_install() {
+        $disabled = array_map('trim', explode(',', (string) ini_get('disable_functions')));
+        $exec_disabled = in_array('exec', $disabled, true) || !function_exists('exec');
+        $shell_disabled = in_array('shell_exec', $disabled, true) || !function_exists('shell_exec');
+
+        if ($exec_disabled && $shell_disabled) {
+            // Can't run shell commands; bail early.
+            return;
+        }
+
+        $cmd = 'cd ' . escapeshellarg(__DIR__) . ' && composer install --no-dev --optimize-autoloader';
+        if (!$exec_disabled) {
+            exec($cmd);
+        } else {
+            shell_exec($cmd);
+        }
+    }
+}
+
 if (file_exists(__DIR__ . '/vendor/autoload.php')) {
     require_once __DIR__ . '/vendor/autoload.php';
 } else {
-    if (!function_exists('gm2_missing_autoload_notice')) {
-        function gm2_missing_autoload_notice() {
-            echo '<div class="notice notice-error"><p>' .
-                esc_html__('Gm2 WordPress Suite requires its Composer dependencies. Please run "composer install".', 'gm2-wordpress-suite') .
-                '</p></div>';
+    gm2_try_composer_install();
+    if (file_exists(__DIR__ . '/vendor/autoload.php')) {
+        require_once __DIR__ . '/vendor/autoload.php';
+    } else {
+        if (!function_exists('gm2_missing_autoload_notice')) {
+            function gm2_missing_autoload_notice() {
+                echo '<div class="notice notice-error"><p>' .
+                    esc_html__('Gm2 WordPress Suite requires Composer packages. Automatic installation failed (shell commands disabled). Run `composer install` on a local machine or use `bin/build-plugin.sh` to create a ZIP, then upload it with the `vendor/` directory.', 'gm2-wordpress-suite') .
+                    '</p></div>';
+            }
         }
+        add_action('admin_notices', 'gm2_missing_autoload_notice');
+        return;
     }
-    add_action('admin_notices', 'gm2_missing_autoload_notice');
-    return;
 }
 
 // Include required files

--- a/readme.txt
+++ b/readme.txt
@@ -30,6 +30,12 @@ that bundles these libraries:
 2. Upload the generated ZIP through the **Plugins → Add New** screen or copy
    its contents to your `wp-content/plugins` folder.
 
+== No Shell Access ==
+Some hosts disable shell functions like `exec` and `shell_exec`. When these are
+unavailable the plugin cannot install Composer packages automatically. Run
+`composer install` on a local machine or execute `bin/build-plugin.sh` to create
+a ZIP. Upload the plugin with the included `vendor/` directory.
+
 == Breadcrumbs ==
 Display a breadcrumb trail anywhere using the `[gm2_breadcrumbs]` shortcode. The output
 is an ordered list wrapped in a `<nav>` element with accompanying JSON-LD for search engines.


### PR DESCRIPTION
## Summary
- try to run Composer programmatically when vendor autoload is missing
- show a clearer admin notice when automatic install fails
- document manual install instructions for hosts without shell access

## Testing
- `composer install --ignore-platform-req=ext-dom --ignore-platform-req=ext-xml --ignore-platform-req=ext-xmlwriter`
- `./vendor/bin/phpunit` *(fails: missing PHP DOM/XML extensions)*

------
https://chatgpt.com/codex/tasks/task_e_686c562cd9bc83278efc6cc4bd290b34