### PR TITLE
Handle array responses from AI research rules

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1946,13 +1946,25 @@ class Gm2_SEO_Admin {
         if (!isset($rules[$target]) || !is_array($rules[$target])) {
             $rules[$target] = [];
         }
+
+        $formatted = [];
         foreach ($data as $cat => $text) {
-            $rules[$target][sanitize_key($cat)] = sanitize_textarea_field($text);
+            $key = sanitize_key($cat);
+            if (is_array($text)) {
+                $lines = array_map(static function($t){
+                    return sanitize_textarea_field((string) $t);
+                }, array_values($text));
+                $text = implode("\n", $lines);
+            } else {
+                $text = sanitize_textarea_field($text);
+            }
+            $rules[$target][$key] = $text;
+            $formatted[$key]     = $text;
         }
 
         update_option('gm2_content_rules', $rules);
 
-        wp_send_json_success($data);
+        wp_send_json_success($formatted);
     }
 
     public function ajax_ai_research() {

--- a/admin/js/gm2-content-rules.js
+++ b/admin/js/gm2-content-rules.js
@@ -17,6 +17,11 @@ jQuery(function($){
             if(resp && resp.success && typeof resp.data === 'object'){
                 $.each(resp.data, function(key,val){
                     var selector = 'textarea[name="gm2_content_rules['+base+']['+key+']"]';
+                    if($.isArray(val)){
+                        val = val.join("\n");
+                    }else if(typeof val === 'object' && val !== null){
+                        val = Object.values(val).join("\n");
+                    }
                     $(selector).val(val);
                 });
             }else if(resp && resp.data){


### PR DESCRIPTION
## Summary
- sanitize AI Research Content Rules responses into newline strings
- handle array or object values in JS before populating fields

## Testing
- `make test` *(fails: WordPress test suite missing)*

------
https://chatgpt.com/codex/tasks/task_e_687546eb86d08327b684e723a624379c