### PR TITLE
Add GAds language and geo target options

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -142,6 +142,12 @@ class Gm2_SEO_Admin {
         register_setting('gm2_seo_options', 'gm2_gads_customer_id', [
             'sanitize_callback' => 'sanitize_text_field',
         ]);
+        register_setting('gm2_seo_options', 'gm2_gads_language', [
+            'sanitize_callback' => 'sanitize_text_field',
+        ]);
+        register_setting('gm2_seo_options', 'gm2_gads_geo_target', [
+            'sanitize_callback' => 'sanitize_text_field',
+        ]);
 
         add_settings_section(
             'gm2_seo_main',
@@ -368,6 +374,20 @@ class Gm2_SEO_Admin {
             $enabled = trim(get_option('gm2_gads_developer_token', '')) !== '' &&
                 trim(get_option('gm2_gads_customer_id', '')) !== '' &&
                 get_option('gm2_google_refresh_token', '') !== '';
+
+            $lang = get_option('gm2_gads_language', 'languageConstants/1000');
+            $geo  = get_option('gm2_gads_geo_target', 'geoTargetConstants/2840');
+
+            echo '<form method="post" action="options.php">';
+            settings_fields('gm2_seo_options');
+            echo '<table class="form-table"><tbody>';
+            echo '<tr><th scope="row">Language Constant</th><td><input type="text" name="gm2_gads_language" id="gm2_gads_language" value="' . esc_attr($lang) . '" class="regular-text" /></td></tr>';
+            echo '<tr><th scope="row">Geo Target Constant</th><td><input type="text" name="gm2_gads_geo_target" id="gm2_gads_geo_target" value="' . esc_attr($geo) . '" class="regular-text" /></td></tr>';
+            echo '</tbody></table>';
+            echo '<p class="description">Defaults: English / United States.</p>';
+            submit_button('Save Settings');
+            echo '</form>';
+
             echo '<form id="gm2-keyword-research-form">';
             echo '<p><label for="gm2_seed_keyword">Seed Keyword</label>';
             echo '<input type="text" id="gm2_seed_keyword" class="regular-text" /></p>';

--- a/includes/Gm2_Keyword_Planner.php
+++ b/includes/Gm2_Keyword_Planner.php
@@ -33,8 +33,8 @@ class Gm2_Keyword_Planner {
 
         $url = sprintf('https://googleads.googleapis.com/%s/customers/%s:generateKeywordIdeas', \Gm2\Gm2_Google_OAuth::GOOGLE_ADS_API_VERSION, $creds['customer_id']);
 
-        $language    = get_option('gm2_kwp_language', 'languageConstants/1000');
-        $geo_targets = get_option('gm2_kwp_geo_targets', 'geoTargetConstants/2840');
+        $language    = get_option('gm2_gads_language', 'languageConstants/1000');
+        $geo_targets = get_option('gm2_gads_geo_target', 'geoTargetConstants/2840');
         $network     = get_option('gm2_kwp_network', 'GOOGLE_SEARCH');
 
         if (!is_array($geo_targets)) {


### PR DESCRIPTION
## Summary
- allow admins to set Google Ads language and geo target constants
- expose new settings on the Keyword Research tab
- use the saved values when calling the Google Ads API

## Testing
- `php -l admin/Gm2_SEO_Admin.php`
- `php -l includes/Gm2_Keyword_Planner.php`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_686e01d815ec8327832a0c302db62196