### PR TITLE
Add quantity discount tests

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,6 +3,12 @@ $_tests_dir = getenv('WP_TESTS_DIR');
 if (!$_tests_dir) {
     $_tests_dir = '/tmp/wordpress-tests-lib';
 }
+$polyfills_path = dirname(__DIR__) . '/vendor/yoast/phpunit-polyfills';
+if (!defined('WP_TESTS_PHPUNIT_POLYFILLS_PATH') && is_dir($polyfills_path)) {
+    define('WP_TESTS_PHPUNIT_POLYFILLS_PATH', $polyfills_path);
+} elseif (!defined('WP_TESTS_PHPUNIT_POLYFILLS_PATH') && is_dir('/tmp/wordpress-develop/vendor/yoast/phpunit-polyfills')) {
+    define('WP_TESTS_PHPUNIT_POLYFILLS_PATH', '/tmp/wordpress-develop/vendor/yoast/phpunit-polyfills');
+}
 require_once $_tests_dir . '/includes/functions.php';
 $vendor_autoload = dirname(__DIR__) . '/vendor/autoload.php';
 if (file_exists($vendor_autoload)) {

--- a/tests/js/gm2-quantity-discounts.test.js
+++ b/tests/js/gm2-quantity-discounts.test.js
@@ -1,0 +1,54 @@
+const { JSDOM } = require('jsdom');
+const jquery = require('jquery');
+
+test('renders groups from gm2Qd', async () => {
+  const dom = new JSDOM(`
+    <form id="gm2-qd-form">
+      <div id="gm2-qd-groups"></div>
+      <button id="gm2-qd-add-group"></button>
+    </form>
+  `, { url: 'http://localhost' });
+  const $ = jquery(dom.window);
+  Object.assign(global, { window: dom.window, document: dom.window.document, jQuery: $, $ });
+  global.gm2Qd = { nonce: 'n', ajax_url: '/fake', groups: [{ name: 'Group A', products: [], rules: [] }], categories: [] };
+
+  jest.resetModules();
+  require('../../admin/js/gm2-quantity-discounts.js');
+  await new Promise(r => setTimeout(r, 0));
+  await new Promise(r => setTimeout(r, 0));
+
+  expect($('.gm2-qd-name').val()).toBe('Group A');
+});
+
+test('submits group data via ajax', async () => {
+  const dom = new JSDOM(`
+    <form id="gm2-qd-form">
+      <div id="gm2-qd-groups"></div>
+      <button id="gm2-qd-add-group" type="button"></button>
+    </form>
+    <div id="gm2-qd-msg" class="hidden"></div>
+  `, { url: 'http://localhost' });
+  const $ = jquery(dom.window);
+  Object.assign(global, { window: dom.window, document: dom.window.document, jQuery: $, $ });
+  global.gm2Qd = { nonce: 'n', ajax_url: '/fake', groups: [], categories: [] };
+  $.post = jest.fn(() => $.Deferred().resolve({ success: true }));
+
+  jest.resetModules();
+  require('../../admin/js/gm2-quantity-discounts.js');
+  await new Promise(r => setTimeout(r, 0));
+  await new Promise(r => setTimeout(r, 0));
+
+  $('#gm2-qd-add-group').trigger('click');
+  $('.gm2-qd-add-rule').trigger('click');
+  $('.gm2-qd-name').val('Test');
+  $('.gm2-qd-min').val('2');
+  $('.gm2-qd-percent').val('10');
+
+  $('#gm2-qd-form').trigger('submit');
+  await new Promise(r => setTimeout(r, 0));
+
+  expect($.post).toHaveBeenCalled();
+  const data = $.post.mock.calls[0][1].groups[0];
+  expect(data.name).toBe('Test');
+  expect(data.rules[0]).toEqual({ min: 2, type: 'percent', amount: 10 });
+});

--- a/tests/test-quantity-discounts.php
+++ b/tests/test-quantity-discounts.php
@@ -1,0 +1,69 @@
+<?php
+use Gm2\Gm2_Quantity_Discount_Manager;
+use Gm2\Gm2_Quantity_Discounts_Public;
+
+if (!class_exists('WooCommerce')) {
+    class WooCommerce {}
+}
+if (!class_exists('WC_Cart')) {
+    class WC_Cart {
+        public $cart_contents = [];
+        public function get_cart() { return $this->cart_contents; }
+    }
+}
+if (!class_exists('WC_Product')) {
+    class WC_Product {
+        private $price;
+        public function __construct($price) { $this->price = $price; }
+        public function get_price($ctx = '') { return $this->price; }
+        public function set_price($p) { $this->price = $p; }
+    }
+}
+if (!function_exists('wc_get_product')) {
+    function wc_get_product($id) { return new WC_Product(100); }
+}
+if (!function_exists('is_admin')) {
+    function is_admin() { return false; }
+}
+
+class QuantityDiscountsTest extends WP_UnitTestCase {
+    public function setUp(): void {
+        parent::setUp();
+        delete_option('gm2_quantity_discount_groups');
+    }
+
+    public function test_add_and_get_group() {
+        $m = new Gm2_Quantity_Discount_Manager();
+        $id = $m->add_group([
+            'name' => 'Test',
+            'products' => [1],
+            'rules' => [ [ 'min' => 3, 'type' => 'percent', 'amount' => 10 ] ]
+        ]);
+        $this->assertNotFalse($id);
+        $group = $m->get_group($id);
+        $this->assertSame('Test', $group['name']);
+        $this->assertSame([1], $group['products']);
+        $groups = $m->get_groups();
+        $this->assertCount(1, $groups);
+    }
+
+    public function test_adjust_price_applies_discount() {
+        $m = new Gm2_Quantity_Discount_Manager();
+        $m->add_group([
+            'name' => 'Test',
+            'products' => [1],
+            'rules' => [ [ 'min' => 2, 'type' => 'percent', 'amount' => 50 ] ]
+        ]);
+        $cart = new WC_Cart();
+        $product = new WC_Product(100);
+        $cart->cart_contents['item'] = [
+            'product_id' => 1,
+            'quantity' => 2,
+            'data' => $product
+        ];
+        $qd = new Gm2_Quantity_Discounts_Public();
+        $qd->run();
+        $qd->adjust_prices($cart);
+        $this->assertSame(50.0, $cart->cart_contents['item']['data']->get_price());
+    }
+}


### PR DESCRIPTION
## Summary
- add PHPUnit polyfills path handling in test bootstrap
- test quantity discount group storage and pricing logic
- test admin quantity discount JS behavior

## Testing
- `npm test`
- `php /usr/bin/phpunit` *(fails: Errors: 8, Failures: 34)*

------
https://chatgpt.com/codex/tasks/task_e_6876f0d223108327bf5736d230cddb89