### PR TITLE
Implement quantity discounts admin UI

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -8,10 +8,13 @@ if (!defined('ABSPATH')) {
 
 class Gm2_Admin {
     private $diagnostics;
+    private $quantity_discounts;
 
     public function run() {
         $this->diagnostics = new Gm2_Diagnostics();
         $this->diagnostics->run();
+        $this->quantity_discounts = new Gm2_Quantity_Discounts_Admin();
+        $this->quantity_discounts->register_hooks();
         add_action('admin_menu', [$this, 'add_admin_menu']);
         add_action('admin_enqueue_scripts', [$this, 'enqueue_admin_scripts']);
         add_action('wp_ajax_gm2_add_tariff', [$this, 'ajax_add_tariff']);

--- a/admin/Gm2_Quantity_Discounts_Admin.php
+++ b/admin/Gm2_Quantity_Discounts_Admin.php
@@ -1,0 +1,135 @@
+<?php
+namespace Gm2;
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Gm2_Quantity_Discounts_Admin {
+    public function register_hooks() {
+        add_action('admin_menu', [ $this, 'add_admin_menu' ]);
+        add_action('admin_enqueue_scripts', [ $this, 'enqueue_scripts' ]);
+        add_action('wp_ajax_gm2_qd_search_products', [ $this, 'ajax_search_products' ]);
+        add_action('wp_ajax_gm2_qd_save_groups', [ $this, 'ajax_save_groups' ]);
+    }
+
+    public function add_admin_menu() {
+        add_submenu_page(
+            'gm2',
+            esc_html__( 'Quantity Discounts', 'gm2-wordpress-suite' ),
+            esc_html__( 'Quantity Discounts', 'gm2-wordpress-suite' ),
+            'manage_options',
+            'gm2-quantity-discounts',
+            [ $this, 'render_page' ]
+        );
+    }
+
+    public function enqueue_scripts( $hook ) {
+        if ( $hook !== 'gm2_page_gm2-quantity-discounts' ) {
+            return;
+        }
+        wp_enqueue_script(
+            'gm2-quantity-discounts',
+            GM2_PLUGIN_URL . 'admin/js/gm2-quantity-discounts.js',
+            [ 'jquery' ],
+            GM2_VERSION,
+            true
+        );
+        $groups = get_option( 'gm2_quantity_discount_groups', [] );
+        $cats   = [];
+        if ( taxonomy_exists( 'product_cat' ) ) {
+            $terms = get_terms( [
+                'taxonomy'   => 'product_cat',
+                'hide_empty' => false,
+            ] );
+            foreach ( $terms as $t ) {
+                $cats[] = [ 'id' => $t->term_id, 'name' => $t->name ];
+            }
+        }
+        wp_localize_script(
+            'gm2-quantity-discounts',
+            'gm2Qd',
+            [
+                'nonce'      => wp_create_nonce( 'gm2_qd_nonce' ),
+                'ajax_url'   => admin_url( 'admin-ajax.php' ),
+                'groups'     => $groups,
+                'categories' => $cats,
+            ]
+        );
+    }
+
+    public function render_page() {
+        echo '<div class="wrap">';
+        echo '<h1>' . esc_html__( 'Quantity Discounts', 'gm2-wordpress-suite' ) . '</h1>';
+        echo '<div id="gm2-qd-msg" class="notice hidden"></div>';
+        echo '<form id="gm2-qd-form"><div id="gm2-qd-groups"></div>';
+        echo '<p><button type="button" id="gm2-qd-add-group" class="button">' . esc_html__( 'Add Group', 'gm2-wordpress-suite' ) . '</button></p>';
+        submit_button( esc_html__( 'Save Changes', 'gm2-wordpress-suite' ) );
+        echo '</form></div>';
+    }
+
+    public function ajax_search_products() {
+        if ( ! current_user_can( 'edit_posts' ) ) {
+            wp_send_json_error( __( 'Permission denied', 'gm2-wordpress-suite' ) );
+        }
+        check_ajax_referer( 'gm2_qd_nonce', 'nonce' );
+        $term  = sanitize_text_field( $_GET['term'] ?? '' );
+        $cat   = absint( $_GET['category'] ?? 0 );
+        $args  = [
+            'post_type'      => 'product',
+            'posts_per_page' => 20,
+            's'              => $term,
+        ];
+        if ( $cat ) {
+            $args['tax_query'] = [
+                [
+                    'taxonomy' => 'product_cat',
+                    'terms'    => [ $cat ],
+                ],
+            ];
+        }
+        $q      = new \WP_Query( $args );
+        $result = [];
+        foreach ( $q->posts as $p ) {
+            $result[] = [
+                'id'   => $p->ID,
+                'text' => $p->post_title,
+            ];
+        }
+        wp_send_json_success( $result );
+    }
+
+    public function ajax_save_groups() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( __( 'Permission denied', 'gm2-wordpress-suite' ) );
+        }
+        check_ajax_referer( 'gm2_qd_nonce', 'nonce' );
+        $groups = isset( $_POST['groups'] ) && is_array( $_POST['groups'] ) ? $_POST['groups'] : [];
+        $clean  = [];
+        foreach ( $groups as $g ) {
+            $name     = sanitize_text_field( $g['name'] ?? '' );
+            $products = array_map( 'intval', $g['products'] ?? [] );
+            $rules    = [];
+            if ( ! empty( $g['rules'] ) && is_array( $g['rules'] ) ) {
+                foreach ( $g['rules'] as $r ) {
+                    $min    = intval( $r['min'] ?? 1 );
+                    $type   = $r['type'] === 'fixed' ? 'fixed' : 'percent';
+                    $amount = floatval( $r['amount'] ?? 0 );
+                    $rules[] = [
+                        'min'    => $min,
+                        'type'   => $type,
+                        'amount' => $amount,
+                    ];
+                }
+            }
+            if ( $name !== '' ) {
+                $clean[] = [
+                    'name'     => $name,
+                    'products' => $products,
+                    'rules'    => $rules,
+                ];
+            }
+        }
+        update_option( 'gm2_quantity_discount_groups', $clean );
+        wp_send_json_success( [ 'saved' => true ] );
+    }
+}

--- a/admin/js/gm2-quantity-discounts.js
+++ b/admin/js/gm2-quantity-discounts.js
@@ -1,0 +1,96 @@
+jQuery(function($){
+    var groups = gm2Qd.groups || [];
+    var categories = gm2Qd.categories || [];
+    function createRuleRow(rule){
+        rule = rule || {min:'',type:'percent',amount:''};
+        var row = $('<tr class="gm2-qd-rule">\
+            <td><input type="number" class="gm2-qd-min" value="'+rule.min+'" min="1"></td>\
+            <td><input type="number" step="0.01" class="gm2-qd-percent" '+(rule.type==='percent'?'' : 'disabled')+' value="'+(rule.type==='percent'?rule.amount:'')+'"></td>\
+            <td><input type="number" step="0.01" class="gm2-qd-fixed" '+(rule.type==='fixed'?'' : 'disabled')+' value="'+(rule.type==='fixed'?rule.amount:'')+'"></td>\
+            <td><button type="button" class="button gm2-qd-remove-rule">&times;</button></td></tr>');
+        return row;
+    }
+    function createGroup(g){
+        g = g || {name:'',products:[],rules:[]};
+        var container = $('<div class="gm2-qd-group"></div>');
+        container.append('<h2><input type="text" class="gm2-qd-name" placeholder="Group name" value="'+(g.name||'')+'"> <button type="button" class="button gm2-qd-remove-group">&times;</button></h2>');
+        var prodSection = $('<div class="gm2-qd-products"><select class="gm2-qd-cat"><option value="">All Categories</option></select> <input type="text" class="gm2-qd-search" placeholder="Search products"> <ul class="gm2-qd-results"></ul><ul class="gm2-qd-selected"></ul></div>');
+        categories.forEach(function(c){prodSection.find('select').append('<option value="'+c.id+'">'+c.name+'</option>');});
+        container.append(prodSection);
+        var table = $('<table class="widefat gm2-qd-rules"><thead><tr><th>Min Qty</th><th>% Off</th><th>Fixed Off</th><th></th></tr></thead><tbody></tbody></table>');
+        g.rules.forEach(function(r){table.find('tbody').append(createRuleRow(r));});
+        container.append(table);
+        container.append('<p><button type="button" class="button gm2-qd-add-rule">Add Rule</button></p>');
+        g.products.forEach(function(id){
+            addSelectedProduct(container, {id:id,text:id});
+        });
+        return container;
+    }
+    function addSelectedProduct(group, item){
+        var ul = group.find('.gm2-qd-selected');
+        if( ul.find('li[data-id="'+item.id+'"]').length ) return;
+        ul.append('<li data-id="'+item.id+'">'+item.text+' <span class="remove">x</span></li>');
+    }
+    function renderGroups(){
+        var holder = $('#gm2-qd-groups').empty();
+        groups.forEach(function(g){holder.append(createGroup(g));});
+    }
+    renderGroups();
+    $('#gm2-qd-add-group').on('click',function(){
+        $('#gm2-qd-groups').append(createGroup());
+    });
+    $(document).on('click','.gm2-qd-remove-group',function(){
+        $(this).closest('.gm2-qd-group').remove();
+    });
+    $(document).on('click','.gm2-qd-add-rule',function(){
+        var group=$(this).closest('.gm2-qd-group');
+        group.find('.gm2-qd-rules tbody').append(createRuleRow());
+    });
+    $(document).on('click','.gm2-qd-remove-rule',function(){
+        $(this).closest('tr').remove();
+    });
+    $(document).on('input','.gm2-qd-search',function(){
+        var group=$(this).closest('.gm2-qd-group');
+        var term=$(this).val();
+        var cat=group.find('.gm2-qd-cat').val();
+        if(term.length<2){group.find('.gm2-qd-results').empty();return;}
+        $.get(gm2Qd.ajax_url,{action:'gm2_qd_search_products',nonce:gm2Qd.nonce,term:term,category:cat}).done(function(res){
+            var ul=group.find('.gm2-qd-results').empty();
+            if(res.success){res.data.forEach(function(i){ul.append('<li data-id="'+i.id+'">'+i.text+'</li>');});}
+        });
+    });
+    $(document).on('click','.gm2-qd-results li',function(){
+        var group=$(this).closest('.gm2-qd-group');
+        addSelectedProduct(group,{id:$(this).data('id'),text:$(this).text()});
+    });
+    $(document).on('click','.gm2-qd-selected .remove',function(){
+        $(this).parent().remove();
+    });
+    $('#gm2-qd-form').on('submit',function(e){
+        e.preventDefault();
+        var data=[];
+        $('#gm2-qd-groups .gm2-qd-group').each(function(){
+            var g=$(this);var obj={name:g.find('.gm2-qd-name').val(),products:[],rules:[]};
+            g.find('.gm2-qd-selected li').each(function(){obj.products.push($(this).data('id'));});
+            g.find('.gm2-qd-rules tbody tr').each(function(){
+                var min=parseInt($(this).find('.gm2-qd-min').val(),10)||0;
+                var percent=$(this).find('.gm2-qd-percent').val();
+                var fixed=$(this).find('.gm2-qd-fixed').val();
+                var type='percent';var amount=parseFloat(percent)||0;
+                if(fixed){type='fixed';amount=parseFloat(fixed)||0;}
+                obj.rules.push({min:min,type:type,amount:amount});
+            });
+            data.push(obj);
+        });
+        var $msg=$('#gm2-qd-msg');
+        $msg.removeClass('notice-success notice-error').addClass('hidden');
+        $.post(gm2Qd.ajax_url,{action:'gm2_qd_save_groups',nonce:gm2Qd.nonce,groups:data}).done(function(res){
+            if(res.success){$msg.text('Saved.').addClass('notice-success');}
+            else{$msg.text(res.data&&res.data.message?res.data.message:'Error').addClass('notice-error');}
+        }).fail(function(){
+            $msg.text('Error').addClass('notice-error');
+        }).always(function(){
+            $msg.removeClass('hidden');
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- add new `Gm2_Quantity_Discounts_Admin` class and menu
- hook into `admin_menu` from `Gm2_Admin::run()`
- implement AJAX handlers and page skeleton
- provide JS for group and rule management

## Testing
- `npm test`
- `phpunit` *(fails: missing wordpress-tests-lib)*

------
https://chatgpt.com/codex/tasks/task_e_6876e66a7c2483279dc6e4435eefe2d6