### PR TITLE
Fix content rule save logic

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1392,6 +1392,7 @@ class Gm2_SEO_Admin {
                 $rules[$k] = [];
                 if (is_array($v)) {
                     foreach ($v as $cat => $val) {
+                        $val = $this->flatten_rule_value($val);
                         $rules[$k][$cat] = sanitize_textarea_field($val);
                     }
                 }

--- a/tests/test-content-rules.php
+++ b/tests/test-content-rules.php
@@ -93,4 +93,25 @@ class ContentRulesAjaxTest extends WP_Ajax_UnitTestCase {
         $this->assertStringContainsString('Content Rules', $out);
     }
 }
+
+class ContentRulesFormTest extends WP_UnitTestCase {
+    public function test_form_flattens_arrays() {
+        $admin = new \Gm2\Gm2_SEO_Admin();
+        $user  = self::factory()->user->create(['role' => 'administrator']);
+        wp_set_current_user($user);
+
+        $_POST['gm2_content_rules_nonce'] = wp_create_nonce('gm2_content_rules_save');
+        $_POST['gm2_content_rules'] = [
+            'post_post' => [
+                'content' => ['First', 'Second']
+            ]
+        ];
+
+        $admin->handle_content_rules_form();
+
+        $rules = get_option('gm2_content_rules');
+        $this->assertIsString($rules['post_post']['content']);
+        $this->assertSame("First\nSecond", $rules['post_post']['content']);
+    }
+}
 ?>


### PR DESCRIPTION
## Summary
- flatten posted content rules before saving
- keep `gm2_content_rules` stored as newline-separated strings
- test that rule arrays from the admin form are flattened

## Testing
- `php -l admin/Gm2_SEO_Admin.php`
- `php -l tests/test-content-rules.php`
- `phpunit` *(fails: PHPUnit Polyfills missing)*

------
https://chatgpt.com/codex/tasks/task_e_68754bf2e5b083279cd876fe5b9986b5