### PR TITLE
Handle invalid ChatGPT JSON response

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1908,7 +1908,13 @@ class Gm2_SEO_Admin {
                 $data = json_decode($m[0], true);
             }
         }
-        if (json_last_error() === JSON_ERROR_NONE && is_array($data)) {
+
+        if (json_last_error() !== JSON_ERROR_NONE || !is_array($data)) {
+            $this->debug_log('AI Research: invalid JSON response - ' . $resp);
+            wp_send_json_error( __( 'Invalid AI response', 'gm2-wordpress-suite' ) );
+        }
+
+        if (is_array($data)) {
             if (!isset($data['html_issues'])) {
                 $data['html_issues'] = [];
             }


### PR DESCRIPTION
## Summary
- handle invalid JSON from AI research requests
- test that invalid ChatGPT replies return a JSON error

## Testing
- `php -l admin/Gm2_SEO_Admin.php`
- `php -l tests/test-ai-seo.php`
- `phpunit` *(fails: PHPUnit Polyfills library missing)*

------
https://chatgpt.com/codex/tasks/task_e_68728dc67a0c8327b4a469de30f89653