### PR TITLE
Fix slash accumulation in content rules

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1393,13 +1393,13 @@ class Gm2_SEO_Admin {
                 if (is_array($v)) {
                     foreach ($v as $cat => $val) {
                         $rules[$k][$cat] = sanitize_textarea_field(
-                            $this->flatten_rule_value($val)
+                            wp_unslash($this->flatten_rule_value($val))
                         );
                     }
                 } else {
                     // Support legacy or single-category submissions.
                     $rules[$k]['general'] = sanitize_textarea_field(
-                        $this->flatten_rule_value($v)
+                        wp_unslash($this->flatten_rule_value($v))
                     );
                 }
             }


### PR DESCRIPTION
## Summary
- unslash textarea values before saving Content Rules

## Testing
- `php -l admin/Gm2_SEO_Admin.php`
- `phpunit -c phpunit.xml` *(fails: missing WordPress test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68759bba24e8832793bb4600c4e6e1a8