### PR TITLE
Refactor OAuth helper to use wp_remote_get/post

### DIFF
--- a/includes/Gm2_Google_OAuth.php
+++ b/includes/Gm2_Google_OAuth.php
@@ -32,7 +32,6 @@ class Gm2_Google_OAuth {
 
     private function api_request($method, $url, $body = null, $headers = []) {
         $args = [
-            'method'  => $method,
             'timeout' => 20,
             'headers' => $headers,
         ];
@@ -40,7 +39,11 @@ class Gm2_Google_OAuth {
             $args['body'] = wp_json_encode($body);
             $args['headers']['Content-Type'] = 'application/json';
         }
-        $resp = wp_remote_request($url, $args);
+        if (strtoupper($method) === 'POST') {
+            $resp = wp_remote_post($url, $args);
+        } else {
+            $resp = wp_remote_get($url, $args);
+        }
         if (is_wp_error($resp)) {
             return $resp;
         }


### PR DESCRIPTION
## Summary
- refactor OAuth helper to explicitly use `wp_remote_get` and `wp_remote_post`

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c6db53a18832786e0b012ffbc0375