### PR TITLE
Check term edit capability in AI research

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1345,13 +1345,20 @@ class Gm2_SEO_Admin {
 
     public function ajax_ai_research() {
         check_ajax_referer('gm2_ai_research');
-        if (!current_user_can('edit_posts')) {
-            wp_send_json_error('permission denied', 403);
-        }
 
         $post_id  = isset($_POST['post_id']) ? absint($_POST['post_id']) : 0;
         $term_id  = isset($_POST['term_id']) ? absint($_POST['term_id']) : 0;
         $taxonomy = isset($_POST['taxonomy']) ? sanitize_key($_POST['taxonomy']) : '';
+
+        if ($term_id) {
+            if (!current_user_can('edit_term', $term_id)) {
+                wp_send_json_error('permission denied', 403);
+            }
+        } else {
+            if (!current_user_can('edit_posts')) {
+                wp_send_json_error('permission denied', 403);
+            }
+        }
 
         $title = $url = '';
         $seo_title = $seo_description = $focus = $canonical = '';

--- a/tests/test-ai-seo.php
+++ b/tests/test-ai-seo.php
@@ -151,6 +151,37 @@ class AiResearchAjaxTest extends WP_Ajax_UnitTestCase {
         $this->assertTrue($resp['success']);
         $this->assertSame('Parsed', $resp['data']['seo_title']);
     }
+
+    public function test_ai_research_requires_edit_posts_cap() {
+        $post_id = self::factory()->post->create();
+
+        $this->_setRole('subscriber');
+        $_POST['post_id'] = $post_id;
+        $_POST['_ajax_nonce'] = wp_create_nonce('gm2_ai_research');
+        $_REQUEST['_ajax_nonce'] = $_POST['_ajax_nonce'];
+        try {
+            $this->_handleAjax('gm2_ai_research');
+        } catch (WPAjaxDieContinueException $e) {
+        }
+        $resp = json_decode($this->_last_response, true);
+        $this->assertFalse($resp['success']);
+    }
+
+    public function test_ai_research_requires_edit_term_cap() {
+        $term_id = self::factory()->term->create(['taxonomy' => 'category']);
+
+        $this->_setRole('subscriber');
+        $_POST['term_id'] = $term_id;
+        $_POST['taxonomy'] = 'category';
+        $_POST['_ajax_nonce'] = wp_create_nonce('gm2_ai_research');
+        $_REQUEST['_ajax_nonce'] = $_POST['_ajax_nonce'];
+        try {
+            $this->_handleAjax('gm2_ai_research');
+        } catch (WPAjaxDieContinueException $e) {
+        }
+        $resp = json_decode($this->_last_response, true);
+        $this->assertFalse($resp['success']);
+    }
 }
 
 class AdminTabsTest extends WP_UnitTestCase {


### PR DESCRIPTION
## Summary
- adjust capability check in `ajax_ai_research()` to respect term editing rights
- add tests for required capabilities when using posts or terms

## Testing
- `php -l admin/Gm2_SEO_Admin.php`
- `php -l tests/test-ai-seo.php`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_686f3fcb747883278f1c4cfa89b5e92c