### PR TITLE
Add permission check when saving taxonomy meta

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -845,6 +845,9 @@ class Gm2_SEO_Admin {
         if (!isset($_POST['gm2_seo_nonce']) || !wp_verify_nonce($_POST['gm2_seo_nonce'], 'gm2_save_seo_meta')) {
             return;
         }
+        if (!current_user_can('edit_term', $term_id)) {
+            return;
+        }
         $title       = isset($_POST['gm2_seo_title']) ? sanitize_text_field($_POST['gm2_seo_title']) : '';
         $description = isset($_POST['gm2_seo_description']) ? sanitize_textarea_field($_POST['gm2_seo_description']) : '';
         $noindex     = isset($_POST['gm2_noindex']) ? '1' : '0';

--- a/tests/test-taxonomy-permissions.php
+++ b/tests/test-taxonomy-permissions.php
@@ -1,0 +1,23 @@
+<?php
+use Gm2\Gm2_SEO_Admin;
+
+class TaxonomyPermissionsTest extends WP_UnitTestCase {
+    public function test_save_taxonomy_meta_without_permission_does_nothing() {
+        $term_id = self::factory()->term->create(['taxonomy' => 'category']);
+        $user_id = self::factory()->user->create(['role' => 'subscriber']);
+        wp_set_current_user($user_id);
+
+        $admin = new Gm2_SEO_Admin();
+
+        $_POST['gm2_seo_nonce'] = wp_create_nonce('gm2_save_seo_meta');
+        $_POST['gm2_seo_title'] = 'Title';
+
+        $admin->save_taxonomy_meta($term_id);
+
+        wp_set_current_user(0);
+        $_POST = [];
+
+        $this->assertFalse(metadata_exists('term', $term_id, '_gm2_title'));
+    }
+}
+


### PR DESCRIPTION
## Summary
- ensure users can't save taxonomy SEO fields without `edit_term` capability
- cover new capability logic with a unit test

## Testing
- `phpunit` *(fails: missing WordPress test suite)*

------
https://chatgpt.com/codex/tasks/task_e_686f3ecf19988327ad4601da84776ce4