### PR TITLE
Add Jest tests for keyword research

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /tmp/
 *.log
+node_modules/
+package-lock.json

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ check-tests:
 
 test: check-tests
 	phpunit
+	npm test
 
 install-tests:
 	bash bin/install-wp-tests.sh $(DB_NAME) $(DB_USER) $(DB_PASS) $(DB_HOST) $(WP_VERSION)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The PHPUnit tests rely on the official WordPress test suite. Before running the 
 
 - **PHP** 7.4 or higher
 - **Composer** for installing PHPUnit
+- **Node.js** and **npm** for running JavaScript tests
 
 Install PHPUnit globally with Composer if it is not already available:
 
@@ -18,6 +19,7 @@ composer global require phpunit/phpunit
 ```
 
 Make sure `~/.composer/vendor/bin` (or your global Composer bin directory) is on your `PATH`.
+Run `npm install` once to install the JavaScript test dependencies.
 
 ### Installing the WordPress test suite
 
@@ -37,7 +39,13 @@ After the test suite is installed, execute:
 phpunit
 ```
 
-The Makefile includes a `test` target which automatically checks for the test suite and runs PHPUnit:
+JavaScript tests live in `tests/js` and are executed with:
+
+```bash
+npm test
+```
+
+The Makefile includes a `test` target which automatically checks for the test suite and runs PHPUnit and the Jest tests:
 
 ```bash
 make test

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "gm2-wordpress-suite",
+  "version": "1.0.0",
+  "description": "This repository contains the development version of the Gm2 WordPress Suite plugin. For plugin installation steps and feature documentation see [readme.txt](readme.txt).",
+  "main": "index.js",
+  "directories": {
+    "test": "tests"
+  },
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^30.0.4",
+    "jquery": "^3.7.1",
+    "jsdom": "^26.1.0"
+  }
+}

--- a/tests/js/gm2-keyword-research.test.js
+++ b/tests/js/gm2-keyword-research.test.js
@@ -1,0 +1,38 @@
+const { JSDOM } = require('jsdom');
+const jquery = require('jquery');
+
+test('renders complex keyword objects without [object Object]', async () => {
+  const dom = new JSDOM(`
+    <form id="gm2-keyword-research-form">
+      <input id="gm2_seed_keyword" />
+    </form>
+    <ul id="gm2-keyword-results"></ul>
+  `, { url: 'http://localhost' });
+
+  const $ = jquery(dom.window);
+  Object.assign(global, { window: dom.window, document: dom.window.document, jQuery: $, $ });
+  global.gm2KeywordResearch = { enabled: true, ajax_url: '/fake', nonce: 'nonce' };
+
+  $.post = jest.fn(() => $.Deferred().resolve({
+    success: true,
+    data: [
+      { text: { value: 'hello' } },
+      { text: { value: 'world' }, metrics: { competition: { value: 'low' } } }
+    ]
+  }));
+
+  require('../../admin/js/gm2-keyword-research.js');
+
+  // wait for jQuery ready callbacks to run
+  await new Promise(r => setTimeout(r, 0));
+  await new Promise(r => setTimeout(r, 0));
+
+  $('#gm2-keyword-research-form').triggerHandler('submit');
+
+  await new Promise(r => setTimeout(r, 0));
+
+  const text = $('#gm2-keyword-results').text();
+  expect(text).toContain('hello');
+  expect(text).toContain('world');
+  expect(text).not.toContain('[object Object]');
+});


### PR DESCRIPTION
## Summary
- add npm config and Jest unit test for gm2-keyword-research.js
- hook npm tests into `make test`
- document JS test setup in README
- ignore node dependencies

## Testing
- `npx jest tests/js/gm2-keyword-research.test.js`
- `npm test`
- `make test` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68768bf14d9483279a384933ceaa872d