### PR TITLE
Update docs for system phpunit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,11 @@
 # Contributing
 
-This project includes a PHPUnit test suite that relies on the WordPress test library.
+This project includes a PHPUnit test suite that relies on the WordPress test library. PHPUnit is expected to be installed globally, so the `phpunit` command is available on your system path.
 
 ## Installation
 
-1. Set up the WordPress testing suite. This script downloads WordPress and configures the test environment:
+1. Install PHPUnit through your package manager so the `phpunit` command is available globally.
+2. Set up the WordPress testing suite. This script downloads WordPress and configures the test environment:
 
    ```bash
    bash bin/install-wp-tests.sh <db-name> <db-user> <db-pass> [db-host] [wp-version]

--- a/readme.txt
+++ b/readme.txt
@@ -64,4 +64,4 @@ When enabled, uploaded images are sent to the API and replaced with the optimize
 * Initial release.
 
 == Testing ==
-For contributing and running the automated test suite, see `CONTRIBUTING.md` for detailed setup instructions.
+The automated tests use the WordPress test suite and assume `phpunit` is installed globally. See `CONTRIBUTING.md` for setup details.


### PR DESCRIPTION
## Summary
- mention global phpunit requirement in contribution guide
- clarify the test section in the WordPress readme

## Testing
- `phpunit` *(fails: could not find `/tmp/wordpress-tests-lib`)*
- `bash bin/install-wp-tests.sh wordpress root '' localhost latest` *(fails: Can't connect to MySQL server)*

------
https://chatgpt.com/codex/tasks/task_e_686c6edcc00083279fc4268fa2f19635