### PR TITLE
Add localized labels for AI SEO suggestions

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -2039,6 +2039,14 @@ class Gm2_SEO_Admin {
                     'contentSuggestions' => __( 'Content Suggestions', 'gm2-wordpress-suite' ),
                     'htmlIssues'  => __( 'HTML Issues', 'gm2-wordpress-suite' ),
                     'applyFix'    => __( 'Apply fix', 'gm2-wordpress-suite' ),
+                    'labels' => [
+                        'seoTitle'       => __( 'SEO Title', 'gm2-wordpress-suite' ),
+                        'description'    => __( 'SEO Description', 'gm2-wordpress-suite' ),
+                        'focusKeywords'  => __( 'Focus Keywords', 'gm2-wordpress-suite' ),
+                        'canonical'      => __( 'Canonical URL', 'gm2-wordpress-suite' ),
+                        'pageName'       => __( 'Page Name', 'gm2-wordpress-suite' ),
+                        'slug'           => __( 'Slug', 'gm2-wordpress-suite' ),
+                    ],
                 ],
             ]
         );
@@ -2132,6 +2140,14 @@ class Gm2_SEO_Admin {
                     'contentSuggestions' => __( 'Content Suggestions', 'gm2-wordpress-suite' ),
                     'htmlIssues'  => __( 'HTML Issues', 'gm2-wordpress-suite' ),
                     'applyFix'    => __( 'Apply fix', 'gm2-wordpress-suite' ),
+                    'labels' => [
+                        'seoTitle'       => __( 'SEO Title', 'gm2-wordpress-suite' ),
+                        'description'    => __( 'SEO Description', 'gm2-wordpress-suite' ),
+                        'focusKeywords'  => __( 'Focus Keywords', 'gm2-wordpress-suite' ),
+                        'canonical'      => __( 'Canonical URL', 'gm2-wordpress-suite' ),
+                        'pageName'       => __( 'Page Name', 'gm2-wordpress-suite' ),
+                        'slug'           => __( 'Slug', 'gm2-wordpress-suite' ),
+                    ],
                 ],
             ]
         );

--- a/admin/js/gm2-ai-seo.js
+++ b/admin/js/gm2-ai-seo.js
@@ -96,15 +96,16 @@ jQuery(function($){
     function buildResults(data, $out){
         var $wrap = $('<div>');
         var $list = $('<div>', {id:'gm2-ai-suggestions'});
+        var labels = window.gm2AiSeo && gm2AiSeo.i18n && gm2AiSeo.i18n.labels ? gm2AiSeo.i18n.labels : {};
         var fields = {
-            seo_title: 'SEO Title',
-            description: 'SEO Description',
-            focus_keywords: 'Focus Keywords',
-            canonical: 'Canonical URL',
-            page_name: 'Page Name'
+            seo_title: labels.seoTitle || 'SEO Title',
+            description: labels.description || 'SEO Description',
+            focus_keywords: labels.focusKeywords || 'Focus Keywords',
+            canonical: labels.canonical || 'Canonical URL',
+            page_name: labels.pageName || 'Page Name'
         };
         if(typeof data.slug !== 'undefined'){
-            fields.slug = 'Slug';
+            fields.slug = labels.slug || 'Slug';
         }
         var added = 0;
         Object.keys(fields).forEach(function(key){


### PR DESCRIPTION
## Summary
- localize field labels when enqueuing `gm2-ai-seo.js`
- reference localized labels inside `gm2-ai-seo.js`

## Testing
- `vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `make test` *(fails: phpunit: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687184347adc8327bb6743bffc2ba3d2