### PR TITLE
Bump plugin version to 1.6.5

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Gm2 WordPress Suite
  * Description:       A powerful suite of tools and features for WordPress, by Gm2.
- * Version:           1.6.4
+ * Version:           1.6.5
  * Author:            Your Name or Team Gm2
  * Author URI:        https://yourwebsite.com
  * License:           GPL-2.0+
@@ -15,7 +15,7 @@
 defined('ABSPATH') or die('No script kiddies please!');
 
 // Define constants
-define('GM2_VERSION', '1.6.4');
+define('GM2_VERSION', '1.6.5');
 define('GM2_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('GM2_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('GM2_CONTENT_RULES_VERSION', 2);

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: gm2team
 Tags: admin, tools, suite, performance
 Requires at least: 7.0
 Tested up to: 6.5
-Stable tag: 1.6.4
+Stable tag: 1.6.5
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -207,6 +207,8 @@ the last 100 missing URLs to help you create new redirects.
   `nofollow` or `sponsored` to outbound links.
 
 == Changelog ==
+= 1.6.5 =
+* Added loading state for AI Research Content Rules button.
 = 1.6.4 =
 * Optional slug cleaner with customizable stopwords.
 * Option to clean image filenames on upload.


### PR DESCRIPTION
## Summary
- bump plugin header and constant to 1.6.5
- document new stable tag
- add changelog entry for AI research button loading state

## Testing
- `make test` *(fails: install-tests usage message)*

------
https://chatgpt.com/codex/tasks/task_e_68756b33c9dc832797d33ef2ccf664be