### PR TITLE
Refactor content rules storage

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -96,20 +96,39 @@ function gm2_initialize_content_rules() {
     unset($posts['attachment']);
     $posts = apply_filters('gm2_supported_post_types', array_values($posts));
     $post_defaults = [
-        'Title length between 30 and 60 characters',
-        'Description length between 50 and 160 characters',
-        'At least one focus keyword',
-        'Content has at least 300 words',
-        'Focus keyword appears in first paragraph',
-        'Only one H1 tag present',
-        'At least one internal link',
-        'At least one external link',
-        'Focus keyword included in meta description',
-        'SEO title is unique',
-        'Meta description is unique',
+        'seo_title' => [
+            'Title length between 30 and 60 characters',
+            'SEO title is unique',
+        ],
+        'seo_description' => [
+            'Description length between 50 and 160 characters',
+            'Meta description is unique',
+            'Focus keyword included in meta description',
+        ],
+        'focus_keywords' => [
+            'At least one focus keyword',
+        ],
+        'long_tail_keywords' => [
+            'Consider including long-tail keywords',
+        ],
+        'canonical_url' => [
+            'Use a canonical URL',
+        ],
+        'content' => [
+            'Content has at least 300 words',
+            'Focus keyword appears in first paragraph',
+            'Only one H1 tag present',
+            'At least one internal link',
+            'At least one external link',
+            'Image alt text contains focus keyword',
+        ],
+        'general' => [],
     ];
     foreach ($posts as $pt) {
-        $rules['post_' . $pt] = implode("\n", $post_defaults);
+        $rules['post_' . $pt] = [];
+        foreach ($post_defaults as $key => $vals) {
+            $rules['post_' . $pt][$key] = implode("\n", $vals);
+        }
     }
 
     $taxonomies = ['category'];
@@ -123,14 +142,27 @@ function gm2_initialize_content_rules() {
         $taxonomies[] = 'product_brand';
     }
     $tax_defaults = [
-        'Title length between 30 and 60 characters',
-        'Description length between 50 and 160 characters',
-        'Description has at least 150 words',
-        'SEO title is unique',
-        'Meta description is unique',
+        'seo_title' => [
+            'Title length between 30 and 60 characters',
+            'SEO title is unique',
+        ],
+        'seo_description' => [
+            'Description length between 50 and 160 characters',
+            'Meta description is unique',
+        ],
+        'focus_keywords' => [],
+        'long_tail_keywords' => [],
+        'canonical_url' => [],
+        'content' => [
+            'Description has at least 150 words',
+        ],
+        'general' => [],
     ];
     foreach ($taxonomies as $tax) {
-        $rules['tax_' . $tax] = implode("\n", $tax_defaults);
+        $rules['tax_' . $tax] = [];
+        foreach ($tax_defaults as $key => $vals) {
+            $rules['tax_' . $tax][$key] = implode("\n", $vals);
+        }
     }
 
     add_option('gm2_content_rules', $rules);

--- a/tests/ContentAnalysisTest.php
+++ b/tests/ContentAnalysisTest.php
@@ -88,7 +88,7 @@ class ContentRulesNewTest extends WP_Ajax_UnitTestCase {
     }
 
     public function test_min_link_rules_pass() {
-        update_option('gm2_content_rules', ['post_post' => "Minimum X internal links\nMinimum X external links"]);
+        update_option('gm2_content_rules', ['post_post' => ['content' => "Minimum X internal links\nMinimum X external links"]]);
         update_option('gm2_min_internal_links', 2);
         update_option('gm2_min_external_links', 1);
         $content = '<a href="' . home_url('/a') . '">1</a>' .
@@ -101,7 +101,7 @@ class ContentRulesNewTest extends WP_Ajax_UnitTestCase {
     }
 
     public function test_min_link_rules_fail() {
-        update_option('gm2_content_rules', ['post_post' => "Minimum X internal links\nMinimum X external links"]);
+        update_option('gm2_content_rules', ['post_post' => ['content' => "Minimum X internal links\nMinimum X external links"]]);
         update_option('gm2_min_internal_links', 2);
         update_option('gm2_min_external_links', 1);
         $content = '<a href="' . home_url('/a') . '">1</a>';

--- a/tests/test-taxonomy-permissions.php
+++ b/tests/test-taxonomy-permissions.php
@@ -35,7 +35,7 @@ class TaxonomyContentRulesTest extends WP_Ajax_UnitTestCase {
     }
 
     public function test_description_word_count_rule() {
-        update_option('gm2_content_rules', ['tax_category' => 'Description has at least 150 words']);
+        update_option('gm2_content_rules', ['tax_category' => ['content' => 'Description has at least 150 words']]);
         $resp = $this->run_check(str_repeat('word ', 160));
         $this->assertTrue($resp['success']);
         $this->assertTrue($resp['data']['description-has-at-least-150-words']);


### PR DESCRIPTION
## Summary
- categorize default content rules for each post type and taxonomy
- display separate textareas for every rule category in the admin UI
- save nested rule arrays and flatten them when rendering analysis sections
- update unit tests for the new rule structure

## Testing
- `php -l gm2-wordpress-suite.php`
- `php -l admin/Gm2_SEO_Admin.php`
- `php -l tests/test-taxonomy-permissions.php`
- `php -l tests/ContentAnalysisTest.php`
- `phpunit` *(fails: missing WordPress test library)*

------
https://chatgpt.com/codex/tasks/task_e_6874d07259e083278ee17135ea744db6