### PR TITLE
Fix metrics display for keyword research

### DIFF
--- a/admin/js/gm2-keyword-research.js
+++ b/admin/js/gm2-keyword-research.js
@@ -33,6 +33,9 @@ jQuery(function($){
                             Object.keys(item.metrics).forEach(function(key){
                                 var val = item.metrics[key];
                                 if(val !== null && val !== ''){
+                                    if(typeof val === 'object'){
+                                        val = val.value || JSON.stringify(val);
+                                    }
                                     parts.push(key.replace(/_/g,' ') + ': ' + val);
                                 }
                             });


### PR DESCRIPTION
## Summary
- avoid `[object Object]` in keyword research results by converting metric values to strings

## Testing
- `phpunit` *(fails: WordPress test suite missing)*

------
https://chatgpt.com/codex/tasks/task_e_6876733f8ef88327a718f8a5eabfef01