### PR TITLE
Add SEO guidelines tab

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -82,6 +82,13 @@ class Gm2_Admin {
                 GM2_VERSION,
                 true
             );
+            wp_enqueue_script(
+                'gm2-guidelines',
+                GM2_PLUGIN_URL . 'admin/js/gm2-guidelines.js',
+                ['jquery'],
+                GM2_VERSION,
+                true
+            );
             $gads_ready = trim(get_option('gm2_gads_developer_token', '')) !== '' &&
                 trim(get_option('gm2_gads_customer_id', '')) !== '' &&
                 get_option('gm2_google_refresh_token', '') !== '';

--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -157,6 +157,9 @@ class Gm2_SEO_Admin {
         register_setting('gm2_seo_options', 'gm2_gads_geo_target', [
             'sanitize_callback' => 'sanitize_text_field',
         ]);
+        register_setting('gm2_seo_options', 'gm2_seo_guidelines', [
+            'sanitize_callback' => 'sanitize_textarea_field',
+        ]);
 
         add_settings_section(
             'gm2_seo_main',
@@ -225,6 +228,7 @@ class Gm2_SEO_Admin {
             'performance' => 'Performance',
             'keywords'    => 'Keyword Research',
             'rules'       => 'Content Rules',
+            'guidelines'  => 'SEO Guidelines',
         ];
 
         $active = isset($_GET['tab']) ? sanitize_key($_GET['tab']) : 'general';
@@ -434,6 +438,14 @@ class Gm2_SEO_Admin {
             echo '</tbody></table>';
             submit_button('Save Rules');
             echo '</form>';
+        } elseif ($active === 'guidelines') {
+            $guidelines = get_option('gm2_seo_guidelines', '');
+            echo '<form method="post" action="options.php">';
+            settings_fields('gm2_seo_options');
+            echo '<textarea name="gm2_seo_guidelines" rows="6" class="large-text">' . esc_textarea($guidelines) . '</textarea>';
+            submit_button('Save Guidelines');
+            echo '</form>';
+            echo '<p><button id="gm2-research-guidelines" class="button">Research SEO Guidelines</button></p>';
         } else {
             echo '<form method="post" action="' . admin_url('admin-post.php') . '">';
             wp_nonce_field('gm2_general_settings_save', 'gm2_general_settings_nonce');

--- a/admin/js/gm2-guidelines.js
+++ b/admin/js/gm2-guidelines.js
@@ -1,0 +1,6 @@
+jQuery(function($){
+    $('#gm2-research-guidelines').on('click', function(e){
+        e.preventDefault();
+        alert('Researching guidelines...');
+    });
+});


### PR DESCRIPTION
## Summary
- add `gm2-guidelines.js` and enqueue it
- register `gm2_seo_guidelines` option
- support new "SEO Guidelines" tab in dashboard

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eee3033e88327849f9b307597daca