### PR TITLE
Update alert for empty content rules

### DIFF
--- a/admin/js/gm2-content-rules.js
+++ b/admin/js/gm2-content-rules.js
@@ -20,7 +20,7 @@ jQuery(function($){
         }).done(function(resp){
             if(resp && resp.success && typeof resp.data === 'object'){
                 if($.isEmptyObject(resp.data)){
-                    alert('No rules returned. Please verify the categories or check the server logs.');
+                    alert('No recognized rules returned. Check the categories or server logs.');
                 }else{
                     $.each(resp.data, function(key,val){
                         var selector = 'textarea[name="gm2_content_rules['+base+']['+key+']"]';


### PR DESCRIPTION
## Summary
- clarify alert when no valid content rules are returned

## Testing
- `make test` *(fails: WordPress test suite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687580917de48327b007d380fe2e885d