### PR TITLE
Add new SEO content rules

### DIFF
--- a/admin/js/gm2-content-analysis.js
+++ b/admin/js/gm2-content-analysis.js
@@ -51,11 +51,16 @@
     }
 
     function applyRuleResults(results){
-        $('.gm2-analysis-rules li').each(function(){
-            const key = $(this).data('key');
-            if(!key || typeof results[key] === 'undefined') return;
+        const list = $('.gm2-analysis-rules');
+        Object.keys(results).forEach(function(key){
+            let $li = list.find('li[data-key="' + key + '"]');
+            if(!$li.length){
+                $li = $('<li>').attr('data-key', key)
+                    .append('<span class="dashicons"></span> ' + key.replace(/-/g,' '))
+                    .appendTo(list);
+            }
             const pass = results[key];
-            $(this).toggleClass('pass', pass).toggleClass('fail', !pass)
+            $li.toggleClass('pass', pass).toggleClass('fail', !pass)
                 .find('.dashicons').removeClass('dashicons-no dashicons-yes')
                 .addClass(pass ? 'dashicons-yes' : 'dashicons-no');
         });

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -76,6 +76,11 @@ function gm2_initialize_content_rules() {
         'Description length between 50 and 160 characters',
         'At least one focus keyword',
         'Content has at least 300 words',
+        'Focus keyword appears in first paragraph',
+        'Only one H1 tag present',
+        'At least one internal link',
+        'At least one external link',
+        'Focus keyword included in meta description',
     ];
     foreach ($posts as $pt) {
         $rules['post_' . $pt] = implode("\n", $post_defaults);


### PR DESCRIPTION
## Summary
- expand default content rules for posts
- validate new rules on `gm2_check_rules` endpoint
- show rule results dynamically in content analysis script
- test new rule logic

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f7d8fa4f48327a44b0c15c82ded3f