### PR TITLE
Fix AI research failure without DOM extension

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1479,6 +1479,10 @@ class Gm2_SEO_Admin {
             return $issues;
         }
 
+        if (!class_exists('\\DOMDocument')) {
+            return $issues;
+        }
+
         $doc = new \DOMDocument();
         libxml_use_internal_errors(true);
         $doc->loadHTML('<?xml encoding="utf-8" ?>' . $html);

--- a/public/Gm2_SEO_Public.php
+++ b/public/Gm2_SEO_Public.php
@@ -593,6 +593,10 @@ class Gm2_SEO_Public {
         if (!is_array($map) || empty($map)) {
             return $content;
         }
+        if (!class_exists('\\DOMDocument')) {
+            return $content;
+        }
+
         $doc = new \DOMDocument();
         libxml_use_internal_errors(true);
         $doc->loadHTML('<?xml encoding="utf-8" ?>' . $content, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);

--- a/readme.txt
+++ b/readme.txt
@@ -20,11 +20,13 @@ A powerful suite of WordPress enhancements including admin tools, frontend optim
    Finally, use **SEO → Connect Google Account** to authorize your Google account. After connecting, you will be able to select your Analytics Measurement ID and Ads Customer ID from dropdown menus.
 4. The plugin relies on WordPress's built-in HTTP API and has no external
    dependencies.
-5. Follow the steps in the **Google integration** section below to copy your
+5. Ensure the PHP DOM extension is installed. Without it, HTML analysis and AI
+   research features will be unavailable.
+6. Follow the steps in the **Google integration** section below to copy your
    Search Console verification code and Google Ads developer token. These values
    cannot be fetched via API and must be entered manually on the SEO settings
    page.
-6. Select your Analytics Measurement ID and Ads Customer ID on the
+7. Select your Analytics Measurement ID and Ads Customer ID on the
    **SEO → Connect Google Account** page after connecting, or enter them
    manually on the SEO settings screen if needed.
 


### PR DESCRIPTION
## Summary
- avoid fatal errors when the PHP DOM extension is unavailable
- add installation note about needing the DOM extension

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68714c8518548327bf41568526c5be1b