### PR TITLE
Return error on empty keyword ideas

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1026,7 +1026,7 @@ class Gm2_SEO_Admin {
         $planner = new Gm2_Keyword_Planner();
         $ideas   = $planner->generate_keyword_ideas($query);
         if (is_wp_error($ideas)) {
-            wp_send_json_error($ideas->get_error_message());
+            wp_send_json_error($ideas);
         }
 
         wp_send_json_success($ideas);

--- a/admin/js/gm2-keyword-research.js
+++ b/admin/js/gm2-keyword-research.js
@@ -15,9 +15,14 @@ jQuery(function($){
                     $('<li>').text(k).appendTo($list);
                 });
             } else {
-                var msg = (resp && resp.data && typeof resp.data === 'string')
-                    ? resp.data
-                    : 'No results';
+                var msg = 'No results';
+                if(resp && resp.data){
+                    if(typeof resp.data === 'string'){
+                        msg = resp.data;
+                    } else if(resp.data.message){
+                        msg = resp.data.message;
+                    }
+                }
                 $list.append($('<li>').text(msg));
             }
         }).fail(function(){

--- a/includes/Gm2_Keyword_Planner.php
+++ b/includes/Gm2_Keyword_Planner.php
@@ -72,6 +72,10 @@ class Gm2_Keyword_Planner {
             }
         }
 
+        if (empty($ideas)) {
+            return new \WP_Error('no_results', 'No keyword ideas found.');
+        }
+
         return $ideas;
     }
 }


### PR DESCRIPTION
## Summary
- return WP_Error when the keyword planner has no ideas
- propagate error object in `ajax_keyword_ideas`
- show returned message in keyword research UI

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686de3cc864c8327b623af3d5e489406