### PR TITLE
Handle missing keyword metrics gracefully

### DIFF
--- a/admin/js/gm2-ai-seo.js
+++ b/admin/js/gm2-ai-seo.js
@@ -48,6 +48,10 @@ jQuery(function($){
                 }
                 if(typeof resp.data === 'object' && !resp.data.response){
                     buildResults(resp.data, $out);
+                    if(resp.data.kwp_notice){
+                        $('<div>', {'class':'notice notice-warning gm2-ai-warning'})
+                            .text(resp.data.kwp_notice).appendTo($out);
+                    }
                     if(window.gm2AiSeo && parseInt(gm2AiSeo.post_id, 10) === 0){
                         try{ localStorage.setItem(LS_KEY, JSON.stringify(resp.data)); }catch(e){}
                     }
@@ -59,6 +63,10 @@ jQuery(function($){
                                 parsed.html_issues = resp.data.html_issues;
                             }
                             buildResults(parsed, $out);
+                            if(resp.data.kwp_notice){
+                                $('<div>', {'class':'notice notice-warning gm2-ai-warning'})
+                                    .text(resp.data.kwp_notice).appendTo($out);
+                            }
                             if(window.gm2AiSeo && parseInt(gm2AiSeo.post_id, 10) === 0){
                                 try{ localStorage.setItem(LS_KEY, JSON.stringify(parsed)); }catch(e){}
                             }

--- a/tests/test-ai-seo.php
+++ b/tests/test-ai-seo.php
@@ -682,7 +682,9 @@ class AiResearchErrorHandlingTest extends WP_Ajax_UnitTestCase {
         remove_filter('pre_http_request', $filter, 10);
 
         $resp = json_decode($this->_last_response, true);
-        $this->assertFalse($resp['success']);
-        $this->assertSame('Keyword Planner returned no metrics.', $resp['data']);
+        $this->assertTrue($resp['success']);
+        $this->assertSame('alpha', $resp['data']['focus_keywords']);
+        $this->assertSame([], $resp['data']['long_tail_keywords']);
+        $this->assertSame('Google Ads API did not return keyword metrics.', $resp['data']['kwp_notice']);
     }
 }


### PR DESCRIPTION
## Summary
- fallback to top keyword results when Google Ads metrics are missing
- surface `kwp_notice` to JavaScript and display warning after AI research
- adjust unit test for new behaviour

## Testing
- `npm test`
- `make test` *(fails: Can't connect to MySQL server)*

------
https://chatgpt.com/codex/tasks/task_e_68769466efc08327bce8684294e02665