### PR TITLE
Handle Keyword Planner no-metrics responses

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -2266,6 +2266,12 @@ class Gm2_SEO_Admin {
             $chosen = $this->select_best_keywords($ideas);
             $final_focus = $chosen['focus'] ?: $seeds[0];
             $final_long  = $chosen['long_tail'];
+
+            if ($chosen['focus'] === '' && empty($chosen['long_tail'])) {
+                $raw = $planner->get_last_response_body();
+                error_log('Keyword Planner returned no metrics: ' . $raw);
+                wp_send_json_error(__('Keyword Planner returned no metrics.', 'gm2-wordpress-suite'));
+            }
         }
 
         $prompt2 = '';

--- a/admin/js/gm2-keyword-research.js
+++ b/admin/js/gm2-keyword-research.js
@@ -81,7 +81,8 @@ jQuery(function($){
                         msg = resp.data.errors[code][0];
                     }
                 }
-                $list.append($('<li>').text(msg));
+                $msg.text(msg).addClass('notice-error').removeClass('hidden');
+                $list.empty();
             }
         }).fail(function(){
             $list.empty().append($('<li>').text('Request failed'));

--- a/includes/Gm2_Keyword_Planner.php
+++ b/includes/Gm2_Keyword_Planner.php
@@ -7,6 +7,22 @@ if (!defined('ABSPATH')) {
 }
 
 class Gm2_Keyword_Planner {
+    /**
+     * Stores the raw response body from the most recent API request.
+     *
+     * @var string
+     */
+    private $last_response_body = '';
+
+    /**
+     * Return the raw response body from the last request.
+     *
+     * @return string
+     */
+    public function get_last_response_body() {
+        return $this->last_response_body;
+    }
+
     private function get_credentials() {
         $id = preg_replace('/\D/', '', get_option('gm2_gads_customer_id', ''));
         return [
@@ -74,6 +90,7 @@ class Gm2_Keyword_Planner {
 
         $code = wp_remote_retrieve_response_code($resp);
         $body = wp_remote_retrieve_body($resp);
+        $this->last_response_body = $body;
         $data = $body !== '' ? json_decode($body, true) : null;
 
         if (defined('WP_DEBUG') && WP_DEBUG) {

--- a/tests/test-ai-seo.php
+++ b/tests/test-ai-seo.php
@@ -647,4 +647,42 @@ class AiResearchErrorHandlingTest extends WP_Ajax_UnitTestCase {
         $resp = json_decode($this->_last_response, true);
         $this->assertFalse($resp['success']);
     }
+
+    public function test_keyword_planner_no_metrics_handled() {
+        update_option('gm2_chatgpt_api_key', 'key');
+        update_option('gm2_gads_developer_token', 'dev');
+        update_option('gm2_gads_customer_id', '123-456-7890');
+        update_option('gm2_google_refresh_token', 'refresh');
+        update_option('gm2_google_access_token', 'access');
+        update_option('gm2_google_expires_at', time() + 3600);
+
+        $step = 0;
+        $filter = function($pre, $args, $url) use (&$step) {
+            if ($url === 'https://api.openai.com/v1/chat/completions') {
+                if ($step === 0) {
+                    $step++;
+                    return [ 'response' => ['code' => 200], 'body' => json_encode(['choices' => [ ['message' => ['content' => json_encode(['seed_keywords' => 'alpha'])]] ]]) ];
+                }
+                return [ 'response' => ['code' => 200], 'body' => json_encode(['choices' => [ ['message' => ['content' => '{}']] ]]) ];
+            }
+            if (false !== strpos($url, 'generateKeywordIdeas')) {
+                return [ 'response' => ['code' => 200], 'body' => json_encode(['results' => [ ['text' => 'alpha'] ]]) ];
+            }
+            return false;
+        };
+        add_filter('pre_http_request', $filter, 10, 3);
+
+        $post_id = self::factory()->post->create(['post_title' => 'Post', 'post_content' => 'Content']);
+
+        $this->_setRole('administrator');
+        $_POST['post_id'] = $post_id;
+        $_POST['_ajax_nonce'] = wp_create_nonce('gm2_ai_research');
+        $_REQUEST['_ajax_nonce'] = $_POST['_ajax_nonce'];
+        try { $this->_handleAjax('gm2_ai_research'); } catch (WPAjaxDieContinueException $e) {}
+        remove_filter('pre_http_request', $filter, 10);
+
+        $resp = json_decode($this->_last_response, true);
+        $this->assertFalse($resp['success']);
+        $this->assertSame('Keyword Planner returned no metrics.', $resp['data']);
+    }
 }


### PR DESCRIPTION
## Summary
- capture last response body from Keyword Planner
- log and error when AI SEO research gets results with no metrics
- show server error messages in keyword research UI
- test Keyword Planner no-metrics behavior

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876afc8dd148327b7a5e65dd5f46ca8