### PR TITLE
Integrate SEO panel into Elementor UI

### DIFF
--- a/admin/css/gm2-seo.css
+++ b/admin/css/gm2-seo.css
@@ -16,3 +16,6 @@
 .gm2-tab-panel.active { display:block; }
 .gm2-analysis-rules li.pass { color:#46b450; }
 .gm2-analysis-rules li.fail { color:#d63638; }
+
+#gm2-elementor-seo-panel { padding:10px; }
+#elementor-panel-footer #gm2-elementor-seo-panel .gm2-tab-panel { border:none; }

--- a/admin/js/gm2-content-analysis.js
+++ b/admin/js/gm2-content-analysis.js
@@ -139,14 +139,29 @@
         if(typeof wp !== 'undefined' && wp.data){
             wp.data.subscribe(update);
         }
-        if(window.elementor){
+
+        function initElementorPanel(){
+            var $panel = jQuery('#gm2-elementor-seo-panel');
+            if($panel.length){
+                jQuery('#elementor-panel-footer').append($panel);
+            }
             if(elementor.hooks && elementor.hooks.addAction){
                 elementor.hooks.addAction('document:save', update);
             }
             if(elementor.channels && elementor.channels.editor){
                 elementor.channels.editor.on('change', update);
             }
+            update();
         }
+
+        if(window.elementor){
+            if(elementor.on){
+                elementor.on('init', initElementorPanel);
+            } else {
+                initElementorPanel();
+            }
+        }
+
         $(document).on('input', '#gm2_focus_keywords', update);
     });
 })(jQuery);


### PR DESCRIPTION
## Summary
- insert the SEO content analysis panel into Elementor's footer panel
- listen for Elementor `init` before attaching handlers
- tweak styles for Elementor panel

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d759d8970832793001b951c1f3358