### PR TITLE
Fix OAuth code handling

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -389,11 +389,11 @@ class Gm2_SEO_Admin {
 
         $notice = '';
         if (isset($_GET['code'])) {
-            $_GET['code']  = sanitize_text_field(wp_unslash($_GET['code']));
+            $code = sanitize_text_field(wp_unslash($_GET['code']));
             if (isset($_GET['state'])) {
                 $_GET['state'] = sanitize_text_field(wp_unslash($_GET['state']));
             }
-            $result = $oauth->handle_callback();
+            $result = $oauth->handle_callback($code);
             if (is_wp_error($result)) {
                 $notice = '<div class="error notice"><p>' . esc_html($result->get_error_message()) . '</p></div>';
             } elseif ($result) {

--- a/includes/Gm2_Google_OAuth.php
+++ b/includes/Gm2_Google_OAuth.php
@@ -74,12 +74,12 @@ class Gm2_Google_OAuth {
         return 'https://accounts.google.com/o/oauth2/v2/auth?' . http_build_query($params, '', '&', PHP_QUERY_RFC3986);
     }
 
-    public function handle_callback() {
-        if (!isset($_GET['code'])) {
+    public function handle_callback($code = '') {
+        if ('' === $code) {
             return false;
         }
 
-        $code  = sanitize_text_field(wp_unslash($_GET['code']));
+        $code  = sanitize_text_field($code);
         $state = isset($_GET['state']) ? sanitize_text_field(wp_unslash($_GET['state'])) : '';
 
         $expected_state = get_user_meta(get_current_user_id(), 'gm2_oauth_state', true);

--- a/tests/test-connect-page.php
+++ b/tests/test-connect-page.php
@@ -13,7 +13,7 @@ class GoogleConnectPageTest extends WP_UnitTestCase {
             return new class {
                 public function is_connected() { return false; }
                 public function get_auth_url() { return 'https://accounts.google.com/mock'; }
-                public function handle_callback() { return false; }
+                public function handle_callback($code) { return false; }
             };
         });
         $admin = new Gm2_SEO_Admin();
@@ -30,7 +30,7 @@ class GoogleConnectPageTest extends WP_UnitTestCase {
             return new class {
                 public function is_connected() { return false; }
                 public function get_auth_url() { return ''; }
-                public function handle_callback() {
+                public function handle_callback($code) {
                     update_option('gm2_google_refresh_token', 'saved');
                     return true;
                 }

--- a/tests/test-oauth.php
+++ b/tests/test-oauth.php
@@ -53,7 +53,7 @@ class OAuthTest extends WP_UnitTestCase {
         parse_str(parse_url($url, PHP_URL_QUERY), $params);
         $_GET['state'] = $params['state'];
 
-        $oauth->handle_callback();
+        $oauth->handle_callback('test');
 
         remove_filter('pre_http_request', $filter, 10);
 


### PR DESCRIPTION
## Summary
- allow passing sanitized `code` to OAuth handler
- update Google connect page to pass code parameter
- adjust tests for new signature

## Testing
- `phpunit --configuration phpunit.xml` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_686c732801248327a72a9d1f347ccc03