### PR TITLE
Add OG image support and meta tag output

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -699,6 +699,13 @@ class Gm2_SEO_Admin {
         echo '<p><label><input type="checkbox" name="gm2_nofollow" value="1" ' . checked($nofollow, '1', false) . '> nofollow</label></p>';
         echo '<p><label for="gm2_canonical_url">Canonical URL</label>';
         echo '<input type="url" id="gm2_canonical_url" name="gm2_canonical_url" value="' . esc_attr($canonical) . '" class="widefat" /></p>';
+
+        $og_image = is_object($term) ? get_term_meta($term->term_id, '_gm2_og_image', true) : '';
+        $og_image_url = $og_image ? wp_get_attachment_url($og_image) : '';
+        echo '<p><label for="gm2_og_image">OG Image</label>';
+        echo '<input type="hidden" id="gm2_og_image" name="gm2_og_image" value="' . esc_attr($og_image) . '" />';
+        echo '<input type="button" class="button gm2-upload-image" data-target="gm2_og_image" value="Select Image" />';
+        echo '<span class="gm2-image-preview">' . ($og_image_url ? '<img src="' . esc_url($og_image_url) . '" style="max-width:100%;height:auto;" />' : '') . '</span></p>';
         echo '</div>';
 
         echo '<div id="gm2-content-analysis" class="gm2-tab-panel">';
@@ -735,12 +742,14 @@ class Gm2_SEO_Admin {
         $nofollow    = isset($_POST['gm2_nofollow']) ? '1' : '0';
         $canonical      = isset($_POST['gm2_canonical_url']) ? esc_url_raw($_POST['gm2_canonical_url']) : '';
         $focus_keywords = isset($_POST['gm2_focus_keywords']) ? sanitize_text_field($_POST['gm2_focus_keywords']) : '';
+        $og_image    = isset($_POST['gm2_og_image']) ? absint($_POST['gm2_og_image']) : 0;
         update_post_meta($post_id, '_gm2_title', $title);
         update_post_meta($post_id, '_gm2_description', $description);
         update_post_meta($post_id, '_gm2_noindex', $noindex);
         update_post_meta($post_id, '_gm2_nofollow', $nofollow);
         update_post_meta($post_id, '_gm2_canonical', $canonical);
         update_post_meta($post_id, '_gm2_focus_keywords', $focus_keywords);
+        update_post_meta($post_id, '_gm2_og_image', $og_image);
     }
 
     public function save_taxonomy_meta($term_id) {
@@ -753,12 +762,14 @@ class Gm2_SEO_Admin {
         $nofollow    = isset($_POST['gm2_nofollow']) ? '1' : '0';
         $canonical      = isset($_POST['gm2_canonical_url']) ? esc_url_raw($_POST['gm2_canonical_url']) : '';
         $focus_keywords = isset($_POST['gm2_focus_keywords']) ? sanitize_text_field($_POST['gm2_focus_keywords']) : '';
+        $og_image    = isset($_POST['gm2_og_image']) ? absint($_POST['gm2_og_image']) : 0;
         update_term_meta($term_id, '_gm2_title', $title);
         update_term_meta($term_id, '_gm2_description', $description);
         update_term_meta($term_id, '_gm2_noindex', $noindex);
         update_term_meta($term_id, '_gm2_nofollow', $nofollow);
         update_term_meta($term_id, '_gm2_canonical', $canonical);
         update_term_meta($term_id, '_gm2_focus_keywords', $focus_keywords);
+        update_term_meta($term_id, '_gm2_og_image', $og_image);
     }
 
     public function handle_sitemap_form() {
@@ -1315,6 +1326,8 @@ class Gm2_SEO_Admin {
             return;
         }
 
+        wp_enqueue_media();
+
         wp_enqueue_script(
             'gm2-content-analysis',
             GM2_PLUGIN_URL . 'admin/js/gm2-content-analysis.js',
@@ -1402,6 +1415,8 @@ class Gm2_SEO_Admin {
             return;
         }
 
+        wp_enqueue_media();
+
         wp_enqueue_script(
             'gm2-seo-tabs',
             GM2_PLUGIN_URL . 'admin/js/gm2-seo.js',
@@ -1463,6 +1478,13 @@ class Gm2_SEO_Admin {
         echo '<p><label><input type="checkbox" name="gm2_nofollow" value="1" ' . checked($nofollow, '1', false) . '> nofollow</label></p>';
         echo '<p><label for="gm2_canonical_url">Canonical URL</label>';
         echo '<input type="url" id="gm2_canonical_url" name="gm2_canonical_url" value="' . esc_attr($canonical) . '" class="widefat" /></p>';
+
+        $og_image = get_post_meta($post->ID, '_gm2_og_image', true);
+        $og_image_url = $og_image ? wp_get_attachment_url($og_image) : '';
+        echo '<p><label for="gm2_og_image">OG Image</label>';
+        echo '<input type="hidden" id="gm2_og_image" name="gm2_og_image" value="' . esc_attr($og_image) . '" />';
+        echo '<input type="button" class="button gm2-upload-image" data-target="gm2_og_image" value="Select Image" />';
+        echo '<span class="gm2-image-preview">' . ($og_image_url ? '<img src="' . esc_url($og_image_url) . '" style="max-width:100%;height:auto;" />' : '') . '</span></p>';
         echo '</div>';
 
         echo '<div id="gm2-content-analysis" class="gm2-tab-panel">';

--- a/admin/js/gm2-seo.js
+++ b/admin/js/gm2-seo.js
@@ -6,10 +6,27 @@ jQuery(function($){
         $container.find('#'+tab).addClass('active').show();
     }
 
-    $(document).on('click', '.gm2-nav-tab', function(e){
-        e.preventDefault();
-        var $c = $(this).closest('.gm2-seo-tabs');
-        switchTab($c, $(this).data('tab'));
+$(document).on('click', '.gm2-nav-tab', function(e){
+    e.preventDefault();
+    var $c = $(this).closest('.gm2-seo-tabs');
+    switchTab($c, $(this).data('tab'));
+});
+
+$(document).on('click', '.gm2-upload-image', function(e){
+    e.preventDefault();
+    var button = $(this);
+    var field  = $('#' + button.data('target'));
+    var frame = wp.media({
+        title: 'Select Image',
+        button: { text: 'Use image' },
+        multiple: false
     });
+    frame.on('select', function(){
+        var attachment = frame.state().get('selection').first().toJSON();
+        field.val(attachment.id);
+        button.siblings('.gm2-image-preview').html('<img src="'+attachment.url+'" style="max-width:100%;height:auto;" />');
+    });
+    frame.open();
+});
 
 });

--- a/includes/Gm2_Elementor_SEO.php
+++ b/includes/Gm2_Elementor_SEO.php
@@ -82,6 +82,14 @@ class Gm2_Elementor_SEO {
                 'default' => [ 'url' => get_post_meta($post_id, '_gm2_canonical', true) ],
             ]
         );
+        $document->add_control(
+            'gm2_og_image',
+            [
+                'label' => __('OG Image', 'gm2-wordpress-suite'),
+                'type'  => \Elementor\Controls_Manager::MEDIA,
+                'default' => [ 'id' => get_post_meta($post_id, '_gm2_og_image', true) ],
+            ]
+        );
         $document->end_controls_section();
     }
 
@@ -109,6 +117,11 @@ class Gm2_Elementor_SEO {
             $canonical_val = $canonical_val['url'] ?? '';
         }
         $canonical   = esc_url_raw($canonical_val);
+        $og_val = $data['gm2_og_image'] ?? '';
+        if (is_array($og_val)) {
+            $og_val = $og_val['id'] ?? 0;
+        }
+        $og_image = absint($og_val);
         $focus       = isset($data['gm2_focus_keywords']) ? sanitize_text_field($data['gm2_focus_keywords']) : '';
         update_post_meta($post_id, '_gm2_title', $title);
         update_post_meta($post_id, '_gm2_description', $description);
@@ -116,5 +129,6 @@ class Gm2_Elementor_SEO {
         update_post_meta($post_id, '_gm2_nofollow', $nofollow);
         update_post_meta($post_id, '_gm2_canonical', $canonical);
         update_post_meta($post_id, '_gm2_focus_keywords', $focus);
+        update_post_meta($post_id, '_gm2_og_image', $og_image);
     }
 }

--- a/public/Gm2_SEO_Public.php
+++ b/public/Gm2_SEO_Public.php
@@ -164,6 +164,7 @@ class Gm2_SEO_Public {
         $noindex     = '';
         $nofollow    = '';
         $canonical   = '';
+        $og_image    = '';
 
         if (is_singular()) {
             $post_id    = get_queried_object_id();
@@ -172,6 +173,7 @@ class Gm2_SEO_Public {
             $noindex     = get_post_meta($post_id, '_gm2_noindex', true);
             $nofollow    = get_post_meta($post_id, '_gm2_nofollow', true);
             $canonical   = get_post_meta($post_id, '_gm2_canonical', true);
+            $og_image    = get_post_meta($post_id, '_gm2_og_image', true);
 
             if (class_exists('WooCommerce') && function_exists('is_product') && is_product()) {
                 $product = wc_get_product($post_id);
@@ -192,6 +194,7 @@ class Gm2_SEO_Public {
                 $noindex     = get_term_meta($term->term_id, '_gm2_noindex', true);
                 $nofollow    = get_term_meta($term->term_id, '_gm2_nofollow', true);
                 $canonical   = get_term_meta($term->term_id, '_gm2_canonical', true);
+                $og_image    = get_term_meta($term->term_id, '_gm2_og_image', true);
             }
         }
 
@@ -219,6 +222,7 @@ class Gm2_SEO_Public {
             'noindex'     => $noindex,
             'nofollow'    => $nofollow,
             'canonical'   => $canonical,
+            'og_image'    => $og_image,
         ];
     }
 
@@ -230,6 +234,11 @@ class Gm2_SEO_Public {
         $robots[]    = ($data['noindex'] === '1') ? 'noindex' : 'index';
         $robots[]    = ($data['nofollow'] === '1') ? 'nofollow' : 'follow';
         $canonical   = $data['canonical'];
+        $og_image_id = $data['og_image'];
+        if (!$og_image_id && is_singular()) {
+            $og_image_id = get_post_thumbnail_id();
+        }
+        $og_image_url = $og_image_id ? wp_get_attachment_url($og_image_id) : '';
 
         // Output the canonical link tag first if it isn't already hooked.
         if (!has_action('wp_head', [$this, 'output_canonical_url'])) {
@@ -249,6 +258,11 @@ class Gm2_SEO_Public {
         echo '<meta property="og:description" content="' . esc_attr($description) . '" />' . "\n";
         echo '<meta property="og:url" content="' . esc_url($url) . '" />' . "\n";
         echo '<meta property="og:type" content="' . esc_attr($type) . '" />' . "\n";
+
+        if ($og_image_url) {
+            echo '<meta property="og:image" content="' . esc_url($og_image_url) . '" />' . "\n";
+            echo '<meta name="twitter:image" content="' . esc_url($og_image_url) . '" />' . "\n";
+        }
 
         echo '<meta name="twitter:card" content="summary" />' . "\n";
         echo '<meta name="twitter:title" content="' . esc_attr($title) . '" />' . "\n";

--- a/tests/test-meta-tags.php
+++ b/tests/test-meta-tags.php
@@ -99,5 +99,27 @@ class MetaTagsTest extends WP_UnitTestCase {
         $this->assertStringContainsString('<meta name="robots" content="noindex,nofollow"', $output);
         $this->assertStringContainsString('<link rel="canonical" href="https://example.com/canonical" />', $output);
     }
+
+    public function test_custom_og_image_in_meta_tags() {
+        $post_id = self::factory()->post->create([
+            'post_title'   => 'Image Post',
+            'post_content' => 'Content',
+        ]);
+
+        $filename = DIR_TESTDATA . '/images/canola.jpg';
+        $attachment_id = self::factory()->attachment->create_upload_object($filename, $post_id);
+        update_post_meta($post_id, '_gm2_og_image', $attachment_id);
+
+        $seo = new Gm2_SEO_Public();
+        $this->go_to(get_permalink($post_id));
+        setup_postdata(get_post($post_id));
+        ob_start();
+        $seo->output_meta_tags();
+        $output = ob_get_clean();
+
+        $url = wp_get_attachment_url($attachment_id);
+        $this->assertStringContainsString('property="og:image" content="' . esc_url($url) . '"', $output);
+        $this->assertStringContainsString('name="twitter:image" content="' . esc_url($url) . '"', $output);
+    }
 }
 


### PR DESCRIPTION
## Summary
- add an OG Image uploader to SEO meta boxes and taxonomy screens
- save `_gm2_og_image` meta in posts and taxonomies
- output `og:image` and `twitter:image` tags on the front end
- expose the OG Image field in Elementor
- extend meta tag tests with OG image coverage

## Testing
- `bash bin/install-wp-tests.sh wordpress_test root '' localhost latest` *(fails: Latest WordPress version could not be found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686efe1902ac8327ba044ce53ef9d344