### PR TITLE
Add Ads account dropdown

### DIFF
--- a/tests/test-connect-page.php
+++ b/tests/test-connect-page.php
@@ -4,6 +4,7 @@ class GoogleConnectPageTest extends WP_UnitTestCase {
     public function tearDown(): void {
         delete_option('gm2_google_refresh_token');
         delete_option('gm2_ga_measurement_id');
+        delete_option('gm2_gads_customer_id');
         remove_all_filters('gm2_google_oauth_instance');
         parent::tearDown();
     }
@@ -55,6 +56,7 @@ class GoogleConnectPageTest extends WP_UnitTestCase {
                 public function get_auth_url() { return ''; }
                 public function handle_callback($code) { return true; }
                 public function list_analytics_properties() { return ['G-1' => 'Site 1', 'G-2' => 'Site 2']; }
+                public function list_ads_accounts() { return []; }
             };
         });
         $admin = new Gm2_SEO_Admin();
@@ -65,5 +67,28 @@ class GoogleConnectPageTest extends WP_UnitTestCase {
         $this->assertStringContainsString('<select', $output);
         $this->assertStringContainsString('G-1', $output);
         $this->assertStringContainsString('G-2', $output);
+    }
+
+    public function test_ads_accounts_list_saved_after_callback() {
+        delete_option('gm2_google_refresh_token');
+        delete_option('gm2_gads_customer_id');
+        $_GET['code'] = 'abc';
+        add_filter('gm2_google_oauth_instance', function() {
+            return new class {
+                public function is_connected() { return true; }
+                public function get_auth_url() { return ''; }
+                public function handle_callback($code) { return true; }
+                public function list_analytics_properties() { return []; }
+                public function list_ads_accounts() { return ['123' => '123', '456' => '456']; }
+            };
+        });
+        $admin = new Gm2_SEO_Admin();
+        ob_start();
+        $admin->display_google_connect_page();
+        $output = ob_get_clean();
+        $this->assertSame('123', get_option('gm2_gads_customer_id'));
+        $this->assertStringContainsString('gm2_gads_account', $output);
+        $this->assertStringContainsString('123', $output);
+        $this->assertStringContainsString('456', $output);
     }
 }


### PR DESCRIPTION
## Summary
- connect page: save Ads accounts
- allow selecting Ads account after OAuth
- test Google connection ads accounts

## Testing
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_686d905384908327876cafac3a9ab8bc