### PR TITLE
Automate OAuth redirect registration

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -19,6 +19,12 @@ define('GM2_VERSION', '1.6.9');
 define('GM2_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('GM2_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('GM2_CONTENT_RULES_VERSION', 2);
+if (!defined('GM2_GCLOUD_PROJECT_ID')) {
+    define('GM2_GCLOUD_PROJECT_ID', getenv('GM2_GCLOUD_PROJECT_ID') ?: '');
+}
+if (!defined('GM2_SERVICE_ACCOUNT_JSON')) {
+    define('GM2_SERVICE_ACCOUNT_JSON', getenv('GM2_SERVICE_ACCOUNT_JSON') ?: '');
+}
 
 use Gm2\Gm2_Loader;
 use Gm2\Gm2_SEO_Public;

--- a/readme.txt
+++ b/readme.txt
@@ -43,6 +43,7 @@ These credentials must be copied from your Google accounts:
 * **Google Ads login customer ID** – Optional manager account ID associated with your developer token. Enter this value if the token belongs to a manager account so requests include the `login-customer-id` header.
 * **Google Ads API version** – The plugin uses the API version defined by the `Gm2_Google_OAuth::GOOGLE_ADS_API_VERSION` constant (default `v18`). Update this constant and any tests referencing it when a new Ads API version becomes available.
 * **Analytics Admin API version** – The GA4 endpoints use the version specified by `Gm2_Google_OAuth::ANALYTICS_ADMIN_API_VERSION` (default `v1beta`). Update this constant along with related tests when Google releases a new version.
+* **Automatic redirect URI registration** – Define `GM2_GCLOUD_PROJECT_ID` and `GM2_SERVICE_ACCOUNT_JSON` in your `wp-config.php` so the plugin can add the current site's redirect URI to the OAuth client via the Google Cloud API.
 
 == Troubleshooting ==
 If you see errors when connecting your Google account:

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,6 +8,12 @@ $vendor_autoload = dirname(__DIR__) . '/vendor/autoload.php';
 if (file_exists($vendor_autoload)) {
     require_once $vendor_autoload;
 }
+if (!defined('GM2_GCLOUD_PROJECT_ID') && getenv('GM2_GCLOUD_PROJECT_ID')) {
+    define('GM2_GCLOUD_PROJECT_ID', getenv('GM2_GCLOUD_PROJECT_ID'));
+}
+if (!defined('GM2_SERVICE_ACCOUNT_JSON') && getenv('GM2_SERVICE_ACCOUNT_JSON')) {
+    define('GM2_SERVICE_ACCOUNT_JSON', getenv('GM2_SERVICE_ACCOUNT_JSON'));
+}
 function _manually_load_plugin() {
     require dirname(__DIR__) . '/gm2-wordpress-suite.php';
 }

--- a/tests/test-redirect-registration.php
+++ b/tests/test-redirect-registration.php
@@ -1,0 +1,46 @@
+<?php
+use Gm2\Gm2_Google_OAuth;
+
+class RedirectRegistrationTest extends WP_UnitTestCase {
+    public function tearDown(): void {
+        remove_filter('pre_http_request', [ $this, 'intercept' ], 10);
+        parent::tearDown();
+    }
+
+    public function intercept($pre, $args, $url) {
+        if (false !== strpos($url, '/token')) {
+            return [ 'response' => ['code' => 200], 'body' => json_encode(['access_token' => 'x']) ];
+        }
+        if (false !== strpos($url, '/projects/')) {
+            $this->calls[] = $args['method'];
+            return [ 'response' => ['code' => 200], 'body' => json_encode(['redirectUris' => []]) ];
+        }
+        return false;
+    }
+
+    public function test_auth_url_triggers_registration() {
+        $this->calls = [];
+        add_filter('pre_http_request', [ $this, 'intercept' ], 10, 3);
+        add_filter('gm2_gcloud_project_id', function() { return 'p'; });
+        $tmp = tempnam(sys_get_temp_dir(), 'key');
+        $key = <<<'KEY'
+-----BEGIN PRIVATE KEY-----
+MIIBVAIBADANBgkqhkiG9w0BAQEFAASCAT4wggE6AgEAAkEA2555iIYJyFM8/Uz1
+3XcS7C1nfVhYTQD0X0WE6kVncN8GPfh44TtXB8mGeJeZaDlhwBnoEA++BYtloXi1
+8/xkeQIDAQABAkAUF8+uufSzK0ptMllcRcSpbw4E3cxWXzv8a3PZqzfnj5Sqf4CH
+Cnb47kb9eMoopaK4pjnzxIN8Bvrqd+0syfLxAiEA9se3A4qA2COkzkwOp3q/lryA
+G36H/IpUSh9SNo+lMYcCIQDj0vt63bApspBQhVmnk6drG8+nmEGYz/zqmnNdNI85
+/wIgZN3epRjgbveqrhOSTcwzMQZdCl/eb0+PAjjpHpn5+FMCIQCuRpXTPkRlEVBu
+GCQmGcBHIgYuaT08vVX2zOGVGgC6VwIgJC/63eSSnL7QMLP3TAo3KvXI12wFph4+
+vmEAqoYdIGk=
+-----END PRIVATE KEY-----
+KEY;
+        file_put_contents($tmp, json_encode(['client_email'=>'test@example.com','private_key'=>$key]));
+        add_filter('gm2_service_account_json', function() use ($tmp) { return $tmp; });
+        update_option('gm2_gads_client_id', '123.apps.googleusercontent.com');
+        $oauth = new Gm2_Google_OAuth();
+        $oauth->get_auth_url();
+        unlink($tmp);
+        $this->assertContains('PATCH', $this->calls);
+    }
+}


### PR DESCRIPTION
## Summary
- define environment constants for a Google Cloud project and service account
- use those constants to register the site's redirect URI via Google API
- document the optional automatic redirect registration
- expose constants in the test bootstrap
- add regression test for redirect registration

## Testing
- `npm test --silent`
- `phpunit` *(fails: command not found)*
- `make test` *(fails: DB credentials must be supplied)*

------
https://chatgpt.com/codex/tasks/task_e_6876bea67c04832799977fb1c5308f45