### PR TITLE
Improve test setup docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,14 @@
-.PHONY: test install-tests
+.PHONY: test install-tests check-tests
 
-test:
+WP_TESTS_DIR ?= $(TMPDIR)/wordpress-tests-lib
+
+check-tests:
+	@if [ ! -f "$(WP_TESTS_DIR)/includes/functions.php" ]; then \
+		echo "WordPress test suite not found. Installing..."; \
+		$(MAKE) install-tests; \
+	fi
+
+test: check-tests
 	phpunit
 
 install-tests:

--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# Gm2 WordPress Suite
+
+This repository contains the development version of the Gm2 WordPress Suite plugin. For plugin installation steps and feature documentation see [readme.txt](readme.txt).
+
+## Running Tests
+
+The PHPUnit tests rely on the official WordPress test suite. Before running the tests you must install the suite using the helper script provided in `bin`.
+
+### Prerequisites
+
+- **PHP** 7.4 or higher
+- **Composer** for installing PHPUnit
+
+Install PHPUnit globally with Composer if it is not already available:
+
+```bash
+composer global require phpunit/phpunit
+```
+
+Make sure `~/.composer/vendor/bin` (or your global Composer bin directory) is on your `PATH`.
+
+### Installing the WordPress test suite
+
+Run the following command once using your database credentials:
+
+```bash
+bash bin/install-wp-tests.sh <db-name> <db-user> <db-pass> [db-host] [wp-version]
+```
+
+This downloads WordPress and configures the test database. The script uses `$WP_TESTS_DIR` or defaults to `/tmp/wordpress-tests-lib`.
+
+### Running the tests
+
+After the test suite is installed, execute:
+
+```bash
+phpunit
+```
+
+The Makefile includes a `test` target which automatically checks for the test suite and runs PHPUnit:
+
+```bash
+make test
+```
+
+
+

--- a/readme.txt
+++ b/readme.txt
@@ -240,16 +240,17 @@ the last 100 missing URLs to help you create new redirects.
 == Testing ==
 The PHPUnit tests rely on the WordPress test suite and the `phpunit` executable.
 
-1. **Install PHP and PHPUnit.** Install via your package manager or with Composer:
+
+1. **Install PHP and Composer.** PHPUnit is required for the tests and can be installed globally:
    ```bash
    composer global require phpunit/phpunit
    ```
-   Ensure `phpunit` is on your `PATH`.
-2. **Install the WordPress test suite.** Run the helper script once using your database credentials:
+   Ensure the Composer global bin directory is on your `PATH`.
+2. **Install the WordPress test suite.** Run the helper script before executing the tests:
    ```bash
    bash bin/install-wp-tests.sh <db-name> <db-user> <db-pass> [db-host] [wp-version]
    ```
-   This downloads WordPress and sets up the test database.
-3. **Run the tests.** Execute `phpunit` (or `make test` with the provided Makefile) from the project root. Set `WP_TESTS_DIR` if you installed the suite elsewhere.
+   This downloads WordPress and prepares the test database.
+3. **Run the tests.** Execute `phpunit` or `make test` from the project root. The Makefile will install the test suite automatically if it is missing. Set `WP_TESTS_DIR` if you installed the suite elsewhere.
 
 The tests cover the AJAX endpoints used for content analysis and AI research (`gm2_check_rules`, `gm2_keyword_ideas`, `gm2_research_guidelines` and `gm2_ai_research`).


### PR DESCRIPTION
## Summary
- add README with dev setup instructions
- expand Testing section in `readme.txt`
- update `Makefile` with `check-tests` auto install

## Testing
- `make test` *(fails: `mysqladmin: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68754f48e3a083278a1b355be75e0f0d