### PR TITLE
Enhance AI content rules UX

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -134,6 +134,7 @@ class Gm2_Admin {
                     'nonce'    => wp_create_nonce('gm2_research_content_rules'),
                     'ajax_url' => admin_url('admin-ajax.php'),
                     'prompt'   => __( 'Enter rule categories (comma separated):', 'gm2-wordpress-suite' ),
+                    'loading'  => __( 'Researching...', 'gm2-wordpress-suite' ),
                 ]
             );
             if ($hook === 'gm2_page_gm2-bulk-ai-review') {

--- a/admin/js/gm2-content-rules.js
+++ b/admin/js/gm2-content-rules.js
@@ -2,12 +2,16 @@ jQuery(function($){
     $('.gm2-research-rules').on('click', function(e){
         e.preventDefault();
         if(!window.gm2ContentRules) return;
-        var base = $(this).data('base');
-        var cat  = $(this).data('category');
+        var $btn = $(this);
+        var base = $btn.data('base');
+        var cat  = $btn.data('category');
         if(!base) return;
         var promptText = gm2ContentRules.prompt || 'Enter rule categories (comma separated):';
         var cats = prompt(promptText, cat);
         if(cats === null || !cats.trim()) return;
+        var loadingText = gm2ContentRules.loading || 'Researching...';
+        var originalText = $btn.text();
+        $btn.prop('disabled', true).text(loadingText);
         $.post(gm2ContentRules.ajax_url, {
             action: 'gm2_research_content_rules',
             target: base,
@@ -31,6 +35,8 @@ jQuery(function($){
             }
         }).fail(function(){
             alert('Request failed');
+        }).always(function(){
+            $btn.prop('disabled', false).text(originalText);
         });
     });
 });


### PR DESCRIPTION
## Summary
- show loading state while researching AI content rules
- localize a `Researching...` label for JS

## Testing
- `make test` *(fails: WordPress test suite not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687561a182548327a5f08b0f5dacebaa