### PR TITLE
Add keyword metrics to planner output

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1884,6 +1884,7 @@ class Gm2_SEO_Admin {
             wp_send_json_error( $ideas->get_error_message() );
         }
 
+        // Results now include metric information when available.
         wp_send_json_success($ideas);
     }
 

--- a/admin/js/gm2-keyword-research.js
+++ b/admin/js/gm2-keyword-research.js
@@ -18,8 +18,26 @@ jQuery(function($){
                 return;
             }
             if(resp.success && Array.isArray(resp.data)){
-                resp.data.forEach(function(k){
-                    $('<li>').text(k).appendTo($list);
+                resp.data.forEach(function(item){
+                    var li = $('<li>');
+                    if(typeof item === 'string'){
+                        li.text(item);
+                    }else{
+                        li.text(item.text || '');
+                        if(item.metrics){
+                            var parts = [];
+                            Object.keys(item.metrics).forEach(function(key){
+                                var val = item.metrics[key];
+                                if(val !== null && val !== ''){
+                                    parts.push(key.replace(/_/g,' ') + ': ' + val);
+                                }
+                            });
+                            if(parts.length){
+                                li.append(' (' + parts.join(', ') + ')');
+                            }
+                        }
+                    }
+                    li.appendTo($list);
                 });
             } else {
                 var msg = 'No results';

--- a/includes/Gm2_Keyword_Planner.php
+++ b/includes/Gm2_Keyword_Planner.php
@@ -89,9 +89,25 @@ class Gm2_Keyword_Planner {
         $ideas = [];
         if (!empty($data['results'])) {
             foreach ($data['results'] as $res) {
-                if (!empty($res['text'])) {
-                    $ideas[] = $res['text'];
+                if (empty($res['text'])) {
+                    continue;
                 }
+
+                $idea = ['text' => $res['text']];
+
+                if (!empty($res['keyword_idea_metrics']) && is_array($res['keyword_idea_metrics'])) {
+                    $metrics = [];
+                    foreach ($res['keyword_idea_metrics'] as $m_key => $m_val) {
+                        if ($m_val !== '' && $m_val !== null) {
+                            $metrics[$m_key] = $m_val;
+                        }
+                    }
+                    if ($metrics) {
+                        $idea['metrics'] = $metrics;
+                    }
+                }
+
+                $ideas[] = $idea;
             }
         }
 

--- a/tests/test-keyword-planner.php
+++ b/tests/test-keyword-planner.php
@@ -1,0 +1,60 @@
+<?php
+use Gm2\Gm2_Keyword_Planner;
+
+class KeywordPlannerTest extends WP_UnitTestCase {
+    public function setUp(): void {
+        parent::setUp();
+        update_option('gm2_gads_developer_token', 'dev');
+        update_option('gm2_gads_customer_id', '123-456-7890');
+        update_option('gm2_google_refresh_token', 'refresh');
+        update_option('gm2_google_access_token', 'access');
+        update_option('gm2_google_expires_at', time() + 3600);
+    }
+
+    public function test_metrics_parsed_from_response() {
+        $response = [
+            'results' => [
+                [
+                    'text' => 'alpha',
+                    'keyword_idea_metrics' => [
+                        'avg_monthly_searches'      => 100,
+                        'competition'               => 'LOW',
+                        'three_month_avg_searches'  => 110
+                    ]
+                ],
+                [
+                    'text' => 'beta',
+                    'keyword_idea_metrics' => [
+                        'avg_monthly_searches' => 50,
+                        'competition'          => null
+                    ]
+                ]
+            ]
+        ];
+
+        $filter = function($pre, $args, $url) use ($response) {
+            if (false !== strpos($url, 'generateKeywordIdeas')) {
+                return [
+                    'response' => ['code' => 200],
+                    'body'     => json_encode($response)
+                ];
+            }
+            return false;
+        };
+        add_filter('pre_http_request', $filter, 10, 3);
+
+        $planner = new Gm2_Keyword_Planner();
+        $ideas   = $planner->generate_keyword_ideas('seed');
+
+        remove_filter('pre_http_request', $filter, 10);
+
+        $this->assertIsArray($ideas);
+        $this->assertCount(2, $ideas);
+        $this->assertSame('alpha', $ideas[0]['text']);
+        $this->assertSame(100, $ideas[0]['metrics']['avg_monthly_searches']);
+        $this->assertSame('LOW', $ideas[0]['metrics']['competition']);
+        $this->assertSame('beta', $ideas[1]['text']);
+        $this->assertSame(50, $ideas[1]['metrics']['avg_monthly_searches']);
+        $this->assertArrayNotHasKey('competition', $ideas[1]['metrics']);
+    }
+}


### PR DESCRIPTION
## Summary
- include Google Ads metrics when generating keyword ideas
- pass metrics through AJAX keyword ideas handler
- show metrics in the keyword research UI
- test parsing of Google Ads metrics

## Testing
- `make test` *(fails: install-tests)*

------
https://chatgpt.com/codex/tasks/task_e_68766a24d57c83279ecd99367d628940