### PR TITLE
Implement quantity discount public logic

### DIFF
--- a/includes/Gm2_Loader.php
+++ b/includes/Gm2_Loader.php
@@ -27,6 +27,9 @@ class Gm2_Loader {
         $public = new Gm2_Public();
         $public->run();
 
+        $qd_public = new Gm2_Quantity_Discounts_Public();
+        $qd_public->run();
+
         $seo_public = new Gm2_SEO_Public();
         $seo_public->run();
 

--- a/public/Gm2_Quantity_Discounts_Public.php
+++ b/public/Gm2_Quantity_Discounts_Public.php
@@ -1,0 +1,70 @@
+<?php
+namespace Gm2;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Gm2_Quantity_Discounts_Public {
+    public function run() {
+        add_action('woocommerce_before_calculate_totals', [ $this, 'adjust_prices' ], 20);
+    }
+
+    public function adjust_prices($cart) {
+        if (is_admin() && !defined('DOING_AJAX')) {
+            return;
+        }
+        if (!class_exists('WooCommerce') || !is_a($cart, 'WC_Cart')) {
+            return;
+        }
+        $groups = get_option('gm2_quantity_discount_groups', []);
+        if (empty($groups)) {
+            return;
+        }
+        foreach ($cart->get_cart() as $key => $item) {
+            $product_id = $item['product_id'];
+            $group      = null;
+            foreach ($groups as $g) {
+                if (!empty($g['products']) && in_array($product_id, $g['products'], true)) {
+                    $group = $g;
+                    break;
+                }
+            }
+            if (!$group || empty($group['rules'])) {
+                continue;
+            }
+            $product = $item['data'];
+            if (!isset($cart->cart_contents[$key]['gm2_qd_original_price'])) {
+                $cart->cart_contents[$key]['gm2_qd_original_price'] = (float) $product->get_price('edit');
+            } else {
+                $product->set_price($cart->cart_contents[$key]['gm2_qd_original_price']);
+            }
+            $base  = $cart->cart_contents[$key]['gm2_qd_original_price'];
+            $qty   = $item['quantity'];
+            $rules = $group['rules'];
+            usort($rules, function($a, $b) {
+                return $b['min'] <=> $a['min'];
+            });
+            $applied = null;
+            foreach ($rules as $rule) {
+                if ($qty >= intval($rule['min'])) {
+                    $applied = $rule;
+                    break;
+                }
+            }
+            if ($applied) {
+                $new_price = $base;
+                if ($applied['type'] === 'percent') {
+                    $new_price = $base * (1 - ($applied['amount'] / 100));
+                } else {
+                    $new_price = $base - $applied['amount'];
+                }
+                if ($new_price < 0) {
+                    $new_price = 0;
+                }
+                $product->set_price($new_price);
+                $cart->cart_contents[$key]['data'] = $product;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add new class `Gm2_Quantity_Discounts_Public` for applying quantity-based price adjustments
- load the public quantity discount handler from the plugin loader

## Testing
- `php -l public/Gm2_Quantity_Discounts_Public.php`
- `php -l includes/Gm2_Loader.php`
- `make test DB_NAME=wp DB_USER=root DB_PASS=pass` *(fails: mysqld not running)*

------
https://chatgpt.com/codex/tasks/task_e_6876ec6b4a9c8327aae00342267b77b5