### PR TITLE
Refactor taxonomy hook setup

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -48,16 +48,7 @@ class Gm2_SEO_Admin {
 
         add_action('transition_post_status', [$this, 'maybe_generate_sitemap'], 10, 3);
 
-        $taxonomies = $this->get_supported_taxonomies();
-        foreach ($taxonomies as $tax) {
-            add_action("{$tax}_add_form_fields", [$this, 'render_taxonomy_meta_box']);
-            add_action("{$tax}_edit_form_fields", [$this, 'render_taxonomy_meta_box']);
-            add_action("create_{$tax}", [$this, 'save_taxonomy_meta']);
-            add_action("edited_{$tax}", [$this, 'save_taxonomy_meta']);
-            add_action("created_{$tax}", [$this, 'maybe_generate_sitemap'], 10, 0);
-            add_action("edited_{$tax}", [$this, 'maybe_generate_sitemap'], 10, 0);
-            add_action("delete_{$tax}", [$this, 'maybe_generate_sitemap'], 10, 0);
-        }
+        add_action('init', [$this, 'register_taxonomy_hooks'], 20);
 
         if (did_action('elementor/loaded')) {
             $this->setup_elementor_integration();
@@ -110,6 +101,19 @@ class Gm2_SEO_Admin {
             $taxonomies[] = 'product_brand';
         }
         return $taxonomies;
+    }
+
+    public function register_taxonomy_hooks() {
+        $taxonomies = $this->get_supported_taxonomies();
+        foreach ($taxonomies as $tax) {
+            add_action("{$tax}_add_form_fields", [$this, 'render_taxonomy_meta_box']);
+            add_action("{$tax}_edit_form_fields", [$this, 'render_taxonomy_meta_box']);
+            add_action("create_{$tax}", [$this, 'save_taxonomy_meta']);
+            add_action("edited_{$tax}", [$this, 'save_taxonomy_meta']);
+            add_action("created_{$tax}", [$this, 'maybe_generate_sitemap'], 10, 0);
+            add_action("edited_{$tax}", [$this, 'maybe_generate_sitemap'], 10, 0);
+            add_action("delete_{$tax}", [$this, 'maybe_generate_sitemap'], 10, 0);
+        }
     }
 
     public function setup_elementor_integration() {

--- a/tests/test-taxonomy-hooks.php
+++ b/tests/test-taxonomy-hooks.php
@@ -1,0 +1,31 @@
+<?php
+use Gm2\Gm2_SEO_Admin;
+
+class TaxonomyHooksTest extends WP_UnitTestCase {
+    public function setUp(): void {
+        parent::setUp();
+        register_post_type('product');
+        register_taxonomy('product_cat', 'product');
+    }
+
+    public function test_hooks_registered_and_term_meta_saved() {
+        $admin = new Gm2_SEO_Admin();
+        $admin->run();
+
+        // Hooks are added on init, so before that nothing should be registered.
+        $this->assertFalse( has_action('product_cat_add_form_fields', [$admin, 'render_taxonomy_meta_box']) );
+
+        do_action('init');
+
+        $this->assertNotFalse( has_action('product_cat_add_form_fields', [$admin, 'render_taxonomy_meta_box']) );
+        $this->assertNotFalse( has_action('create_product_cat', [$admin, 'save_taxonomy_meta']) );
+
+        $_POST['gm2_seo_nonce'] = wp_create_nonce('gm2_save_seo_meta');
+        $_POST['gm2_seo_title'] = 'Cat Title';
+        $term  = wp_insert_term('New Cat', 'product_cat');
+        $term_id = $term['term_id'];
+
+        $this->assertSame('Cat Title', get_term_meta($term_id, '_gm2_title', true));
+    }
+}
+


### PR DESCRIPTION
## Summary
- move taxonomy hook setup to new method `register_taxonomy_hooks`
- call new method on the `init` action
- test that hooks are registered on init and metadata saves correctly

## Testing
- `phpunit` *(fails: The PHPUnit Polyfills library is a requirement for running the WP test suite)*

------
https://chatgpt.com/codex/tasks/task_e_6876d0020fdc8327bd4866b830e71456