### PR TITLE
Fix missing closing brace in SEO admin

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1076,6 +1076,7 @@ class Gm2_SEO_Admin {
     public function auto_fill_alt_on_upload($attachment_id) {
         if (get_option('gm2_auto_fill_alt', '0') !== '1') {
             return;
+        }
 
         $alt = get_post_meta($attachment_id, '_wp_attachment_image_alt', true);
         if ($alt === '') {


### PR DESCRIPTION
## Summary
- fix missing curly in `auto_fill_alt_on_upload`

## Testing
- `awk 'BEGIN{n=0} /{/ {n++} /}/ {n--} END{print n}' admin/Gm2_SEO_Admin.php`
- `php -l admin/Gm2_SEO_Admin.php`
- `phpunit -c phpunit.xml` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_686f1d702b2483278a734aacac314c62