### PR TITLE
Update plugin autoloader

### DIFF
--- a/includes/autoload.php
+++ b/includes/autoload.php
@@ -3,10 +3,13 @@ spl_autoload_register(function ($class) {
     if (strpos($class, 'Gm2\\') !== 0) {
         return;
     }
-    $name = substr($class, 4);                  // strip namespace prefix
-    $name = str_replace('_', DIRECTORY_SEPARATOR, $name);
-    $file = GM2_PLUGIN_DIR . $name . '.php';
-    if (file_exists($file)) {
-        require_once $file;
+
+    $name = substr($class, 4); // class name without namespace
+    foreach (['includes', 'admin', 'public'] as $dir) {
+        $file = GM2_PLUGIN_DIR . $dir . '/' . $name . '.php';
+        if (file_exists($file)) {
+            require_once $file;
+            return;
+        }
     }
 });


### PR DESCRIPTION
## Summary
- update plugin autoload logic to search plugin directories

## Testing
- `php -l includes/autoload.php`
- `phpunit -c phpunit.xml` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_686d5df101f8832797e711bdca2dcb8b