### PR TITLE
Extend Keyword Planner request with target defaults

### DIFF
--- a/includes/Gm2_Keyword_Planner.php
+++ b/includes/Gm2_Keyword_Planner.php
@@ -33,9 +33,20 @@ class Gm2_Keyword_Planner {
 
         $url = sprintf('https://googleads.googleapis.com/%s/customers/%s:generateKeywordIdeas', \Gm2\Gm2_Google_OAuth::GOOGLE_ADS_API_VERSION, $creds['customer_id']);
 
+        $language    = get_option('gm2_kwp_language', 'languageConstants/1000');
+        $geo_targets = get_option('gm2_kwp_geo_targets', 'geoTargetConstants/2840');
+        $network     = get_option('gm2_kwp_network', 'GOOGLE_SEARCH');
+
+        if (!is_array($geo_targets)) {
+            $geo_targets = array_filter(array_map('trim', explode(',', $geo_targets)));
+        }
+
         $body = [
-            'customerId' => $creds['customer_id'],
-            'keywordSeed' => [
+            'customerId'        => $creds['customer_id'],
+            'language'          => $language,
+            'geoTargetConstants'=> $geo_targets,
+            'keywordPlanNetwork'=> $network,
+            'keywordSeed'       => [
                 'keywords' => [$keyword],
             ],
         ];


### PR DESCRIPTION
## Summary
- add language, geo target and network defaults to Keyword Planner
- allow these values to be overridden with new options

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dfcd4937c8327b191207fd058e040