### PR TITLE
Sanitize Google Ads customer ID

### DIFF
--- a/includes/Gm2_Keyword_Planner.php
+++ b/includes/Gm2_Keyword_Planner.php
@@ -8,9 +8,10 @@ if (!defined('ABSPATH')) {
 
 class Gm2_Keyword_Planner {
     private function get_credentials() {
+        $id = preg_replace('/\D/', '', get_option('gm2_gads_customer_id', ''));
         return [
             'developer_token' => trim(get_option('gm2_gads_developer_token', '')),
-            'customer_id'     => trim(get_option('gm2_gads_customer_id', '')),
+            'customer_id'     => $id,
         ];
     }
 


### PR DESCRIPTION
## Summary
- sanitize `gm2_gads_customer_id` before returning credentials

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e06e8f8e0832784bf75f3ec973406