### PR TITLE
Add model dropdown for ChatGPT

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -361,7 +361,12 @@ class Gm2_Admin {
         echo '<td><input type="password" id="gm2_chatgpt_api_key" name="gm2_chatgpt_api_key" value="' . esc_attr($key) . '" class="regular-text" />';
         echo ' <button type="button" class="button" id="gm2-chatgpt-toggle">' . esc_html__( 'Show', 'gm2-wordpress-suite' ) . '</button></td></tr>';
         echo '<tr><th scope="row"><label for="gm2_chatgpt_model">' . esc_html__( 'Model', 'gm2-wordpress-suite' ) . '</label></th>';
-        echo '<td><input type="text" id="gm2_chatgpt_model" name="gm2_chatgpt_model" value="' . esc_attr($model) . '" class="regular-text" /></td></tr>';
+        $options = '';
+        foreach (Gm2_ChatGPT::get_available_models() as $m) {
+            $selected = selected($model, $m, false);
+            $options .= '<option value="' . esc_attr($m) . '"' . $selected . '>' . esc_html($m) . '</option>';
+        }
+        echo '<td><select id="gm2_chatgpt_model" name="gm2_chatgpt_model">' . $options . '</select></td></tr>';
         echo '<tr><th scope="row"><label for="gm2_chatgpt_temperature">' . esc_html__( 'Temperature', 'gm2-wordpress-suite' ) . '</label></th>';
         echo '<td><input type="number" step="0.1" id="gm2_chatgpt_temperature" name="gm2_chatgpt_temperature" value="' . esc_attr($temperature) . '" class="small-text" /></td></tr>';
         echo '<tr><th scope="row"><label for="gm2_chatgpt_max_tokens">' . esc_html__( 'Max Tokens', 'gm2-wordpress-suite' ) . '</label></th>';

--- a/readme.txt
+++ b/readme.txt
@@ -15,7 +15,8 @@ A powerful suite of WordPress enhancements including admin tools, frontend optim
 2. Activate the plugin through the 'Plugins' screen in WordPress.
 3. Use the Gm2 Suite menu in the admin sidebar to configure settings. First
    visit **Gm2 → Google OAuth Setup** to enter your client ID and secret, then
-   open **Gm2 → ChatGPT** to provide your OpenAI API key and model settings.
+   open **Gm2 → ChatGPT** to provide your OpenAI API key and choose a model from
+   the dropdown.
    Finally, use **SEO → Connect Google Account** to authorize your Google account. After connecting, you will be able to select your Analytics Measurement ID and Ads Customer ID from dropdown menus.
 4. All required PHP libraries, including the Google API client, are bundled in
    the plugin. No additional installation steps are required.
@@ -56,7 +57,8 @@ When enabled, uploaded images are sent to the API and replaced with the optimize
 Configure the integration from **Gm2 → ChatGPT** in your WordPress admin area. Enter your
 OpenAI API key and adjust these options:
 
-* **Model** – name of the model to use (defaults to `gpt-3.5-turbo`).
+* **Model** – select the model to use from a dropdown. Options are fetched from
+  OpenAI when possible (defaults to `gpt-3.5-turbo`).
 * **Temperature** – controls randomness of responses.
 * **Max Tokens** – optional limit on the length of completions.
 * **API Endpoint** – URL of the chat completions API.

--- a/tests/test-chatgpt.php
+++ b/tests/test-chatgpt.php
@@ -62,6 +62,15 @@ class ChatGPTTest extends WP_UnitTestCase {
         $this->assertStringContainsString('gm2_chatgpt_max_tokens', $out);
         $this->assertStringContainsString('gm2_chatgpt_endpoint', $out);
     }
+
+    public function test_chatgpt_page_model_dropdown() {
+        $admin = new Gm2_Admin();
+        ob_start();
+        $admin->display_chatgpt_page();
+        $out = ob_get_clean();
+        $this->assertStringContainsString('<select id="gm2_chatgpt_model"', $out);
+        $this->assertMatchesRegularExpression('/<select[^>]*id="gm2_chatgpt_model"[^>]*>.*<option/i', $out);
+    }
 }
 
 class ChatGPTAjaxTest extends WP_Ajax_UnitTestCase {


### PR DESCRIPTION
## Summary
- fetch available models from OpenAI
- show dropdown of models on ChatGPT settings page
- describe dropdown behaviour in docs
- test for model dropdown output

## Testing
- `apt-get update`
- `apt-get install -y php-cli phpunit`
- `phpunit` *(fails: cannot find WordPress test suite)*

------
https://chatgpt.com/codex/tasks/task_e_686d98e8d7a483279992b66a5ba2a967