### PR TITLE
Handle WP_Error from get_term_link

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1814,6 +1814,9 @@ class Gm2_SEO_Admin {
             }
             $title = $term->name;
             $url   = get_term_link($term, $taxonomy);
+            if (is_wp_error($url)) {
+                $url = '';
+            }
             $seo_title       = get_term_meta($term_id, '_gm2_title', true);
             $seo_description = get_term_meta($term_id, '_gm2_description', true);
             $focus           = get_term_meta($term_id, '_gm2_focus_keywords', true);


### PR DESCRIPTION
## Summary
- sanitize URL in `ajax_ai_research()` if `get_term_link()` fails
- test blank URL when taxonomy permalink generation fails

## Testing
- `php -l admin/Gm2_SEO_Admin.php`
- `php -l tests/test-ai-seo.php`
- `phpunit` *(fails: require_once /tmp/wordpress-tests-lib/includes/functions.php: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68717d1ef8708327bc1a284d2a330ffc