### PR TITLE
Implement AI SEO enhancements

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1204,6 +1204,20 @@ class Gm2_SEO_Admin {
             wp_send_json_error('invalid parameters');
         }
 
+        // override with submitted values if provided
+        if (isset($_POST['seo_title'])) {
+            $seo_title = sanitize_text_field(wp_unslash($_POST['seo_title']));
+        }
+        if (isset($_POST['seo_description'])) {
+            $seo_description = sanitize_textarea_field(wp_unslash($_POST['seo_description']));
+        }
+        if (isset($_POST['focus_keywords'])) {
+            $focus = sanitize_text_field(wp_unslash($_POST['focus_keywords']));
+        }
+        if (isset($_POST['canonical'])) {
+            $canonical = esc_url_raw(wp_unslash($_POST['canonical']));
+        }
+
         $guidelines = trim(get_option('gm2_seo_guidelines', ''));
         $prompt  = "SEO guidelines:\n" . $guidelines . "\n\n";
         $prompt .= "Page title: {$title}\nURL: {$url}\n";

--- a/admin/css/gm2-seo.css
+++ b/admin/css/gm2-seo.css
@@ -17,5 +17,10 @@
 .gm2-analysis-rules li.pass { color:#46b450; }
 .gm2-analysis-rules li.fail { color:#d63638; }
 
+#gm2-ai-results h4 { margin-top:1em; }
+#gm2-ai-suggestions p { margin:4px 0; }
+.gm2-html-issue { margin-bottom:5px; }
+.gm2-html-issue button { margin-left:10px; }
+
 #gm2-elementor-seo-panel { padding:10px; }
 #elementor-panel-footer #gm2-elementor-seo-panel .gm2-tab-panel { border:none; }


### PR DESCRIPTION
## Summary
- collect unsaved SEO field values before AI research
- display AI suggestions with checkboxes and a Select All toggle
- allow copying selected suggestions back into SEO fields
- list HTML issues with optional fix actions
- accept posted SEO values in `ajax_ai_research`
- style AI SEO results

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ef4406cbc8327819e7c25e6cd43d1