### PR TITLE
Update no metrics message

### DIFF
--- a/admin/js/gm2-keyword-research.js
+++ b/admin/js/gm2-keyword-research.js
@@ -67,7 +67,7 @@ jQuery(function($){
                     li.appendTo($list);
                 });
                 if(!metricsFound){
-                    $msg.text('Google Ads API did not return keyword metrics.').addClass('notice-error').removeClass('hidden');
+                    $msg.text('Google Ads API did not return keyword metrics. Ads accounts without historical metrics access or unapproved developer tokens can cause this.').addClass('notice-error').removeClass('hidden');
                 }
             } else {
                 var msg = 'No results';


### PR DESCRIPTION
## Summary
- clarify the error shown when the Keyword Planner doesn't return metrics

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876ad46b8bc8327b08d0cba52695ec8