### PR TITLE
Add helper text for ID fields and clarify docs

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -156,6 +156,7 @@ class Gm2_SEO_Admin {
             function () {
                 $value = get_option('gm2_ga_measurement_id', '');
                 echo '<input type="text" name="gm2_ga_measurement_id" value="' . esc_attr($value) . '" class="regular-text" />';
+                echo '<p class="description">Use <strong>SEO → Connect Google Account</strong> to fetch available IDs.</p>';
             },
             'gm2_seo',
             'gm2_seo_main'
@@ -192,6 +193,7 @@ class Gm2_SEO_Admin {
             function () {
                 $value = get_option('gm2_gads_customer_id', '');
                 echo '<input type="text" name="gm2_gads_customer_id" value="' . esc_attr($value) . '" class="regular-text" />';
+                echo '<p class="description">Use <strong>SEO → Connect Google Account</strong> to fetch available IDs.</p>';
             },
             'gm2_seo',
             'gm2_seo_main'

--- a/readme.txt
+++ b/readme.txt
@@ -24,6 +24,9 @@ A powerful suite of WordPress enhancements including admin tools, frontend optim
    directly from your Google accounts. The developer token is required for
    listing Ads accounts. These values cannot be fetched via API and must be
    entered manually on the SEO settings page.
+6. Select your Analytics Measurement ID and Ads Customer ID on the
+   **SEO → Connect Google Account** page after connecting. These IDs cannot be
+   entered manually on the SEO settings screen.
 
 If you plan to distribute or manually upload the plugin, you can create a ZIP
 archive with `bash bin/build-plugin.sh`. This command packages the plugin with


### PR DESCRIPTION
## Summary
- show Connect page hint under Google ID fields on the SEO settings page
- document that ID selection occurs on the Connect page

## Testing
- `phpunit -v` *(fails: command not found)*
- `php -l admin/Gm2_SEO_Admin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686da083e078832797ff4a624f12402b