### PR TITLE
Fix translation call for weekly schedule

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -37,7 +37,7 @@ function gm2_add_weekly_schedule($schedules) {
     if (!isset($schedules['weekly'])) {
         $schedules['weekly'] = [
             'interval' => WEEK_IN_SECONDS,
-            'display'  => __('Once Weekly')
+            'display'  => __('Once Weekly', 'gm2-wordpress-suite')
         ];
     }
     return $schedules;


### PR DESCRIPTION
## Summary
- load textdomain for the 'Once Weekly' schedule label

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68712039c26883279c07493faaae1c25