### PR TITLE
Fix gm2AiSeo.results parsing

### DIFF
--- a/admin/js/gm2-ai-seo.js
+++ b/admin/js/gm2-ai-seo.js
@@ -201,6 +201,19 @@ jQuery(function($){
     }
 
     if(window.gm2AiSeo && gm2AiSeo.results){
-        buildResults(gm2AiSeo.results, $('#gm2-ai-results'));
+        var results = gm2AiSeo.results;
+        if(typeof results === 'string'){
+            try {
+                results = JSON.parse(results);
+            } catch(err){
+                if(window.console && console.error){
+                    console.error('Invalid gm2AiSeo.results JSON', err);
+                }
+                results = null;
+            }
+        }
+        if(results && typeof results === 'object'){
+            buildResults(results, $('#gm2-ai-results'));
+        }
     }
 });


### PR DESCRIPTION
## Summary
- handle gm2AiSeo.results that may come as a JSON string
- avoid breaking the page on invalid JSON

## Testing
- `phpunit` *(fails: missing wordpress-tests-lib)*

------
https://chatgpt.com/codex/tasks/task_e_6875304cdbdc8327899a2b32e0527dee