### PR TITLE
Add clean image filenames setting

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -132,7 +132,9 @@ before clicking **Implement Selected** to populate the fields automatically.
 If the description field in the SEO Settings tab is left empty, the plugin sends
 an excerpt of the post to ChatGPT and uses the response as the meta description.
 Enabling **Auto-fill missing alt text** under **SEO → Performance** also uses
-ChatGPT to generate alt text for new images when none is provided.
+ChatGPT to generate alt text for new images when none is provided. Enable
+**Clean Image Filenames** in the same section to automatically rename uploads
+using a sanitized version of the attachment title.
 
 
 The SEO Settings tab also lets you set `max-snippet`, `max-image-preview`, and
@@ -155,6 +157,7 @@ the last 100 missing URLs to help you create new redirects.
 == Changelog ==
 = 1.6.4 =
 * Optional slug cleaner with customizable stopwords.
+* Option to clean image filenames on upload.
 = 1.6.3 =
 * Expanded documentation for Open Graph images, robots meta settings, sitemap
   pinging, robots.txt editing, AI-generated descriptions and alt text, and

--- a/tests/test-generated-fields.php
+++ b/tests/test-generated-fields.php
@@ -54,5 +54,21 @@ class GeneratedFieldsTest extends WP_UnitTestCase {
 
         $this->assertSame('alt text', get_post_meta($attachment_id, '_wp_attachment_image_alt', true));
     }
+
+    public function test_filename_is_cleaned_on_upload() {
+        update_option('gm2_clean_image_filenames', '1');
+        $filename = DIR_TESTDATA . '/images/canola.jpg';
+        $attachment_id = self::factory()->attachment->create_upload_object($filename);
+        wp_update_post([
+            'ID' => $attachment_id,
+            'post_title' => 'My Image Name',
+        ]);
+
+        $admin = new Gm2_SEO_Admin();
+        $admin->auto_fill_alt_on_upload($attachment_id);
+
+        $path = get_attached_file($attachment_id);
+        $this->assertSame('my-image-name.jpg', wp_basename($path));
+    }
 }
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -53,6 +53,7 @@ $option_names = array(
     'gm2_schema_review',
     'gm2_show_footer_breadcrumbs',
     'gm2_auto_fill_alt',
+    'gm2_clean_image_filenames',
     'gm2_enable_compression',
     'gm2_compression_api_key',
     'gm2_compression_api_url',


### PR DESCRIPTION
## Summary
- add a new `gm2_clean_image_filenames` setting
- rename uploads based on the attachment title when enabled
- remove the new option on uninstall
- document cleaning uploads and update changelog
- test filename rewriting

## Testing
- `apt-get update`
- `apt-get install -y php-cli php-mbstring php-xml php-sqlite3`
- `apt-get install -y phpunit`
- `phpunit` *(fails: Error in bootstrap script)*

------
https://chatgpt.com/codex/tasks/task_e_686fe7f228748327a91340777acf3604