### PR TITLE
Fix gm2-ai-seo label injection

### DIFF
--- a/admin/js/gm2-ai-seo.js
+++ b/admin/js/gm2-ai-seo.js
@@ -114,7 +114,7 @@ jQuery(function($){
             var val = Array.isArray(data[key]) ? data[key].join(', ') : data[key];
             var $lbl = $('<label>');
             $('<input>', {type:'checkbox','class':'gm2-ai-select', 'data-field':key, 'data-value':val}).appendTo($lbl);
-            $lbl.append(' '+label+': '+val);
+            $lbl.append(document.createTextNode(' ' + label + ': ' + val));
             $list.append($('<p>').append($lbl));
         });
         if(added){


### PR DESCRIPTION
## Summary
- improve sanitization in `gm2-ai-seo.js` by appending text nodes when building AI SEO results

## Testing
- `make test` *(fails: `phpunit: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_687183a372448327a88505b37df6b89b