### PR TITLE
Improve keyword research error reporting

### DIFF
--- a/admin/js/gm2-keyword-research.js
+++ b/admin/js/gm2-keyword-research.js
@@ -8,15 +8,20 @@ jQuery(function($){
             action: 'gm2_keyword_ideas',
             query: kw,
             _ajax_nonce: gm2KeywordResearch.nonce
-        }, function(resp){
+        }).done(function(resp){
             $list.empty();
-            if(resp && resp.success && resp.data.length){
+            if(resp && resp.success && Array.isArray(resp.data)){
                 resp.data.forEach(function(k){
                     $('<li>').text(k).appendTo($list);
                 });
             } else {
-                $list.append($('<li>').text('No results'));
+                var msg = (resp && resp.data && typeof resp.data === 'string')
+                    ? resp.data
+                    : 'No results';
+                $list.append($('<li>').text(msg));
             }
+        }).fail(function(){
+            $list.empty().append($('<li>').text('Request failed'));
         });
     });
 });


### PR DESCRIPTION
## Summary
- better handling of keyword research AJAX errors
- show server-provided message when available
- display network failure message

## Testing
- `phpunit` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: no such file)*

------
https://chatgpt.com/codex/tasks/task_e_686ddb40bd7c83279e5f72107b9f429e