### PR TITLE
Update content rules prompt

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1938,9 +1938,11 @@ class Gm2_SEO_Admin {
             wp_send_json_error( __( 'invalid target', 'gm2-wordpress-suite' ) );
         }
 
-        $prompt = 'For each of these categories (' . $cats .
-            '), provide one short best-practice rule as text. ' .
-            'Respond only with JSON where keys match the category slugs and values are sentences.';
+        $prompt = sprintf(
+            'For each of these categories (%s) provide one short best-practice rule. ' .
+            'Return ONLY JSON where each key is exactly one of the provided slugs.',
+            $cats
+        );
         $chat   = new Gm2_ChatGPT();
         $resp   = $chat->query($prompt);
 

--- a/readme.txt
+++ b/readme.txt
@@ -116,7 +116,8 @@ Within the Rules table, every category textarea now includes an **AI Research
 Content Rules** button. The button sits directly below the textarea label and
 fetches best-practice suggestions from ChatGPT for the selected post type or
 taxonomy. The results are saved automatically so you can refine them at any
-time.
+time. ChatGPT is instructed to respond **only with JSON** and each key must
+exactly match one of the slugs you provided.
 
 Category names returned by ChatGPT may contain spaces or hyphens. These are
 normalized to use underscores when saving so keys like "SEO Title" or


### PR DESCRIPTION
## Summary
- refine prompt in `ajax_research_content_rules` so ChatGPT only returns JSON using exact slugs
- document new strict JSON requirement in the README

## Testing
- `make test` *(fails: WordPress test suite requires DB credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68757fa09d408327821fe37de91906bf