### PR TITLE
Add long tail keyword field

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -934,6 +934,7 @@ class Gm2_SEO_Admin {
         $nofollow            = '';
         $canonical           = '';
         $focus_keywords      = '';
+        $long_tail_keywords  = '';
         $max_snippet         = '';
         $max_image_preview   = '';
         $max_video_preview   = '';
@@ -946,6 +947,7 @@ class Gm2_SEO_Admin {
             $nofollow       = get_term_meta($term->term_id, '_gm2_nofollow', true);
             $canonical        = get_term_meta($term->term_id, '_gm2_canonical', true);
             $focus_keywords   = get_term_meta($term->term_id, '_gm2_focus_keywords', true);
+            $long_tail_keywords = get_term_meta($term->term_id, '_gm2_long_tail_keywords', true);
             $max_snippet      = get_term_meta($term->term_id, '_gm2_max_snippet', true);
             $max_image_preview = get_term_meta($term->term_id, '_gm2_max_image_preview', true);
             $max_video_preview = get_term_meta($term->term_id, '_gm2_max_video_preview', true);
@@ -1000,6 +1002,8 @@ class Gm2_SEO_Admin {
         echo '<textarea id="gm2_seo_description" name="gm2_seo_description" class="widefat" rows="3">' . esc_textarea($description) . '</textarea></p>';
         echo '<p><label for="gm2_focus_keywords">' . esc_html__( 'Focus Keywords (comma separated)', 'gm2-wordpress-suite' ) . '</label>';
         echo '<input type="text" id="gm2_focus_keywords" name="gm2_focus_keywords" value="' . esc_attr($focus_keywords) . '" class="widefat" /></p>';
+        echo '<p><label for="gm2_long_tail_keywords">' . esc_html__( 'Long Tail Keywords (comma separated)', 'gm2-wordpress-suite' ) . '</label>';
+        echo '<input type="text" id="gm2_long_tail_keywords" name="gm2_long_tail_keywords" value="' . esc_attr($long_tail_keywords) . '" class="widefat" /></p>';
         echo '<p><label><input type="checkbox" name="gm2_noindex" value="1" ' . checked($noindex, '1', false) . '> ' . esc_html__( 'noindex', 'gm2-wordpress-suite' ) . '</label></p>';
         echo '<p><label><input type="checkbox" name="gm2_nofollow" value="1" ' . checked($nofollow, '1', false) . '> ' . esc_html__( 'nofollow', 'gm2-wordpress-suite' ) . '</label></p>';
         echo '<p><label for="gm2_canonical_url">' . esc_html__( 'Canonical URL', 'gm2-wordpress-suite' ) . '</label>';
@@ -1079,6 +1083,7 @@ class Gm2_SEO_Admin {
         $nofollow    = isset($_POST['gm2_nofollow']) ? '1' : '0';
         $canonical      = isset($_POST['gm2_canonical_url']) ? esc_url_raw($_POST['gm2_canonical_url']) : '';
         $focus_keywords   = isset($_POST['gm2_focus_keywords']) ? sanitize_text_field($_POST['gm2_focus_keywords']) : '';
+        $long_tail_keywords = isset($_POST['gm2_long_tail_keywords']) ? sanitize_text_field($_POST['gm2_long_tail_keywords']) : '';
         $max_snippet      = isset($_POST['gm2_max_snippet']) ? sanitize_text_field($_POST['gm2_max_snippet']) : '';
         $max_image_preview = isset($_POST['gm2_max_image_preview']) ? sanitize_text_field($_POST['gm2_max_image_preview']) : '';
         $max_video_preview = isset($_POST['gm2_max_video_preview']) ? sanitize_text_field($_POST['gm2_max_video_preview']) : '';
@@ -1093,6 +1098,7 @@ class Gm2_SEO_Admin {
         update_post_meta($post_id, '_gm2_nofollow', $nofollow);
         update_post_meta($post_id, '_gm2_canonical', $canonical);
         update_post_meta($post_id, '_gm2_focus_keywords', $focus_keywords);
+        update_post_meta($post_id, '_gm2_long_tail_keywords', $long_tail_keywords);
         update_post_meta($post_id, '_gm2_max_snippet', $max_snippet);
         update_post_meta($post_id, '_gm2_max_image_preview', $max_image_preview);
         update_post_meta($post_id, '_gm2_max_video_preview', $max_video_preview);
@@ -1123,6 +1129,7 @@ class Gm2_SEO_Admin {
         update_term_meta($term_id, '_gm2_nofollow', $nofollow);
         update_term_meta($term_id, '_gm2_canonical', $canonical);
         update_term_meta($term_id, '_gm2_focus_keywords', $focus_keywords);
+        update_term_meta($term_id, '_gm2_long_tail_keywords', $long_tail_keywords);
         update_term_meta($term_id, '_gm2_max_snippet', $max_snippet);
         update_term_meta($term_id, '_gm2_max_image_preview', $max_image_preview);
         update_term_meta($term_id, '_gm2_max_video_preview', $max_video_preview);
@@ -2341,6 +2348,7 @@ class Gm2_SEO_Admin {
         $nofollow       = get_post_meta($post->ID, '_gm2_nofollow', true);
         $canonical      = get_post_meta($post->ID, '_gm2_canonical', true);
         $focus_keywords      = get_post_meta($post->ID, '_gm2_focus_keywords', true);
+        $long_tail_keywords  = get_post_meta($post->ID, '_gm2_long_tail_keywords', true);
         $max_snippet         = get_post_meta($post->ID, '_gm2_max_snippet', true);
         $max_image_preview   = get_post_meta($post->ID, '_gm2_max_image_preview', true);
         $max_video_preview   = get_post_meta($post->ID, '_gm2_max_video_preview', true);

--- a/admin/js/gm2-ai-seo.js
+++ b/admin/js/gm2-ai-seo.js
@@ -101,6 +101,7 @@ jQuery(function($){
             seo_title: labels.seoTitle || 'SEO Title',
             description: labels.description || 'SEO Description',
             focus_keywords: labels.focusKeywords || 'Focus Keywords',
+            long_tail_keywords: labels.longTailKeywords || 'Long Tail Keywords',
             canonical: labels.canonical || 'Canonical URL',
             page_name: labels.pageName || 'Page Name'
         };
@@ -133,12 +134,12 @@ jQuery(function($){
         }
 
         if(data.long_tail_keywords){
-            var $kw = $('<ul>');
-            [].concat(data.long_tail_keywords).forEach(function(k){
-                $('<li>').text(k).appendTo($kw);
-            });
+            var valLt = [].concat(data.long_tail_keywords).join(', ');
             var ltText = window.gm2AiSeo && gm2AiSeo.i18n ? gm2AiSeo.i18n.longTailKeywords : 'Long Tail Keywords';
-            $wrap.append('<h4>' + ltText + '</h4>').append($kw);
+            var $lblLt = $('<label>');
+            $('<input>', {type:'checkbox','class':'gm2-ai-select','data-field':'long_tail_keywords','data-value':valLt}).appendTo($lblLt);
+            $lblLt.append(document.createTextNode(' ' + ltText + ': ' + valLt));
+            $list.append($('<p>').append($lblLt));
         }
         if(data.content_suggestions){
             var $cs = $('<ul>');
@@ -177,6 +178,8 @@ jQuery(function($){
                     $('#gm2_seo_description').val(val); break;
                 case 'focus_keywords':
                     $('#gm2_focus_keywords').val(val); break;
+                case 'long_tail_keywords':
+                    $('#gm2_long_tail_keywords').val(val); break;
                 case 'canonical':
                     $('#gm2_canonical_url').val(val); break;
                 case 'page_name':

--- a/readme.txt
+++ b/readme.txt
@@ -120,7 +120,7 @@ time.
 
 == SEO Settings ==
 The SEO meta box appears when editing posts, pages, any public custom post types and taxonomy terms. In the
-**SEO Settings** tab you can enter a custom title and description, toggle
+**SEO Settings** tab you can enter a custom title and description, focus keywords and long tail keywords, toggle
 `noindex` or `nofollow`, and upload an Open Graph image. Click **Select Image**
 to open the WordPress media library and choose a picture for the `og:image` and
 `twitter:image` tags. When inserting a link, you can pick `nofollow` or `sponsored`

--- a/tests/test-ai-seo.php
+++ b/tests/test-ai-seo.php
@@ -80,6 +80,7 @@ class AiResearchAjaxTest extends WP_Ajax_UnitTestCase {
         $this->assertTrue($resp['success']);
         $this->assertSame('New Title', $resp['data']['seo_title']);
         $this->assertSame('Desc', $resp['data']['description']);
+        $this->assertSame(['a','b'], $resp['data']['long_tail_keywords']);
         $this->assertSame('Missing alt', $resp['data']['html_issues'][0]['issue']);
         $this->assertSame('new-post', $resp['data']['slug']);
     }
@@ -389,5 +390,16 @@ class AdminTabsTest extends WP_UnitTestCase {
         $admin->render_seo_tabs_meta_box($post);
         $out = ob_get_clean();
         $this->assertStringContainsString('AI SEO', $out);
+    }
+}
+
+class LongTailKeywordsTest extends WP_UnitTestCase {
+    public function test_long_tail_keywords_saved() {
+        $post_id = self::factory()->post->create();
+        $admin = new Gm2\Gm2_SEO_Admin();
+        $_POST['gm2_seo_nonce'] = wp_create_nonce('gm2_save_seo_meta');
+        $_POST['gm2_long_tail_keywords'] = 'alpha, beta ';
+        $admin->save_post_meta($post_id);
+        $this->assertSame('alpha, beta', get_post_meta($post_id, '_gm2_long_tail_keywords', true));
     }
 }


### PR DESCRIPTION
## Summary
- render a Long Tail Keywords input in post and term SEO meta boxes
- store `_gm2_long_tail_keywords` when posts or terms are saved
- support long tail keyword suggestions in AI SEO JS
- mention the new option in README
- test that long tail keywords are parsed and saved

## Testing
- `phpunit` *(fails: PHPUnit Polyfills missing)*

------
https://chatgpt.com/codex/tasks/task_e_68751e59d8988327b26a94c2054eefb4