### PR TITLE
Handle WP_Error responses in keyword research script

### DIFF
--- a/admin/js/gm2-keyword-research.js
+++ b/admin/js/gm2-keyword-research.js
@@ -24,6 +24,9 @@ jQuery(function($){
                         msg = resp.data;
                     } else if(resp.data.message){
                         msg = resp.data.message;
+                    } else if(resp.data && resp.data.errors){
+                        var code = Object.keys(resp.data.errors)[0];
+                        msg = resp.data.errors[code][0];
                     }
                 }
                 $list.append($('<li>').text(msg));


### PR DESCRIPTION
## Summary
- ensure WP_Error structures are parsed in gm2-keyword-research.js

## Testing
- `phpunit -c phpunit.xml` *(fails: missing WordPress test library)*

------
https://chatgpt.com/codex/tasks/task_e_686de9491f388327ae93f8474931a168