### PR TITLE
Add ChatGPT integration

### DIFF
--- a/admin/js/gm2-chatgpt.js
+++ b/admin/js/gm2-chatgpt.js
@@ -1,0 +1,18 @@
+jQuery(function($){
+    $('#gm2-chatgpt-form').on('submit', function(e){
+        e.preventDefault();
+        var prompt = $('#gm2_chatgpt_prompt').val();
+        var $out = $('#gm2-chatgpt-output').text('Loading...');
+        $.post(gm2ChatGPT.ajax_url, {
+            action: 'gm2_chatgpt_prompt',
+            prompt: prompt,
+            _ajax_nonce: gm2ChatGPT.nonce
+        }, function(resp){
+            if(resp && resp.success){
+                $out.text(resp.data);
+            } else {
+                $out.text(resp.data || 'Error');
+            }
+        });
+    });
+});

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Gm2 WordPress Suite
  * Description:       A powerful suite of tools and features for WordPress, by Gm2.
- * Version:           1.5.0
+ * Version:           1.6.0
  * Author:            Your Name or Team Gm2
  * Author URI:        https://yourwebsite.com
  * License:           GPL-2.0+
@@ -14,7 +14,7 @@
 defined('ABSPATH') or die('No script kiddies please!');
 
 // Define constants
-define('GM2_VERSION', '1.5.0');
+define('GM2_VERSION', '1.6.0');
 define('GM2_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('GM2_PLUGIN_URL', plugin_dir_url(__FILE__));
 

--- a/includes/Gm2_ChatGPT.php
+++ b/includes/Gm2_ChatGPT.php
@@ -1,0 +1,44 @@
+<?php
+namespace Gm2;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Gm2_ChatGPT {
+    private $api_key;
+
+    public function __construct() {
+        $this->api_key = get_option('gm2_chatgpt_api_key', '');
+    }
+
+    public function query($prompt) {
+        if ($this->api_key === '') {
+            return new \WP_Error('no_api_key', 'ChatGPT API key not set');
+        }
+        $args = [
+            'headers' => [
+                'Authorization' => 'Bearer ' . $this->api_key,
+                'Content-Type'  => 'application/json',
+            ],
+            'body'    => wp_json_encode([
+                'model' => 'gpt-3.5-turbo',
+                'messages' => [ [ 'role' => 'user', 'content' => $prompt ] ],
+            ]),
+            'timeout' => 20,
+        ];
+        $response = wp_remote_post('https://api.openai.com/v1/chat/completions', $args);
+        if (is_wp_error($response)) {
+            return $response;
+        }
+        if (wp_remote_retrieve_response_code($response) !== 200) {
+            return new \WP_Error('api_error', 'Non-200 response');
+        }
+        $body = wp_remote_retrieve_body($response);
+        if ($body === '') {
+            return '';
+        }
+        $data = json_decode($body, true);
+        return $data['choices'][0]['message']['content'] ?? '';
+    }
+}

--- a/readme.txt
+++ b/readme.txt
@@ -3,12 +3,12 @@ Contributors: gm2team
 Tags: admin, tools, suite, performance
 Requires at least: 5.6
 Tested up to: 6.5
-Stable tag: 1.5.0
+Stable tag: 1.6.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
 == Description ==
-A powerful suite of WordPress enhancements including admin tools, frontend optimizations, and more.
+A powerful suite of WordPress enhancements including admin tools, frontend optimizations, and ChatGPT-powered content generation.
 
 == Installation ==
 1. Upload the plugin files to the `/wp-content/plugins/gm2-wordpress-suite` directory.
@@ -50,6 +50,8 @@ Enter your compression API key and enable the service from the SEO &gt; Performa
 When enabled, uploaded images are sent to the API and replaced with the optimized result.
 
 == Changelog ==
+= 1.6.0 =
+* ChatGPT integration with admin settings page.
 = 1.5.0 =
 * Google Keyword Planner integration for keyword research.
 = 1.4.0 =

--- a/tests/test-chatgpt.php
+++ b/tests/test-chatgpt.php
@@ -1,0 +1,33 @@
+<?php
+use Gm2\Gm2_ChatGPT;
+use Gm2\Gm2_Admin;
+
+class ChatGPTTest extends WP_UnitTestCase {
+    public function test_query_returns_response() {
+        update_option('gm2_chatgpt_api_key', 'key');
+        $filter = function($pre, $args, $url) {
+            if ($url === 'https://api.openai.com/v1/chat/completions') {
+                return [
+                    'response' => ['code' => 200],
+                    'body' => json_encode([
+                        'choices' => [ ['message' => ['content' => 'hi']] ]
+                    ])
+                ];
+            }
+            return false;
+        };
+        add_filter('pre_http_request', $filter, 10, 3);
+        $chat = new Gm2_ChatGPT();
+        $res = $chat->query('hello');
+        remove_filter('pre_http_request', $filter, 10);
+        $this->assertSame('hi', $res);
+    }
+
+    public function test_chatgpt_page_contains_field() {
+        $admin = new Gm2_Admin();
+        ob_start();
+        $admin->display_chatgpt_page();
+        $out = ob_get_clean();
+        $this->assertStringContainsString('gm2_chatgpt_api_key', $out);
+    }
+}


### PR DESCRIPTION
## Summary
- integrate ChatGPT with new helper class
- create admin page and AJAX actions for ChatGPT
- load chatGPT JS and menu option
- bump plugin version to 1.6.0
- document ChatGPT features
- add basic tests for ChatGPT

## Testing
- `apt-get update`
- `apt-get install -y php phpunit subversion`
- `bash bin/install-wp-tests.sh wordpress_test root '' localhost latest` *(fails: `mysqladmin: command not found`)*
- `phpunit` *(fails: missing WordPress test library)*

------
https://chatgpt.com/codex/tasks/task_e_686d76dbbf84832793c5cace5b29291b