### PR TITLE
Add Elementor quantity discount widget

### DIFF
--- a/includes/Gm2_Elementor_Quantity_Discounts.php
+++ b/includes/Gm2_Elementor_Quantity_Discounts.php
@@ -1,0 +1,109 @@
+<?php
+namespace Gm2;
+
+if (!defined('ABSPATH')) { exit; }
+
+class Gm2_Elementor_Quantity_Discounts {
+    public function __construct() {
+        add_action('init', [ $this, 'init' ]);
+    }
+
+    public function init() {
+        if (!class_exists('Elementor\\Plugin') || !class_exists('WooCommerce')) {
+            return;
+        }
+        add_action('elementor/widgets/register', [ $this, 'register_widget' ]);
+    }
+
+    public function register_widget( $widgets_manager ) {
+        $widgets_manager->register( new GM2_QD_Widget() );
+    }
+}
+
+class GM2_QD_Widget extends \Elementor\Widget_Base {
+    public function get_name() {
+        return 'gm2_quantity_discounts';
+    }
+    public function get_title() {
+        return __( 'GM2 Quantity Options', 'gm2-wordpress-suite' );
+    }
+    public function get_icon() {
+        return 'eicon-cart-medium';
+    }
+    public function get_categories() {
+        return [ 'general' ];
+    }
+
+    protected function register_controls() {
+        $this->start_controls_section(
+            'gm2_qd_style',
+            [
+                'label' => __( 'Options Style', 'gm2-wordpress-suite' ),
+                'tab'   => \Elementor\Controls_Manager::TAB_STYLE,
+            ]
+        );
+        $this->add_control(
+            'text_color',
+            [
+                'label' => __( 'Text Color', 'gm2-wordpress-suite' ),
+                'type'  => \Elementor\Controls_Manager::COLOR,
+                'selectors' => [
+                    '{{WRAPPER}} .gm2-qd-option' => 'color: {{VALUE}};',
+                ],
+            ]
+        );
+        $this->add_control(
+            'bg_color',
+            [
+                'label' => __( 'Background', 'gm2-wordpress-suite' ),
+                'type'  => \Elementor\Controls_Manager::COLOR,
+                'selectors' => [
+                    '{{WRAPPER}} .gm2-qd-option' => 'background-color: {{VALUE}};',
+                ],
+            ]
+        );
+        $this->add_control(
+            'font_size',
+            [
+                'label' => __( 'Font Size', 'gm2-wordpress-suite' ),
+                'type'  => \Elementor\Controls_Manager::NUMBER,
+                'selectors' => [
+                    '{{WRAPPER}} .gm2-qd-option' => 'font-size: {{VALUE}}px;',
+                ],
+            ]
+        );
+        $this->end_controls_section();
+    }
+
+    protected function render() {
+        if ( ! function_exists( 'is_product' ) || ! is_product() ) {
+            return;
+        }
+        global $product;
+        if ( ! $product ) {
+            return;
+        }
+        $rules = $this->get_rules( $product->get_id() );
+        if ( empty( $rules ) ) {
+            return;
+        }
+        echo '<div class="gm2-qd-options">';
+        foreach ( $rules as $rule ) {
+            $qty   = intval( $rule['min'] );
+            $label = sprintf( __( 'Qty: %d', 'gm2-wordpress-suite' ), $qty );
+            echo '<button type="button" class="gm2-qd-option" data-qty="' . esc_attr( $qty ) . '">' . esc_html( $label ) . '</button>';
+        }
+        echo '</div>';
+    }
+
+    private function get_rules( $product_id ) {
+        $m = new Gm2_Quantity_Discount_Manager();
+        $groups = $m->get_groups();
+        foreach ( $groups as $g ) {
+            if ( ! empty( $g['products'] ) && in_array( $product_id, $g['products'], true ) ) {
+                return $g['rules'] ?? [];
+            }
+        }
+        return [];
+    }
+}

--- a/includes/Gm2_Loader.php
+++ b/includes/Gm2_Loader.php
@@ -35,6 +35,7 @@ class Gm2_Loader {
 
         if (class_exists('Elementor\\Plugin')) {
             new Gm2_Elementor_SEO();
+            new Gm2_Elementor_Quantity_Discounts();
         }
     }
 }

--- a/public/Gm2_Public.php
+++ b/public/Gm2_Public.php
@@ -27,6 +27,22 @@ class Gm2_Public {
             GM2_VERSION,
             true
         );
+
+        if (function_exists('is_product') && is_product()) {
+            wp_enqueue_style(
+                'gm2-qd-widget',
+                GM2_PLUGIN_URL . 'public/css/gm2-qd-widget.css',
+                [],
+                GM2_VERSION
+            );
+            wp_enqueue_script(
+                'gm2-qd-widget',
+                GM2_PLUGIN_URL . 'public/js/gm2-qd-widget.js',
+                [ 'jquery' ],
+                GM2_VERSION,
+                true
+            );
+        }
     }
 
     public function add_tariff_fees($cart) {

--- a/public/css/gm2-qd-widget.css
+++ b/public/css/gm2-qd-widget.css
@@ -1,0 +1,2 @@
+.gm2-qd-options{display:flex;gap:6px;margin-bottom:10px;}
+.gm2-qd-option{cursor:pointer;padding:4px 8px;border:1px solid #ccc;background:#f8f8f8;}

--- a/public/js/gm2-qd-widget.js
+++ b/public/js/gm2-qd-widget.js
@@ -1,0 +1,14 @@
+jQuery(function($){
+    $(document).on('click','.gm2-qd-option',function(e){
+        e.preventDefault();
+        var qty = $(this).data('qty');
+        var form = $('form.cart');
+        var input = form.find('input.qty');
+        if(input.length){
+            input.val(qty).trigger('change');
+        }
+        if(form.length){
+            form.find('[name=add-to-cart]').trigger('click');
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- hook Elementor quantity discount integration when Elementor is active
- expose `Gm2_Elementor_Quantity_Discounts` widget
- let users style widget items via Elementor controls
- enqueue widget scripts and styles on product pages
- add simple JS for selecting quantities

## Testing
- `npm test`
- `phpunit` *(fails: missing WordPress test suite)*

------
https://chatgpt.com/codex/tasks/task_e_6876edbf49888327b78eec98755c9681