### PR TITLE
Add Robots.txt editor

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -126,6 +126,15 @@ class Gm2_SEO_Admin {
             'gm2-google-connect',
             [$this, 'display_google_connect_page']
         );
+
+        add_submenu_page(
+            'gm2',
+            'Robots.txt',
+            'Robots.txt',
+            'manage_options',
+            'gm2-robots',
+            [$this, 'display_robots_page']
+        );
     }
 
     public function register_settings() {
@@ -160,6 +169,10 @@ class Gm2_SEO_Admin {
             'sanitize_callback' => 'sanitize_text_field',
         ]);
         register_setting('gm2_seo_options', 'gm2_seo_guidelines', [
+            'sanitize_callback' => 'sanitize_textarea_field',
+        ]);
+
+        register_setting('gm2_robots_options', 'gm2_robots_txt', [
             'sanitize_callback' => 'sanitize_textarea_field',
         ]);
 
@@ -457,6 +470,18 @@ class Gm2_SEO_Admin {
             echo '</form>';
         }
 
+        echo '</div>';
+    }
+
+    public function display_robots_page() {
+        $content = get_option('gm2_robots_txt', '');
+        echo '<div class="wrap">';
+        echo '<h1>Robots.txt</h1>';
+        echo '<form method="post" action="options.php">';
+        settings_fields('gm2_robots_options');
+        echo '<textarea name="gm2_robots_txt" rows="10" class="large-text code">' . esc_textarea($content) . '</textarea>';
+        submit_button('Save');
+        echo '</form>';
         echo '</div>';
     }
 

--- a/public/Gm2_SEO_Public.php
+++ b/public/Gm2_SEO_Public.php
@@ -32,6 +32,7 @@ class Gm2_SEO_Public {
         add_action('template_redirect', [$this, 'maybe_buffer_output'], 1);
         add_action('shutdown', [$this, 'maybe_flush_buffer'], 0);
         add_action('send_headers', [$this, 'send_cache_headers']);
+        add_filter('robots_txt', [$this, 'filter_robots_txt'], 10, 2);
     }
 
     public function add_sitemap_rewrite() {
@@ -537,6 +538,14 @@ class Gm2_SEO_Public {
             }, $html);
         }
         return $html;
+    }
+
+    public function filter_robots_txt($output, $public) {
+        $custom = get_option('gm2_robots_txt', '');
+        if ($custom !== '') {
+            $output .= "\n" . $custom;
+        }
+        return $output;
     }
 
     public function send_cache_headers() {

--- a/tests/test-robots-txt.php
+++ b/tests/test-robots-txt.php
@@ -1,0 +1,15 @@
+<?php
+use Gm2\Gm2_SEO_Public;
+class RobotsTxtTest extends WP_UnitTestCase {
+    public function tearDown(): void {
+        delete_option('gm2_robots_txt');
+        parent::tearDown();
+    }
+    public function test_custom_rules_output_in_filter() {
+        update_option('gm2_robots_txt', "User-agent: *\nDisallow: /secret");
+        $seo = new Gm2_SEO_Public();
+        $seo->run();
+        $output = apply_filters('robots_txt', '', true);
+        $this->assertStringContainsString('Disallow: /secret', $output);
+    }
+}


### PR DESCRIPTION
## Summary
- add Robots.txt submenu page with textarea
- save user rules in `gm2_robots_txt` option
- output saved rules in robots.txt
- test that custom text appears in robots.txt

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f03ca32408327806d585cfc13119a