### PR TITLE
Fix asset enqueue versioning

### DIFF
--- a/public/Gm2_Public.php
+++ b/public/Gm2_Public.php
@@ -14,8 +14,19 @@ class Gm2_Public {
     }
 
     public function enqueue_scripts() {
-        wp_enqueue_style('gm2-public-style', GM2_PLUGIN_URL . 'public/css/gm2-public.css');
-        wp_enqueue_script('gm2-public-script', GM2_PLUGIN_URL . 'public/js/gm2-public.js', [], false, true);
+        wp_enqueue_style(
+            'gm2-public-style',
+            GM2_PLUGIN_URL . 'public/css/gm2-public.css',
+            [],
+            GM2_VERSION
+        );
+        wp_enqueue_script(
+            'gm2-public-script',
+            GM2_PLUGIN_URL . 'public/js/gm2-public.js',
+            [],
+            GM2_VERSION,
+            true
+        );
     }
 
     public function add_tariff_fees($cart) {


### PR DESCRIPTION
## Summary
- enqueue public assets with plugin version to help with browser caching

## Testing
- `phpunit` *(fails: failed to open /tmp/wordpress-tests-lib/includes/functions.php)*

------
https://chatgpt.com/codex/tasks/task_e_686d7dc263748327b3f14a88262eb98e