### PR TITLE
Add AI research persistence test

### DIFF
--- a/tests/ContentAnalysisTest.php
+++ b/tests/ContentAnalysisTest.php
@@ -11,7 +11,15 @@ let code = fs.readFileSync(filePath, 'utf8');
 const start = code.indexOf('function countSyllables');
 const end = code.indexOf('function analyzeFocusKeywords');
 let snippet = code.substring(start, end);
-function jQuery(){return {_html:'',html:function(c){this._html=c;return this;},text:function(){return this._html.replace(/<[^>]*>/g,'');}};}
+function jQuery(){
+    return {
+        _html:'',
+        html:function(c){this._html=c;return this;},
+        text:function(){return this._html.replace(/<[^>]*>/g,'');},
+        find:function(){return {each:function(){}};},
+        attr:function(){return '';}
+    };
+}
 const vm = require('vm');
 const context = {jQuery:jQuery, $: jQuery, location:{hostname:'example.com'}};
 vm.createContext(context);


### PR DESCRIPTION
## Summary
- extend jQuery stub in `ContentAnalysisTest` for Node execution
- add `AiResearchPersistenceTest` to verify `_gm2_ai_research` meta is saved and passed to `gm2AiSeo` localization

## Testing
- `phpunit --filter AiResearchPersistenceTest` *(fails: Undefined constant PHPUnit\TextUI\TestRunner::FAILURE_EXIT)*

------
https://chatgpt.com/codex/tasks/task_e_687536cc88d0832782cf15dcb8c50cf3