### PR TITLE
Remove duplicate long tail keyword checkbox

### DIFF
--- a/admin/js/gm2-ai-seo.js
+++ b/admin/js/gm2-ai-seo.js
@@ -143,14 +143,6 @@ jQuery(function($){
                 .text(parseErrorText).appendTo($wrap);
         }
 
-        if(data.long_tail_keywords){
-            var valLt = [].concat(data.long_tail_keywords).join(', ');
-            var ltText = window.gm2AiSeo && gm2AiSeo.i18n ? gm2AiSeo.i18n.longTailKeywords : 'Long Tail Keywords';
-            var $lblLt = $('<label>');
-            $('<input>', {type:'checkbox','class':'gm2-ai-select','data-field':'long_tail_keywords','data-value':valLt}).appendTo($lblLt);
-            $lblLt.append(document.createTextNode(' ' + ltText + ': ' + valLt));
-            $list.append($('<p>').append($lblLt));
-        }
         if(data.content_suggestions){
             var $cs = $('<ul>');
             [].concat(data.content_suggestions).forEach(function(c){


### PR DESCRIPTION
## Summary
- avoid rendering long_tail_keywords twice in AI SEO suggestions

## Testing
- `make test` *(fails: WordPress test suite not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68768606cb888327a13072b241309ff6