### PR TITLE
Add image alt text focus keyword rule

### DIFF
--- a/tests/ContentAnalysisTest.php
+++ b/tests/ContentAnalysisTest.php
@@ -45,6 +45,7 @@ class ContentRulesNewTest extends WP_Ajax_UnitTestCase {
 
     public function test_new_rules_pass() {
         $content = '<p>keyword first</p><h1>Heading</h1>' .
+            '<img src="img.jpg" alt="keyword image" />' .
             '<a href="' . home_url('/') . '">int</a>' .
             '<a href="https://example.com">ext</a> ' . str_repeat('word ', 300);
         $resp = $this->run_check($content, 'meta with keyword', 'keyword');
@@ -54,10 +55,12 @@ class ContentRulesNewTest extends WP_Ajax_UnitTestCase {
         $this->assertTrue($data['at-least-one-internal-link']);
         $this->assertTrue($data['at-least-one-external-link']);
         $this->assertTrue($data['focus-keyword-included-in-meta-description']);
+        $this->assertTrue($data['image-alt-text-contains-focus-keyword']);
     }
 
     public function test_new_rules_fail() {
-        $content = '<p>no key</p><h1>h1</h1><h1>h2</h1>' . str_repeat('word ', 10);
+        $content = '<p>no key</p><img src="img.jpg" alt="no match" />' .
+            '<h1>h1</h1><h1>h2</h1>' . str_repeat('word ', 10);
         $resp = $this->run_check($content, 'no match', 'keyword');
         $data = $resp['data'];
         $this->assertFalse($data['focus-keyword-appears-in-first-paragraph']);
@@ -65,6 +68,21 @@ class ContentRulesNewTest extends WP_Ajax_UnitTestCase {
         $this->assertFalse($data['at-least-one-internal-link']);
         $this->assertFalse($data['at-least-one-external-link']);
         $this->assertFalse($data['focus-keyword-included-in-meta-description']);
+        $this->assertFalse($data['image-alt-text-contains-focus-keyword']);
+    }
+
+    public function test_alt_text_rule_passes() {
+        $content = '<p>text</p><img src="img.jpg" alt="keyword here" />';
+        $resp = $this->run_check($content, 'desc keyword', 'keyword');
+        $data = $resp['data'];
+        $this->assertTrue($data['image-alt-text-contains-focus-keyword']);
+    }
+
+    public function test_alt_text_rule_fails() {
+        $content = '<p>text</p><img src="img.jpg" alt="something else" />';
+        $resp = $this->run_check($content, 'desc keyword', 'keyword');
+        $data = $resp['data'];
+        $this->assertFalse($data['image-alt-text-contains-focus-keyword']);
     }
 }
 

--- a/tests/test-content-rules.php
+++ b/tests/test-content-rules.php
@@ -10,7 +10,7 @@ class ContentRulesAjaxTest extends WP_Ajax_UnitTestCase {
         $_POST['title'] = str_repeat('T', 35);
         $_POST['description'] = str_repeat('D', 80);
         $_POST['focus'] = 'keyword';
-        $_POST['content'] = str_repeat('word ', 300);
+        $_POST['content'] = '<img src="img.jpg" alt="keyword" /> ' . str_repeat('word ', 300);
         $_POST['_ajax_nonce'] = wp_create_nonce('gm2_check_rules');
         $_REQUEST['_ajax_nonce'] = $_POST['_ajax_nonce'];
         try {


### PR DESCRIPTION
## Summary
- detect missing focus keywords in image alt text
- check alt text rule via content analysis
- update content rules default lists
- test new rule for pass/fail cases

## Testing
- `phpunit --configuration phpunit.xml` *(fails: PHPUnit Polyfills library missing)*

------
https://chatgpt.com/codex/tasks/task_e_686fd4f771a883278a8800db16eb54c2