### PR TITLE
Add warnings for missing Google API data

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -456,6 +456,13 @@ class Gm2_SEO_Admin {
             if (!$accounts) {
                 $accounts = $oauth->list_ads_accounts();
             }
+
+            if (empty($properties)) {
+                $notice .= '<div class="error notice"><p>' . esc_html__('No Analytics properties found. Check API permissions.', 'gm2-wordpress-suite') . '</p></div>';
+            }
+            if (empty($accounts)) {
+                $notice .= '<div class="error notice"><p>' . esc_html__('No Ads accounts found. Check API permissions.', 'gm2-wordpress-suite') . '</p></div>';
+            }
         }
 
         echo '<div class="wrap">';

--- a/tests/test-connect-page.php
+++ b/tests/test-connect-page.php
@@ -91,4 +91,40 @@ class GoogleConnectPageTest extends WP_UnitTestCase {
         $this->assertStringContainsString('123', $output);
         $this->assertStringContainsString('456', $output);
     }
+
+    public function test_notice_shown_when_no_properties() {
+        delete_option('gm2_google_refresh_token');
+        add_filter('gm2_google_oauth_instance', function() {
+            return new class {
+                public function is_connected() { return true; }
+                public function get_auth_url() { return ''; }
+                public function handle_callback($code) { return true; }
+                public function list_analytics_properties() { return []; }
+                public function list_ads_accounts() { return []; }
+            };
+        });
+        $admin = new Gm2_SEO_Admin();
+        ob_start();
+        $admin->display_google_connect_page();
+        $output = ob_get_clean();
+        $this->assertStringContainsString('No Analytics properties found', $output);
+    }
+
+    public function test_notice_shown_when_no_ads_accounts() {
+        delete_option('gm2_google_refresh_token');
+        add_filter('gm2_google_oauth_instance', function() {
+            return new class {
+                public function is_connected() { return true; }
+                public function get_auth_url() { return ''; }
+                public function handle_callback($code) { return true; }
+                public function list_analytics_properties() { return ['G-1' => 'Site 1']; }
+                public function list_ads_accounts() { return []; }
+            };
+        });
+        $admin = new Gm2_SEO_Admin();
+        ob_start();
+        $admin->display_google_connect_page();
+        $output = ob_get_clean();
+        $this->assertStringContainsString('No Ads accounts found', $output);
+    }
 }


### PR DESCRIPTION
## Summary
- notify when Analytics properties or Ads accounts are missing
- test admin notices for empty results

## Testing
- `php -l admin/Gm2_SEO_Admin.php`
- `php -l tests/test-connect-page.php`
- `phpunit` *(fails: requires WordPress tests)*

------
https://chatgpt.com/codex/tasks/task_e_686d9973bcf88327b6d1353a53d7c3bb