### PR TITLE
Add new options to uninstall

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -72,6 +72,11 @@ $option_names = array(
     'gm2_pagespeed_scores',
     'gm2_bulk_ai_page_size',
     'gm2_bulk_ai_status',
+    'gm2_clean_slugs',
+    'gm2_slug_stopwords',
+    'gm2_tax_desc_prompt',
+    'gm2_sc_query_limit',
+    'gm2_analytics_days',
 );
 
 foreach ( $option_names as $option ) {


### PR DESCRIPTION
## Summary
- remove newly added options when the plugin is uninstalled

## Testing
- `phpunit` *(fails: missing WordPress test suite)*

------
https://chatgpt.com/codex/tasks/task_e_6871374de3688327b8a31dfe54cdbf89