### PR TITLE
Fix developer token instructions

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -512,7 +512,7 @@ class Gm2_SEO_Admin {
                         $msg .= '<pre>' . esc_html(trim($data['body'])) . '</pre>';
                     }
                     if ('missing_developer_token' === $accounts->get_error_code()) {
-                        $msg .= '<p>' . esc_html__( 'Sign in at Google Ads and open Tools & Settings → Setup → API Center (manager account required). Copy your Developer token and enter it on the OAuth setup page.', 'gm2-wordpress-suite' ) . '</p>';
+                        $msg .= '<p>' . esc_html__( 'Sign in at Google Ads and open Tools & Settings → Setup → API Center (manager account required). Copy your Developer token and enter it in the Google Ads Developer Token field on the SEO settings page.', 'gm2-wordpress-suite' ) . '</p>';
                     } else {
                         $msg .= $help;
                     }
@@ -546,7 +546,7 @@ class Gm2_SEO_Admin {
                     $msg .= '<pre>' . esc_html(trim($data['body'])) . '</pre>';
                 }
                 if ('missing_developer_token' === $accounts->get_error_code()) {
-                    $msg .= '<p>' . esc_html__( 'Sign in at Google Ads and open Tools & Settings → Setup → API Center (manager account required). Copy your Developer token and enter it on the OAuth setup page.', 'gm2-wordpress-suite' ) . '</p>';
+                    $msg .= '<p>' . esc_html__( 'Sign in at Google Ads and open Tools & Settings → Setup → API Center (manager account required). Copy your Developer token and enter it in the Google Ads Developer Token field on the SEO settings page.', 'gm2-wordpress-suite' ) . '</p>';
                 } else {
                     $msg .= $help;
                 }

--- a/readme.txt
+++ b/readme.txt
@@ -45,7 +45,7 @@ These credentials must be copied from your Google accounts:
 == Troubleshooting ==
 If you see errors when connecting your Google account:
 
-* **Missing developer token** – Sign in at <https://ads.google.com/aw/apicenter> and open **Tools & Settings → Setup → API Center** (manager account required). Copy your **Developer token** and enter it on the OAuth setup page.
+* **Missing developer token** – Sign in at <https://ads.google.com/aw/apicenter> and open **Tools & Settings → Setup → API Center** (manager account required). Copy your **Developer token** and enter it in the **Google Ads Developer Token** field on the SEO settings page.
 * **No Analytics properties found** or **No Ads accounts found** –
   * Enable the Analytics Admin, Google Analytics (v3) for UA properties, Search Console, and Google Ads APIs for your OAuth client.
   * Confirm the connected Google account can access the required properties and accounts. The OAuth client can belong to a different Google account.


### PR DESCRIPTION
## Summary
- fix the instructions for entering the Google Ads developer token in docs and admin notices

## Testing
- `bash bin/install-wp-tests.sh wordpress_test root '' localhost latest`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ec20adbfc832795becf0aa3797879