### PR TITLE
Add Bulk AI Review admin page

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -39,6 +39,7 @@ class Gm2_Admin {
 
         $seo_pages = [
             'gm2_page_gm2-seo',
+            'gm2_page_gm2-bulk-ai-review',
         ];
 
         if ($hook === 'gm2_page_gm2-chatgpt') {
@@ -109,6 +110,24 @@ class Gm2_Admin {
                     'ajax_url' => admin_url('admin-ajax.php'),
                 ]
             );
+            if ($hook === 'gm2_page_gm2-bulk-ai-review') {
+                wp_enqueue_script(
+                    'gm2-bulk-ai',
+                    GM2_PLUGIN_URL . 'admin/js/gm2-bulk-ai.js',
+                    ['jquery'],
+                    GM2_VERSION,
+                    true
+                );
+                wp_localize_script(
+                    'gm2-bulk-ai',
+                    'gm2BulkAi',
+                    [
+                        'nonce'       => wp_create_nonce('gm2_ai_research'),
+                        'apply_nonce' => wp_create_nonce('gm2_bulk_ai_apply'),
+                        'ajax_url'    => admin_url('admin-ajax.php'),
+                    ]
+                );
+            }
         }
     }
 

--- a/admin/js/gm2-bulk-ai.js
+++ b/admin/js/gm2-bulk-ai.js
@@ -1,0 +1,39 @@
+jQuery(function($){
+    $('#gm2-bulk-ai').on('click','#gm2-bulk-select-all',function(){
+        var c=$(this).prop('checked');
+        $('#gm2-bulk-list .gm2-select').prop('checked',c);
+    });
+    $('#gm2-bulk-ai').on('click','#gm2-bulk-analyze',function(e){
+        e.preventDefault();
+        var ids=[];
+        $('#gm2-bulk-list .gm2-select:checked').each(function(){ids.push($(this).val());});
+        if(!ids.length) return;
+        ids.forEach(function(id){
+            var row=$('#gm2-row-'+id);row.find('.gm2-result').text('...');
+            $.post(gm2BulkAi.ajax_url,{action:'gm2_ai_research',post_id:id,_ajax_nonce:gm2BulkAi.nonce})
+            .done(function(resp){
+                if(resp&&resp.success&&resp.data){
+                    var html='';
+                    if(resp.data.seo_title){html+='<p><label><input type="checkbox" class="gm2-apply" data-field="seo_title" data-value="'+resp.data.seo_title.replace(/"/g,'&quot;')+'"> '+resp.data.seo_title+'</label></p>';}
+                    if(resp.data.description){html+='<p><label><input type="checkbox" class="gm2-apply" data-field="seo_description" data-value="'+resp.data.description.replace(/"/g,'&quot;')+'"> '+resp.data.description+'</label></p>';}
+                    if(resp.data.slug){html+='<p><label><input type="checkbox" class="gm2-apply" data-field="slug" data-value="'+resp.data.slug+'"> Slug: '+resp.data.slug+'</label></p>';}
+                    if(resp.data.page_name){html+='<p><label><input type="checkbox" class="gm2-apply" data-field="title" data-value="'+resp.data.page_name.replace(/"/g,'&quot;')+'"> Title: '+resp.data.page_name+'</label></p>';}
+                    html+='<p><button class="button gm2-apply-btn" data-id="'+id+'">Apply</button></p>';
+                    row.find('.gm2-result').html(html);
+                }else{row.find('.gm2-result').text('Error');}
+            })
+            .fail(function(){row.find('.gm2-result').text('Error');});
+        });
+    });
+    $('#gm2-bulk-list').on('click','.gm2-apply-btn',function(e){
+        e.preventDefault();
+        var id=$(this).data('id');
+        var data={action:'gm2_bulk_ai_apply',post_id:id,_ajax_nonce:gm2BulkAi.apply_nonce};
+        $(this).closest('.gm2-result').find('.gm2-apply:checked').each(function(){
+            data[$(this).data('field')]= $(this).data('value');
+        });
+        $.post(gm2BulkAi.ajax_url,data).done(function(){
+            $('#gm2-row-'+id+' .gm2-result').append('<span> ✓</span>');
+        });
+    });
+});

--- a/tests/test-bulk-ai.php
+++ b/tests/test-bulk-ai.php
@@ -1,0 +1,46 @@
+<?php
+use Gm2\Gm2_SEO_Admin;
+
+class BulkAiPageTest extends WP_UnitTestCase {
+    public function test_page_requires_edit_posts_cap() {
+        $admin = new Gm2_SEO_Admin();
+        $user = self::factory()->user->create(['role' => 'subscriber']);
+        wp_set_current_user($user);
+        ob_start();
+        $admin->display_bulk_ai_page();
+        $out = ob_get_clean();
+        $this->assertStringContainsString('Permission denied', $out);
+    }
+}
+
+class BulkAiApplyAjaxTest extends WP_Ajax_UnitTestCase {
+    public function test_apply_updates_post_meta() {
+        $post_id = self::factory()->post->create();
+        $this->_setRole('administrator');
+        $_POST['post_id'] = $post_id;
+        $_POST['seo_title'] = 'New';
+        $_POST['seo_description'] = 'Desc';
+        $_POST['slug'] = 'new-slug';
+        $_POST['title'] = 'New Title';
+        $_POST['_ajax_nonce'] = wp_create_nonce('gm2_bulk_ai_apply');
+        $_REQUEST['_ajax_nonce'] = $_POST['_ajax_nonce'];
+        try { $this->_handleAjax('gm2_bulk_ai_apply'); } catch (WPAjaxDieContinueException $e) {}
+        $resp = json_decode($this->_last_response, true);
+        $this->assertTrue($resp['success']);
+        $post = get_post($post_id);
+        $this->assertSame('new-slug', $post->post_name);
+        $this->assertSame('New', get_post_meta($post_id, '_gm2_title', true));
+        $this->assertSame('Desc', get_post_meta($post_id, '_gm2_description', true));
+    }
+
+    public function test_apply_requires_cap() {
+        $post_id = self::factory()->post->create();
+        $this->_setRole('subscriber');
+        $_POST['post_id'] = $post_id;
+        $_POST['_ajax_nonce'] = wp_create_nonce('gm2_bulk_ai_apply');
+        $_REQUEST['_ajax_nonce'] = $_POST['_ajax_nonce'];
+        try { $this->_handleAjax('gm2_bulk_ai_apply'); } catch (WPAjaxDieContinueException $e) {}
+        $resp = json_decode($this->_last_response, true);
+        $this->assertFalse($resp['success']);
+    }
+}


### PR DESCRIPTION
## Summary
- add new "Bulk AI Review" submenu page
- allow editing posts via gm2_bulk_ai_apply ajax
- store bulk AI options
- add client-side script for the new page
- cover capability checks and ajax behaviour with tests

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870b89b16bc8327adeb10a6f8b462b7