### PR TITLE
Handle JSON guidelines responses

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1897,8 +1897,15 @@ class Gm2_SEO_Admin {
             wp_send_json_error($resp->get_error_message());
         }
 
-        update_option($target, $resp);
-        wp_send_json_success($resp);
+        $decoded = json_decode($resp, true);
+        if (json_last_error() === JSON_ERROR_NONE) {
+            $resp = $decoded;
+        }
+
+        $flat = $this->flatten_rule_value($resp);
+
+        update_option($target, $flat);
+        wp_send_json_success($flat);
     }
 
     public function ajax_research_content_rules() {

--- a/tests/test-ai-seo.php
+++ b/tests/test-ai-seo.php
@@ -32,6 +32,68 @@ class GuidelinesAjaxTest extends WP_Ajax_UnitTestCase {
         $this->assertSame('guidelines', $resp['data']);
         $this->assertSame('guidelines', get_option('gm2_seo_guidelines_post_post'));
     }
+
+    public function test_guidelines_ajax_handles_array_json() {
+        update_option('gm2_chatgpt_api_key', 'key');
+        $filter = function($pre, $args, $url) {
+            if ($url === 'https://api.openai.com/v1/chat/completions') {
+                return [
+                    'response' => ['code' => 200],
+                    'body' => json_encode([
+                        'choices' => [ ['message' => ['content' => json_encode(['one','two'])]] ]
+                    ])
+                ];
+            }
+            return false;
+        };
+        add_filter('pre_http_request', $filter, 10, 3);
+
+        $this->_setRole('administrator');
+        $_POST['categories'] = 'on page';
+        $_POST['target'] = 'gm2_seo_guidelines_post_post';
+        $_POST['_ajax_nonce'] = wp_create_nonce('gm2_research_guidelines');
+        $_REQUEST['_ajax_nonce'] = $_POST['_ajax_nonce'];
+        try {
+            $this->_handleAjax('gm2_research_guidelines');
+        } catch (WPAjaxDieContinueException $e) {
+        }
+        remove_filter('pre_http_request', $filter, 10);
+        $resp = json_decode($this->_last_response, true);
+        $this->assertTrue($resp['success']);
+        $this->assertSame("one\ntwo", $resp['data']);
+        $this->assertSame("one\ntwo", get_option('gm2_seo_guidelines_post_post'));
+    }
+
+    public function test_guidelines_ajax_handles_object_json() {
+        update_option('gm2_chatgpt_api_key', 'key');
+        $filter = function($pre, $args, $url) {
+            if ($url === 'https://api.openai.com/v1/chat/completions') {
+                return [
+                    'response' => ['code' => 200],
+                    'body' => json_encode([
+                        'choices' => [ ['message' => ['content' => json_encode(['first' => 'one','second' => 'two'])]] ]
+                    ])
+                ];
+            }
+            return false;
+        };
+        add_filter('pre_http_request', $filter, 10, 3);
+
+        $this->_setRole('administrator');
+        $_POST['categories'] = 'on page';
+        $_POST['target'] = 'gm2_seo_guidelines_post_post';
+        $_POST['_ajax_nonce'] = wp_create_nonce('gm2_research_guidelines');
+        $_REQUEST['_ajax_nonce'] = $_POST['_ajax_nonce'];
+        try {
+            $this->_handleAjax('gm2_research_guidelines');
+        } catch (WPAjaxDieContinueException $e) {
+        }
+        remove_filter('pre_http_request', $filter, 10);
+        $resp = json_decode($this->_last_response, true);
+        $this->assertTrue($resp['success']);
+        $this->assertSame("one\ntwo", $resp['data']);
+        $this->assertSame("one\ntwo", get_option('gm2_seo_guidelines_post_post'));
+    }
 }
 
 class AiResearchAjaxTest extends WP_Ajax_UnitTestCase {


### PR DESCRIPTION
## Summary
- allow `ajax_research_guidelines()` to decode JSON
- flatten guidelines results before saving/returning
- test guidelines ajax handler with JSON array/object

## Testing
- `phpunit` *(fails: PHPUnit Polyfills library missing)*

------
https://chatgpt.com/codex/tasks/task_e_68754e08cc208327944b7adcf0ec34e8