### PR TITLE
Add slug cleaning option

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -115,6 +115,9 @@ The **Sitemap** tab lets you regenerate your XML sitemap. Each time a sitemap is
 created, the plugin pings Google and Bing so they can re-crawl it. You can also
 edit your robots file from **SEO → Robots.txt**.
 
+Enable **Clean Slugs** from **SEO → General** to strip stopwords from new
+permalinks. Enter the words to remove in the accompanying field.
+
 == AI SEO ==
 While editing a post or taxonomy term, open the **AI SEO** tab in the SEO meta
 box. Click **AI Research** and you'll first be asked whether to use any existing
@@ -150,6 +153,8 @@ Create 301 or 302 redirects from the **SEO → Redirects** tab. The plugin logs
 the last 100 missing URLs to help you create new redirects.
 
 == Changelog ==
+= 1.6.4 =
+* Optional slug cleaner with customizable stopwords.
 = 1.6.3 =
 * Expanded documentation for Open Graph images, robots meta settings, sitemap
   pinging, robots.txt editing, AI-generated descriptions and alt text, and

--- a/tests/test-slug-cleaner.php
+++ b/tests/test-slug-cleaner.php
@@ -1,0 +1,14 @@
+<?php
+use Gm2\Gm2_SEO_Admin;
+
+class SlugCleanerTest extends WP_UnitTestCase {
+    public function test_stopwords_are_removed_from_slug() {
+        update_option('gm2_clean_slugs', '1');
+        update_option('gm2_slug_stopwords', "the of");
+        $admin = new Gm2_SEO_Admin();
+        $admin->run();
+        $slug = sanitize_title('The Best of the Products');
+        remove_filter('sanitize_title', [$admin, 'clean_slug'], 20);
+        $this->assertSame('best-products', $slug);
+    }
+}


### PR DESCRIPTION
## Summary
- add optional slug cleaner and stopword list
- hook into `sanitize_title` when enabled
- document clean slug feature
- test slug sanitization

## Testing
- `phpunit --configuration phpunit.xml` *(fails: PHPUnit polyfills/DB not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686f86e5a7108327b142ecbdba49fc7e