### PR TITLE
Add notice if Google Ads metrics missing

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -560,6 +560,7 @@ class Gm2_SEO_Admin {
                 echo '<p class="description">' . esc_html__('Google Ads credentials are not configured.', 'gm2-wordpress-suite') . '</p>';
             }
             echo '</form>';
+            echo '<div class="notice notice-error hidden" id="gm2-keyword-msg"></div>';
             echo '<ul id="gm2-keyword-results"></ul>';
 
             $oauth = apply_filters('gm2_google_oauth_instance', new Gm2_Google_OAuth());

--- a/admin/js/gm2-keyword-research.js
+++ b/admin/js/gm2-keyword-research.js
@@ -5,6 +5,7 @@ jQuery(function($){
         three_month_change: '3‑month change',
         yoy_change: 'YoY change'
     };
+    var $msg = $('#gm2-keyword-msg');
     if(!gm2KeywordResearch.enabled){
         $('#gm2-keyword-research-form button[type="submit"]').prop('disabled', true);
     }
@@ -12,6 +13,7 @@ jQuery(function($){
         e.preventDefault();
         var kw = $('#gm2_seed_keyword').val();
         var $list = $('#gm2-keyword-results').empty();
+        $msg.addClass('hidden').removeClass('notice-error').text('');
         $list.text('Loading...');
         $.post(gm2KeywordResearch.ajax_url, {
             action: 'gm2_keyword_ideas',
@@ -24,6 +26,7 @@ jQuery(function($){
                 return;
             }
             if(resp.success && Array.isArray(resp.data)){
+                var metricsFound = false;
                 resp.data.forEach(function(item){
                     var li = $('<li>');
                     if(typeof item === 'string'){
@@ -51,6 +54,9 @@ jQuery(function($){
                                     }
                                     var label = labels[key] || key.replace(/_/g,' ');
                                     parts.push(label + ': ' + val);
+                                    if(key === 'avg_monthly_searches' || key === 'competition' || key === 'three_month_change' || key === 'yoy_change'){
+                                        metricsFound = true;
+                                    }
                                 }
                             });
                             if(parts.length){
@@ -60,6 +66,9 @@ jQuery(function($){
                     }
                     li.appendTo($list);
                 });
+                if(!metricsFound){
+                    $msg.text('Google Ads API did not return keyword metrics.').addClass('notice-error').removeClass('hidden');
+                }
             } else {
                 var msg = 'No results';
                 if(resp && resp.data){


### PR DESCRIPTION
## Summary
- show inline notice on Keyword Research form when Google Ads API doesn't return metrics

## Testing
- `npm test`
- `phpunit` *(fails: cannot find WordPress test suite)*

------
https://chatgpt.com/codex/tasks/task_e_687693b8b75c8327bc42a038451092a6