### PR TITLE
Add AI-generated taxonomy descriptions

### DIFF
--- a/admin/js/gm2-tax-desc.js
+++ b/admin/js/gm2-tax-desc.js
@@ -1,0 +1,34 @@
+jQuery(function($){
+    function insertButton($ta){
+        if(!$ta.length || $ta.data('gm2-enhanced')) return;
+        var $btn = $('<p><button class="button gm2-generate-desc">Generate Description</button></p>');
+        $btn.insertAfter($ta);
+        $ta.data('gm2-enhanced', true);
+    }
+    insertButton($('#tag-description'));
+    insertButton($('#description'));
+
+    $(document).on('click', '.gm2-generate-desc', function(e){
+        e.preventDefault();
+        var $btn = $(this);
+        var $ta = $btn.closest('p').prev('textarea');
+        var name = $('#tag-name').val() || $('#name').val() || '';
+        $.post(gm2TaxDesc.ajax_url, {
+            action: 'gm2_ai_generate_tax_description',
+            term_id: gm2TaxDesc.term_id,
+            taxonomy: gm2TaxDesc.taxonomy,
+            name: name,
+            _ajax_nonce: gm2TaxDesc.nonce
+        }).done(function(resp){
+            if(resp && resp.success){
+                $ta.val(resp.data);
+            } else if(resp && resp.data){
+                alert(resp.data);
+            } else {
+                alert('Error');
+            }
+        }).fail(function(){
+            alert('Request failed');
+        });
+    });
+});

--- a/readme.txt
+++ b/readme.txt
@@ -136,6 +136,11 @@ ChatGPT to generate alt text for new images when none is provided. Enable
 **Clean Image Filenames** in the same section to automatically rename uploads
 using a sanitized version of the attachment title.
 
+On taxonomy edit screens you'll also find a **Generate Description** button next
+to the description field. The prompt can be customised via the
+`gm2_tax_desc_prompt` setting and includes any saved SEO guidelines for that
+taxonomy.
+
 
 The SEO Settings tab also lets you set `max-snippet`, `max-image-preview`, and
 `max-video-preview` values that will be added to the robots meta tag.

--- a/tests/test-tax-description.php
+++ b/tests/test-tax-description.php
@@ -1,0 +1,45 @@
+<?php
+use Gm2\Gm2_SEO_Admin;
+
+class TaxDescriptionAjaxTest extends WP_Ajax_UnitTestCase {
+    public function test_generate_tax_description_updates_term() {
+        update_option('gm2_chatgpt_api_key', 'key');
+        update_option('gm2_seo_guidelines_tax_category', 'guidelines');
+        update_option('gm2_tax_desc_prompt', 'Prompt {name} {guidelines}');
+
+        $captured = null;
+        $filter = function($pre, $args, $url) use (&$captured) {
+            if ($url === 'https://api.openai.com/v1/chat/completions') {
+                $body = json_decode($args['body'], true);
+                $captured = $body['messages'][0]['content'];
+                return [
+                    'response' => ['code' => 200],
+                    'body' => json_encode(['choices' => [ ['message' => ['content' => 'desc']] ]])
+                ];
+            }
+            return false;
+        };
+        add_filter('pre_http_request', $filter, 10, 3);
+
+        $term_id = self::factory()->term->create(['taxonomy' => 'category', 'name' => 'Books']);
+
+        $this->_setRole('administrator');
+        $_POST['taxonomy'] = 'category';
+        $_POST['term_id'] = $term_id;
+        $_POST['name'] = 'Books';
+        $_POST['_ajax_nonce'] = wp_create_nonce('gm2_ai_generate_tax_description');
+        $_REQUEST['_ajax_nonce'] = $_POST['_ajax_nonce'];
+
+        try { $this->_handleAjax('gm2_ai_generate_tax_description'); } catch (WPAjaxDieContinueException $e) {}
+
+        remove_filter('pre_http_request', $filter, 10);
+
+        $resp = json_decode($this->_last_response, true);
+        $this->assertTrue($resp['success']);
+        $this->assertSame('desc', $resp['data']);
+        $term = get_term($term_id, 'category');
+        $this->assertSame('desc', $term->description);
+        $this->assertStringContainsString('Books', $captured);
+        $this->assertStringContainsString('guidelines', $captured);
+    }
+}


### PR DESCRIPTION
## Summary
- add JS for Generate Description button on taxonomy forms
- create AJAX handler for `gm2_ai_generate_tax_description`
- store prompt template in `gm2_tax_desc_prompt` option
- document taxonomy description generator in readme
- test new AJAX helper

## Testing
- `phpunit -c phpunit.xml` *(fails: require_once /tmp/wordpress-tests-lib/includes/functions.php: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687002024c9883279bfb45ac6306b69c