### PR TITLE
Fix content rule migration

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -607,6 +607,7 @@ class Gm2_SEO_Admin {
                 echo '<tr><th scope="row"><label>' . esc_html($label) . '</label></th><td>';
                 foreach ($cats as $c => $clabel) {
                     $val = $vals[$c] ?? '';
+                    $val = $this->flatten_rule_value($val);
                     echo '<p><label for="gm2_rule_post_' . esc_attr($pt . '_' . $c) . '">' . esc_html($clabel) . '</label><br />';
                     echo '<textarea id="gm2_rule_post_' . esc_attr($pt . '_' . $c) . '" name="gm2_content_rules[post_' . esc_attr($pt) . '][' . esc_attr($c) . ']" rows="3" class="large-text">' . esc_textarea($val) . '</textarea>';
                     echo ' <button type="button" class="button gm2-research-rules" data-base="post_' . esc_attr($pt) . '" data-category="' . esc_attr($c) . '">' . esc_html__( 'AI Research Content Rules', 'gm2-wordpress-suite' ) . '</button></p>';
@@ -626,6 +627,7 @@ class Gm2_SEO_Admin {
                 echo '<tr><th scope="row"><label>' . esc_html($label) . '</label></th><td>';
                 foreach ($cats as $c => $clabel) {
                     $val = $vals[$c] ?? '';
+                    $val = $this->flatten_rule_value($val);
                     echo '<p><label for="gm2_rule_tax_' . esc_attr($tax . '_' . $c) . '">' . esc_html($clabel) . '</label><br />';
                     echo '<textarea id="gm2_rule_tax_' . esc_attr($tax . '_' . $c) . '" name="gm2_content_rules[tax_' . esc_attr($tax) . '][' . esc_attr($c) . ']" rows="3" class="large-text">' . esc_textarea($val) . '</textarea>';
                     echo ' <button type="button" class="button gm2-research-rules" data-base="tax_' . esc_attr($tax) . '" data-category="' . esc_attr($c) . '">' . esc_html__( 'AI Research Content Rules', 'gm2-wordpress-suite' ) . '</button></p>';
@@ -1575,6 +1577,19 @@ class Gm2_SEO_Admin {
         return substr($text, 0, $length);
     }
 
+    /**
+     * Convert a rule value to a string for display.
+     *
+     * @param mixed $value Rule value which may be array or string.
+     * @return string Flattened rule string.
+     */
+    private function flatten_rule_value($value) {
+        if (is_array($value)) {
+            return implode("\n", array_values($value));
+        }
+        return (string) $value;
+    }
+
     public function ajax_check_rules() {
         check_ajax_referer('gm2_check_rules');
         if (!current_user_can('edit_posts')) {
@@ -1600,10 +1615,12 @@ class Gm2_SEO_Admin {
         $rule_lines = [];
         if ($taxonomy && isset($rules_option['tax_' . $taxonomy]) && is_array($rules_option['tax_' . $taxonomy])) {
             foreach ($rules_option['tax_' . $taxonomy] as $txt) {
+                $txt = $this->flatten_rule_value($txt);
                 $rule_lines = array_merge($rule_lines, array_filter(array_map('trim', explode("\n", $txt))));
             }
         } elseif (isset($rules_option['post_' . $post_type]) && is_array($rules_option['post_' . $post_type])) {
             foreach ($rules_option['post_' . $post_type] as $txt) {
+                $txt = $this->flatten_rule_value($txt);
                 $rule_lines = array_merge($rule_lines, array_filter(array_map('trim', explode("\n", $txt))));
             }
         }

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -206,28 +206,21 @@ function gm2_maybe_migrate_content_rules() {
 
     if (is_array($rules)) {
         foreach ($rules as $base => $cats) {
-            // Old format stored strings
             if (is_string($cats)) {
-                $lines = array_filter(array_map('trim', explode("\n", $cats)));
-                $new   = [];
-                foreach ($lines as $line) {
-                    $new[sanitize_title($line)] = $line;
-                }
-                $rules[$base] = ['general' => $new];
+                // Previously stored as a single string without categories
+                $rules[$base] = [ 'general' => $cats ];
                 $changed      = true;
             } elseif (is_array($cats)) {
-                $first = reset($cats);
-                if ($first !== false && !is_array($first)) {
-                    $new_cats = [];
-                    foreach ($cats as $cat => $text) {
-                        $lines = array_filter(array_map('trim', explode("\n", $text)));
-                        foreach ($lines as $line) {
-                            $new_cats[$cat][sanitize_title($line)] = $line;
-                        }
+                $new_cats = [];
+                foreach ($cats as $cat => $lines) {
+                    if (is_array($lines)) {
+                        $new_cats[$cat] = implode("\n", array_values($lines));
+                    } else {
+                        $new_cats[$cat] = (string) $lines;
                     }
-                    $rules[$base] = $new_cats;
-                    $changed      = true;
                 }
+                $rules[$base] = $new_cats;
+                $changed      = true;
             }
         }
     }

--- a/tests/test-content-rules.php
+++ b/tests/test-content-rules.php
@@ -72,5 +72,25 @@ class ContentRulesAjaxTest extends WP_Ajax_UnitTestCase {
         $this->assertFalse($resp['data']['seo-title-is-unique']);
         $this->assertFalse($resp['data']['meta-description-is-unique']);
     }
+
+    public function test_dashboard_handles_legacy_rule_array() {
+        $_GET['tab'] = 'rules';
+        $legacy = [
+            'post_post' => [
+                'general' => [
+                    'rule-one' => 'Old rule one',
+                    'rule-two' => 'Old rule two',
+                ],
+            ],
+        ];
+        update_option('gm2_content_rules', $legacy);
+
+        $admin = new \Gm2\Gm2_SEO_Admin();
+        ob_start();
+        $admin->display_dashboard();
+        $out = ob_get_clean();
+
+        $this->assertStringContainsString('Content Rules', $out);
+    }
 }
 ?>


### PR DESCRIPTION
## Summary
- migrate single string rules to `'general' => $string`
- flatten legacy arrays of rules when migrating
- handle array values in dashboard and rule checker
- test legacy rules don't break dashboard

## Testing
- `phpunit` *(fails: Error in bootstrap script)*

------
https://chatgpt.com/codex/tasks/task_e_6874db140d448327a65a6f255f1d1a77