### PR TITLE
Ensure rule values are flattened when saved

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1392,9 +1392,15 @@ class Gm2_SEO_Admin {
                 $rules[$k] = [];
                 if (is_array($v)) {
                     foreach ($v as $cat => $val) {
-                        $val = $this->flatten_rule_value($val);
-                        $rules[$k][$cat] = sanitize_textarea_field($val);
+                        $rules[$k][$cat] = sanitize_textarea_field(
+                            $this->flatten_rule_value($val)
+                        );
                     }
+                } else {
+                    // Support legacy or single-category submissions.
+                    $rules[$k]['general'] = sanitize_textarea_field(
+                        $this->flatten_rule_value($v)
+                    );
                 }
             }
         }

--- a/tests/test-content-rules.php
+++ b/tests/test-content-rules.php
@@ -113,5 +113,21 @@ class ContentRulesFormTest extends WP_UnitTestCase {
         $this->assertIsString($rules['post_post']['content']);
         $this->assertSame("First\nSecond", $rules['post_post']['content']);
     }
+
+    public function test_form_flattens_scalar_value() {
+        $admin = new \Gm2\Gm2_SEO_Admin();
+        $user  = self::factory()->user->create(['role' => 'administrator']);
+        wp_set_current_user($user);
+
+        $_POST['gm2_content_rules_nonce'] = wp_create_nonce('gm2_content_rules_save');
+        $_POST['gm2_content_rules'] = [
+            'post_post' => 'One\nTwo'
+        ];
+
+        $admin->handle_content_rules_form();
+
+        $rules = get_option('gm2_content_rules');
+        $this->assertSame('One\nTwo', $rules['post_post']['general']);
+    }
 }
 ?>


### PR DESCRIPTION
## Summary
- normalize incoming content rule values
- cover scalar rule input in tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68755db699b48327bb24b03f01a2120f