### PR TITLE
Fix disconnect cleanup and add regression test

### DIFF
--- a/includes/Gm2_Google_OAuth.php
+++ b/includes/Gm2_Google_OAuth.php
@@ -311,7 +311,5 @@ class Gm2_Google_OAuth {
         delete_option('gm2_google_access_token');
         delete_option('gm2_google_expires_at');
         delete_option('gm2_google_profile');
-        delete_option('gm2_ga_measurement_id');
-        delete_option('gm2_gads_customer_id');
     }
 }

--- a/tests/test-connect-page.php
+++ b/tests/test-connect-page.php
@@ -331,4 +331,20 @@ class GoogleConnectPageTest extends WP_UnitTestCase {
         ob_end_clean();
         $this->assertSame('', get_option('gm2_google_refresh_token'));
     }
+
+    public function test_disconnect_does_not_remove_saved_options() {
+        update_option('gm2_google_refresh_token', 'tok');
+        update_option('gm2_ga_measurement_id', 'G-1');
+        update_option('gm2_gads_customer_id', '123');
+
+        $_POST['gm2_google_disconnect'] = wp_create_nonce('gm2_google_disconnect');
+        $admin = new Gm2_SEO_Admin();
+        ob_start();
+        $admin->display_google_connect_page();
+        ob_end_clean();
+
+        $this->assertSame('', get_option('gm2_google_refresh_token'));
+        $this->assertSame('G-1', get_option('gm2_ga_measurement_id'));
+        $this->assertSame('123', get_option('gm2_gads_customer_id'));
+    }
 }


### PR DESCRIPTION
## Summary
- stop removing measurement/ads IDs when disconnecting OAuth tokens
- test that disconnect leaves measurement ID and Ads account ID intact

## Testing
- `php -l includes/Gm2_Google_OAuth.php`
- `php -l tests/test-connect-page.php`
- `phpunit` *(fails: missing WordPress test environment)*

------
https://chatgpt.com/codex/tasks/task_e_686de1b213c4832789c09ca82a7500e0