### PR TITLE
Add robots preview controls

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -640,12 +640,15 @@ class Gm2_SEO_Admin {
 
 
     public function render_taxonomy_meta_box($term) {
-        $title          = '';
-        $description    = '';
-        $noindex        = '';
-        $nofollow       = '';
-        $canonical      = '';
-        $focus_keywords = '';
+        $title               = '';
+        $description         = '';
+        $noindex             = '';
+        $nofollow            = '';
+        $canonical           = '';
+        $focus_keywords      = '';
+        $max_snippet         = '';
+        $max_image_preview   = '';
+        $max_video_preview   = '';
         $taxonomy       = is_object($term) ? $term->taxonomy : (string) $term;
 
         if (is_object($term)) {
@@ -653,8 +656,11 @@ class Gm2_SEO_Admin {
             $description    = get_term_meta($term->term_id, '_gm2_description', true);
             $noindex        = get_term_meta($term->term_id, '_gm2_noindex', true);
             $nofollow       = get_term_meta($term->term_id, '_gm2_nofollow', true);
-            $canonical      = get_term_meta($term->term_id, '_gm2_canonical', true);
-            $focus_keywords = get_term_meta($term->term_id, '_gm2_focus_keywords', true);
+            $canonical        = get_term_meta($term->term_id, '_gm2_canonical', true);
+            $focus_keywords   = get_term_meta($term->term_id, '_gm2_focus_keywords', true);
+            $max_snippet      = get_term_meta($term->term_id, '_gm2_max_snippet', true);
+            $max_image_preview = get_term_meta($term->term_id, '_gm2_max_image_preview', true);
+            $max_video_preview = get_term_meta($term->term_id, '_gm2_max_video_preview', true);
         }
 
         wp_nonce_field('gm2_save_seo_meta', 'gm2_seo_nonce');
@@ -700,6 +706,15 @@ class Gm2_SEO_Admin {
         echo '<p><label for="gm2_canonical_url">Canonical URL</label>';
         echo '<input type="url" id="gm2_canonical_url" name="gm2_canonical_url" value="' . esc_attr($canonical) . '" class="widefat" /></p>';
 
+        echo '<p><label for="gm2_max_snippet">Max Snippet</label>';
+        echo '<input type="text" id="gm2_max_snippet" name="gm2_max_snippet" value="' . esc_attr($max_snippet) . '" class="small-text" /></p>';
+        echo '<p><label for="gm2_max_image_preview">Max Image Preview</label>';
+        echo '<input type="text" id="gm2_max_image_preview" name="gm2_max_image_preview" value="' . esc_attr($max_image_preview) . '" class="small-text" /></p>';
+        echo '<p><label for="gm2_max_video_preview">Max Video Preview</label>';
+        echo '<input type="text" id="gm2_max_video_preview" name="gm2_max_video_preview" value="' . esc_attr($max_video_preview) . '" class="small-text" /></p>';
+
+
+
         $og_image = is_object($term) ? get_term_meta($term->term_id, '_gm2_og_image', true) : '';
         $og_image_url = $og_image ? wp_get_attachment_url($og_image) : '';
         echo '<p><label for="gm2_og_image">OG Image</label>';
@@ -741,14 +756,20 @@ class Gm2_SEO_Admin {
         $noindex     = isset($_POST['gm2_noindex']) ? '1' : '0';
         $nofollow    = isset($_POST['gm2_nofollow']) ? '1' : '0';
         $canonical      = isset($_POST['gm2_canonical_url']) ? esc_url_raw($_POST['gm2_canonical_url']) : '';
-        $focus_keywords = isset($_POST['gm2_focus_keywords']) ? sanitize_text_field($_POST['gm2_focus_keywords']) : '';
-        $og_image    = isset($_POST['gm2_og_image']) ? absint($_POST['gm2_og_image']) : 0;
+        $focus_keywords   = isset($_POST['gm2_focus_keywords']) ? sanitize_text_field($_POST['gm2_focus_keywords']) : '';
+        $max_snippet      = isset($_POST['gm2_max_snippet']) ? sanitize_text_field($_POST['gm2_max_snippet']) : '';
+        $max_image_preview = isset($_POST['gm2_max_image_preview']) ? sanitize_text_field($_POST['gm2_max_image_preview']) : '';
+        $max_video_preview = isset($_POST['gm2_max_video_preview']) ? sanitize_text_field($_POST['gm2_max_video_preview']) : '';
+        $og_image         = isset($_POST['gm2_og_image']) ? absint($_POST['gm2_og_image']) : 0;
         update_post_meta($post_id, '_gm2_title', $title);
         update_post_meta($post_id, '_gm2_description', $description);
         update_post_meta($post_id, '_gm2_noindex', $noindex);
         update_post_meta($post_id, '_gm2_nofollow', $nofollow);
         update_post_meta($post_id, '_gm2_canonical', $canonical);
         update_post_meta($post_id, '_gm2_focus_keywords', $focus_keywords);
+        update_post_meta($post_id, '_gm2_max_snippet', $max_snippet);
+        update_post_meta($post_id, '_gm2_max_image_preview', $max_image_preview);
+        update_post_meta($post_id, '_gm2_max_video_preview', $max_video_preview);
         update_post_meta($post_id, '_gm2_og_image', $og_image);
     }
 
@@ -761,14 +782,20 @@ class Gm2_SEO_Admin {
         $noindex     = isset($_POST['gm2_noindex']) ? '1' : '0';
         $nofollow    = isset($_POST['gm2_nofollow']) ? '1' : '0';
         $canonical      = isset($_POST['gm2_canonical_url']) ? esc_url_raw($_POST['gm2_canonical_url']) : '';
-        $focus_keywords = isset($_POST['gm2_focus_keywords']) ? sanitize_text_field($_POST['gm2_focus_keywords']) : '';
-        $og_image    = isset($_POST['gm2_og_image']) ? absint($_POST['gm2_og_image']) : 0;
+        $focus_keywords   = isset($_POST['gm2_focus_keywords']) ? sanitize_text_field($_POST['gm2_focus_keywords']) : '';
+        $max_snippet      = isset($_POST['gm2_max_snippet']) ? sanitize_text_field($_POST['gm2_max_snippet']) : '';
+        $max_image_preview = isset($_POST['gm2_max_image_preview']) ? sanitize_text_field($_POST['gm2_max_image_preview']) : '';
+        $max_video_preview = isset($_POST['gm2_max_video_preview']) ? sanitize_text_field($_POST['gm2_max_video_preview']) : '';
+        $og_image         = isset($_POST['gm2_og_image']) ? absint($_POST['gm2_og_image']) : 0;
         update_term_meta($term_id, '_gm2_title', $title);
         update_term_meta($term_id, '_gm2_description', $description);
         update_term_meta($term_id, '_gm2_noindex', $noindex);
         update_term_meta($term_id, '_gm2_nofollow', $nofollow);
         update_term_meta($term_id, '_gm2_canonical', $canonical);
         update_term_meta($term_id, '_gm2_focus_keywords', $focus_keywords);
+        update_term_meta($term_id, '_gm2_max_snippet', $max_snippet);
+        update_term_meta($term_id, '_gm2_max_image_preview', $max_image_preview);
+        update_term_meta($term_id, '_gm2_max_video_preview', $max_video_preview);
         update_term_meta($term_id, '_gm2_og_image', $og_image);
     }
 
@@ -1456,7 +1483,10 @@ class Gm2_SEO_Admin {
         $noindex        = get_post_meta($post->ID, '_gm2_noindex', true);
         $nofollow       = get_post_meta($post->ID, '_gm2_nofollow', true);
         $canonical      = get_post_meta($post->ID, '_gm2_canonical', true);
-        $focus_keywords = get_post_meta($post->ID, '_gm2_focus_keywords', true);
+        $focus_keywords      = get_post_meta($post->ID, '_gm2_focus_keywords', true);
+        $max_snippet         = get_post_meta($post->ID, '_gm2_max_snippet', true);
+        $max_image_preview   = get_post_meta($post->ID, '_gm2_max_image_preview', true);
+        $max_video_preview   = get_post_meta($post->ID, '_gm2_max_video_preview', true);
 
         wp_nonce_field('gm2_save_seo_meta', 'gm2_seo_nonce');
 
@@ -1478,6 +1508,13 @@ class Gm2_SEO_Admin {
         echo '<p><label><input type="checkbox" name="gm2_nofollow" value="1" ' . checked($nofollow, '1', false) . '> nofollow</label></p>';
         echo '<p><label for="gm2_canonical_url">Canonical URL</label>';
         echo '<input type="url" id="gm2_canonical_url" name="gm2_canonical_url" value="' . esc_attr($canonical) . '" class="widefat" /></p>';
+
+        echo '<p><label for="gm2_max_snippet">Max Snippet</label>';
+        echo '<input type="text" id="gm2_max_snippet" name="gm2_max_snippet" value="' . esc_attr($max_snippet) . '" class="small-text" /></p>';
+        echo '<p><label for="gm2_max_image_preview">Max Image Preview</label>';
+        echo '<input type="text" id="gm2_max_image_preview" name="gm2_max_image_preview" value="' . esc_attr($max_image_preview) . '" class="small-text" /></p>';
+        echo '<p><label for="gm2_max_video_preview">Max Video Preview</label>';
+        echo '<input type="text" id="gm2_max_video_preview" name="gm2_max_video_preview" value="' . esc_attr($max_video_preview) . '" class="small-text" /></p>';
 
         $og_image = get_post_meta($post->ID, '_gm2_og_image', true);
         $og_image_url = $og_image ? wp_get_attachment_url($og_image) : '';

--- a/public/Gm2_SEO_Public.php
+++ b/public/Gm2_SEO_Public.php
@@ -155,7 +155,10 @@ class Gm2_SEO_Public {
      *     description:string,
      *     noindex:string,
      *     nofollow:string,
-     *     canonical:string
+     *     canonical:string,
+     *     max_snippet:string,
+     *     max_image_preview:string,
+     *     max_video_preview:string
      * }
      */
     private function get_seo_meta() {
@@ -163,8 +166,11 @@ class Gm2_SEO_Public {
         $description = '';
         $noindex     = '';
         $nofollow    = '';
-        $canonical   = '';
-        $og_image    = '';
+        $canonical         = '';
+        $og_image          = '';
+        $max_snippet       = '';
+        $max_image_preview = '';
+        $max_video_preview = '';
 
         if (is_singular()) {
             $post_id    = get_queried_object_id();
@@ -172,8 +178,11 @@ class Gm2_SEO_Public {
             $description = get_post_meta($post_id, '_gm2_description', true);
             $noindex     = get_post_meta($post_id, '_gm2_noindex', true);
             $nofollow    = get_post_meta($post_id, '_gm2_nofollow', true);
-            $canonical   = get_post_meta($post_id, '_gm2_canonical', true);
-            $og_image    = get_post_meta($post_id, '_gm2_og_image', true);
+            $canonical         = get_post_meta($post_id, '_gm2_canonical', true);
+            $og_image          = get_post_meta($post_id, '_gm2_og_image', true);
+            $max_snippet       = get_post_meta($post_id, '_gm2_max_snippet', true);
+            $max_image_preview = get_post_meta($post_id, '_gm2_max_image_preview', true);
+            $max_video_preview = get_post_meta($post_id, '_gm2_max_video_preview', true);
 
             if (class_exists('WooCommerce') && function_exists('is_product') && is_product()) {
                 $product = wc_get_product($post_id);
@@ -193,8 +202,11 @@ class Gm2_SEO_Public {
                 $description = get_term_meta($term->term_id, '_gm2_description', true);
                 $noindex     = get_term_meta($term->term_id, '_gm2_noindex', true);
                 $nofollow    = get_term_meta($term->term_id, '_gm2_nofollow', true);
-                $canonical   = get_term_meta($term->term_id, '_gm2_canonical', true);
-                $og_image    = get_term_meta($term->term_id, '_gm2_og_image', true);
+                $canonical         = get_term_meta($term->term_id, '_gm2_canonical', true);
+                $og_image          = get_term_meta($term->term_id, '_gm2_og_image', true);
+                $max_snippet       = get_term_meta($term->term_id, '_gm2_max_snippet', true);
+                $max_image_preview = get_term_meta($term->term_id, '_gm2_max_image_preview', true);
+                $max_video_preview = get_term_meta($term->term_id, '_gm2_max_video_preview', true);
             }
         }
 
@@ -223,6 +235,9 @@ class Gm2_SEO_Public {
             'nofollow'    => $nofollow,
             'canonical'   => $canonical,
             'og_image'    => $og_image,
+            'max_snippet' => $max_snippet,
+            'max_image_preview' => $max_image_preview,
+            'max_video_preview' => $max_video_preview,
         ];
     }
 
@@ -233,6 +248,15 @@ class Gm2_SEO_Public {
         $robots      = [];
         $robots[]    = ($data['noindex'] === '1') ? 'noindex' : 'index';
         $robots[]    = ($data['nofollow'] === '1') ? 'nofollow' : 'follow';
+        if ($data['max_snippet'] !== '') {
+            $robots[] = 'max-snippet:' . $data['max_snippet'];
+        }
+        if ($data['max_image_preview'] !== '') {
+            $robots[] = 'max-image-preview:' . $data['max_image_preview'];
+        }
+        if ($data['max_video_preview'] !== '') {
+            $robots[] = 'max-video-preview:' . $data['max_video_preview'];
+        }
         $canonical   = $data['canonical'];
         $og_image_id = $data['og_image'];
         if (!$og_image_id && is_singular()) {

--- a/readme.txt
+++ b/readme.txt
@@ -104,6 +104,8 @@ While editing a post or taxonomy term, open the **AI SEO** tab in the SEO meta
 box. Use **AI Research** to request suggestions for titles, descriptions,
 keywords and canonical URLs. Select the items you want and click **Implement
 Selected** to populate the fields automatically.
+The SEO Settings tab also lets you set `max-snippet`, `max-image-preview`, and
+`max-video-preview` values that will be added to the robots meta tag.
 
 == Tariff Management ==
 Manage percentage-based fees for WooCommerce orders. Open **Gm2 → Tariff** to
@@ -115,6 +117,8 @@ Create 301 or 302 redirects from the **SEO → Redirects** tab. The plugin logs
 the last 100 missing URLs to help you create new redirects.
 
 == Changelog ==
+= 1.6.2 =
+* Added max-snippet, max-image-preview and max-video-preview options in SEO meta boxes.
 = 1.6.1 =
 * Improved error guidance for OAuth connection issues.
 = 1.6.0 =

--- a/tests/test-meta-tags.php
+++ b/tests/test-meta-tags.php
@@ -100,6 +100,27 @@ class MetaTagsTest extends WP_UnitTestCase {
         $this->assertStringContainsString('<link rel="canonical" href="https://example.com/canonical" />', $output);
     }
 
+    public function test_max_preview_directives_appended_to_robots() {
+        $post_id = self::factory()->post->create([
+            'post_title'   => 'Robots',
+            'post_content' => 'Content',
+        ]);
+        update_post_meta($post_id, '_gm2_max_snippet', '50');
+        update_post_meta($post_id, '_gm2_max_image_preview', 'large');
+        update_post_meta($post_id, '_gm2_max_video_preview', '10');
+
+        $seo = new Gm2_SEO_Public();
+        $this->go_to(get_permalink($post_id));
+        setup_postdata(get_post($post_id));
+        ob_start();
+        $seo->output_meta_tags();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('max-snippet:50', $output);
+        $this->assertStringContainsString('max-image-preview:large', $output);
+        $this->assertStringContainsString('max-video-preview:10', $output);
+    }
+
     public function test_custom_og_image_in_meta_tags() {
         $post_id = self::factory()->post->create([
             'post_title'   => 'Image Post',


### PR DESCRIPTION
## Summary
- add inputs for `max-snippet`, `max-image-preview` and `max-video-preview`
- persist robots directives as post/term meta
- include preview limits in robots tag
- document new options and update tests

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f004eec0c8327b1f328da70c9fd9f