### PR TITLE
Add dev token to ads account request header

### DIFF
--- a/includes/Gm2_Google_OAuth.php
+++ b/includes/Gm2_Google_OAuth.php
@@ -197,12 +197,14 @@ class Gm2_Google_OAuth {
         if (!$this->is_connected()) {
             return [];
         }
-        $token = $this->get_access_token();
-        if (!$token) {
+        $access = $this->get_access_token();
+        if (!$access) {
             return [];
         }
+        $token = get_option('gm2_gads_developer_token', '');
         $resp = $this->api_request('GET', 'https://googleads.googleapis.com/v15/customers:listAccessibleCustomers', null, [
-            'Authorization' => 'Bearer ' . $token,
+            'Authorization'   => 'Bearer ' . $access,
+            'developer-token' => $token,
         ]);
         if (is_wp_error($resp) || empty($resp['resourceNames'])) {
             return [];

--- a/readme.txt
+++ b/readme.txt
@@ -19,8 +19,9 @@ A powerful suite of WordPress enhancements including admin tools, frontend optim
 4. All required PHP libraries, including the Google API client, are bundled in
    the plugin. No additional installation steps are required.
 5. Obtain your Search Console verification code and Google Ads developer token
-   directly from your Google accounts. These values cannot be fetched via API
-   and must be entered manually on the SEO settings page.
+   directly from your Google accounts. The developer token is required for
+   listing Ads accounts. These values cannot be fetched via API and must be
+   entered manually on the SEO settings page.
 
 If you plan to distribute or manually upload the plugin, you can create a ZIP
 archive with `bash bin/build-plugin.sh`. This command packages the plugin with

--- a/tests/test-oauth.php
+++ b/tests/test-oauth.php
@@ -59,4 +59,32 @@ class OAuthTest extends WP_UnitTestCase {
 
         $this->assertSame('saved', get_option('gm2_google_refresh_token'));
     }
+
+    public function test_ads_request_includes_developer_token_header() {
+        update_option('gm2_google_refresh_token', 'refresh');
+        update_option('gm2_google_access_token', 'access');
+        update_option('gm2_google_expires_at', time() + 3600);
+        update_option('gm2_gads_developer_token', 'devtoken');
+
+        $captured = null;
+        $filter   = function ($pre, $args, $url) use (&$captured) {
+            if (0 === strpos($url, 'https://googleads.googleapis.com/v15/customers:listAccessibleCustomers')) {
+                $captured = $args;
+                return [
+                    'response' => ['code' => 200],
+                    'body'     => json_encode(['resourceNames' => []]),
+                ];
+            }
+            return false;
+        };
+        add_filter('pre_http_request', $filter, 10, 3);
+
+        $oauth = new Gm2_Google_OAuth();
+        $oauth->list_ads_accounts();
+
+        remove_filter('pre_http_request', $filter, 10);
+
+        $this->assertIsArray($captured);
+        $this->assertSame('devtoken', $captured['headers']['developer-token']);
+    }
 }


### PR DESCRIPTION
## Summary
- include Google Ads developer token when listing accounts
- test that Ads API request uses developer token header
- mention developer token requirement in installation docs

## Testing
- `bash bin/install-wp-tests.sh wordpress_test root "" localhost latest true` *(fails: Unable to connect to develop.svn.wordpress.org)*
- `phpunit` *(fails: missing WordPress test suite)*

------
https://chatgpt.com/codex/tasks/task_e_686d937100bc8327994d56326f2bf26a