### PR TITLE
Fix long tail keyword meta

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1197,6 +1197,7 @@ class Gm2_SEO_Admin {
         $nofollow    = isset($_POST['gm2_nofollow']) ? '1' : '0';
         $canonical      = isset($_POST['gm2_canonical_url']) ? esc_url_raw($_POST['gm2_canonical_url']) : '';
         $focus_keywords   = isset($_POST['gm2_focus_keywords']) ? sanitize_text_field($_POST['gm2_focus_keywords']) : '';
+        $long_tail_keywords = isset($_POST['gm2_long_tail_keywords']) ? sanitize_text_field($_POST['gm2_long_tail_keywords']) : '';
         $max_snippet      = isset($_POST['gm2_max_snippet']) ? sanitize_text_field($_POST['gm2_max_snippet']) : '';
         $max_image_preview = isset($_POST['gm2_max_image_preview']) ? sanitize_text_field($_POST['gm2_max_image_preview']) : '';
         $max_video_preview = isset($_POST['gm2_max_video_preview']) ? sanitize_text_field($_POST['gm2_max_video_preview']) : '';

--- a/tests/test-tax-long-tail.php
+++ b/tests/test-tax-long-tail.php
@@ -1,0 +1,14 @@
+<?php
+use Gm2\Gm2_SEO_Admin;
+
+class TaxonomyLongTailKeywordsTest extends WP_UnitTestCase {
+    public function test_long_tail_keywords_saved_for_term() {
+        $term_id = self::factory()->term->create(['taxonomy' => 'category']);
+        $admin = new Gm2_SEO_Admin();
+        $_POST['gm2_seo_nonce'] = wp_create_nonce('gm2_save_seo_meta');
+        $_POST['gm2_long_tail_keywords'] = 'alpha, beta ';
+        $admin->save_taxonomy_meta($term_id);
+        $this->assertSame('alpha, beta', get_term_meta($term_id, '_gm2_long_tail_keywords', true));
+    }
+}
+


### PR DESCRIPTION
## Summary
- sanitize `gm2_long_tail_keywords` in `save_taxonomy_meta`
- test taxonomy long tail keywords persistence

## Testing
- `phpunit --configuration phpunit.xml --testsuite Plugin\ Test\ Suite` *(fails: missing WordPress test suite)*

------
https://chatgpt.com/codex/tasks/task_e_6876cefc5844832790d8f09125f25f15