### PR TITLE
Handle nested arrays in content rules

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1649,8 +1649,24 @@ class Gm2_SEO_Admin {
      */
     private function flatten_rule_value($value) {
         if (is_array($value)) {
-            return implode("\n", array_values($value));
+            $parts = [];
+            foreach ($value as $v) {
+                $flat = $this->flatten_rule_value($v);
+                if ($flat !== '') {
+                    $parts[] = $flat;
+                }
+            }
+            return implode("\n", $parts);
         }
+
+        if (is_object($value)) {
+            if (method_exists($value, '__toString')) {
+                return (string) $value;
+            }
+            $value = (array) $value;
+            return $this->flatten_rule_value($value);
+        }
+
         return (string) $value;
     }
 

--- a/admin/js/gm2-content-rules.js
+++ b/admin/js/gm2-content-rules.js
@@ -1,4 +1,12 @@
 jQuery(function($){
+    function flatten(val){
+        if($.isArray(val)){
+            return $.map(val, flatten).join("\n");
+        }else if(val && typeof val === "object"){
+            return $.map(Object.values(val), flatten).join("\n");
+        }
+        return String(val);
+    }
     $('.gm2-research-rules').on('click', function(e){
         e.preventDefault();
         if(!window.gm2ContentRules) return;
@@ -24,12 +32,7 @@ jQuery(function($){
                 }else{
                     $.each(resp.data, function(key,val){
                         var selector = 'textarea[name="gm2_content_rules['+base+']['+key+']"]';
-                        if($.isArray(val)){
-                            val = val.join("\n");
-                        }else if(typeof val === 'object' && val !== null){
-                            val = Object.values(val).join("\n");
-                        }
-                        $(selector).val(val);
+                        $(selector).val(flatten(val));
                     });
                 }
             }else if(resp && resp.data){

--- a/readme.txt
+++ b/readme.txt
@@ -231,6 +231,7 @@ the last 100 missing URLs to help you create new redirects.
 == Changelog ==
 = 1.6.5 =
 * Added loading state for AI Research Content Rules button.
+* Fixed nested-array handling for AI Research Content Rules.
 = 1.6.4 =
 * Optional slug cleaner with customizable stopwords.
 * Option to clean image filenames on upload.

--- a/tests/test-content-rules.php
+++ b/tests/test-content-rules.php
@@ -114,6 +114,24 @@ class ContentRulesFormTest extends WP_UnitTestCase {
         $this->assertSame("First\nSecond", $rules['post_post']['content']);
     }
 
+    public function test_form_flattens_nested_arrays() {
+        $admin = new \Gm2\Gm2_SEO_Admin();
+        $user  = self::factory()->user->create(['role' => 'administrator']);
+        wp_set_current_user($user);
+
+        $_POST['gm2_content_rules_nonce'] = wp_create_nonce('gm2_content_rules_save');
+        $_POST['gm2_content_rules'] = [
+            'post_post' => [
+                'canonical_url' => [[ 'Rule A' ], ['Rule B']]
+            ]
+        ];
+
+        $admin->handle_content_rules_form();
+
+        $rules = get_option('gm2_content_rules');
+        $this->assertSame("Rule A\nRule B", $rules['post_post']['canonical_url']);
+    }
+
     public function test_form_flattens_scalar_value() {
         $admin = new \Gm2\Gm2_SEO_Admin();
         $user  = self::factory()->user->create(['role' => 'administrator']);
@@ -198,6 +216,38 @@ class ContentRulesNormalizationTest extends WP_Ajax_UnitTestCase {
         $rules = get_option('gm2_content_rules');
         $this->assertArrayHasKey('seo_title', $rules['post_post']);
         $this->assertArrayNotHasKey('unknown', $rules['post_post']);
+    }
+
+    public function test_nested_arrays_are_flattened_via_ajax() {
+        update_option('gm2_chatgpt_api_key', 'key');
+        $resp_data = [ 'canonical_url' => [[ 'Rule A' ], ['Rule B' ]] ];
+        $filter = function($pre, $args, $url) use ($resp_data) {
+            if ($url === 'https://api.openai.com/v1/chat/completions') {
+                return [
+                    'response' => ['code' => 200],
+                    'body'     => json_encode([
+                        'choices' => [ ['message' => ['content' => json_encode($resp_data)]] ]
+                    ])
+                ];
+            }
+            return false;
+        };
+        add_filter('pre_http_request', $filter, 10, 3);
+
+        $this->_setRole('administrator');
+        $_POST['categories'] = 'canonical_url';
+        $_POST['target'] = 'post_post';
+        $_POST['_ajax_nonce'] = wp_create_nonce('gm2_research_content_rules');
+        $_REQUEST['_ajax_nonce'] = $_POST['_ajax_nonce'];
+        try { $this->_handleAjax('gm2_research_content_rules'); } catch (WPAjaxDieContinueException $e) {}
+
+        remove_filter('pre_http_request', $filter, 10);
+
+        $resp = json_decode($this->_last_response, true);
+        $this->assertTrue($resp['success']);
+        $this->assertSame("Rule A\nRule B", $resp['data']['canonical_url']);
+        $rules = get_option('gm2_content_rules');
+        $this->assertSame("Rule A\nRule B", $rules['post_post']['canonical_url']);
     }
 
     public function test_only_unknown_categories_returns_error() {


### PR DESCRIPTION
## Summary
- recursively flatten rule values in PHP admin
- ensure nested arrays convert to strings in the admin JS
- test nested array handling in content rules
- document content rules fix in readme

## Testing
- `make test` *(fails: `bin/install-wp-tests.sh` requires DB credentials)*

------
https://chatgpt.com/codex/tasks/task_e_687592430d3483279053d30ab37b6758