### PR TITLE
Add per-post-type SEO guideline options

### DIFF
--- a/admin/js/gm2-guidelines.js
+++ b/admin/js/gm2-guidelines.js
@@ -1,14 +1,20 @@
 jQuery(function($){
-    $('#gm2-research-guidelines').on('click', function(e){
+    $('.gm2-research-guidelines').on('click', function(e){
         e.preventDefault();
+        var $btn = $(this);
+        var target = $btn.data('target');
+        if(!target){
+            return;
+        }
         var cats = prompt('Enter guideline categories (comma separated):', 'general, keyword research, titles');
         if(cats === null || !cats.trim()){
             return;
         }
-        var $ta = $('textarea[name="gm2_seo_guidelines"]');
+        var $ta = $('textarea[name="' + target + '"]');
         $.post(gm2Guidelines.ajax_url, {
             action: 'gm2_research_guidelines',
             categories: cats,
+            target: target,
             _ajax_nonce: gm2Guidelines.nonce
         }).done(function(resp){
             if(resp && resp.success){

--- a/tests/test-ai-seo.php
+++ b/tests/test-ai-seo.php
@@ -19,6 +19,7 @@ class GuidelinesAjaxTest extends WP_Ajax_UnitTestCase {
 
         $this->_setRole('administrator');
         $_POST['categories'] = 'on page';
+        $_POST['target'] = 'gm2_seo_guidelines_post_post';
         $_POST['_ajax_nonce'] = wp_create_nonce('gm2_research_guidelines');
         $_REQUEST['_ajax_nonce'] = $_POST['_ajax_nonce'];
         try {
@@ -29,7 +30,7 @@ class GuidelinesAjaxTest extends WP_Ajax_UnitTestCase {
         $resp = json_decode($this->_last_response, true);
         $this->assertTrue($resp['success']);
         $this->assertSame('guidelines', $resp['data']);
-        $this->assertSame('guidelines', get_option('gm2_seo_guidelines'));
+        $this->assertSame('guidelines', get_option('gm2_seo_guidelines_post_post'));
     }
 }
 


### PR DESCRIPTION
## Summary
- support separate SEO guideline fields per post type and taxonomy
- update AJAX handlers and JS to accept a target option
- prepend relevant guidelines in AI research
- adjust unit tests for new option names

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f0faca2bc8327814188c910c3a8ad