### PR TITLE
Improve Ads account listing error handling

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -450,7 +450,10 @@ class Gm2_SEO_Admin {
                     update_option('gm2_ga_measurement_id', array_key_first($properties));
                 }
                 $accounts = $oauth->list_ads_accounts();
-                if (!empty($accounts) && '' === get_option('gm2_gads_customer_id', '')) {
+                if (is_wp_error($accounts)) {
+                    $notice .= '<div class="error notice"><p>' . esc_html($accounts->get_error_message()) . '</p></div>';
+                    $accounts = [];
+                } elseif (!empty($accounts) && '' === get_option('gm2_gads_customer_id', '')) {
                     update_option('gm2_gads_customer_id', array_key_first($accounts));
                 }
             }
@@ -462,6 +465,10 @@ class Gm2_SEO_Admin {
             }
             if (!$accounts) {
                 $accounts = $oauth->list_ads_accounts();
+            }
+            if (is_wp_error($accounts)) {
+                $notice .= '<div class="error notice"><p>' . esc_html($accounts->get_error_message()) . '</p></div>';
+                $accounts = [];
             }
 
             if (empty($properties)) {

--- a/includes/Gm2_Google_OAuth.php
+++ b/includes/Gm2_Google_OAuth.php
@@ -234,7 +234,13 @@ class Gm2_Google_OAuth {
         if (!$access) {
             return [];
         }
-        $token = get_option('gm2_gads_developer_token', '');
+        $token = trim(get_option('gm2_gads_developer_token', ''));
+        if ($token === '') {
+            return new \WP_Error(
+                'missing_developer_token',
+                __('A Google Ads developer token is required to list accounts.', 'gm2-wordpress-suite')
+            );
+        }
         $resp = $this->api_request('GET', 'https://googleads.googleapis.com/v15/customers:listAccessibleCustomers', null, [
             'Authorization'   => 'Bearer ' . $access,
             'developer-token' => $token,

--- a/tests/test-oauth.php
+++ b/tests/test-oauth.php
@@ -88,6 +88,19 @@ class OAuthTest extends WP_UnitTestCase {
         $this->assertSame('devtoken', $captured['headers']['developer-token']);
     }
 
+    public function test_error_returned_when_no_developer_token() {
+        update_option('gm2_google_refresh_token', 'refresh');
+        update_option('gm2_google_access_token', 'access');
+        update_option('gm2_google_expires_at', time() + 3600);
+        delete_option('gm2_gads_developer_token');
+
+        $oauth  = new Gm2_Google_OAuth();
+        $result = $oauth->list_ads_accounts();
+
+        $this->assertInstanceOf('WP_Error', $result);
+        $this->assertSame('missing_developer_token', $result->get_error_code());
+    }
+
     public function test_ga4_properties_returned() {
         update_option('gm2_google_refresh_token', 'refresh');
         update_option('gm2_google_access_token', 'access');


### PR DESCRIPTION
## Summary
- guard against missing Google Ads developer token in Gm2_Google_OAuth
- surface the WP_Error on the Connect page
- test the new behaviour

## Testing
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_686da14d23ec8327b8f7640893a2bdd5