### PR TITLE
Fix postdata reset order

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1467,8 +1467,8 @@ class Gm2_SEO_Admin {
                 $post      = $post_obj;
                 setup_postdata($post);
                 $html = apply_filters('the_content', $post_obj->post_content);
-                $post = $prev_post;
                 wp_reset_postdata();
+                $post = $prev_post;
                 return $html;
             }
         } elseif ($term_id && $taxonomy) {
@@ -1485,8 +1485,8 @@ class Gm2_SEO_Admin {
             $post      = $post_obj;
             setup_postdata($post);
             $html = apply_filters('the_content', $desc);
-            $post = $prev_post;
             wp_reset_postdata();
+            $post = $prev_post;
             return $html;
         }
         return '';


### PR DESCRIPTION
## Summary
- ensure `wp_reset_postdata()` runs before restoring global `$post`

## Testing
- `make test` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_687178b328b88327a1c9dd797626e158