### PR TITLE
Handle missing OpenSSL

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -43,6 +43,7 @@ class Gm2_SEO_Admin {
         add_action('add_attachment', [$this, 'auto_fill_alt_on_upload']);
         add_action('admin_notices', [$this, 'admin_notices']);
         add_action('admin_notices', [$this, 'dom_extension_warning']);
+        add_action('admin_notices', [$this, 'openssl_extension_warning']);
         add_action('add_attachment', [$this, 'compress_image_on_upload'], 20);
         add_action('save_post', [$this, 'auto_fill_product_alt'], 20, 3);
 
@@ -2888,6 +2889,12 @@ class Gm2_SEO_Admin {
     public function dom_extension_warning() {
         if (!class_exists('\\DOMDocument')) {
             echo '<div class="notice notice-warning"><p>' . esc_html__( 'PHP DOM/LibXML extension not installed—HTML analysis and AI features are unavailable.', 'gm2-wordpress-suite' ) . '</p></div>';
+        }
+    }
+
+    public function openssl_extension_warning() {
+        if (!function_exists('openssl_sign')) {
+            echo '<div class="notice notice-warning"><p>' . esc_html__( 'PHP OpenSSL extension not installed—Google OAuth features are unavailable.', 'gm2-wordpress-suite' ) . '</p></div>';
         }
     }
     public function enqueue_elementor_scripts() {

--- a/includes/Gm2_Google_OAuth.php
+++ b/includes/Gm2_Google_OAuth.php
@@ -90,6 +90,10 @@ class Gm2_Google_OAuth {
         $hdr  = rtrim(strtr($hdr, '+/', '-_'), '=');
         $clm  = rtrim(strtr($clm, '+/', '-_'), '=');
         $sig_data = $hdr . '.' . $clm;
+        if (!function_exists('openssl_sign')) {
+            error_log('OpenSSL extension missing: cannot sign JWT.');
+            return '';
+        }
         openssl_sign($sig_data, $signature, $data['private_key'], 'sha256');
         $sig = rtrim(strtr(base64_encode($signature), '+/', '-_'), '=');
         $jwt = $sig_data . '.' . $sig;


### PR DESCRIPTION
## Summary
- check if `openssl_sign` exists in `Gm2_Google_OAuth`
- log a debug message and skip JWT signing when the function is missing
- add admin notice in `Gm2_SEO_Admin` to warn about missing OpenSSL

## Testing
- `npm test`
- `make test` *(fails: mysqladmin command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876d0d9f6a0832787187a44c665586e