### PR TITLE
Add debug logging for research content rules

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1944,6 +1944,10 @@ class Gm2_SEO_Admin {
         $chat   = new Gm2_ChatGPT();
         $resp   = $chat->query($prompt);
 
+        if (defined('WP_DEBUG') && WP_DEBUG) {
+            error_log('Content rules response: ' . $resp);
+        }
+
         if (is_wp_error($resp)) {
             wp_send_json_error($resp->get_error_message());
         }
@@ -1977,6 +1981,10 @@ class Gm2_SEO_Admin {
             }
             $rules[$target][$key] = $text;
             $formatted[$key]     = $text;
+        }
+
+        if (defined('WP_DEBUG') && WP_DEBUG) {
+            error_log('Content rules formatted: ' . print_r($formatted, true));
         }
 
         update_option('gm2_content_rules', $rules);


### PR DESCRIPTION
## Summary
- log raw response from ChatGPT when generating content rules
- log formatted rules array before saving

## Testing
- `make test` *(fails: WordPress test suite not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687578a86d488327b1f4ef956c1bf1e1