### PR TITLE
Add OAuth state verification

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -389,7 +389,10 @@ class Gm2_SEO_Admin {
 
         $notice = '';
         if (isset($_GET['code'])) {
-            if ($oauth->handle_callback()) {
+            $result = $oauth->handle_callback();
+            if (is_wp_error($result)) {
+                $notice = '<div class="error notice"><p>' . esc_html($result->get_error_message()) . '</p></div>';
+            } elseif ($result) {
                 $notice = '<div class="updated notice"><p>Google account connected.</p></div>';
             }
         }

--- a/tests/test-oauth.php
+++ b/tests/test-oauth.php
@@ -32,6 +32,9 @@ class OAuthTest extends WP_UnitTestCase {
             public function fetchAccessTokenWithAuthCode($code) { return ['refresh_token'=>'saved']; }
         };
         $oauth = new Gm2_Google_OAuth($client);
+        $url = $oauth->get_auth_url();
+        parse_str(parse_url($url, PHP_URL_QUERY), $params);
+        $_GET['state'] = $params['state'];
         $oauth->handle_callback();
         $this->assertSame('saved', get_option('gm2_google_refresh_token'));
     }


### PR DESCRIPTION
## Summary
- use nonce-based `state` parameter in Google OAuth flow
- handle invalid states in `handle_callback`
- show an error notice when callback fails
- adjust tests for new `state` parameter

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686c61846cc88327bac7f1b866f3e20e