### PR TITLE
Add GA Admin API version constant and bump Ads API

### DIFF
--- a/includes/Gm2_Google_OAuth.php
+++ b/includes/Gm2_Google_OAuth.php
@@ -8,7 +8,10 @@ if (!defined('ABSPATH')) {
 
 class Gm2_Google_OAuth {
     /** Latest supported Google Ads API version. */
-    public const GOOGLE_ADS_API_VERSION = 'v17';
+    public const GOOGLE_ADS_API_VERSION = 'v18';
+
+    /** Latest supported Analytics Admin API version for GA4 requests. */
+    public const ANALYTICS_ADMIN_API_VERSION = 'v1beta';
 
     private $client_id;
     private $client_secret;
@@ -159,9 +162,14 @@ class Gm2_Google_OAuth {
         $last_error  = null;
 
         // GA4 properties via Analytics Admin API.
-        $accounts = $this->api_request('GET', 'https://analyticsadmin.googleapis.com/v1/accountSummaries', null, [
+        $accounts = $this->api_request(
+            'GET',
+            sprintf('https://analyticsadmin.googleapis.com/%s/accountSummaries', self::ANALYTICS_ADMIN_API_VERSION),
+            null,
+            [
             'Authorization' => 'Bearer ' . $token,
-        ]);
+            ]
+        );
         if (is_wp_error($accounts)) {
             return $accounts;
         }
@@ -174,9 +182,18 @@ class Gm2_Google_OAuth {
                     $propName = $p['displayName'] ?? $p['property'];
                     $propId   = $p['property'];
                     // Query for web data streams to get measurement ID.
-                    $streams = $this->api_request('GET', sprintf('https://analyticsadmin.googleapis.com/v1/%s/dataStreams', $propId), null, [
-                        'Authorization' => 'Bearer ' . $token,
-                    ]);
+                    $streams = $this->api_request(
+                        'GET',
+                        sprintf(
+                            'https://analyticsadmin.googleapis.com/%s/%s/dataStreams',
+                            self::ANALYTICS_ADMIN_API_VERSION,
+                            $propId
+                        ),
+                        null,
+                        [
+                            'Authorization' => 'Bearer ' . $token,
+                        ]
+                    );
                     if (is_wp_error($streams)) {
                         $had_error  = true;
                         $last_error = $streams;

--- a/readme.txt
+++ b/readme.txt
@@ -38,7 +38,8 @@ These credentials must be copied from your Google accounts:
 
 * **Search Console verification code** – Log in to <https://search.google.com/search-console>, open **Settings → Ownership verification**, and choose the *HTML tag* option. Copy the code displayed in the meta tag and paste it into the **Search Console Verification Code** field on the SEO settings page. See <https://support.google.com/webmasters/answer/9008080> for details.
 * **Google Ads developer token** – Sign in at <https://ads.google.com>, then go to **Tools → API Center**. Copy your **Developer token** and enter it into the **Google Ads Developer Token** field. Documentation: <https://developers.google.com/google-ads/api/docs/first-call/dev-token>.
-* **Google Ads API version** – The plugin uses the API version defined by the `Gm2_Google_OAuth::GOOGLE_ADS_API_VERSION` constant (default `v17`). Update this constant and any tests referencing it when a new Ads API version becomes available.
+* **Google Ads API version** – The plugin uses the API version defined by the `Gm2_Google_OAuth::GOOGLE_ADS_API_VERSION` constant (default `v18`). Update this constant and any tests referencing it when a new Ads API version becomes available.
+* **Analytics Admin API version** – The GA4 endpoints use the version specified by `Gm2_Google_OAuth::ANALYTICS_ADMIN_API_VERSION` (default `v1beta`). Update this constant along with related tests when Google releases a new version.
 
 == Troubleshooting ==
 If you see errors when connecting your Google account:

--- a/tests/test-oauth.php
+++ b/tests/test-oauth.php
@@ -108,7 +108,11 @@ class OAuthTest extends WP_UnitTestCase {
         update_option('gm2_google_expires_at', time() + 3600);
 
         $filter = function ($pre, $args, $url) {
-            if (0 === strpos($url, 'https://analyticsadmin.googleapis.com/v1/accountSummaries')) {
+            $acct_url = sprintf(
+                'https://analyticsadmin.googleapis.com/%s/accountSummaries',
+                Gm2_Google_OAuth::ANALYTICS_ADMIN_API_VERSION
+            );
+            if (0 === strpos($url, $acct_url)) {
                 return [
                     'response' => ['code' => 200],
                     'body'     => json_encode([
@@ -125,7 +129,11 @@ class OAuthTest extends WP_UnitTestCase {
                     ]),
                 ];
             }
-            if (0 === strpos($url, 'https://analyticsadmin.googleapis.com/v1/properties/123/dataStreams')) {
+            $stream_url = sprintf(
+                'https://analyticsadmin.googleapis.com/%s/properties/123/dataStreams',
+                Gm2_Google_OAuth::ANALYTICS_ADMIN_API_VERSION
+            );
+            if (0 === strpos($url, $stream_url)) {
                 return [
                     'response' => ['code' => 200],
                     'body'     => json_encode([
@@ -188,7 +196,11 @@ class OAuthTest extends WP_UnitTestCase {
         update_option('gm2_google_expires_at', time() + 3600);
 
         $filter = function ($pre, $args, $url) {
-            if (0 === strpos($url, 'https://analyticsadmin.googleapis.com/v1/accountSummaries')) {
+            $acct_url = sprintf(
+                'https://analyticsadmin.googleapis.com/%s/accountSummaries',
+                Gm2_Google_OAuth::ANALYTICS_ADMIN_API_VERSION
+            );
+            if (0 === strpos($url, $acct_url)) {
                 return [
                     'response' => ['code' => 200],
                     'body'     => json_encode([
@@ -204,11 +216,19 @@ class OAuthTest extends WP_UnitTestCase {
                 ];
             }
 
-            if (0 === strpos($url, 'https://analyticsadmin.googleapis.com/v1/properties/123/dataStreams')) {
+            $stream_a = sprintf(
+                'https://analyticsadmin.googleapis.com/%s/properties/123/dataStreams',
+                Gm2_Google_OAuth::ANALYTICS_ADMIN_API_VERSION
+            );
+            if (0 === strpos($url, $stream_a)) {
                 return new WP_Error('fail', 'oops');
             }
 
-            if (0 === strpos($url, 'https://analyticsadmin.googleapis.com/v1/properties/456/dataStreams')) {
+            $stream_b = sprintf(
+                'https://analyticsadmin.googleapis.com/%s/properties/456/dataStreams',
+                Gm2_Google_OAuth::ANALYTICS_ADMIN_API_VERSION
+            );
+            if (0 === strpos($url, $stream_b)) {
                 return [
                     'response' => ['code' => 200],
                     'body'     => json_encode([


### PR DESCRIPTION
## Summary
- add `ANALYTICS_ADMIN_API_VERSION` constant
- bump Google Ads API version to v18
- use the new constant in GA4 endpoints
- document both API version constants
- update OAuth unit tests to use these constants

## Testing
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_686dd5449a108327b0ac6d276cdac7bc