### PR TITLE
Clarify manual entry for search console and ads tokens

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -167,6 +167,7 @@ class Gm2_SEO_Admin {
             function () {
                 $value = get_option('gm2_search_console_verification', '');
                 echo '<input type="text" name="gm2_search_console_verification" value="' . esc_attr($value) . '" class="regular-text" />';
+                echo '<p class="description">Enter this code manually from Search Console. It cannot be retrieved automatically.</p>';
             },
             'gm2_seo',
             'gm2_seo_main'
@@ -178,6 +179,7 @@ class Gm2_SEO_Admin {
             function () {
                 $value = get_option('gm2_gads_developer_token', '');
                 echo '<input type="text" name="gm2_gads_developer_token" value="' . esc_attr($value) . '" class="regular-text" />';
+                echo '<p class="description">This token must be generated in your Google Ads account and entered here manually.</p>';
             },
             'gm2_seo',
             'gm2_seo_main'

--- a/readme.txt
+++ b/readme.txt
@@ -18,6 +18,9 @@ A powerful suite of WordPress enhancements including admin tools, frontend optim
    use **SEO → Connect Google Account** to authorize your Google account.
 4. All required PHP libraries, including the Google API client, are bundled in
    the plugin. No additional installation steps are required.
+5. Obtain your Search Console verification code and Google Ads developer token
+   directly from your Google accounts. These values cannot be fetched via API
+   and must be entered manually on the SEO settings page.
 
 If you plan to distribute or manually upload the plugin, you can create a ZIP
 archive with `bash bin/build-plugin.sh`. This command packages the plugin with


### PR DESCRIPTION
## Summary
- document that Search Console codes and Ads developer tokens must be copied by hand
- show explanatory notes in the SEO settings fields

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d88c681208327b4b5f01eba97070d