### PR TITLE
Add gm2_get_seo_context helper

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -48,6 +48,7 @@ require_once GM2_PLUGIN_DIR . 'includes/Gm2_Loader.php';
 require_once GM2_PLUGIN_DIR . 'public/Gm2_SEO_Public.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_Sitemap.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_PageSpeed.php';
+require_once GM2_PLUGIN_DIR . 'includes/Gm2_SEO_Utils.php';
 
 function gm2_add_weekly_schedule($schedules) {
     if (!isset($schedules['weekly'])) {

--- a/includes/Gm2_SEO_Utils.php
+++ b/includes/Gm2_SEO_Utils.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Gm2 {
+    if (!defined('ABSPATH')) {
+        exit;
+    }
+}
+
+namespace {
+    function gm2_get_seo_context() {
+        $context = [
+            'business_model'        => sanitize_textarea_field(get_option('gm2_context_business_model', '')),
+            'industry_category'     => sanitize_text_field(get_option('gm2_context_industry_category', '')),
+            'target_audience'       => sanitize_textarea_field(get_option('gm2_context_target_audience', '')),
+            'unique_selling_points' => sanitize_textarea_field(get_option('gm2_context_unique_selling_points', '')),
+        ];
+        /**
+         * Filter the assembled SEO context options.
+         *
+         * @param array $context Associative array of context strings.
+         */
+        $context = apply_filters('gm2_seo_context', $context);
+        return $context;
+    }
+}

--- a/tests/test-seo-context.php
+++ b/tests/test-seo-context.php
@@ -1,0 +1,38 @@
+<?php
+class SeoContextHelperTest extends WP_UnitTestCase {
+    public function tearDown(): void {
+        delete_option('gm2_context_business_model');
+        delete_option('gm2_context_industry_category');
+        delete_option('gm2_context_target_audience');
+        delete_option('gm2_context_unique_selling_points');
+        remove_all_filters('gm2_seo_context');
+        parent::tearDown();
+    }
+
+    public function test_helper_returns_sanitized_and_filtered_values() {
+        update_option('gm2_context_business_model', '<b>Model</b>');
+        update_option('gm2_context_industry_category', ' <i>Tech</i> ');
+        update_option('gm2_context_target_audience', "Audience <script>bad()</script>");
+        update_option('gm2_context_unique_selling_points', 'USP <span>great</span>');
+
+        $filtered = null;
+        add_filter('gm2_seo_context', function($context) use (&$filtered) {
+            $filtered = $context;
+            $context['industry_category'] = 'filtered';
+            return $context;
+        });
+
+        $context = gm2_get_seo_context();
+
+        $this->assertIsArray($filtered);
+        $this->assertSame(sanitize_textarea_field('<b>Model</b>'), $filtered['business_model']);
+        $this->assertSame(sanitize_text_field(' <i>Tech</i> '), $filtered['industry_category']);
+        $this->assertSame(sanitize_textarea_field("Audience <script>bad()</script>"), $filtered['target_audience']);
+        $this->assertSame(sanitize_textarea_field('USP <span>great</span>'), $filtered['unique_selling_points']);
+
+        $this->assertSame('filtered', $context['industry_category']);
+        $this->assertSame($filtered['business_model'], $context['business_model']);
+        $this->assertSame($filtered['target_audience'], $context['target_audience']);
+        $this->assertSame($filtered['unique_selling_points'], $context['unique_selling_points']);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `gm2_get_seo_context` helper
- load new helper in main plugin file
- cover helper with unit test

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6876f0e50c248327865c6fb055b1c2cd