### PR TITLE
Fix ChatGPT prompt sanitization

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -401,7 +401,7 @@ class Gm2_Admin {
 
     public function ajax_chatgpt_prompt() {
         check_ajax_referer('gm2_chatgpt_nonce');
-        $prompt = sanitize_text_field($_POST['prompt'] ?? '');
+        $prompt = sanitize_textarea_field($_POST['prompt'] ?? '');
         $chat = new Gm2_ChatGPT();
         $resp = $chat->query($prompt);
         if (is_wp_error($resp)) {


### PR DESCRIPTION
## Summary
- ensure ajax prompt keeps line breaks by using `sanitize_textarea_field`
- test AJAX handler for multi-line prompts

## Testing
- `phpunit` *(fails: requires WordPress test suite)*

------
https://chatgpt.com/codex/tasks/task_e_686d88a12d108327ad2f11e684734841