### PR TITLE
Fix taxonomy script loading on term screen

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1556,7 +1556,7 @@ class Gm2_SEO_Admin {
 
 
     public function enqueue_taxonomy_scripts($hook) {
-        if ($hook !== 'edit-tags.php') {
+        if ($hook !== 'edit-tags.php' && $hook !== 'term.php') {
             return;
         }
         $screen = get_current_screen();


### PR DESCRIPTION
## Summary
- load taxonomy edit scripts on term.php as well

## Testing
- `phpunit` *(fails: missing `/tmp/wordpress-tests-lib`)*
- `bash bin/install-wp-tests.sh wordpress_test root '' localhost latest true` *(fails: Latest WordPress version could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_686f32f7a3a883279ecd67d2813001a1