### PR TITLE
Implement pagination for bulk AI review

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -729,6 +729,7 @@ class Gm2_SEO_Admin {
         $status    = get_option('gm2_bulk_ai_status', 'publish');
         $post_type = get_option('gm2_bulk_ai_post_type', 'all');
         $term      = get_option('gm2_bulk_ai_term', '');
+        $current_page = isset($_GET['paged']) ? max(1, absint($_GET['paged'])) : 1;
 
         if (isset($_POST['gm2_bulk_ai_save']) && check_admin_referer('gm2_bulk_ai_settings')) {
             $page_size = max(1, absint($_POST['page_size'] ?? 10));
@@ -749,6 +750,7 @@ class Gm2_SEO_Admin {
             'post_type'      => $types,
             'post_status'    => $status,
             'posts_per_page' => $page_size,
+            'paged'          => $current_page,
         ];
         if ($term && strpos($term, ':') !== false) {
             list($tax, $id) = explode(':', $term);
@@ -810,6 +812,15 @@ class Gm2_SEO_Admin {
             echo '</tr>';
         }
         echo '</tbody></table>';
+        $links = paginate_links([
+            'base'    => add_query_arg('paged', '%#%', admin_url('admin.php?page=gm2-bulk-ai-review')),
+            'format'  => '',
+            'current' => $current_page,
+            'total'   => max(1, $query->max_num_pages),
+        ]);
+        if ($links) {
+            echo '<div class="tablenav"><div class="tablenav-pages">' . $links . '</div></div>';
+        }
         echo '<p><button type="button" class="button" id="gm2-bulk-analyze">' . esc_html__( 'Analyze Selected', 'gm2-wordpress-suite' ) . '</button></p>';
         echo '</div>';
     }

--- a/tests/test-bulk-ai.php
+++ b/tests/test-bulk-ai.php
@@ -77,3 +77,21 @@ class BulkAiFilterTest extends WP_UnitTestCase {
         $this->assertStringNotContainsString('Out', $html);
     }
 }
+
+class BulkAiPaginationTest extends WP_UnitTestCase {
+    public function test_second_page_shows_expected_posts() {
+        update_option('gm2_bulk_ai_page_size', 2);
+        $posts = self::factory()->post->create_many(3);
+        $admin = new Gm2_SEO_Admin();
+        $user = self::factory()->user->create(['role' => 'administrator']);
+        wp_set_current_user($user);
+        $_GET['paged'] = 2;
+        ob_start();
+        $admin->display_bulk_ai_page();
+        $html = ob_get_clean();
+        $this->assertStringContainsString(get_post($posts[2])->post_title, $html);
+        $this->assertStringNotContainsString(get_post($posts[0])->post_title, $html);
+        $this->assertStringContainsString('paged=1', $html);
+        unset($_GET['paged']);
+    }
+}


### PR DESCRIPTION
## Summary
- paginate Bulk AI Review list via `paged` query arg
- add pagination tests

## Testing
- `npm test --silent`
- `phpunit --configuration phpunit.xml --stop-on-failure` *(fails: wordpress-tests missing)*

------
https://chatgpt.com/codex/tasks/task_e_6876bbb7a2888327aff5ea82b49f7091