### PR TITLE
Update Google Ads API version constant

### DIFF
--- a/includes/Gm2_Google_OAuth.php
+++ b/includes/Gm2_Google_OAuth.php
@@ -7,6 +7,9 @@ if (!defined('ABSPATH')) {
 }
 
 class Gm2_Google_OAuth {
+    /** Latest supported Google Ads API version. */
+    public const GOOGLE_ADS_API_VERSION = 'v17';
+
     private $client_id;
     private $client_secret;
     private $redirect_uri;
@@ -253,7 +256,8 @@ class Gm2_Google_OAuth {
                 __('A Google Ads developer token is required to list accounts.', 'gm2-wordpress-suite')
             );
         }
-        $resp = $this->api_request('GET', 'https://googleads.googleapis.com/v15/customers:listAccessibleCustomers', null, [
+        $url  = sprintf('https://googleads.googleapis.com/%s/customers:listAccessibleCustomers', self::GOOGLE_ADS_API_VERSION);
+        $resp = $this->api_request('GET', $url, null, [
             'Authorization'   => 'Bearer ' . $access,
             'developer-token' => $token,
         ]);

--- a/includes/Gm2_Keyword_Planner.php
+++ b/includes/Gm2_Keyword_Planner.php
@@ -31,7 +31,7 @@ class Gm2_Keyword_Planner {
             return new \WP_Error('no_token', 'Unable to obtain access token');
         }
 
-        $url = sprintf('https://googleads.googleapis.com/v15/customers/%s:generateKeywordIdeas', $creds['customer_id']);
+        $url = sprintf('https://googleads.googleapis.com/%s/customers/%s:generateKeywordIdeas', \Gm2\Gm2_Google_OAuth::GOOGLE_ADS_API_VERSION, $creds['customer_id']);
 
         $body = [
             'customerId' => $creds['customer_id'],

--- a/readme.txt
+++ b/readme.txt
@@ -38,6 +38,7 @@ These credentials must be copied from your Google accounts:
 
 * **Search Console verification code** – Log in to <https://search.google.com/search-console>, open **Settings → Ownership verification**, and choose the *HTML tag* option. Copy the code displayed in the meta tag and paste it into the **Search Console Verification Code** field on the SEO settings page. See <https://support.google.com/webmasters/answer/9008080> for details.
 * **Google Ads developer token** – Sign in at <https://ads.google.com>, then go to **Tools → API Center**. Copy your **Developer token** and enter it into the **Google Ads Developer Token** field. Documentation: <https://developers.google.com/google-ads/api/docs/first-call/dev-token>.
+* **Google Ads API version** – The plugin uses the API version defined by the `Gm2_Google_OAuth::GOOGLE_ADS_API_VERSION` constant (default `v17`). Update this constant and any tests referencing it when a new Ads API version becomes available.
 
 == Troubleshooting ==
 If you see errors when connecting your Google account:

--- a/tests/test-oauth.php
+++ b/tests/test-oauth.php
@@ -67,8 +67,9 @@ class OAuthTest extends WP_UnitTestCase {
         update_option('gm2_gads_developer_token', 'devtoken');
 
         $captured = null;
-        $filter   = function ($pre, $args, $url) use (&$captured) {
-            if (0 === strpos($url, 'https://googleads.googleapis.com/v15/customers:listAccessibleCustomers')) {
+        $expected = 'https://googleads.googleapis.com/' . Gm2_Google_OAuth::GOOGLE_ADS_API_VERSION . '/customers:listAccessibleCustomers';
+        $filter   = function ($pre, $args, $url) use (&$captured, $expected) {
+            if (0 === strpos($url, $expected)) {
                 $captured = $args;
                 return [
                     'response' => ['code' => 200],


### PR DESCRIPTION
## Summary
- add `GOOGLE_ADS_API_VERSION` constant
- use the constant instead of hard-coded `v15`
- update tests for new constant
- document the constant in readme

## Testing
- `php -l includes/Gm2_Google_OAuth.php`
- `php -l includes/Gm2_Keyword_Planner.php`
- `php -l tests/test-oauth.php`
- `phpunit` *(fails: failed to open wordpress-tests-lib)*

------
https://chatgpt.com/codex/tasks/task_e_686dc215eb04832789c5fc3cfa813576