### PR TITLE
Add Article schema support

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -303,6 +303,7 @@ class Gm2_SEO_Admin {
             $product     = get_option('gm2_schema_product', '1');
             $brand       = get_option('gm2_schema_brand', '1');
             $breadcrumbs = get_option('gm2_schema_breadcrumbs', '1');
+            $article     = get_option('gm2_schema_article', '1');
             $review      = get_option('gm2_schema_review', '1');
             $footer_bc   = get_option('gm2_show_footer_breadcrumbs', '1');
             if (!empty($_GET['updated'])) {
@@ -315,6 +316,7 @@ class Gm2_SEO_Admin {
             echo '<tr><th scope="row">Product Schema</th><td><input type="checkbox" name="gm2_schema_product" value="1" ' . checked($product, '1', false) . '></td></tr>';
             echo '<tr><th scope="row">Brand Schema</th><td><input type="checkbox" name="gm2_schema_brand" value="1" ' . checked($brand, '1', false) . '></td></tr>';
             echo '<tr><th scope="row">Breadcrumb Schema</th><td><input type="checkbox" name="gm2_schema_breadcrumbs" value="1" ' . checked($breadcrumbs, '1', false) . '></td></tr>';
+            echo '<tr><th scope="row">Article Schema</th><td><input type="checkbox" name="gm2_schema_article" value="1" ' . checked($article, '1', false) . '></td></tr>';
             echo '<tr><th scope="row">Show Breadcrumbs in Footer</th><td><input type="checkbox" name="gm2_show_footer_breadcrumbs" value="1" ' . checked($footer_bc, '1', false) . '></td></tr>';
             echo '<tr><th scope="row">Review Schema</th><td><input type="checkbox" name="gm2_schema_review" value="1" ' . checked($review, '1', false) . '></td></tr>';
             echo '</tbody></table>';
@@ -900,6 +902,9 @@ class Gm2_SEO_Admin {
 
         $breadcrumbs = isset($_POST['gm2_schema_breadcrumbs']) ? '1' : '0';
         update_option('gm2_schema_breadcrumbs', $breadcrumbs);
+
+        $article = isset($_POST['gm2_schema_article']) ? '1' : '0';
+        update_option('gm2_schema_article', $article);
 
         $footer_bc = isset($_POST['gm2_show_footer_breadcrumbs']) ? '1' : '0';
         update_option('gm2_show_footer_breadcrumbs', $footer_bc);

--- a/public/Gm2_SEO_Public.php
+++ b/public/Gm2_SEO_Public.php
@@ -23,6 +23,7 @@ class Gm2_SEO_Public {
         add_action('wp_head', [$this, 'output_brand_schema'], 20);
         add_action('wp_head', [$this, 'output_breadcrumb_schema'], 20);
         add_action('wp_head', [$this, 'output_review_schema'], 20);
+        add_action('wp_head', [$this, 'output_article_schema'], 20);
         if (get_option('gm2_show_footer_breadcrumbs', '1') === '1') {
             add_action('wp_footer', [$this, 'output_breadcrumbs']);
         }
@@ -322,6 +323,35 @@ class Gm2_SEO_Public {
                 'url'           => get_permalink(),
             ],
         ];
+
+        echo '<script type="application/ld+json">' . wp_json_encode($data) . "</script>\n";
+    }
+
+    public function output_article_schema() {
+        if (get_option('gm2_schema_article', '1') !== '1') {
+            return;
+        }
+
+        if (!is_singular('post') && !is_page()) {
+            return;
+        }
+
+        $image = get_the_post_thumbnail_url(get_the_ID(), 'full');
+
+        $data = [
+            '@context' => 'https://schema.org/',
+            '@type'    => 'Article',
+            'headline' => get_the_title(),
+            'author'   => [
+                '@type' => 'Person',
+                'name'  => get_the_author(),
+            ],
+            'datePublished' => get_the_date('c'),
+        ];
+
+        if ($image) {
+            $data['image'] = $image;
+        }
 
         echo '<script type="application/ld+json">' . wp_json_encode($data) . "</script>\n";
     }

--- a/tests/test-schema.php
+++ b/tests/test-schema.php
@@ -69,4 +69,21 @@ class SchemaOutputTest extends WP_UnitTestCase {
         $this->assertIsArray($data);
         $this->assertSame('Brand', $data['@type']);
     }
+
+    public function test_article_schema_json_ld_output() {
+        $post_id = self::factory()->post->create(['post_title' => 'Sample Post']);
+        $seo = new Gm2_SEO_Public();
+        $this->go_to(get_permalink($post_id));
+        setup_postdata(get_post($post_id));
+        update_option('gm2_schema_article', '1');
+        ob_start();
+        $seo->output_article_schema();
+        $output = ob_get_clean();
+        $this->assertNotEmpty($output);
+        preg_match('/<script type="application\/ld\+json">(.*?)<\/script>/s', $output, $m);
+        $json = $m[1] ?? '';
+        $data = json_decode($json, true);
+        $this->assertIsArray($data);
+        $this->assertSame('Article', $data['@type']);
+    }
 }


### PR DESCRIPTION
## Summary
- output `Article` schema in SEO public class
- add option to enable Article schema
- surface checkbox in Structured Data settings
- cover Article schema with new test

## Testing
- `phpunit` *(fails: missing WordPress test library)*

------
https://chatgpt.com/codex/tasks/task_e_686f07aa9b008327bd2611b8106dc165