### PR TITLE
Clarify DOM extension warning

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -2768,7 +2768,7 @@ class Gm2_SEO_Admin {
 
     public function dom_extension_warning() {
         if (!class_exists('\\DOMDocument')) {
-            echo '<div class="notice notice-warning"><p>' . esc_html__( 'PHP DOM extension not installed—HTML analysis and AI features are unavailable.', 'gm2-wordpress-suite' ) . '</p></div>';
+            echo '<div class="notice notice-warning"><p>' . esc_html__( 'PHP DOM/LibXML extension not installed—HTML analysis and AI features are unavailable.', 'gm2-wordpress-suite' ) . '</p></div>';
         }
     }
     public function enqueue_elementor_scripts() {


### PR DESCRIPTION
## Summary
- clarify DOM extension notice in `dom_extension_warning()`

## Testing
- `npm test`
- `phpunit` *(fails: wordpress-tests-lib not found)*


------
https://chatgpt.com/codex/tasks/task_e_6876b19fa9648327a72ca536ec703a9f