### PR TITLE
Fix compatibility with older PHP versions

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -100,12 +100,13 @@ class Gm2_Admin {
 
         check_ajax_referer('gm2_add_tariff');
 
-        $name = sanitize_text_field($_POST['tariff_name'] ?? '');
+        $name_val = isset($_POST['tariff_name']) ? $_POST['tariff_name'] : '';
+        $name = sanitize_text_field($name_val);
         if ($name === '') {
             wp_send_json_error( __( 'Tariff name is required', 'gm2-wordpress-suite' ) );
         }
 
-        $percentage_raw = $_POST['tariff_percentage'] ?? '';
+        $percentage_raw = isset($_POST['tariff_percentage']) ? $_POST['tariff_percentage'] : '';
 
         if (!is_numeric($percentage_raw)) {
             wp_send_json_error( __( 'Tariff percentage must be a number', 'gm2-wordpress-suite' ) );
@@ -116,7 +117,8 @@ class Gm2_Admin {
         if ($percentage < 0 || $percentage > 100) {
             wp_send_json_error( __( 'Tariff percentage must be between 0 and 100', 'gm2-wordpress-suite' ) );
         }
-        $status = ($_POST['tariff_status'] ?? '') === 'enabled' ? 'enabled' : 'disabled';
+        $status_raw = isset($_POST['tariff_status']) ? $_POST['tariff_status'] : '';
+        $status = $status_raw === 'enabled' ? 'enabled' : 'disabled';
 
         $manager = new Gm2_Tariff_Manager();
         $id      = $manager->add_tariff([
@@ -413,7 +415,8 @@ class Gm2_Admin {
 
     public function ajax_chatgpt_prompt() {
         check_ajax_referer('gm2_chatgpt_nonce');
-        $prompt = sanitize_textarea_field($_POST['prompt'] ?? '');
+        $prompt_val = isset($_POST['prompt']) ? $_POST['prompt'] : '';
+        $prompt = sanitize_textarea_field($prompt_val);
         $chat = new Gm2_ChatGPT();
         $resp = $chat->query($prompt);
         if (is_wp_error($resp)) {

--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -381,15 +381,16 @@ class Gm2_SEO_Admin {
             echo '<input type="hidden" name="action" value="gm2_content_rules" />';
             echo '<table class="form-table"><tbody>';
             foreach ($this->get_supported_post_types() as $pt) {
-                $label = get_post_type_object($pt)->labels->singular_name ?? ucfirst($pt);
-                $val   = $all_rules['post_' . $pt] ?? '';
+                $pt_obj = get_post_type_object($pt);
+                $label  = $pt_obj ? $pt_obj->labels->singular_name : ucfirst($pt);
+                $val    = isset($all_rules['post_' . $pt]) ? $all_rules['post_' . $pt] : '';
                 echo '<tr><th scope="row"><label for="gm2_rule_post_' . esc_attr($pt) . '">' . esc_html($label) . '</label></th>';
                 echo '<td><textarea id="gm2_rule_post_' . esc_attr($pt) . '" name="gm2_content_rules[post_' . esc_attr($pt) . ']" rows="3" class="large-text">' . esc_textarea($val) . '</textarea></td></tr>';
             }
             foreach ($this->get_supported_taxonomies() as $tax) {
                 $tax_obj = get_taxonomy($tax);
                 $label   = $tax_obj ? $tax_obj->labels->singular_name : $tax;
-                $val     = $all_rules['tax_' . $tax] ?? '';
+                $val     = isset($all_rules['tax_' . $tax]) ? $all_rules['tax_' . $tax] : '';
                 echo '<tr><th scope="row"><label for="gm2_rule_tax_' . esc_attr($tax) . '">' . esc_html($label) . '</label></th>';
                 echo '<td><textarea id="gm2_rule_tax_' . esc_attr($tax) . '" name="gm2_content_rules[tax_' . esc_attr($tax) . ']" rows="3" class="large-text">' . esc_textarea($val) . '</textarea></td></tr>';
             }
@@ -420,7 +421,8 @@ class Gm2_SEO_Admin {
         }
 
         if (isset($_POST['gm2_ga_property_nonce']) && wp_verify_nonce($_POST['gm2_ga_property_nonce'], 'gm2_ga_property_save')) {
-            $prop = sanitize_text_field(wp_unslash($_POST['gm2_ga_property'] ?? ''));
+            $prop_val = isset($_POST['gm2_ga_property']) ? $_POST['gm2_ga_property'] : '';
+            $prop = sanitize_text_field(wp_unslash($prop_val));
             if ($prop !== '') {
                 update_option('gm2_ga_measurement_id', $prop);
                 $notice = '<div class="updated notice"><p>' . esc_html__('Analytics property saved.', 'gm2-wordpress-suite') . '</p></div>';
@@ -428,7 +430,8 @@ class Gm2_SEO_Admin {
         }
 
         if (isset($_POST['gm2_gads_account_nonce']) && wp_verify_nonce($_POST['gm2_gads_account_nonce'], 'gm2_gads_account_save')) {
-            $acct = sanitize_text_field(wp_unslash($_POST['gm2_gads_account'] ?? ''));
+            $acct_val = isset($_POST['gm2_gads_account']) ? $_POST['gm2_gads_account'] : '';
+            $acct = sanitize_text_field(wp_unslash($acct_val));
             if ($acct !== '') {
                 update_option('gm2_gads_customer_id', $acct);
                 $notice = '<div class="updated notice"><p>' . esc_html__('Ads account saved.', 'gm2-wordpress-suite') . '</p></div>';
@@ -773,7 +776,8 @@ class Gm2_SEO_Admin {
 
         $source = isset($_POST['gm2_redirect_source']) ? sanitize_text_field($_POST['gm2_redirect_source']) : '';
         $target = isset($_POST['gm2_redirect_target']) ? esc_url_raw($_POST['gm2_redirect_target']) : '';
-        $type   = ($_POST['gm2_redirect_type'] ?? '301') === '302' ? '302' : '301';
+        $rtype  = isset($_POST['gm2_redirect_type']) ? $_POST['gm2_redirect_type'] : '301';
+        $type   = $rtype === '302' ? '302' : '301';
 
         if ($source && $target) {
             $redirects   = get_option('gm2_redirects', []);


### PR DESCRIPTION
## Summary
- replace PHP 7+ null coalescing operators with `isset` checks in admin classes

## Testing
- `find admin -name '*.php' -print0 | xargs -0 -I{} php -l {} | grep -v "No syntax errors"; echo 'lint done'`
- `find . -name '*.php' -print0 | xargs -0 -I{} php -l {} | grep -v "No syntax errors"; echo 'lint done'`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_686f1825f0908327b9d4ae312d2076c9