### PR TITLE
Add new keyword metrics

### DIFF
--- a/admin/js/gm2-keyword-research.js
+++ b/admin/js/gm2-keyword-research.js
@@ -1,4 +1,10 @@
 jQuery(function($){
+    const labels = {
+        avg_monthly_searches: 'Avg. Monthly Searches',
+        competition: 'Competition',
+        three_month_change: '3‑month change',
+        yoy_change: 'YoY change'
+    };
     if(!gm2KeywordResearch.enabled){
         $('#gm2-keyword-research-form button[type="submit"]').prop('disabled', true);
     }
@@ -35,12 +41,16 @@ jQuery(function($){
                         if(item.metrics){
                             var parts = [];
                             Object.keys(item.metrics).forEach(function(key){
+                                if(key === 'monthly_search_volumes'){
+                                    return;
+                                }
                                 var val = item.metrics[key];
                                 if(val !== null && val !== ''){
                                     if(typeof val === 'object'){
                                         val = val.value || JSON.stringify(val);
                                     }
-                                    parts.push(key.replace(/_/g,' ') + ': ' + val);
+                                    var label = labels[key] || key.replace(/_/g,' ');
+                                    parts.push(label + ': ' + val);
                                 }
                             });
                             if(parts.length){

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Gm2 WordPress Suite
  * Description:       A powerful suite of tools and features for WordPress, by Gm2.
- * Version:           1.6.7
+ * Version:           1.6.8
  * Author:            Your Name or Team Gm2
  * Author URI:        https://yourwebsite.com
  * License:           GPL-2.0+
@@ -15,7 +15,7 @@
 defined('ABSPATH') or die('No script kiddies please!');
 
 // Define constants
-define('GM2_VERSION', '1.6.7');
+define('GM2_VERSION', '1.6.8');
 define('GM2_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('GM2_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('GM2_CONTENT_RULES_VERSION', 2);

--- a/includes/Gm2_Keyword_Planner.php
+++ b/includes/Gm2_Keyword_Planner.php
@@ -102,6 +102,23 @@ class Gm2_Keyword_Planner {
                             $metrics[$m_key] = $m_val;
                         }
                     }
+
+                    if (!empty($metrics['monthly_search_volumes']) && is_array($metrics['monthly_search_volumes'])) {
+                        $vols = $metrics['monthly_search_volumes'];
+                        usort($vols, function ($a, $b) {
+                            $ta = ($a['year'] ?? 0) * 12 + ($a['month'] ?? 0);
+                            $tb = ($b['year'] ?? 0) * 12 + ($b['month'] ?? 0);
+                            return $ta <=> $tb;
+                        });
+                        $n = count($vols);
+                        if ($n >= 3) {
+                            $metrics['three_month_change'] = $vols[$n - 1]['monthly_searches'] - $vols[$n - 3]['monthly_searches'];
+                        }
+                        if ($n >= 13) {
+                            $metrics['yoy_change'] = $vols[$n - 1]['monthly_searches'] - $vols[$n - 13]['monthly_searches'];
+                        }
+                    }
+
                     if ($metrics) {
                         $idea['metrics'] = $metrics;
                     }

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: gm2team
 Tags: admin, tools, suite, performance
 Requires at least: 7.0
 Tested up to: 6.5
-Stable tag: 1.6.7
+Stable tag: 1.6.8
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -239,6 +239,8 @@ the last 100 missing URLs to help you create new redirects.
   `nofollow` or `sponsored` to outbound links.
 
 == Changelog ==
+= 1.6.8 =
+* Added three-month and year-over-year change metrics to keyword research results.
 = 1.6.7 =
 * Fixed display of keyword research results when API returns complex objects.
 = 1.6.6 =

--- a/tests/test-keyword-planner.php
+++ b/tests/test-keyword-planner.php
@@ -12,21 +12,34 @@ class KeywordPlannerTest extends WP_UnitTestCase {
     }
 
     public function test_metrics_parsed_from_response() {
+        $months = [];
+        for ($i = 1; $i <= 14; $i++) {
+            $months[] = [
+                'year' => 2024 + intdiv($i - 1, 12),
+                'month' => (($i - 1) % 12) + 1,
+                'monthly_searches' => $i * 10,
+            ];
+        }
         $response = [
             'results' => [
                 [
                     'text' => 'alpha',
                     'keyword_idea_metrics' => [
-                        'avg_monthly_searches'      => 100,
-                        'competition'               => 'LOW',
-                        'three_month_avg_searches'  => 110
+                        'avg_monthly_searches' => 100,
+                        'competition'          => 'LOW',
+                        'monthly_search_volumes' => $months,
                     ]
                 ],
                 [
                     'text' => 'beta',
                     'keyword_idea_metrics' => [
                         'avg_monthly_searches' => 50,
-                        'competition'          => null
+                        'competition'          => null,
+                        'monthly_search_volumes' => [
+                            ['year' => 2025, 'month' => 1, 'monthly_searches' => 200],
+                            ['year' => 2025, 'month' => 2, 'monthly_searches' => 210],
+                            ['year' => 2025, 'month' => 3, 'monthly_searches' => 220],
+                        ]
                     ]
                 ]
             ]
@@ -53,8 +66,12 @@ class KeywordPlannerTest extends WP_UnitTestCase {
         $this->assertSame('alpha', $ideas[0]['text']);
         $this->assertSame(100, $ideas[0]['metrics']['avg_monthly_searches']);
         $this->assertSame('LOW', $ideas[0]['metrics']['competition']);
+        $this->assertSame(30, $ideas[0]['metrics']['three_month_change']);
+        $this->assertSame(130, $ideas[0]['metrics']['yoy_change']);
         $this->assertSame('beta', $ideas[1]['text']);
         $this->assertSame(50, $ideas[1]['metrics']['avg_monthly_searches']);
         $this->assertArrayNotHasKey('competition', $ideas[1]['metrics']);
+        $this->assertSame(20, $ideas[1]['metrics']['three_month_change']);
+        $this->assertArrayNotHasKey('yoy_change', $ideas[1]['metrics']);
     }
 }


### PR DESCRIPTION
## Summary
- compute 3-month and year-over-year changes in Keyword Planner
- surface friendly metric labels in the keyword research script
- validate the new metrics via Keyword Planner unit test
- bump version numbers to 1.6.8 and document the change

## Testing
- `./vendor/bin/phpunit` *(fails: Class not found warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68767f3793d48327b199398119a90704