### PR TITLE
Fix min WP version

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Gm2 WordPress Suite ===
 Contributors: gm2team
 Tags: admin, tools, suite, performance
-Requires at least: 7.3
+Requires at least: 6.0
 Tested up to: 6.5
 Stable tag: 1.6.10
 License: GPLv2 or later


### PR DESCRIPTION
## Summary
- ensure WordPress minimum version in `readme.txt` references a valid version

## Testing
- `npm test`
- `phpunit` *(fails: missing WordPress test suite)*
- `make test` *(fails: database credentials missing)*

------
https://chatgpt.com/codex/tasks/task_e_6876cf8f000c8327be14708c7b048fc7