### PR TITLE
Handle missing ChatGPT seed keywords

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -2349,6 +2349,19 @@ class Gm2_SEO_Admin {
         $final_focus = '';
         $final_long  = [];
         $kwp_notice  = '';
+
+        if (!$seeds) {
+            $query = $seo_title !== '' ? $seo_title : ($seo_description !== '' ? $seo_description : $title);
+            $ideas = $this->chatgpt_keyword_ideas($query);
+            if (!is_wp_error($ideas)) {
+                $seeds = array_map(function($i) { return $i['text']; }, $ideas);
+                $chosen = $this->select_top_keywords($ideas);
+                $final_focus = $chosen['focus'];
+                $final_long  = $chosen['long_tail'];
+                $kwp_notice  = __('AI response contained no seed keywords—using generated suggestions.', 'gm2-wordpress-suite');
+            }
+        }
+
         if ($seeds) {
             $seed_ideas = array_map(function($kw) { return ['text' => $kw]; }, $seeds);
 

--- a/readme.txt
+++ b/readme.txt
@@ -186,7 +186,8 @@ whether to use any existing SEO field values. If all fields are empty, provide a
 short description so ChatGPT has extra context.
 
 Step one sends the post content to ChatGPT which returns a title, description
-and a list of seed keywords. Step two refines those keywords with the Google
+and a list of seed keywords. If no seed keywords are returned, the plugin
+generates them automatically before querying Google Ads. Step two refines those keywords with the Google
 Keyword Planner, ranking them by **Avg. Monthly Searches**, **competition** and
 the **3‑month** and **year-over-year change** metrics. A valid Google Ads
 developer token, connected account and customer ID are required for this step.

--- a/tests/test-ai-seo.php
+++ b/tests/test-ai-seo.php
@@ -724,4 +724,52 @@ class AiResearchErrorHandlingTest extends WP_Ajax_UnitTestCase {
         $this->assertContains('beta', $resp['data']['long_tail_keywords']);
         $this->assertSame('Google Ads keyword research unavailable—using AI suggestions only.', $resp['data']['kwp_notice']);
     }
+
+    public function test_seed_keywords_missing_uses_ai_fallback() {
+        update_option('gm2_chatgpt_api_key', 'key');
+        update_option('gm2_gads_developer_token', 'dev');
+        update_option('gm2_gads_customer_id', '123-456-7890');
+        update_option('gm2_google_refresh_token', 'refresh');
+        update_option('gm2_google_access_token', 'access');
+        update_option('gm2_google_expires_at', time() + 3600);
+
+        $step = 0;
+        $captured = null;
+        $filter = function($pre, $args, $url) use (&$step, &$captured) {
+            if ($url === 'https://api.openai.com/v1/chat/completions') {
+                $body = json_decode($args['body'], true);
+                if ($step === 0) {
+                    $step++;
+                    return [ 'response' => ['code' => 200], 'body' => json_encode(['choices' => [ ['message' => ['content' => '{}']] ]]) ];
+                } elseif ($step === 1) {
+                    $step++;
+                    return [ 'response' => ['code' => 200], 'body' => json_encode(['choices' => [ ['message' => ['content' => 'alpha,beta']] ]]) ];
+                } else {
+                    $captured = $body['messages'][0]['content'];
+                    return [ 'response' => ['code' => 200], 'body' => json_encode(['choices' => [ ['message' => ['content' => json_encode(['seo_title' => 'Title'])]] ]]) ];
+                }
+            }
+            if (false !== strpos($url, 'generateKeywordIdeas')) {
+                return [ 'response' => ['code' => 200], 'body' => json_encode(['results' => [ ['text' => 'alpha'], ['text' => 'beta'] ]]) ];
+            }
+            return false;
+        };
+        add_filter('pre_http_request', $filter, 10, 3);
+
+        $post_id = self::factory()->post->create(['post_title' => 'Post', 'post_content' => 'Content']);
+
+        $this->_setRole('administrator');
+        $_POST['post_id'] = $post_id;
+        $_POST['_ajax_nonce'] = wp_create_nonce('gm2_ai_research');
+        $_REQUEST['_ajax_nonce'] = $_POST['_ajax_nonce'];
+        try { $this->_handleAjax('gm2_ai_research'); } catch (WPAjaxDieContinueException $e) {}
+        remove_filter('pre_http_request', $filter, 10);
+
+        $resp = json_decode($this->_last_response, true);
+        $this->assertTrue($resp['success']);
+        $this->assertSame('alpha', $resp['data']['focus_keywords']);
+        $this->assertContains('beta', $resp['data']['long_tail_keywords']);
+        $this->assertSame('AI response contained no seed keywords—using generated suggestions.', $resp['data']['kwp_notice']);
+        $this->assertStringContainsString('alpha', $captured);
+    }
 }


### PR DESCRIPTION
## Summary
- generate keyword ideas if ChatGPT omits seed keywords
- document the fallback in the AI SEO docs
- test that fallback seeds are used when missing

## Testing
- `phpunit` *(fails: WordPress test suite missing)*

------
https://chatgpt.com/codex/tasks/task_e_6876e070a85083279f4f6acc2222c555