### PR TITLE
Improve taxonomy HTML rendering

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1473,7 +1473,17 @@ class Gm2_SEO_Admin {
             }
         } elseif ($term_id && $taxonomy) {
             $desc = term_description($term_id, $taxonomy);
-            return apply_filters('the_content', $desc);
+            $stub = new \stdClass();
+            $stub->ID = 0;
+            $post_obj = new \WP_Post($stub);
+            global $post;
+            $prev_post = $post;
+            $post      = $post_obj;
+            setup_postdata($post);
+            $html = apply_filters('the_content', $desc);
+            $post = $prev_post;
+            wp_reset_postdata();
+            return $html;
         }
         return '';
     }


### PR DESCRIPTION
## Summary
- avoid fatal errors by setting stub post data while rendering taxonomy HTML
- expand AI SEO test coverage for terms

## Testing
- `phpunit -c phpunit.xml` *(fails: WordPress test suite missing)*

------
https://chatgpt.com/codex/tasks/task_e_68716dffca3c832782f9c1bbba4f4f41