### PR TITLE
Fix keyword ideas error handling

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1039,7 +1039,7 @@ class Gm2_SEO_Admin {
         $planner = new Gm2_Keyword_Planner();
         $ideas   = $planner->generate_keyword_ideas($query);
         if (is_wp_error($ideas)) {
-            wp_send_json_error($ideas);
+            wp_send_json_error( $ideas->get_error_message() );
         }
 
         wp_send_json_success($ideas);


### PR DESCRIPTION
## Summary
- better AJAX error handling for keyword ideas

## Testing
- `phpunit -v` *(fails: missing WordPress test library)*

------
https://chatgpt.com/codex/tasks/task_e_686de8856dec83278d9c0c49a8117fca