### PR TITLE
Use GitHub mirror for WP tests

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -34,7 +34,7 @@ jobs:
           coverage: none
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y subversion mysql-client
+        run: sudo apt-get update && sudo apt-get install -y mysql-client
 
       - name: Install WordPress test suite
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,10 +15,11 @@ This project includes a PHPUnit test suite that relies on the WordPress test lib
 
 ## WordPress Test Suite
 
-The PHPUnit tests depend on the WordPress testing suite. The installation script above downloads it automatically. You can also check out the suite manually, for example:
+The PHPUnit tests depend on the WordPress testing suite. The installation script above downloads it automatically from GitHub. You can also fetch the suite manually if you prefer:
 
 ```bash
-svn co https://develop.svn.wordpress.org/trunk/tests/phpunit $WP_TESTS_DIR
+curl -L https://codeload.github.com/WordPress/wordpress-develop/tar.gz/refs/heads/trunk | \
+  tar -xz --strip-components=1 wordpress-develop-*/tests/phpunit -C "$WP_TESTS_DIR"
 ```
 
 Set the `WP_TESTS_DIR` environment variable to the directory where the suite resides. PHPUnit tests cannot run without this directory. If the variable is not set, `tests/bootstrap.php` falls back to `/tmp/wordpress-tests-lib`.

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 if [ $# -lt 3 ]; then
-	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version] [skip-database-creation]"
-	exit 1
+    echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version] [skip-database-creation]"
+    exit 1
 fi
 
 DB_NAME=$1
@@ -18,133 +18,111 @@ WP_TESTS_DIR=${WP_TESTS_DIR-$TMPDIR/wordpress-tests-lib}
 WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress/}
 
 download() {
-    if [ `which curl` ]; then
-        curl -s "$1" > "$2";
-    elif [ `which wget` ]; then
+    if [ "$(command -v curl)" ]; then
+        curl -sL "$1" -o "$2"
+    elif [ "$(command -v wget)" ]; then
         wget -nv -O "$2" "$1"
     fi
 }
 
 if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+$ ]]; then
-	WP_TESTS_TAG="branches/$WP_VERSION"
+    WP_TESTS_TAG="branches/$WP_VERSION"
 elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
-	if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
-		# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
-		WP_TESTS_TAG="tags/${WP_VERSION%??}"
-	else
-		WP_TESTS_TAG="tags/$WP_VERSION"
-	fi
+    if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
+        WP_TESTS_TAG="tags/${WP_VERSION%??}"
+    else
+        WP_TESTS_TAG="tags/$WP_VERSION"
+    fi
 elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
-	WP_TESTS_TAG="trunk"
+    WP_TESTS_TAG="trunk"
 else
