### PR TITLE
Update wording for Google Ads API Center

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -180,7 +180,7 @@ class Gm2_SEO_Admin {
             function () {
                 $value = get_option('gm2_gads_developer_token', '');
                 echo '<input type="text" name="gm2_gads_developer_token" value="' . esc_attr($value) . '" class="regular-text" />';
-                echo '<p class="description">Sign in at <a href="https://ads.google.com" target="_blank">Google Ads</a> and open <strong>Tools → API Center</strong>. Copy your <strong>Developer token</strong> and paste it here.</p>';
+                echo '<p class="description">Sign in at <a href="https://ads.google.com/aw/apicenter" target="_blank">Google Ads</a> and open <strong>Tools & Settings → Setup → API Center</strong> (manager account required). Copy your <strong>Developer token</strong> and paste it here.</p>';
             },
             'gm2_seo',
             'gm2_seo_main'
@@ -473,7 +473,7 @@ class Gm2_SEO_Admin {
                         $msg .= '<pre>' . esc_html(trim($data['body'])) . '</pre>';
                     }
                     if ('missing_developer_token' === $accounts->get_error_code()) {
-                        $msg .= '<p>' . esc_html__( 'Sign in at Google Ads and open Tools → API Center. Copy your Developer token and enter it on the OAuth setup page.', 'gm2-wordpress-suite' ) . '</p>';
+                        $msg .= '<p>' . esc_html__( 'Sign in at Google Ads and open Tools & Settings → Setup → API Center (manager account required). Copy your Developer token and enter it on the OAuth setup page.', 'gm2-wordpress-suite' ) . '</p>';
                     } else {
                         $msg .= $help;
                     }
@@ -507,7 +507,7 @@ class Gm2_SEO_Admin {
                     $msg .= '<pre>' . esc_html(trim($data['body'])) . '</pre>';
                 }
                 if ('missing_developer_token' === $accounts->get_error_code()) {
-                    $msg .= '<p>' . esc_html__( 'Sign in at Google Ads and open Tools → API Center. Copy your Developer token and enter it on the OAuth setup page.', 'gm2-wordpress-suite' ) . '</p>';
+                    $msg .= '<p>' . esc_html__( 'Sign in at Google Ads and open Tools & Settings → Setup → API Center (manager account required). Copy your Developer token and enter it on the OAuth setup page.', 'gm2-wordpress-suite' ) . '</p>';
                 } else {
                     $msg .= $help;
                 }

--- a/readme.txt
+++ b/readme.txt
@@ -37,14 +37,14 @@ all dependencies into `gm2-wordpress-suite.zip` for installation via the
 These credentials must be copied from your Google accounts:
 
 * **Search Console verification code** – Log in to <https://search.google.com/search-console>, open **Settings → Ownership verification**, and choose the *HTML tag* option. Copy the code displayed in the meta tag and paste it into the **Search Console Verification Code** field on the SEO settings page. See <https://support.google.com/webmasters/answer/9008080> for details.
-* **Google Ads developer token** – Sign in at <https://ads.google.com>, then go to **Tools → API Center**. Copy your **Developer token** and enter it into the **Google Ads Developer Token** field. Documentation: <https://developers.google.com/google-ads/api/docs/first-call/dev-token>.
+* **Google Ads developer token** – Sign in at <https://ads.google.com/aw/apicenter> and open **Tools & Settings → Setup → API Center** (manager account required). Copy your **Developer token** and enter it into the **Google Ads Developer Token** field. Documentation: <https://developers.google.com/google-ads/api/docs/first-call/dev-token>.
 * **Google Ads API version** – The plugin uses the API version defined by the `Gm2_Google_OAuth::GOOGLE_ADS_API_VERSION` constant (default `v18`). Update this constant and any tests referencing it when a new Ads API version becomes available.
 * **Analytics Admin API version** – The GA4 endpoints use the version specified by `Gm2_Google_OAuth::ANALYTICS_ADMIN_API_VERSION` (default `v1beta`). Update this constant along with related tests when Google releases a new version.
 
 == Troubleshooting ==
 If you see errors when connecting your Google account:
 
-* **Missing developer token** – Sign in at <https://ads.google.com> and open **Tools → API Center**. Copy your **Developer token** and enter it on the OAuth setup page.
+* **Missing developer token** – Sign in at <https://ads.google.com/aw/apicenter> and open **Tools & Settings → Setup → API Center** (manager account required). Copy your **Developer token** and enter it on the OAuth setup page.
 * **No Analytics properties found** or **No Ads accounts found** –
   * Enable the Analytics Admin, Google Analytics (v3) for UA properties, Search Console, and Google Ads APIs for your OAuth client.
   * Confirm the connected Google account can access the required properties and accounts. The OAuth client can belong to a different Google account.

--- a/tests/test-connect-page.php
+++ b/tests/test-connect-page.php
@@ -169,7 +169,7 @@ class GoogleConnectPageTest extends WP_UnitTestCase {
         $admin->display_google_connect_page();
         $output = ob_get_clean();
         $this->assertStringContainsString('developer token', $output);
-        $this->assertStringContainsString('Tools → API Center', $output);
+        $this->assertStringContainsString('Tools & Settings → Setup → API Center', $output);
     }
 
     public function test_error_displayed_when_analytics_api_fails() {


### PR DESCRIPTION
## Summary
- clarify API Center location and add manager account requirement
- update admin-facing text and OAuth error messages to show new location
- update unit test expectation for the new phrase

## Testing
- `phpunit` *(fails: missing WordPress test suite)*

------
https://chatgpt.com/codex/tasks/task_e_686dd8ee144c8327b79495e76026064f