### PR TITLE
Add AI-assisted content rules

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -100,6 +100,13 @@ class Gm2_Admin {
                 GM2_VERSION,
                 true
             );
+            wp_enqueue_script(
+                'gm2-content-rules',
+                GM2_PLUGIN_URL . 'admin/js/gm2-content-rules.js',
+                ['jquery'],
+                GM2_VERSION,
+                true
+            );
             $gads_ready = trim(get_option('gm2_gads_developer_token', '')) !== '' &&
                 trim(get_option('gm2_gads_customer_id', '')) !== '' &&
                 get_option('gm2_google_refresh_token', '') !== '';
@@ -118,6 +125,15 @@ class Gm2_Admin {
                 [
                     'nonce'    => wp_create_nonce('gm2_research_guidelines'),
                     'ajax_url' => admin_url('admin-ajax.php'),
+                ]
+            );
+            wp_localize_script(
+                'gm2-content-rules',
+                'gm2ContentRules',
+                [
+                    'nonce'    => wp_create_nonce('gm2_research_content_rules'),
+                    'ajax_url' => admin_url('admin-ajax.php'),
+                    'prompt'   => __( 'Enter rule categories (comma separated):', 'gm2-wordpress-suite' ),
                 ]
             );
             if ($hook === 'gm2_page_gm2-bulk-ai-review') {

--- a/admin/js/gm2-content-rules.js
+++ b/admin/js/gm2-content-rules.js
@@ -1,0 +1,31 @@
+jQuery(function($){
+    $('.gm2-research-rules').on('click', function(e){
+        e.preventDefault();
+        if(!window.gm2ContentRules) return;
+        var base = $(this).data('base');
+        var cat  = $(this).data('category');
+        if(!base) return;
+        var promptText = gm2ContentRules.prompt || 'Enter rule categories (comma separated):';
+        var cats = prompt(promptText, cat);
+        if(cats === null || !cats.trim()) return;
+        $.post(gm2ContentRules.ajax_url, {
+            action: 'gm2_research_content_rules',
+            target: base,
+            categories: cats,
+            _ajax_nonce: gm2ContentRules.nonce
+        }).done(function(resp){
+            if(resp && resp.success && typeof resp.data === 'object'){
+                $.each(resp.data, function(key,val){
+                    var selector = 'textarea[name="gm2_content_rules['+base+']['+key+']"]';
+                    $(selector).val(val);
+                });
+            }else if(resp && resp.data){
+                alert(resp.data);
+            }else{
+                alert('Error');
+            }
+        }).fail(function(){
+            alert('Request failed');
+        });
+    });
+});

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,13 @@ has its own textarea. Click **Research SEO Guidelines** next to a content type
 to generate best-practice rules. The generated text is saved automatically so
 you can revisit this screen later and adjust the guidelines as needed.
 
+== Content Rules ==
+Open the **Rules** tab under **SEO** to define checks for each post type and
+taxonomy. Next to every rule field you'll find an **AI Research Content Rules**
+button. Click it to fetch best-practice suggestions from ChatGPT for the
+selected categories. The response is stored automatically so you can refine the
+rules at any time.
+
 == SEO Settings ==
 The SEO meta box appears when editing posts, pages, any public custom post types and taxonomy terms. In the
 **SEO Settings** tab you can enter a custom title and description, toggle


### PR DESCRIPTION
## Summary
- add AI Research Content Rules button for each rule field
- implement AJAX endpoint to fetch rules from ChatGPT
- enqueue new script on SEO admin pages and localize data
- document new feature in readme

## Testing
- `phpunit` *(fails: missing WordPress test suite)*

------
https://chatgpt.com/codex/tasks/task_e_6874d27392f483279da1c544eb7e129b