### PR TITLE
Display API error body

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -456,13 +456,22 @@ class Gm2_SEO_Admin {
                 $notice     = '<div class="updated notice"><p>' . esc_html__('Google account connected.', 'gm2-wordpress-suite') . '</p></div>';
                 $properties = $oauth->list_analytics_properties();
                 if (is_wp_error($properties)) {
-                    $notice .= '<div class="error notice"><p>' . esc_html($properties->get_error_message()) . '</p>' . $help . '</div>';
+                    $notice .= '<div class="error notice"><p>' . esc_html($properties->get_error_message()) . '</p>';
+                    $data = $properties->get_error_data();
+                    if (!empty($data['body'])) {
+                        $notice .= '<pre>' . esc_html(trim($data['body'])) . '</pre>';
+                    }
+                    $notice .= $help . '</div>';
                 } elseif (!empty($properties) && '' === get_option('gm2_ga_measurement_id', '')) {
                     update_option('gm2_ga_measurement_id', is_array($properties) ? array_key_first($properties) : '');
                 }
                 $accounts = $oauth->list_ads_accounts();
                 if (is_wp_error($accounts)) {
                     $msg = '<div class="error notice"><p>' . esc_html($accounts->get_error_message()) . '</p>';
+                    $data = $accounts->get_error_data();
+                    if (!empty($data['body'])) {
+                        $msg .= '<pre>' . esc_html(trim($data['body'])) . '</pre>';
+                    }
                     if ('missing_developer_token' === $accounts->get_error_code()) {
                         $msg .= '<p>' . esc_html__( 'Sign in at Google Ads and open Tools → API Center. Copy your Developer token and enter it on the OAuth setup page.', 'gm2-wordpress-suite' ) . '</p>';
                     } else {
@@ -481,13 +490,22 @@ class Gm2_SEO_Admin {
                 $properties = $oauth->list_analytics_properties();
             }
             if (is_wp_error($properties)) {
-                $notice .= '<div class="error notice"><p>' . esc_html($properties->get_error_message()) . '</p>' . $help . '</div>';
+                $notice .= '<div class="error notice"><p>' . esc_html($properties->get_error_message()) . '</p>';
+                $data = $properties->get_error_data();
+                if (!empty($data['body'])) {
+                    $notice .= '<pre>' . esc_html(trim($data['body'])) . '</pre>';
+                }
+                $notice .= $help . '</div>';
             }
             if (!$accounts) {
                 $accounts = $oauth->list_ads_accounts();
             }
             if (is_wp_error($accounts)) {
                 $msg = '<div class="error notice"><p>' . esc_html($accounts->get_error_message()) . '</p>';
+                $data = $accounts->get_error_data();
+                if (!empty($data['body'])) {
+                    $msg .= '<pre>' . esc_html(trim($data['body'])) . '</pre>';
+                }
                 if ('missing_developer_token' === $accounts->get_error_code()) {
                     $msg .= '<p>' . esc_html__( 'Sign in at Google Ads and open Tools → API Center. Copy your Developer token and enter it on the OAuth setup page.', 'gm2-wordpress-suite' ) . '</p>';
                 } else {

--- a/tests/test-connect-page.php
+++ b/tests/test-connect-page.php
@@ -180,7 +180,9 @@ class GoogleConnectPageTest extends WP_UnitTestCase {
                 public function get_auth_url() { return ''; }
                 public function handle_callback($code) { return true; }
                 public function list_analytics_properties() {
-                    return new WP_Error('api_error', 'HTTP 500 response');
+                    return new WP_Error('api_error', 'HTTP 500 response', [
+                        'body' => 'Server error',
+                    ]);
                 }
                 public function list_ads_accounts() { return []; }
             };
@@ -190,6 +192,7 @@ class GoogleConnectPageTest extends WP_UnitTestCase {
         $admin->display_google_connect_page();
         $output = ob_get_clean();
         $this->assertStringContainsString('HTTP 500 response', $output);
+        $this->assertStringContainsString('Server error', $output);
         $this->assertStringContainsString('enable the Analytics', $output);
     }
 
@@ -223,7 +226,9 @@ class GoogleConnectPageTest extends WP_UnitTestCase {
                 public function handle_callback($code) { return true; }
                 public function list_analytics_properties() { return ['G-1' => 'Site']; }
                 public function list_ads_accounts() {
-                    return new WP_Error('api_error', 'HTTP 500 response');
+                    return new WP_Error('api_error', 'HTTP 500 response', [
+                        'body' => 'Server error',
+                    ]);
                 }
             };
         });
@@ -232,6 +237,7 @@ class GoogleConnectPageTest extends WP_UnitTestCase {
         $admin->display_google_connect_page();
         $output = ob_get_clean();
         $this->assertStringContainsString('HTTP 500 response', $output);
+        $this->assertStringContainsString('Server error', $output);
         $this->assertStringContainsString('enable the Analytics', $output);
     }
 


### PR DESCRIPTION
## Summary
- show API error response bodies when listing analytics properties or ads accounts
- expect body text in connect page error tests

## Testing
- `phpunit` *(fails: missing wordpress-tests-lib)*

------
https://chatgpt.com/codex/tasks/task_e_686dd26f5fe88327947ecee5b8e8002f