### PR TITLE
Clarify Ads metric warning behaviour

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -54,6 +54,7 @@ If you see errors when connecting your Google account:
   * Disconnect and reconnect after adjusting permissions.
 * **Invalid OAuth state** – Reconnect from **SEO → Connect Google Account** to refresh the authorization flow.
 * **Keyword Research returns no results** – Ensure you have entered your Google Ads developer token, connected a Google account with Ads access, and selected a valid Ads customer ID. AI Research uses the same credentials when refining ChatGPT keywords, so missing or invalid details will cause the Keyword Planner request to fail.
+* **Google Ads API did not return keyword metrics** – The Keyword Planner may return keyword ideas without search volume data. AI Research still analyzes the top results and displays a notice when metrics are missing. Verify the selected Ads account and date range have sufficient data.
 * "The caller does not have permission" – This usually means your developer token isn't approved for the selected Ads account or the login customer ID is missing or incorrect. Verify the token status in the Google Ads API Center and ensure the OAuth account can access that customer ID.
 * **Testing with an unapproved token** – Unapproved developer tokens can be used with [Google Ads test accounts](https://developers.google.com/google-ads/api/docs/best-practices/test-accounts). The login customer ID must be the manager ID for that token, and test accounts don't serve ads and have limited features.
 * **Viewing debug logs** – Add `define('WP_DEBUG', true);` and `define('WP_DEBUG_LOG', true);` to your `wp-config.php` file, then check `wp-content/debug.log` for errors.
@@ -254,7 +255,7 @@ the last 100 missing URLs to help you create new redirects.
 
 == Changelog ==
 = 1.6.9 =
-* Added warning when Google Ads metrics are missing.
+* Added warning when Google Ads metrics are missing. AI Research continues using the top keywords and displays a notice.
 = 1.6.8 =
 * Added three-month and year-over-year change metrics to keyword research results.
 = 1.6.7 =


### PR DESCRIPTION
## Summary
- mention the "Google Ads API did not return keyword metrics" warning in the troubleshooting section
- explain that AI research continues with top keyword results and shows a notice
- add a matching note in the changelog for v1.6.9

## Testing
- `make test` *(fails: Database credentials must be supplied via DB_NAME, DB_USER and DB_PASS)*

------
https://chatgpt.com/codex/tasks/task_e_6876b6bf2cec8327a0032369f051684c