### PR TITLE
Add page title and slug selection

### DIFF
--- a/admin/js/gm2-ai-seo.js
+++ b/admin/js/gm2-ai-seo.js
@@ -83,8 +83,12 @@ jQuery(function($){
             seo_title: 'SEO Title',
             description: 'SEO Description',
             focus_keywords: 'Focus Keywords',
-            canonical: 'Canonical URL'
+            canonical: 'Canonical URL',
+            page_name: 'Page Name'
         };
+        if(typeof data.slug !== 'undefined'){
+            fields.slug = 'Slug';
+        }
         Object.keys(fields).forEach(function(key){
             if(typeof data[key] === 'undefined') return;
             var label = fields[key];
@@ -139,6 +143,20 @@ jQuery(function($){
                     $('#gm2_focus_keywords').val(val); break;
                 case 'canonical':
                     $('#gm2_canonical_url').val(val); break;
+                case 'page_name':
+                    if(window.gm2AiSeo && gm2AiSeo.post_id){
+                        $('#title').val(val);
+                    } else if(window.gm2AiSeo && gm2AiSeo.term_id){
+                        $('#tag-name').val(val);
+                    }
+                    break;
+                case 'slug':
+                    if(window.gm2AiSeo && gm2AiSeo.post_id){
+                        $('#post_name').val(val);
+                    } else if(window.gm2AiSeo && gm2AiSeo.term_id){
+                        $('#tag-slug').val(val);
+                    }
+                    break;
             }
         });
     }


### PR DESCRIPTION
## Summary
- update AI SEO suggestions list to include page title and slug
- support copying page title and slug into post or term forms

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f0eecd8a48327b332f2ee4e9b36af