-	# http serves a single offer, whereas https serves multiple. we only want one
-	download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
-	grep '[0-9]+\.[0-9]+(\.[0-9]+)?' /tmp/wp-latest.json
-	LATEST_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
-	if [[ -z "$LATEST_VERSION" ]]; then
-		echo "Latest WordPress version could not be found"
-		exit 1
-	fi
-	WP_TESTS_TAG="tags/$LATEST_VERSION"
+    LATEST_VERSION=$(curl -s https://api.github.com/repos/WordPress/WordPress/tags?per_page=1 | grep -o '"name": "[^"]*"' | head -1 | sed 's/"name": "\([^"]*\)"/\1/')
+    if [[ -z "$LATEST_VERSION" ]]; then
+        echo "Latest WordPress version could not be found"
+        exit 1
+    fi
+    WP_VERSION=$LATEST_VERSION
+    WP_TESTS_TAG="tags/$LATEST_VERSION"
 fi
 
 set -ex
 
 install_wp() {
+    if [ -d "$WP_CORE_DIR" ]; then
+        return
+    fi
 
-	if [ -d $WP_CORE_DIR ]; then
-		return;
-	fi
+    mkdir -p "$WP_CORE_DIR"
 
-	mkdir -p $WP_CORE_DIR
+    local DOWNLOAD_TAG
+    if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+        DOWNLOAD_TAG="master"
+    else
+        DOWNLOAD_TAG="$WP_VERSION"
+    fi
 
-	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
-		mkdir -p $TMPDIR/wordpress-nightly
-		download https://wordpress.org/nightly-builds/wordpress-latest.zip  $TMPDIR/wordpress-nightly/wordpress-nightly.zip
-		unzip -q $TMPDIR/wordpress-nightly/wordpress-nightly.zip -d $TMPDIR/wordpress-nightly/
-		mv $TMPDIR/wordpress-nightly/wordpress/* $WP_CORE_DIR
-	else
-		if [ $WP_VERSION == 'latest' ]; then
-			local ARCHIVE_NAME='latest'
-		elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+ ]]; then
-			# https serves multiple offers, whereas http serves single.
-			download https://api.wordpress.org/core/version-check/1.7/ $TMPDIR/wp-latest.json
-			if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
-				# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
-				LATEST_VERSION=${WP_VERSION%??}
-			else
-				# otherwise, scan the releases and get the most up to date minor version of the major release
-				local VERSION_ESCAPED=`echo $WP_VERSION | sed 's/\./\\\\./g'`
-				LATEST_VERSION=$(grep -o '"version":"'$VERSION_ESCAPED'[^"]*' $TMPDIR/wp-latest.json | sed 's/"version":"//' | head -1)
-			fi
-			if [[ -z "$LATEST_VERSION" ]]; then
-				local ARCHIVE_NAME="wordpress-$WP_VERSION"
-			else
-				local ARCHIVE_NAME="wordpress-$LATEST_VERSION"
-			fi
-		else
-			local ARCHIVE_NAME="wordpress-$WP_VERSION"
-		fi
-		download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  $TMPDIR/wordpress.tar.gz
-		tar --strip-components=1 -zxmf $TMPDIR/wordpress.tar.gz -C $WP_CORE_DIR
-	fi
+    download "https://codeload.github.com/WordPress/WordPress/tar.gz/$DOWNLOAD_TAG" "$TMPDIR/wordpress.tar.gz"
+    tar --strip-components=1 -xzf "$TMPDIR/wordpress.tar.gz" -C "$WP_CORE_DIR"
 
-	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
+    download https://raw.githubusercontent.com/markoheijnen/wp-mysqli/master/db.php "$WP_CORE_DIR/wp-content/db.php"
 }
 
 install_test_suite() {
-	# portable in-place argument for both GNU sed and Mac OSX sed
-	if [[ $(uname -s) == 'Darwin' ]]; then
-		local ioption='-i .bak'
-	else
-		local ioption='-i'
-	fi
+    if [[ $(uname -s) == 'Darwin' ]]; then
+        local ioption='-i .bak'
+    else
+        local ioption='-i'
+    fi
 
-	# set up testing suite if it doesn't yet exist
-	if [ ! -d $WP_TESTS_DIR ]; then
-		# set up testing suite
-		mkdir -p $WP_TESTS_DIR
-		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
-		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
-	fi
+    if [ ! -d "$WP_TESTS_DIR" ]; then
+        mkdir -p "$WP_TESTS_DIR"
+        local REF
+        if [[ $WP_TESTS_TAG == branches/* ]]; then
+            REF="refs/heads/${WP_TESTS_TAG#branches/}"
+        elif [[ $WP_TESTS_TAG == tags/* ]]; then
+            REF="refs/tags/${WP_TESTS_TAG#tags/}"
+        else
+            REF="refs/heads/$WP_TESTS_TAG"
+        fi
+        download "https://codeload.github.com/WordPress/wordpress-develop/tar.gz/$REF" "$TMPDIR/wordpress-develop.tar.gz"
+        mkdir -p "$TMPDIR/wordpress-develop"
+        tar --strip-components=1 -xzf "$TMPDIR/wordpress-develop.tar.gz" -C "$TMPDIR/wordpress-develop"
+        cp -R "$TMPDIR/wordpress-develop/tests/phpunit/includes" "$WP_TESTS_DIR"
+        cp -R "$TMPDIR/wordpress-develop/tests/phpunit/data" "$WP_TESTS_DIR"
+    fi
 
-	if [ ! -f wp-tests-config.php ]; then
-		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
-		# remove all forward slashes in the end
-		WP_CORE_DIR=$(echo $WP_CORE_DIR | sed "s:/\+$::")
-		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
-		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
-		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
-		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
-		sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR"/wp-tests-config.php
-	fi
-
+    if [ ! -f "$WP_TESTS_DIR/wp-tests-config.php" ]; then
+        download "https://raw.githubusercontent.com/WordPress/wordpress-develop/${WP_TESTS_TAG#*/}/wp-tests-config-sample.php" "$WP_TESTS_DIR/wp-tests-config.php"
+        WP_CORE_DIR=$(echo "$WP_CORE_DIR" | sed "s:/\+$::")
+        sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR/wp-tests-config.php"
+        sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR/wp-tests-config.php"
+        sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR/wp-tests-config.php"
+        sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR/wp-tests-config.php"
+        sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR/wp-tests-config.php"
+    fi
 }
 
 install_db() {
+    if [ ${SKIP_DB_CREATE} = "true" ]; then
+        return 0
+    fi
 
-	if [ ${SKIP_DB_CREATE} = "true" ]; then
-		return 0
-	fi
+    local PARTS=(${DB_HOST//:/ })
+    local DB_HOSTNAME=${PARTS[0]}
+    local DB_SOCK_OR_PORT=${PARTS[1]}
+    local EXTRA=""
 
-	# parse DB_HOST for port or socket references
-	local PARTS=(${DB_HOST//\:/ })
-	local DB_HOSTNAME=${PARTS[0]};
-	local DB_SOCK_OR_PORT=${PARTS[1]};
-	local EXTRA=""
+    if ! [ -z $DB_HOSTNAME ] ; then
+        if [ $(echo $DB_SOCK_OR_PORT | grep -e '^[0-9]\{1,\}$') ]; then
+            EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
+        elif ! [ -z $DB_SOCK_OR_PORT ] ; then
+            EXTRA=" --socket=$DB_SOCK_OR_PORT"
+        elif ! [ -z $DB_HOSTNAME ] ; then
+            EXTRA=" --host=$DB_HOSTNAME --protocol=tcp"
+        fi
+    fi
 
-	if ! [ -z $DB_HOSTNAME ] ; then
-		if [ $(echo $DB_SOCK_OR_PORT | grep -e '^[0-9]\{1,\}$') ]; then
-			EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
-		elif ! [ -z $DB_SOCK_OR_PORT ] ; then
-			EXTRA=" --socket=$DB_SOCK_OR_PORT"
-		elif ! [ -z $DB_HOSTNAME ] ; then
-			EXTRA=" --host=$DB_HOSTNAME --protocol=tcp"
-		fi
-	fi
-
-	# create database
-	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+    mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
 }
 
 install_wp

--- a/readme.txt
+++ b/readme.txt
@@ -176,4 +176,4 @@ the last 100 missing URLs to help you create new redirects.
 * Initial release.
 
 == Testing ==
-The automated tests use the WordPress test suite and assume `phpunit` is installed globally. They cover the AJAX endpoints used for content analysis and AI research (`gm2_check_rules`, `gm2_keyword_ideas`, `gm2_research_guidelines` and `gm2_ai_research`). See `CONTRIBUTING.md` for setup details.
+The automated tests rely on the WordPress test suite, fetched from GitHub by `bin/install-wp-tests.sh`. PHPUnit must be installed globally. The tests cover the AJAX endpoints used for content analysis and AI research (`gm2_check_rules`, `gm2_keyword_ideas`, `gm2_research_guidelines` and `gm2_ai_research`). See `CONTRIBUTING.md` for setup details.


### PR DESCRIPTION
## Summary
- download WordPress and the test suite from GitHub in `install-wp-tests.sh`
- update CONTRIBUTING docs with manual GitHub download instructions
- note GitHub mirror in readme's Testing section
- remove subversion from CI workflow

## Testing
- `bash bin/install-wp-tests.sh wordpress root root localhost latest true`
- `phpunit --version`

------
https://chatgpt.com/codex/tasks/task_e_686f5b34bc9c8327857b5a2f016e01a0