### PR TITLE
Add login customer ID setting

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -146,6 +146,9 @@ class Gm2_SEO_Admin {
         register_setting('gm2_seo_options', 'gm2_gads_customer_id', [
             'sanitize_callback' => [$this, 'sanitize_customer_id'],
         ]);
+        register_setting('gm2_seo_options', 'gm2_gads_login_customer_id', [
+            'sanitize_callback' => [$this, 'sanitize_customer_id'],
+        ]);
         register_setting('gm2_seo_options', 'gm2_gads_language', [
             'sanitize_callback' => 'sanitize_text_field',
         ]);
@@ -379,14 +382,16 @@ class Gm2_SEO_Admin {
                 trim(get_option('gm2_gads_customer_id', '')) !== '' &&
                 get_option('gm2_google_refresh_token', '') !== '';
 
-            $lang = get_option('gm2_gads_language', 'languageConstants/1000');
-            $geo  = get_option('gm2_gads_geo_target', 'geoTargetConstants/2840');
+            $lang  = get_option('gm2_gads_language', 'languageConstants/1000');
+            $geo   = get_option('gm2_gads_geo_target', 'geoTargetConstants/2840');
+            $login = get_option('gm2_gads_login_customer_id', '');
 
             echo '<form method="post" action="options.php">';
             settings_fields('gm2_seo_options');
             echo '<table class="form-table"><tbody>';
             echo '<tr><th scope="row">Language Constant</th><td><input type="text" name="gm2_gads_language" id="gm2_gads_language" value="' . esc_attr($lang) . '" class="regular-text" /></td></tr>';
             echo '<tr><th scope="row">Geo Target Constant</th><td><input type="text" name="gm2_gads_geo_target" id="gm2_gads_geo_target" value="' . esc_attr($geo) . '" class="regular-text" /></td></tr>';
+            echo '<tr><th scope="row">Login Customer ID</th><td><input type="text" name="gm2_gads_login_customer_id" id="gm2_gads_login_customer_id" value="' . esc_attr($login) . '" class="regular-text" /></td></tr>';
             echo '</tbody></table>';
             echo '<p class="description">Defaults: English / United States.</p>';
             submit_button('Save Settings');

--- a/includes/Gm2_Keyword_Planner.php
+++ b/includes/Gm2_Keyword_Planner.php
@@ -52,12 +52,18 @@ class Gm2_Keyword_Planner {
             ],
         ];
 
+        $headers = [
+            'Authorization'   => 'Bearer ' . $token,
+            'developer-token' => $creds['developer_token'],
+            'Content-Type'    => 'application/json',
+        ];
+
+        if ($login = preg_replace('/\D/', '', get_option('gm2_gads_login_customer_id'))) {
+            $headers['login-customer-id'] = $login;
+        }
+
         $resp = wp_remote_post($url, [
-            'headers' => [
-                'Authorization'   => 'Bearer ' . $token,
-                'developer-token' => $creds['developer_token'],
-                'Content-Type'    => 'application/json',
-            ],
+            'headers' => $headers,
             'body'    => wp_json_encode($body),
             'timeout' => 20,
         ]);

--- a/readme.txt
+++ b/readme.txt
@@ -38,6 +38,7 @@ These credentials must be copied from your Google accounts:
 
 * **Search Console verification code** – Log in to <https://search.google.com/search-console>, open **Settings → Ownership verification**, and choose the *HTML tag* option. Copy the code displayed in the meta tag and paste it into the **Search Console Verification Code** field on the SEO settings page. See <https://support.google.com/webmasters/answer/9008080> for details.
 * **Google Ads developer token** – Sign in at <https://ads.google.com/aw/apicenter> and open **Tools & Settings → Setup → API Center** (manager account required). Copy your **Developer token** and enter it into the **Google Ads Developer Token** field. Documentation: <https://developers.google.com/google-ads/api/docs/first-call/dev-token>.
+* **Google Ads login customer ID** – Optional manager account ID associated with your developer token. Enter this value if the token belongs to a manager account so requests include the `login-customer-id` header.
 * **Google Ads API version** – The plugin uses the API version defined by the `Gm2_Google_OAuth::GOOGLE_ADS_API_VERSION` constant (default `v18`). Update this constant and any tests referencing it when a new Ads API version becomes available.
 * **Analytics Admin API version** – The GA4 endpoints use the version specified by `Gm2_Google_OAuth::ANALYTICS_ADMIN_API_VERSION` (default `v1beta`). Update this constant along with related tests when Google releases a new version.
 
@@ -69,7 +70,7 @@ For full page caching, hook into the `gm2_set_cache_headers` action
 to configure headers or integrate your preferred caching plugin.
 
 == Keyword Research ==
-After configuring credentials in **Gm2 → Google OAuth Setup**, connect your Google account from **SEO → Connect Google Account**. The plugin automatically fetches your available Analytics Measurement IDs and Ads Customer IDs so you can select them from dropdown menus. Use the **Keyword Research** tab to generate ideas via the Google Keyword Planner. To fetch keywords you must enter a Google Ads developer token, connect a Google account with Ads access, and select a valid Ads customer ID (without dashes, e.g., `1234567890`). Missing or invalid credentials will result in empty or failed searches.
+After configuring credentials in **Gm2 → Google OAuth Setup**, connect your Google account from **SEO → Connect Google Account**. The plugin automatically fetches your available Analytics Measurement IDs and Ads Customer IDs so you can select them from dropdown menus. Use the **Keyword Research** tab to generate ideas via the Google Keyword Planner. To fetch keywords you must enter a Google Ads developer token, connect a Google account with Ads access, and select a valid Ads customer ID (without dashes, e.g., `1234567890`). Missing or invalid credentials will result in empty or failed searches. If your developer token belongs to a manager account, provide the optional Login Customer ID so the value is sent with each request.
 
 The Google Ads request also requires a language constant and a geo target constant. These values are configurable on the same screen and default to `languageConstants/1000` (English) and `geoTargetConstants/2840` (United States). If either option is missing or invalid, the keyword search will fail with an error.
 


### PR DESCRIPTION
## Summary
- register `gm2_gads_login_customer_id`
- add Login Customer ID field on Keyword Research tab
- include login-customer-id header when set
- document the new option

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e0e295c7c8327b2030463c2f07710