### PR TITLE
Improve error handling for keyword research

### DIFF
--- a/admin/js/gm2-keyword-research.js
+++ b/admin/js/gm2-keyword-research.js
@@ -13,7 +13,11 @@ jQuery(function($){
             _ajax_nonce: gm2KeywordResearch.nonce
         }).done(function(resp){
             $list.empty();
-            if(resp && resp.success && Array.isArray(resp.data)){
+            if ((typeof resp === 'string' && resp === '0') || !resp || typeof resp !== 'object') {
+                $list.append($('<li>').text('Invalid request or not logged in'));
+                return;
+            }
+            if(resp.success && Array.isArray(resp.data)){
                 resp.data.forEach(function(k){
                     $('<li>').text(k).appendTo($list);
                 });


### PR DESCRIPTION
## Summary
- better error message when invalid responses are returned from the keyword research AJAX endpoint

## Testing
- `node test.js` (removed after running)
- `phpunit` *(fails: missing wordpress-tests-lib)*

------
https://chatgpt.com/codex/tasks/task_e_686eb670a5d08327b69e3cb2c17af32e