### PR TITLE
Add Requires PHP header line

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -9,6 +9,7 @@
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       gm2-wordpress-suite
  * Domain Path:       /languages
+ * Requires PHP:      7.0
  */
 
 defined('ABSPATH') or die('No script kiddies please!');


### PR DESCRIPTION
## Summary
- declare minimum PHP version in plugin header

## Testing
- `phpunit` *(fails: missing WordPress test suite)*

------
https://chatgpt.com/codex/tasks/task_e_687164e1ae448327921a7b20d56137fe