### PR TITLE
Update WordPress min version

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Gm2 WordPress Suite ===
 Contributors: gm2team
 Tags: admin, tools, suite, performance
-Requires at least: 5.6
+Requires at least: 7.0
 Tested up to: 6.5
 Stable tag: 1.6.3
 License: GPLv2 or later


### PR DESCRIPTION
## Summary
- raise the minimum WordPress requirement in `readme.txt` to 7.0

## Testing
- `make test` *(fails: require WordPress test suite & mysqladmin)*
- `make install-tests DB_NAME=wordpress-tests DB_USER=root DB_PASS='' DB_HOST=localhost WP_VERSION=6.5` *(fails: `mysqladmin` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68716410a54883278311d2bc26697740