### PR TITLE
Improve content rules prompt

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1938,9 +1938,16 @@ class Gm2_SEO_Admin {
             wp_send_json_error( __( 'invalid target', 'gm2-wordpress-suite' ) );
         }
 
+        if (strpos($target, 'post_') === 0) {
+            $prompt_target = sprintf('for the %s post type', substr($target, 5));
+        } else {
+            $prompt_target = sprintf('for the %s taxonomy', substr($target, 4));
+        }
+
         $prompt = sprintf(
-            'For each of these categories (%s) provide one short best-practice rule. ' .
-            'Return ONLY JSON where each key is exactly one of the provided slugs.',
+            'Provide an array of short, measurable rules %s. Use these categories: %s. ' .
+            'Respond ONLY with JSON where each key matches the provided slugs and each value is an array of rules.',
+            $prompt_target,
             $cats
         );
         $chat   = new Gm2_ChatGPT();

--- a/readme.txt
+++ b/readme.txt
@@ -115,13 +115,30 @@ taxonomy term.
 Within the Rules table, every category textarea now includes an **AI Research
 Content Rules** button. The button sits directly below the textarea label and
 fetches best-practice suggestions from ChatGPT for the selected post type or
-taxonomy. The results are saved automatically so you can refine them at any
-time. ChatGPT is instructed to respond **only with JSON** and each key must
-exactly match one of the slugs you provided.
+taxonomy. ChatGPT is told which content type is being analyzed and instructed to
+return an array of short, measurable rules for each requested category. The
+results are saved automatically so you can refine them at any time. ChatGPT is
+instructed to respond **only with JSON** where each key matches one of the slugs
+you provided and each value is an array of rules.
 
 Category names returned by ChatGPT may contain spaces or hyphens. These are
 normalized to use underscores when saving so keys like "SEO Title" or
 "seo-title" populate the `seo_title` textarea.
+
+Example JSON response:
+
+```
+{
+  "seo_title": [
+    "Use the main keyword first",
+    "Keep under 60 characters"
+  ],
+  "seo_description": [
+    "Summarize the page in under 160 characters",
+    "Include a call to action"
+  ]
+}
+```
 
 == SEO Settings ==
 The SEO meta box appears when editing posts, pages, any public custom post types and taxonomy terms. In the


### PR DESCRIPTION
## Summary
- clarify the content rules prompt in `ajax_research_content_rules`
- document new behaviour in **Content Rules** section with example JSON

## Testing
- `make test` *(fails: WordPress test suite not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68758d1f4f948327b7b80ce8c13e0a9e