### PR TITLE
Improve AI SEO fallback

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -190,6 +190,8 @@ and a list of seed keywords. Step two refines those keywords with the Google
 Keyword Planner, ranking them by **Avg. Monthly Searches**, **competition** and
 the **3‑month** and **year-over-year change** metrics. A valid Google Ads
 developer token, connected account and customer ID are required for this step.
+If these credentials are missing or the Keyword Planner fails, AI SEO falls back
+to the ChatGPT suggestions and adds a notice that metrics are unavailable.
 
 The results suggest a title, description, focus keywords, canonical URL, page
 name and slug. Any detected HTML issues—such as multiple `<h1>` tags—are listed

--- a/tests/test-ai-seo.php
+++ b/tests/test-ai-seo.php
@@ -645,7 +645,10 @@ class AiResearchErrorHandlingTest extends WP_Ajax_UnitTestCase {
         remove_filter('pre_http_request', $filter, 10);
 
         $resp = json_decode($this->_last_response, true);
-        $this->assertFalse($resp['success']);
+        $this->assertTrue($resp['success']);
+        $this->assertSame('alpha', $resp['data']['focus_keywords']);
+        $this->assertSame([], $resp['data']['long_tail_keywords']);
+        $this->assertSame('Google Ads keyword research unavailable—using AI suggestions only.', $resp['data']['kwp_notice']);
     }
 
     public function test_keyword_planner_no_metrics_handled() {
@@ -686,5 +689,39 @@ class AiResearchErrorHandlingTest extends WP_Ajax_UnitTestCase {
         $this->assertSame('alpha', $resp['data']['focus_keywords']);
         $this->assertSame([], $resp['data']['long_tail_keywords']);
         $this->assertSame('Google Ads API did not return keyword metrics.', $resp['data']['kwp_notice']);
+    }
+
+    public function test_missing_ads_credentials_fallback() {
+        update_option('gm2_chatgpt_api_key', 'key');
+        $step = 0;
+        $filter = function($pre, $args, $url) use (&$step) {
+            if ($url === 'https://api.openai.com/v1/chat/completions') {
+                if ($step === 0) {
+                    $step++;
+                    return [ 'response' => ['code' => 200], 'body' => json_encode(['choices' => [ ['message' => ['content' => json_encode(['seed_keywords' => 'alpha,beta'])]] ]]) ];
+                }
+                return [ 'response' => ['code' => 200], 'body' => json_encode(['choices' => [ ['message' => ['content' => '{}']] ]]) ];
+            }
+            if (false !== strpos($url, 'generateKeywordIdeas')) {
+                return false;
+            }
+            return false;
+        };
+        add_filter('pre_http_request', $filter, 10, 3);
+
+        $post_id = self::factory()->post->create(['post_title' => 'Post', 'post_content' => 'Content']);
+
+        $this->_setRole('administrator');
+        $_POST['post_id'] = $post_id;
+        $_POST['_ajax_nonce'] = wp_create_nonce('gm2_ai_research');
+        $_REQUEST['_ajax_nonce'] = $_POST['_ajax_nonce'];
+        try { $this->_handleAjax('gm2_ai_research'); } catch (WPAjaxDieContinueException $e) {}
+        remove_filter('pre_http_request', $filter, 10);
+
+        $resp = json_decode($this->_last_response, true);
+        $this->assertTrue($resp['success']);
+        $this->assertSame('alpha', $resp['data']['focus_keywords']);
+        $this->assertContains('beta', $resp['data']['long_tail_keywords']);
+        $this->assertSame('Google Ads keyword research unavailable—using AI suggestions only.', $resp['data']['kwp_notice']);
     }
 }


### PR DESCRIPTION
## Summary
- handle missing Ads credentials or planner errors in AI SEO
- add notice when Google Ads metrics are unavailable
- test fallback when credentials are missing or planner fails
- document fallback behaviour in readme

## Testing
- `npm test`
- `phpunit` *(fails: missing WordPress test suite)*
- `make test DB_NAME=wp_test DB_USER=root DB_PASS=pass` *(fails: mysqladmin not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876d84fd0b48327b9264df6dfdcf53a