### PR TITLE
Add extra context support in AI SEO research

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1355,6 +1355,11 @@ class Gm2_SEO_Admin {
             $canonical = esc_url_raw(wp_unslash($_POST['canonical']));
         }
 
+        $extra_context = '';
+        if (isset($_POST['extra_context'])) {
+            $extra_context = sanitize_textarea_field(wp_unslash($_POST['extra_context']));
+        }
+
         $html        = $this->get_rendered_html($post_id, $term_id, $taxonomy);
         $html_issues = $this->detect_html_issues($html, $canonical);
 
@@ -1363,6 +1368,9 @@ class Gm2_SEO_Admin {
         $prompt .= "Page title: {$title}\nURL: {$url}\n";
         $prompt .= "Existing SEO Title: {$seo_title}\nSEO Description: {$seo_description}\n";
         $prompt .= "Focus Keywords: {$focus}\nCanonical: {$canonical}\n";
+        if ($extra_context !== '') {
+            $prompt .= "Extra context: {$extra_context}\n";
+        }
         $prompt .= "Provide JSON with keys seo_title, description, focus_keywords, long_tail_keywords, canonical, page_name, content_suggestions, html_issues.";
 
         $chat = new Gm2_ChatGPT();

--- a/admin/js/gm2-ai-seo.js
+++ b/admin/js/gm2-ai-seo.js
@@ -28,6 +28,13 @@ jQuery(function($){
                 data.taxonomy = gm2AiSeo.taxonomy;
             }
         }
+
+        if(!data.seo_title && !data.seo_description && !data.focus_keywords && !data.canonical){
+            var extra = prompt('Describe the page or its target audience:');
+            if(extra){
+                data.extra_context = extra;
+            }
+        }
         $.post((window.gm2AiSeo ? gm2AiSeo.ajax_url : ajaxurl), data)
         .done(function(resp){
             $out.empty();


### PR DESCRIPTION
## Summary
- enhance AI SEO research JS handler to ask for extra context when all SEO fields are empty
- append `extra_context` in PHP AJAX handler when building the ChatGPT prompt

## Testing
- `phpunit` *(fails: missing WordPress test library)*

------
https://chatgpt.com/codex/tasks/task_e_686f0d0a3000832787b5f6277f267064