### PR TITLE
Update AI research to return slug

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1417,7 +1417,7 @@ class Gm2_SEO_Admin {
         if ($extra_context !== '') {
             $prompt .= "Extra context: {$extra_context}\n";
         }
-        $prompt .= "Provide JSON with keys seo_title, description, focus_keywords, long_tail_keywords, canonical, page_name, content_suggestions, html_issues.";
+        $prompt .= "Provide JSON with keys seo_title, description, focus_keywords, long_tail_keywords, canonical, page_name, slug, content_suggestions, html_issues.";
 
         $chat = new Gm2_ChatGPT();
         $resp = $chat->query($prompt);
@@ -1432,6 +1432,10 @@ class Gm2_SEO_Admin {
                 $data['html_issues'] = [];
             }
             $data['html_issues'] = array_merge($data['html_issues'], $html_issues);
+            $slug = isset($data['slug']) ? sanitize_title($data['slug']) : '';
+            if ($slug !== '') {
+                $data['slug'] = $slug;
+            }
             wp_send_json_success($data);
         }
 

--- a/tests/test-ai-seo.php
+++ b/tests/test-ai-seo.php
@@ -44,6 +44,7 @@ class AiResearchAjaxTest extends WP_Ajax_UnitTestCase {
             'long_tail_keywords' => ['a','b'],
             'canonical' => 'https://example.com',
             'page_name' => 'Name',
+            'slug' => 'new-post',
             'content_suggestions' => ['x','y'],
             'html_issues' => [ ['issue' => 'Missing alt', 'fix' => 'Add alt'] ]
         ];
@@ -80,6 +81,7 @@ class AiResearchAjaxTest extends WP_Ajax_UnitTestCase {
         $this->assertSame('New Title', $resp['data']['seo_title']);
         $this->assertSame('Desc', $resp['data']['description']);
         $this->assertSame('Missing alt', $resp['data']['html_issues'][0]['issue']);
+        $this->assertSame('new-post', $resp['data']['slug']);
     }
 }
 


### PR DESCRIPTION
## Summary
- request the slug in the ChatGPT prompt
- sanitize the returned slug and include in JSON response
- expect slug in the AI research AJAX test

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f159c87c48327b51a6a88421ce5d8