### PR TITLE
Fix DOMDocument class checks

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1479,7 +1479,7 @@ class Gm2_SEO_Admin {
             return $issues;
         }
 
-        if (!class_exists('\\DOMDocument')) {
+        if (!class_exists('\DOMDocument')) {
             return $issues;
         }
 

--- a/public/Gm2_SEO_Public.php
+++ b/public/Gm2_SEO_Public.php
@@ -593,7 +593,7 @@ class Gm2_SEO_Public {
         if (!is_array($map) || empty($map)) {
             return $content;
         }
-        if (!class_exists('\\DOMDocument')) {
+        if (!class_exists('\DOMDocument')) {
             return $content;
         }
 


### PR DESCRIPTION
## Summary
- correct class existence check in admin/public modules

## Testing
- `php -l admin/Gm2_SEO_Admin.php`
- `php -l public/Gm2_SEO_Public.php`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871554dadb4832788a20e6e488f4a08