### PR TITLE
Add Google OAuth setup page

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -150,6 +150,15 @@ class Gm2_Admin {
             'gm2-add-tariff',
             [$this, 'display_add_tariff_page']
         );
+
+        add_submenu_page(
+            'gm2',
+            esc_html__( 'Google OAuth Setup', 'gm2-wordpress-suite' ),
+            esc_html__( 'Google OAuth Setup', 'gm2-wordpress-suite' ),
+            'manage_options',
+            'gm2-google-oauth-setup',
+            [ $this, 'display_google_oauth_setup_page' ]
+        );
     }
 
     public function display_dashboard() {
@@ -245,6 +254,51 @@ class Gm2_Admin {
             echo '<tr><td colspan="4">No tariffs found.</td></tr>';
         }
         echo '</tbody></table></div>';
+    }
+
+    public function display_google_oauth_setup_page() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'Permission denied', 'gm2-wordpress-suite' ) );
+        }
+
+        $notice = '';
+        if ( isset( $_POST['gm2_gads_oauth_setup_nonce'] ) && wp_verify_nonce( $_POST['gm2_gads_oauth_setup_nonce'], 'gm2_gads_oauth_setup_save' ) ) {
+            $client_id     = isset( $_POST['gm2_gads_client_id'] ) ? sanitize_text_field( wp_unslash( $_POST['gm2_gads_client_id'] ) ) : '';
+            $client_secret = isset( $_POST['gm2_gads_client_secret'] ) ? sanitize_text_field( wp_unslash( $_POST['gm2_gads_client_secret'] ) ) : '';
+
+            update_option( 'gm2_gads_client_id', $client_id );
+            update_option( 'gm2_gads_client_secret', $client_secret );
+
+            $notice = '<div class="updated notice"><p>' . esc_html__( 'Settings saved.', 'gm2-wordpress-suite' ) . '</p></div>';
+        }
+
+        $client_id     = get_option( 'gm2_gads_client_id', '' );
+        $client_secret = get_option( 'gm2_gads_client_secret', '' );
+        $redirect      = admin_url( 'admin.php?page=gm2-google-connect' );
+
+        echo '<div class="wrap">';
+        echo '<h1>' . esc_html__( 'Google OAuth Setup', 'gm2-wordpress-suite' ) . '</h1>';
+        echo $notice;
+        echo '<p>' . esc_html__( 'Follow these steps to create OAuth credentials on the Google Cloud console:', 'gm2-wordpress-suite' ) . '</p>';
+        echo '<ol>';
+        echo '<li>' . esc_html__( 'Open the Google Cloud console and create a new project.', 'gm2-wordpress-suite' ) . '</li>';
+        echo '<li>' . esc_html__( 'Enable the Google Ads API and other required APIs.', 'gm2-wordpress-suite' ) . '</li>';
+        echo '<li>' . esc_html__( 'Create OAuth client ID credentials for a Web application.', 'gm2-wordpress-suite' ) . '</li>';
+        echo '<li>' . sprintf( esc_html__( 'Set the authorized redirect URI to %s.', 'gm2-wordpress-suite' ), esc_url( $redirect ) ) . '</li>';
+        echo '<li>' . esc_html__( 'Copy the client ID and client secret into the fields below.', 'gm2-wordpress-suite' ) . '</li>';
+        echo '</ol>';
+
+        echo '<form method="post">';
+        wp_nonce_field( 'gm2_gads_oauth_setup_save', 'gm2_gads_oauth_setup_nonce' );
+        echo '<table class="form-table"><tbody>';
+        echo '<tr><th scope="row"><label for="gm2_gads_client_id">' . esc_html__( 'Client ID', 'gm2-wordpress-suite' ) . '</label></th>';
+        echo '<td><input name="gm2_gads_client_id" type="text" id="gm2_gads_client_id" value="' . esc_attr( $client_id ) . '" class="regular-text" required></td></tr>';
+        echo '<tr><th scope="row"><label for="gm2_gads_client_secret">' . esc_html__( 'Client Secret', 'gm2-wordpress-suite' ) . '</label></th>';
+        echo '<td><input name="gm2_gads_client_secret" type="text" id="gm2_gads_client_secret" value="' . esc_attr( $client_secret ) . '" class="regular-text" required></td></tr>';
+        echo '</tbody></table>';
+        submit_button();
+        echo '</form>';
+        echo '</div>';
     }
 
 }

--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -405,6 +405,8 @@ class Gm2_SEO_Admin {
 
         echo '<div class="wrap">';
         echo '<h1>Connect Google Account</h1>';
+        $setup_url = admin_url( 'admin.php?page=gm2-google-oauth-setup' );
+        echo '<p><a href="' . esc_url( $setup_url ) . '">' . esc_html__( 'Google OAuth Setup', 'gm2-wordpress-suite' ) . '</a></p>';
         echo $notice;
         if (!$oauth->is_connected()) {
             $url = esc_url($oauth->get_auth_url());

--- a/readme.txt
+++ b/readme.txt
@@ -13,8 +13,9 @@ A powerful suite of WordPress enhancements including admin tools, frontend optim
 == Installation ==
 1. Upload the plugin files to the `/wp-content/plugins/gm2-wordpress-suite` directory.
 2. Activate the plugin through the 'Plugins' screen in WordPress.
-3. Use the Gm2 Suite menu in the admin sidebar to configure settings. Visit
-   **SEO → Connect Google Account** to authorize your Google account.
+3. Use the Gm2 Suite menu in the admin sidebar to configure settings. First
+   visit **Gm2 → Google OAuth Setup** to enter your client ID and secret, then
+   use **SEO → Connect Google Account** to authorize your Google account.
 4. All required PHP libraries, including the Google API client, are bundled in
    the plugin. No additional installation steps are required.
 
@@ -40,7 +41,8 @@ For full page caching, hook into the `gm2_set_cache_headers` action
 to configure headers or integrate your preferred caching plugin.
 
 == Keyword Research ==
-Connect your Google account from **SEO → Connect Google Account** and use the
+After configuring credentials in **Gm2 → Google OAuth Setup**, connect your
+Google account from **SEO → Connect Google Account** and use the
 **Keyword Research** tab to generate ideas via the Google Keyword Planner.
 
 == Image Optimization ==


### PR DESCRIPTION
## Summary
- add an admin submenu for Google OAuth setup
- implement setup form with instructions and nonce handling
- link the connect screen to the new setup page
- document the new screen

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d64db024c83279d47fb577265a15d