### PR TITLE
Detect custom post types for SEO

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -74,10 +74,19 @@ class Gm2_SEO_Admin {
     }
 
     private function get_supported_post_types() {
-        $types = ['post', 'page'];
-        if (post_type_exists('product')) {
-            $types[] = 'product';
-        }
+        $args  = [
+            'public'             => true,
+            'show_ui'            => true,
+            'exclude_from_search' => false,
+        ];
+        $types = get_post_types($args, 'names');
+        unset($types['attachment']);
+        /**
+         * Filter the list of post types that should receive GM2 SEO features.
+         *
+         * @param string[] $types Array of post type slugs.
+         */
+        $types = apply_filters('gm2_supported_post_types', array_values($types));
         return $types;
     }
 
@@ -661,7 +670,7 @@ class Gm2_SEO_Admin {
         }
 
         $query = new \WP_Query([
-            'post_type'      => ['post', 'page'],
+            'post_type'      => $this->get_supported_post_types(),
             'post_status'    => $status,
             'posts_per_page' => $page_size,
         ]);

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -86,10 +86,14 @@ function gm2_initialize_content_rules() {
 
     $rules = [];
 
-    $posts = ['post', 'page'];
-    if (post_type_exists('product')) {
-        $posts[] = 'product';
-    }
+    $args  = [
+        'public'             => true,
+        'show_ui'            => true,
+        'exclude_from_search' => false,
+    ];
+    $posts = get_post_types($args, 'names');
+    unset($posts['attachment']);
+    $posts = apply_filters('gm2_supported_post_types', array_values($posts));
     $post_defaults = [
         'Title length between 30 and 60 characters',
         'Description length between 50 and 160 characters',

--- a/includes/Gm2_Sitemap.php
+++ b/includes/Gm2_Sitemap.php
@@ -14,11 +14,14 @@ class Gm2_Sitemap {
     }
 
     private function get_post_types() {
-        $types = ['post', 'page'];
-        if (post_type_exists('product')) {
-            $types[] = 'product';
-        }
-        return $types;
+        $args  = [
+            'public'             => true,
+            'show_ui'            => true,
+            'exclude_from_search' => false,
+        ];
+        $types = get_post_types($args, 'names');
+        unset($types['attachment']);
+        return apply_filters('gm2_supported_post_types', array_values($types));
     }
 
     private function get_taxonomies() {

--- a/readme.txt
+++ b/readme.txt
@@ -101,7 +101,7 @@ to generate best-practice rules. The generated text is saved automatically so
 you can revisit this screen later and adjust the guidelines as needed.
 
 == SEO Settings ==
-The SEO meta box appears when editing posts, pages and taxonomy terms. In the
+The SEO meta box appears when editing posts, pages, any public custom post types and taxonomy terms. In the
 **SEO Settings** tab you can enter a custom title and description, toggle
 `noindex` or `nofollow`, and upload an Open Graph image. Click **Select Image**
 to open the WordPress media library and choose a picture for the `og:image` and

--- a/tests/test-meta-tags.php
+++ b/tests/test-meta-tags.php
@@ -179,6 +179,24 @@ class MetaTagsTest extends WP_UnitTestCase {
         $this->assertStringContainsString('name="twitter:image" content="' . esc_url($url) . '"', $output);
     }
 
+    public function test_meta_tags_for_custom_post_type() {
+        register_post_type('book');
+        $post_id = self::factory()->post->create([
+            'post_type'    => 'book',
+            'post_title'   => 'Book',
+            'post_content' => 'Content',
+        ]);
+        update_post_meta($post_id, '_gm2_title', 'Book Title');
+        $seo = new Gm2_SEO_Public();
+        $this->go_to(get_permalink($post_id));
+        setup_postdata(get_post($post_id));
+        ob_start();
+        $seo->output_meta_tags();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('content="Book Title"', $output);
+    }
+
     public function test_variation_canonical_points_to_parent() {
         register_post_type('product');
 

--- a/tests/test-sitemap.php
+++ b/tests/test-sitemap.php
@@ -37,6 +37,21 @@ class SitemapTest extends WP_UnitTestCase {
         $this->assertStringContainsString(get_term_link($term_id, 'product_cat'), $content);
     }
 
+    public function test_custom_post_type_in_sitemap() {
+        register_post_type('book');
+        $post_id = self::factory()->post->create([
+            'post_type'   => 'book',
+            'post_title'  => 'Book Title',
+            'post_status' => 'publish',
+        ]);
+
+        $sitemap = new Gm2_Sitemap();
+        $sitemap->generate();
+
+        $content = file_get_contents(ABSPATH . 'sitemap.xml');
+        $this->assertStringContainsString(get_permalink($post_id), $content);
+    }
+
     public function test_generate_sitemap_pings_search_engines() {
         $urls = [];
         $filter = function($pre, $args, $url) use (&$urls) {

--- a/uninstall.php
+++ b/uninstall.php
@@ -88,10 +88,14 @@ foreach ( $option_names as $option ) {
 }
 
 // Remove dynamic SEO guideline options for supported post types and taxonomies.
-$post_types = array( 'post', 'page' );
-if ( post_type_exists( 'product' ) ) {
-    $post_types[] = 'product';
-}
+$args  = array(
+    'public'             => true,
+    'show_ui'            => true,
+    'exclude_from_search' => false,
+);
+$post_types = get_post_types( $args, 'names' );
+unset( $post_types['attachment'] );
+$post_types = apply_filters( 'gm2_supported_post_types', array_values( $post_types ) );
 foreach ( $post_types as $pt ) {
     $opt = 'gm2_seo_guidelines_post_' . $pt;
     delete_option( $opt );


### PR DESCRIPTION
## Summary
- support any public custom post type for SEO features
- detect dynamic post types when generating sitemaps
- handle custom post types during uninstall and plugin activation
- document that the SEO meta box works on custom post types
- add tests for custom post type support

## Testing
- `npm --version`
- `composer --version`
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871450152888327b8ec1975f40a673e