### PR TITLE
Localize keyword research notice

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -120,6 +120,9 @@ class Gm2_Admin {
                     'nonce'    => wp_create_nonce('gm2_keyword_ideas'),
                     'ajax_url' => admin_url('admin-ajax.php'),
                     'enabled'  => $gads_ready,
+                    'i18n'     => [
+                        'metricsUnavailable' => __( 'Keyword metrics unavailable; showing AI-generated ideas only.', 'gm2-wordpress-suite' ),
+                    ],
                 ]
             );
             wp_localize_script(

--- a/admin/js/gm2-keyword-research.js
+++ b/admin/js/gm2-keyword-research.js
@@ -69,7 +69,11 @@ jQuery(function($){
                     li.appendTo($list);
                 });
                 if(data.ai_only){
-                    $msg.text('Keyword metrics unavailable; showing AI-generated ideas only.').addClass('notice-warning').removeClass('hidden');
+                    var msgText = 'Keyword metrics unavailable; showing AI-generated ideas only.';
+                    if(window.gm2KeywordResearch && gm2KeywordResearch.i18n && gm2KeywordResearch.i18n.metricsUnavailable){
+                        msgText = gm2KeywordResearch.i18n.metricsUnavailable;
+                    }
+                    $msg.text(msgText).addClass('notice-warning').removeClass('hidden');
                 } else if(!metricsFound){
                     $msg.text('Google Ads API did not return keyword metrics. Ads accounts without historical metrics access or unapproved developer tokens can cause this.').addClass('notice-error').removeClass('hidden');
                 }

--- a/tests/js/gm2-keyword-research.test.js
+++ b/tests/js/gm2-keyword-research.test.js
@@ -21,6 +21,7 @@ test('renders complex keyword objects without [object Object]', async () => {
     ]
   }));
 
+  jest.resetModules();
   require('../../admin/js/gm2-keyword-research.js');
 
   // wait for jQuery ready callbacks to run
@@ -35,4 +36,43 @@ test('renders complex keyword objects without [object Object]', async () => {
   expect(text).toContain('hello');
   expect(text).toContain('world');
   expect(text).not.toContain('[object Object]');
+});
+
+test('uses translation for metrics unavailable notice', async () => {
+  const dom = new JSDOM(`
+    <form id="gm2-keyword-research-form">
+      <input id="gm2_seed_keyword" />
+    </form>
+    <ul id="gm2-keyword-results"></ul>
+    <div id="gm2-keyword-msg"></div>
+  `, { url: 'http://localhost' });
+
+  const $ = jquery(dom.window);
+  Object.assign(global, { window: dom.window, document: dom.window.document, jQuery: $, $ });
+  global.gm2KeywordResearch = {
+    enabled: true,
+    ajax_url: '/fake',
+    nonce: 'nonce',
+    i18n: { metricsUnavailable: 'translated text' }
+  };
+  dom.window.gm2KeywordResearch = global.gm2KeywordResearch;
+
+  $.post = jest.fn(() => $.Deferred().resolve({
+    success: true,
+    data: { ai_only: true, ideas: [] }
+  }));
+
+  jest.resetModules();
+  require('../../admin/js/gm2-keyword-research.js');
+
+  await new Promise(r => setTimeout(r, 0));
+  await new Promise(r => setTimeout(r, 0));
+
+  $('#gm2-keyword-research-form').triggerHandler('submit');
+
+  await new Promise(r => setTimeout(r, 0));
+  await new Promise(r => setTimeout(r, 0));
+
+  const msg = $('#gm2-keyword-msg').text();
+  expect(msg).toBe('translated text');
 });


### PR DESCRIPTION
## Summary
- add i18n value to `gm2KeywordResearch` when enqueuing script
- read translation from `gm2KeywordResearch.i18n` in keyword research JS
- verify the translated notice text in unit tests

## Testing
- `npm test`
- `phpunit` *(fails: `/tmp/wordpress-tests-lib/includes/functions.php` missing)*

------
https://chatgpt.com/codex/tasks/task_e_6876c1253a808327a9c0af31d0d8d607