### PR TITLE
Fix taxonomy stub context

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1475,6 +1475,10 @@ class Gm2_SEO_Admin {
             $desc = term_description($term_id, $taxonomy);
             $stub = new \stdClass();
             $stub->ID = 0;
+            // Provide a more complete context object for shortcodes and filters.
+            $stub->post_title  = '';
+            $stub->post_type   = 'post';
+            $stub->post_status = 'publish';
             $post_obj = new \WP_Post($stub);
             global $post;
             $prev_post = $post;


### PR DESCRIPTION
## Summary
- fill in missing fields when creating a WP_Post for taxonomy rendering

## Testing
- `make test` *(fails: functions.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_6871708d0c1883278b572b03d46fc3e5