### PR TITLE
Add ChatGPT integration with admin settings

### DIFF
--- a/admin/class-gm2-admin.php
+++ b/admin/class-gm2-admin.php
@@ -19,9 +19,50 @@ class Gm2_Admin {
             [$this, 'display_admin_page'],
             'dashicons-admin-generic'
         );
+
+        add_submenu_page(
+            'gm2-suite',
+            'ChatGPT Settings',
+            'ChatGPT Settings',
+            'manage_options',
+            'gm2-suite-chatgpt',
+            [$this, 'display_chatgpt_page']
+        );
     }
 
     public function display_admin_page() {
         echo '<div class="wrap"><h1>Gm2 WordPress Suite</h1><p>Welcome to the admin interface!</p></div>';
+    }
+
+    public function display_chatgpt_page() {
+        $response = '';
+        if (isset($_POST['gm2_chatgpt_submit'])) {
+            check_admin_referer('gm2_chatgpt_settings');
+            $api_key = sanitize_text_field($_POST['gm2_chatgpt_api_key']);
+            update_option('gm2_chatgpt_api_key', $api_key);
+            $prompt = sanitize_text_field($_POST['gm2_chatgpt_prompt']);
+            if (!empty($prompt)) {
+                $response = Gm2_ChatGPT::send_prompt($prompt);
+            }
+        }
+
+        $saved_key = esc_attr(get_option('gm2_chatgpt_api_key', ''));
+
+        echo '<div class="wrap">';
+        echo '<h1>ChatGPT Settings</h1>';
+        echo '<form method="post">';
+        wp_nonce_field('gm2_chatgpt_settings');
+        echo '<table class="form-table">';
+        echo '<tr><th scope="row"><label for="gm2_chatgpt_api_key">API Key</label></th>';
+        echo '<td><input type="text" id="gm2_chatgpt_api_key" name="gm2_chatgpt_api_key" value="' . $saved_key . '" class="regular-text" /></td></tr>';
+        echo '<tr><th scope="row"><label for="gm2_chatgpt_prompt">Prompt</label></th>';
+        echo '<td><textarea id="gm2_chatgpt_prompt" name="gm2_chatgpt_prompt" rows="5" cols="50"></textarea></td></tr>';
+        echo '</table>';
+        submit_button('Save & Send', 'primary', 'gm2_chatgpt_submit');
+        echo '</form>';
+        if (!empty($response)) {
+            echo '<h2>Response</h2><pre>' . esc_html($response) . '</pre>';
+        }
+        echo '</div>';
     }
 }

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Gm2 WordPress Suite
  * Description:       A powerful suite of tools and features for WordPress, by Gm2.
- * Version:           1.0.0
+ * Version:           1.1.0
  * Author:            Your Name or Team Gm2
  * Author URI:        https://yourwebsite.com
  * License:           GPL-2.0+
@@ -14,7 +14,7 @@
 defined('ABSPATH') or die('No script kiddies please!');
 
 // Define constants
-define('GM2_VERSION', '1.0.0');
+define('GM2_VERSION', '1.1.0');
 define('GM2_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('GM2_PLUGIN_URL', plugin_dir_url(__FILE__));
 

--- a/includes/class-gm2-chatgpt.php
+++ b/includes/class-gm2-chatgpt.php
@@ -1,0 +1,42 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Gm2_ChatGPT {
+    public static function send_prompt($prompt) {
+        $api_key = get_option('gm2_chatgpt_api_key');
+        if (empty($api_key)) {
+            return 'API key not set.';
+        }
+
+        $body = [
+            'model' => 'gpt-3.5-turbo',
+            'messages' => [
+                ['role' => 'user', 'content' => $prompt],
+            ],
+        ];
+
+        $response = wp_remote_post('https://api.openai.com/v1/chat/completions', [
+            'headers' => [
+                'Content-Type' => 'application/json',
+                'Authorization' => 'Bearer ' . $api_key,
+            ],
+            'body' => wp_json_encode($body),
+            'timeout' => 20,
+        ]);
+
+        if (is_wp_error($response)) {
+            return $response->get_error_message();
+        }
+
+        $data = json_decode(wp_remote_retrieve_body($response), true);
+        if (isset($data['choices'][0]['message']['content'])) {
+            return $data['choices'][0]['message']['content'];
+        }
+
+        return 'Unexpected response from API.';
+    }
+}
+?>
+

--- a/includes/class-gm2-loader.php
+++ b/includes/class-gm2-loader.php
@@ -14,6 +14,7 @@ class Gm2_Loader {
     private function load_dependencies() {
         require_once GM2_PLUGIN_DIR . 'admin/class-gm2-admin.php';
         require_once GM2_PLUGIN_DIR . 'public/class-gm2-public.php';
+        require_once GM2_PLUGIN_DIR . 'includes/class-gm2-chatgpt.php';
     }
 
     public function run() {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: gm2team
 Tags: admin, tools, suite, performance
 Requires at least: 5.6
 Tested up to: 6.5
-Stable tag: 1.0.0
+Stable tag: 1.1.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -16,6 +16,9 @@ A powerful suite of WordPress enhancements including admin tools, frontend optim
 3. Use the Gm2 Suite menu in the admin sidebar to configure settings.
 
 == Changelog ==
+= 1.1.0 =
+* Added ChatGPT integration with admin settings page.
+
 = 1.0.0 =
 * Initial release.
 

--- a/tests/test-chatgpt.php
+++ b/tests/test-chatgpt.php
@@ -1,0 +1,27 @@
+<?php
+class ChatGPTTest extends WP_UnitTestCase {
+    public function test_send_prompt_without_key() {
+        delete_option('gm2_chatgpt_api_key');
+        $result = Gm2_ChatGPT::send_prompt('Hello');
+        $this->assertEquals('API key not set.', $result);
+    }
+
+    public function test_send_prompt_with_mock_response() {
+        update_option('gm2_chatgpt_api_key', 'dummy');
+        add_filter('pre_http_request', function($preempt, $r, $url) {
+            if (false !== strpos($url, 'api.openai.com')) {
+                return array(
+                    'headers'  => array(),
+                    'body'     => json_encode(array(
+                        'choices' => array(array('message' => array('content' => 'Hi there')))
+                    )),
+                    'response' => array('code' => 200),
+                );
+            }
+            return false;
+        }, 10, 3);
+        $result = Gm2_ChatGPT::send_prompt('Hello');
+        $this->assertEquals('Hi there', $result);
+    }
+}
+


### PR DESCRIPTION
## Summary
- integrate new `Gm2_ChatGPT` class for talking to OpenAI
- load ChatGPT class in plugin loader
- add ChatGPT Settings admin page with API key field and prompt
- bump plugin version to 1.1.0
- document new version in readme
- add PHPUnit tests for ChatGPT helper

## Testing
- `composer run test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d7314c654832780ef9f6ef7879244