### PR TITLE
Save AJAX results for gm2 ai seo

### DIFF
--- a/admin/js/gm2-ai-seo.js
+++ b/admin/js/gm2-ai-seo.js
@@ -43,6 +43,9 @@ jQuery(function($){
         .done(function(resp){
             $out.empty();
             if(resp && resp.success && resp.data){
+                if(window.gm2AiSeo){
+                    gm2AiSeo.results = resp.data;
+                }
                 if(typeof resp.data === 'object' && !resp.data.response){
                     buildResults(resp.data, $out);
                     if(window.gm2AiSeo && parseInt(gm2AiSeo.post_id, 10) === 0){


### PR DESCRIPTION
## Summary
- store latest results in `gm2AiSeo.results` after the AI SEO research AJAX call

## Testing
- `phpunit` *(fails: missing WordPress test library)*

------
https://chatgpt.com/codex/tasks/task_e_68753c2e14a8832792243c130d1b43e8