### PR TITLE
Add sanitizer for Google Ads customer ID

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -100,6 +100,10 @@ class Gm2_SEO_Admin {
         $this->setup_elementor_integration();
     }
 
+    public function sanitize_customer_id($value) {
+        return preg_replace('/\D/', '', $value);
+    }
+
     public function add_settings_pages() {
         add_submenu_page(
             'gm2',
@@ -140,7 +144,7 @@ class Gm2_SEO_Admin {
             'sanitize_callback' => 'sanitize_text_field',
         ]);
         register_setting('gm2_seo_options', 'gm2_gads_customer_id', [
-            'sanitize_callback' => 'sanitize_text_field',
+            'sanitize_callback' => [$this, 'sanitize_customer_id'],
         ]);
         register_setting('gm2_seo_options', 'gm2_gads_language', [
             'sanitize_callback' => 'sanitize_text_field',


### PR DESCRIPTION
## Summary
- add a `sanitize_customer_id` helper in `Gm2_SEO_Admin`
- use the new sanitizer when registering the `gm2_gads_customer_id` setting

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e0759312c8327b560abf7f86f43ac