### PR TITLE
Raise minimum PHP to 7.3

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['7.4', '8.1']
+        php-version: ['7.3', '8.1']
     services:
       mysql:
         image: mysql:5.7

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The PHPUnit tests rely on the official WordPress test suite. Before running the 
 
 ### Prerequisites
 
-- **PHP** 7.4 or higher
+- **PHP** 7.3 or higher
 - **Composer** for installing PHPUnit
 - **Node.js** and **npm** for running JavaScript tests
 

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -9,7 +9,7 @@
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       gm2-wordpress-suite
  * Domain Path:       /languages
- * Requires PHP:      7.0
+ * Requires PHP:      7.3
  */
 
 defined('ABSPATH') or die('No script kiddies please!');

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Gm2 WordPress Suite ===
 Contributors: gm2team
 Tags: admin, tools, suite, performance
-Requires at least: 7.0
+Requires at least: 7.3
 Tested up to: 6.5
 Stable tag: 1.6.10
 License: GPLv2 or later


### PR DESCRIPTION
## Summary
- require PHP 7.3 or newer in plugin metadata and docs
- update CI matrix to test PHP 7.3

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876ce7d46148327a5e5131653c1b8f8