### PR TITLE
Improve keyword planner error handling

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -2237,12 +2237,20 @@ class Gm2_SEO_Admin {
         if ($seeds) {
             $planner = new Gm2_Keyword_Planner();
             $ideas = [];
+            $ideas_error = null;
             foreach ($seeds as $kw) {
                 $res = $planner->generate_keyword_ideas($kw);
-                if (!is_wp_error($res)) {
-                    $ideas = array_merge($ideas, $res);
+                if (is_wp_error($res)) {
+                    $ideas_error = $res;
+                    break;
                 }
+                $ideas = array_merge($ideas, $res);
             }
+            if ($ideas_error || empty($ideas)) {
+                $msg = $ideas_error ? 'Keyword Planner request failed: ' . $ideas_error->get_error_message() : __( 'Keyword Planner request failed: no keyword ideas found', 'gm2-wordpress-suite' );
+                wp_send_json_error($msg);
+            }
+
             $chosen = $this->select_best_keywords($ideas);
             $final_focus = $chosen['focus'] ?: $seeds[0];
             $final_long  = $chosen['long_tail'];

--- a/admin/js/gm2-ai-seo.js
+++ b/admin/js/gm2-ai-seo.js
@@ -70,7 +70,14 @@ jQuery(function($){
                     $out.text(typeof resp.data === 'string' ? resp.data : 'Error');
                 }
             } else {
-                var msg = resp && resp.data ? resp.data : 'Error';
+                var msg = 'Error';
+                if(resp && resp.data){
+                    if(typeof resp.data === 'string'){
+                        msg = resp.data;
+                    }else if(resp.data.message){
+                        msg = resp.data.message;
+                    }
+                }
                 $('<div>', {'class':'notice notice-error gm2-ai-error'}).text(msg).appendTo($out);
             }
         })


### PR DESCRIPTION
## Summary
- handle WP_Error and empty result in `ajax_ai_research`
- surface WP error messages in client-side script

## Testing
- `make test` *(fails: WordPress test suite missing)*

------
https://chatgpt.com/codex/tasks/task_e_687689c87e348327aeb481773246cf1e