### PR TITLE
Improve Google token instructions

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -168,7 +168,7 @@ class Gm2_SEO_Admin {
             function () {
                 $value = get_option('gm2_search_console_verification', '');
                 echo '<input type="text" name="gm2_search_console_verification" value="' . esc_attr($value) . '" class="regular-text" />';
-                echo '<p class="description">Enter this code manually from Search Console. It cannot be retrieved automatically.</p>';
+                echo '<p class="description">Log in to <a href="https://search.google.com/search-console" target="_blank">Search Console</a>, open <strong>Settings → Ownership verification</strong> and choose the <em>HTML tag</em> option. Copy the code shown there and paste it here.</p>';
             },
             'gm2_seo',
             'gm2_seo_main'
@@ -180,7 +180,7 @@ class Gm2_SEO_Admin {
             function () {
                 $value = get_option('gm2_gads_developer_token', '');
                 echo '<input type="text" name="gm2_gads_developer_token" value="' . esc_attr($value) . '" class="regular-text" />';
-                echo '<p class="description">This token must be generated in your Google Ads account and entered here manually.</p>';
+                echo '<p class="description">Sign in at <a href="https://ads.google.com" target="_blank">Google Ads</a> and open <strong>Tools → API Center</strong>. Copy your <strong>Developer token</strong> and paste it here.</p>';
             },
             'gm2_seo',
             'gm2_seo_main'

--- a/readme.txt
+++ b/readme.txt
@@ -20,10 +20,10 @@ A powerful suite of WordPress enhancements including admin tools, frontend optim
    Finally, use **SEO → Connect Google Account** to authorize your Google account. After connecting, you will be able to select your Analytics Measurement ID and Ads Customer ID from dropdown menus.
 4. All required PHP libraries, including the Google API client, are bundled in
    the plugin. No additional installation steps are required.
-5. Obtain your Search Console verification code and Google Ads developer token
-   directly from your Google accounts. The developer token is required for
-   listing Ads accounts. These values cannot be fetched via API and must be
-   entered manually on the SEO settings page.
+5. Follow the steps in the **Google integration** section below to copy your
+   Search Console verification code and Google Ads developer token. These values
+   cannot be fetched via API and must be entered manually on the SEO settings
+   page.
 6. Select your Analytics Measurement ID and Ads Customer ID on the
    **SEO → Connect Google Account** page after connecting. These IDs cannot be
    entered manually on the SEO settings screen.
@@ -32,6 +32,12 @@ If you plan to distribute or manually upload the plugin, you can create a ZIP
 archive with `bash bin/build-plugin.sh`. This command packages the plugin with
 all dependencies into `gm2-wordpress-suite.zip` for installation via the
 **Plugins → Add New** screen.
+
+== Google integration ==
+These credentials must be copied from your Google accounts:
+
+* **Search Console verification code** – Log in to <https://search.google.com/search-console>, open **Settings → Ownership verification**, and choose the *HTML tag* option. Copy the code displayed in the meta tag and paste it into the **Search Console Verification Code** field on the SEO settings page. See <https://support.google.com/webmasters/answer/9008080> for details.
+* **Google Ads developer token** – Sign in at <https://ads.google.com>, then go to **Tools → API Center**. Copy your **Developer token** and enter it into the **Google Ads Developer Token** field. Documentation: <https://developers.google.com/google-ads/api/docs/first-call/dev-token>.
 
 == Breadcrumbs ==
 Display a breadcrumb trail anywhere using the `[gm2_breadcrumbs]` shortcode. The output


### PR DESCRIPTION
## Summary
- clarify where to find the Search Console verification code and Ads developer token
- add Google integration instructions in the readme

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686da768a5f0832787c32285d1d33d18