### PR TITLE
Add Google disconnect option

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -412,6 +412,11 @@ class Gm2_SEO_Admin {
         $properties = [];
         $accounts   = [];
 
+        if (isset($_POST['gm2_google_disconnect']) && wp_verify_nonce($_POST['gm2_google_disconnect'], 'gm2_google_disconnect')) {
+            $oauth->disconnect();
+            $notice = '<div class="updated notice"><p>' . esc_html__('Google account disconnected.', 'gm2-wordpress-suite') . '</p></div>';
+        }
+
         if (isset($_POST['gm2_ga_property_nonce']) && wp_verify_nonce($_POST['gm2_ga_property_nonce'], 'gm2_ga_property_save')) {
             $prop = sanitize_text_field(wp_unslash($_POST['gm2_ga_property'] ?? ''));
             if ($prop !== '') {
@@ -504,6 +509,11 @@ class Gm2_SEO_Admin {
                 submit_button(__('Save Ads Account', 'gm2-wordpress-suite'));
                 echo '</form>';
             }
+
+            echo '<form method="post">';
+            wp_nonce_field('gm2_google_disconnect', 'gm2_google_disconnect');
+            submit_button(__('Disconnect Google', 'gm2-wordpress-suite'), 'delete');
+            echo '</form>';
         }
         echo '</div>';
     }

--- a/includes/Gm2_Google_OAuth.php
+++ b/includes/Gm2_Google_OAuth.php
@@ -249,4 +249,13 @@ class Gm2_Google_OAuth {
         }
         return $list;
     }
+
+    public function disconnect() {
+        delete_option('gm2_google_refresh_token');
+        delete_option('gm2_google_access_token');
+        delete_option('gm2_google_expires_at');
+        delete_option('gm2_google_profile');
+        delete_option('gm2_ga_measurement_id');
+        delete_option('gm2_gads_customer_id');
+    }
 }

--- a/tests/test-connect-page.php
+++ b/tests/test-connect-page.php
@@ -148,4 +148,14 @@ class GoogleConnectPageTest extends WP_UnitTestCase {
         $output = ob_get_clean();
         $this->assertStringContainsString('No Ads accounts found', $output);
     }
+
+    public function test_disconnect_form_removes_token() {
+        update_option('gm2_google_refresh_token', 'tok');
+        $_POST['gm2_google_disconnect'] = wp_create_nonce('gm2_google_disconnect');
+        $admin = new Gm2_SEO_Admin();
+        ob_start();
+        $admin->display_google_connect_page();
+        ob_end_clean();
+        $this->assertSame('', get_option('gm2_google_refresh_token'));
+    }
 }


### PR DESCRIPTION
## Summary
- add `disconnect` method for Google OAuth
- handle disconnect form in settings page
- display a disconnect button when connected
- test disconnect removes refresh token

## Testing
- `phpunit -c phpunit.xml --filter test_disconnect_form_removes_token` *(fails: Error opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_686d9e5af3388327942a06e4a2b89152