### PR TITLE
Improve AI SEO response handling

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1432,7 +1432,12 @@ class Gm2_SEO_Admin {
         }
 
         $data = json_decode($resp, true);
-        if (json_last_error() === JSON_ERROR_NONE) {
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            if (preg_match('/\{.*\}/s', $resp, $m)) {
+                $data = json_decode($m[0], true);
+            }
+        }
+        if (json_last_error() === JSON_ERROR_NONE && is_array($data)) {
             if (!isset($data['html_issues'])) {
                 $data['html_issues'] = [];
             }

--- a/admin/js/gm2-ai-seo.js
+++ b/admin/js/gm2-ai-seo.js
@@ -38,10 +38,24 @@ jQuery(function($){
         $.post((window.gm2AiSeo ? gm2AiSeo.ajax_url : ajaxurl), data)
         .done(function(resp){
             $out.empty();
-            if(resp && resp.success && resp.data && typeof resp.data === 'object'){
-                buildResults(resp.data, $out);
-            } else if(resp && resp.data){
-                $out.text(typeof resp.data === 'string' ? resp.data : 'Error');
+            if(resp && resp.success && resp.data){
+                if(typeof resp.data === 'object' && !resp.data.response){
+                    buildResults(resp.data, $out);
+                } else if(resp.data.response){
+                    try {
+                        var parsed = JSON.parse(resp.data.response);
+                        if(parsed && typeof parsed === 'object'){
+                            if(resp.data.html_issues){
+                                parsed.html_issues = resp.data.html_issues;
+                            }
+                            buildResults(parsed, $out);
+                            return;
+                        }
+                    } catch(e) {}
+                    $out.text(resp.data.response);
+                } else {
+                    $out.text(typeof resp.data === 'string' ? resp.data : 'Error');
+                }
             } else {
                 $out.text('Error');
             }


### PR DESCRIPTION
## Summary
- parse embedded JSON in `ajax_ai_research`
- allow JS to decode `resp.data.response`
- test AI SEO handling of text plus JSON

## Testing
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_686f234498948327b831690aa9ae18b4