### PR TITLE
Modify content rules prompt

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1938,7 +1938,9 @@ class Gm2_SEO_Admin {
             wp_send_json_error( __( 'invalid target', 'gm2-wordpress-suite' ) );
         }
 
-        $prompt = 'Provide best practice content rules as JSON for these categories: ' . $cats;
+        $prompt = 'For each of these categories (' . $cats .
+            '), provide one short best-practice rule as text. ' .
+            'Respond only with JSON where keys match the category slugs and values are sentences.';
         $chat   = new Gm2_ChatGPT();
         $resp   = $chat->query($prompt);
 


### PR DESCRIPTION
## Summary
- enhance AI prompt for content rule generation to request text rules

## Testing
- `make test` *(fails: WordPress test suite not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687564d5343483279be6930f8a470447