### PR TITLE
Add filters to Bulk AI feature

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -202,7 +202,7 @@ the last 100 missing URLs to help you create new redirects.
 * **Image filename normalization** – automatically sanitize filenames when
   **Clean Image Filenames** is enabled.
 * **Bulk AI suggestions** – bulk action on the posts list to generate AI SEO
-  suggestions for multiple items.
+  suggestions for multiple items with post type and category filters.
 * **Outbound link rel controls** – dropdown in the link dialog to apply
   `nofollow` or `sponsored` to outbound links.
 
@@ -211,6 +211,7 @@ the last 100 missing URLs to help you create new redirects.
 * Optional slug cleaner with customizable stopwords.
 * Option to clean image filenames on upload.
 * Updated AI SEO JavaScript for more accurate suggestions.
+* Bulk AI page now filters posts by type and category.
 = 1.6.3 =
 * Expanded documentation for Open Graph images, robots meta settings, sitemap
   pinging, robots.txt editing, AI-generated descriptions and alt text, and

--- a/uninstall.php
+++ b/uninstall.php
@@ -21,7 +21,8 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 // gm2_compression_api_key, gm2_compression_api_url, gm2_minify_html, gm2_minify_css,
 // gm2_minify_js, gm2_chatgpt_api_key, gm2_chatgpt_model, gm2_chatgpt_temperature,
 // gm2_chatgpt_max_tokens, gm2_chatgpt_endpoint, gm2_pagespeed_api_key, gm2_pagespeed_scores,
-// gm2_bulk_ai_page_size, gm2_bulk_ai_status, gm2_seo_guidelines_post_*, gm2_seo_guidelines_tax_*.
+// gm2_bulk_ai_page_size, gm2_bulk_ai_status, gm2_bulk_ai_post_type, gm2_bulk_ai_term,
+// gm2_seo_guidelines_post_*, gm2_seo_guidelines_tax_*.
 $option_names = array(
     'gm2_suite_settings',
     'gm2_suite_version',
@@ -72,6 +73,8 @@ $option_names = array(
     'gm2_pagespeed_scores',
     'gm2_bulk_ai_page_size',
     'gm2_bulk_ai_status',
+    'gm2_bulk_ai_post_type',
+    'gm2_bulk_ai_term',
     'gm2_clean_slugs',
     'gm2_slug_stopwords',
     'gm2_tax_desc_prompt',


### PR DESCRIPTION
## Summary
- allow filtering Bulk AI review by post type and taxonomy term
- store selected filters and clean them on uninstall
- document Bulk AI filter ability
- test that post type and category filters limit posts returned

## Testing
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6875450d77a88327a760521820dafa1c