### PR TITLE
Add debug logging hooks

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -9,6 +9,12 @@ if (!defined('ABSPATH')) {
 class Gm2_SEO_Admin {
     private $elementor_initialized = false;
     private static $notices = [];
+
+    private function debug_log($message) {
+        if (defined('WP_DEBUG') && WP_DEBUG) {
+            error_log($message);
+        }
+    }
     public function run() {
         add_action('admin_menu', [$this, 'add_settings_pages']);
         add_action('add_meta_boxes', [$this, 'register_meta_boxes']);
@@ -1785,10 +1791,12 @@ class Gm2_SEO_Admin {
 
         if ($term_id) {
             if (!current_user_can('edit_term', $term_id)) {
+                $this->debug_log('AI Research: permission denied for term ' . $term_id);
                 wp_send_json_error( __( 'permission denied', 'gm2-wordpress-suite' ), 403 );
             }
         } else {
             if (!current_user_can('edit_posts')) {
+                $this->debug_log('AI Research: permission denied for post');
                 wp_send_json_error( __( 'permission denied', 'gm2-wordpress-suite' ), 403 );
             }
         }
@@ -1799,6 +1807,7 @@ class Gm2_SEO_Admin {
         if ($post_id) {
             $post = get_post($post_id);
             if (!$post) {
+                $this->debug_log('AI Research: invalid post ID ' . $post_id);
                 wp_send_json_error( __( 'invalid post', 'gm2-wordpress-suite' ) );
             }
             $title = get_the_title($post);
@@ -1810,6 +1819,7 @@ class Gm2_SEO_Admin {
         } elseif ($term_id && $taxonomy) {
             $term = get_term($term_id, $taxonomy);
             if (!$term || is_wp_error($term)) {
+                $this->debug_log('AI Research: invalid term ' . $term_id . ' for taxonomy ' . $taxonomy);
                 wp_send_json_error( __( 'invalid term', 'gm2-wordpress-suite' ) );
             }
             $title = $term->name;
@@ -1822,6 +1832,7 @@ class Gm2_SEO_Admin {
             $focus           = get_term_meta($term_id, '_gm2_focus_keywords', true);
             $canonical       = get_term_meta($term_id, '_gm2_canonical', true);
         } else {
+            $this->debug_log('AI Research: invalid parameters');
             wp_send_json_error( __( 'invalid parameters', 'gm2-wordpress-suite' ) );
         }
 
@@ -1875,6 +1886,7 @@ class Gm2_SEO_Admin {
         $resp = $chat->query($prompt);
 
         if (is_wp_error($resp)) {
+            $this->debug_log('AI Research: ' . $resp->get_error_message());
             wp_send_json_error($resp->get_error_message());
         }
 

--- a/includes/Gm2_ChatGPT.php
+++ b/includes/Gm2_ChatGPT.php
@@ -41,8 +41,14 @@ class Gm2_ChatGPT {
             'body'    => wp_json_encode($payload),
             'timeout' => 20,
         ];
+        if (defined('WP_DEBUG') && WP_DEBUG) {
+            error_log('Gm2_ChatGPT request: ' . wp_json_encode($payload));
+        }
         $response = wp_remote_post($this->endpoint, $args);
         if (is_wp_error($response)) {
+            if (defined('WP_DEBUG') && WP_DEBUG) {
+                error_log('Gm2_ChatGPT error: ' . $response->get_error_message());
+            }
             return $response;
         }
 

--- a/readme.txt
+++ b/readme.txt
@@ -56,6 +56,7 @@ If you see errors when connecting your Google account:
 * **Keyword Research returns no results** – Ensure you have entered your Google Ads developer token, connected a Google account with Ads access, and selected a valid Ads customer ID. Missing or invalid credentials will cause the Keyword Planner request to fail.
 * "The caller does not have permission" – This usually means your developer token isn't approved for the selected Ads account or the login customer ID is missing or incorrect. Verify the token status in the Google Ads API Center and ensure the OAuth account can access that customer ID.
 * **Testing with an unapproved token** – Unapproved developer tokens can be used with [Google Ads test accounts](https://developers.google.com/google-ads/api/docs/best-practices/test-accounts). The login customer ID must be the manager ID for that token, and test accounts don't serve ads and have limited features.
+* **Viewing debug logs** – Enable debugging by adding `define('WP_DEBUG', true);` to your `wp-config.php` file. Errors and request details will then appear in your PHP error log.
 
 == Breadcrumbs ==
 Display a breadcrumb trail anywhere using the `[gm2_breadcrumbs]` shortcode. The output


### PR DESCRIPTION
## Summary
- log ChatGPT request payloads and errors in WP_DEBUG mode
- log AI SEO failures when WP_DEBUG is enabled
- document how to enable WP_DEBUG for troubleshooting

## Testing
- `composer global require phpunit/phpunit --no-interaction`
- `phpunit` *(fails: Error in bootstrap script)*

------
https://chatgpt.com/codex/tasks/task_e_68718adc19b48327b7bd908cd0ddda0c