### PR TITLE
Improve test setup instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,13 @@ WP_TESTS_DIR ?= $(TMPDIR)/wordpress-tests-lib
 
 check-tests:
 	@if [ ! -f "$(WP_TESTS_DIR)/includes/functions.php" ]; then \
-		echo "WordPress test suite not found. Installing..."; \
-		$(MAKE) install-tests; \
+	        if [ -z "$(DB_NAME)" ] || [ -z "$(DB_USER)" ] || [ -z "$(DB_PASS)" ]; then \
+	                echo "Database credentials must be supplied via DB_NAME, DB_USER and DB_PASS."; \
+	                echo "Example: make test DB_NAME=wp_test DB_USER=root DB_PASS=pass"; \
+	                exit 1; \
+	        fi; \
+	        echo "WordPress test suite not found. Installing..."; \
+	        $(MAKE) install-tests; \
 	fi
 
 test: check-tests

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -17,6 +17,12 @@ TMPDIR=$(echo $TMPDIR | sed -e "s/\/$//")
 WP_TESTS_DIR=${WP_TESTS_DIR-$TMPDIR/wordpress-tests-lib}
 WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress/}
 
+# Ensure mysqladmin is available before proceeding
+if ! command -v mysqladmin >/dev/null 2>&1; then
+    echo "Error: mysqladmin command not found. Install MySQL client utilities and ensure they are on your PATH."
+    exit 1
+fi
+
 download() {
     if [ "$(command -v curl)" ]; then
         curl -sL "$1" -o "$2"


### PR DESCRIPTION
## Summary
- validate DB credentials before installing test suite
- stop install-wp-tests.sh if `mysqladmin` isn't available

## Testing
- `npm install`
- `composer global require phpunit/phpunit`
- `make test` *(fails: Database credentials must be supplied via DB_NAME, DB_USER and DB_PASS.)*

------
https://chatgpt.com/codex/tasks/task_e_68769054d120832798f42a5cd052d19d