### PR TITLE
Enhance AI prompts with site context

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -2325,6 +2325,17 @@ class Gm2_SEO_Admin {
             $guidelines = get_option('gm2_seo_guidelines_tax_' . $taxonomy, '');
         }
         $guidelines = trim($guidelines);
+
+        $context_parts = array_filter(array_map('trim', gm2_get_seo_context()));
+        $context_block = '';
+        if ($context_parts) {
+            $pairs = [];
+            foreach ($context_parts as $k => $v) {
+                $pairs[] = ucfirst(str_replace('_', ' ', $k)) . ': ' . $v;
+            }
+            $context_block = 'Site context: ' . implode('; ', $pairs);
+        }
+
         $prompt  = '';
         if ($guidelines !== '') {
             $prompt .= "SEO guidelines:\n" . $guidelines . "\n\n";
@@ -2332,6 +2343,9 @@ class Gm2_SEO_Admin {
         $prompt .= "Page title: {$title}\nURL: {$url}\n";
         $prompt .= "Existing SEO Title: {$seo_title}\nSEO Description: {$seo_description}\n";
         $prompt .= "Focus Keywords: {$focus}\nCanonical: {$canonical}\n";
+        if ($context_block !== '') {
+            $prompt .= $context_block . "\n";
+        }
         if ($extra_context !== '') {
             $prompt .= "Extra context: {$extra_context}\n";
         }
@@ -2457,6 +2471,9 @@ class Gm2_SEO_Admin {
         if ($final_long) {
             $prompt2 .= "Long-tail Keywords: " . implode(', ', $final_long) . "\n";
         }
+        if ($context_block !== '') {
+            $prompt2 .= $context_block . "\n";
+        }
         if ($extra_context !== '') {
             $prompt2 .= "Extra context: {$extra_context}\n";
         }
@@ -2550,6 +2567,15 @@ class Gm2_SEO_Admin {
             '{taxonomy}'   => $taxonomy,
             '{guidelines}' => $guidelines,
         ]);
+
+        $context_parts = array_filter(array_map('trim', gm2_get_seo_context()));
+        if ($context_parts) {
+            $pairs = [];
+            foreach ($context_parts as $k => $v) {
+                $pairs[] = ucfirst(str_replace('_', ' ', $k)) . ': ' . $v;
+            }
+            $prompt .= "\nSite context: " . implode('; ', $pairs);
+        }
 
         $chat = new Gm2_ChatGPT();
         $resp = $chat->query($prompt);
@@ -2668,6 +2694,14 @@ class Gm2_SEO_Admin {
                         }
                     }
                     return null;
+                })(),
+                'context_exists' => (function(){
+                    foreach (gm2_get_seo_context() as $val) {
+                        if (trim($val) !== '') {
+                            return true;
+                        }
+                    }
+                    return false;
                 })(),
                 'i18n'     => [
                     'researching' => __( 'Researching...', 'gm2-wordpress-suite' ),
@@ -2793,6 +2827,14 @@ class Gm2_SEO_Admin {
                         }
                     }
                     return null;
+                })(),
+                'context_exists' => (function(){
+                    foreach (gm2_get_seo_context() as $val) {
+                        if (trim($val) !== '') {
+                            return true;
+                        }
+                    }
+                    return false;
                 })(),
                 'i18n'     => [
                     'researching' => __( 'Researching...', 'gm2-wordpress-suite' ),

--- a/admin/js/gm2-ai-seo.js
+++ b/admin/js/gm2-ai-seo.js
@@ -33,10 +33,13 @@ jQuery(function($){
         }
 
         if(!data.seo_title && !data.seo_description && !data.focus_keywords && !data.canonical){
-            var promptText = window.gm2AiSeo && gm2AiSeo.i18n ? gm2AiSeo.i18n.promptExtra : 'Describe the page or its target audience:';
-            var extra = prompt(promptText);
-            if(extra){
-                data.extra_context = extra;
+            var hasContext = window.gm2AiSeo && gm2AiSeo.context_exists;
+            if(!hasContext){
+                var promptText = window.gm2AiSeo && gm2AiSeo.i18n ? gm2AiSeo.i18n.promptExtra : 'Describe the page or its target audience:';
+                var extra = prompt(promptText);
+                if(extra){
+                    data.extra_context = extra;
+                }
             }
         }
         $.post((window.gm2AiSeo ? gm2AiSeo.ajax_url : ajaxurl), data)

--- a/readme.txt
+++ b/readme.txt
@@ -182,8 +182,9 @@ permalinks. Enter the words to remove in the accompanying field.
 == AI SEO ==
 While editing a post or taxonomy term, open the **AI SEO** tab in the SEO meta
 box. Click **AI Research** to run a two-step workflow. You'll first be asked
-whether to use any existing SEO field values. If all fields are empty, provide a
-short description so ChatGPT has extra context.
+whether to use any existing SEO field values. If all fields are empty and no
+site context is set under **SEO → Context**, you'll be prompted for a short
+description so ChatGPT has extra context.
 
 Step one sends the post content to ChatGPT which returns a title, description
 and a list of seed keywords. If no seed keywords are returned, the plugin


### PR DESCRIPTION
## Summary
- load SEO context via gm2_get_seo_context()
- append formatted context to AI prompts
- skip manual prompt if global context exists
- document new behaviour

## Testing
- `npm test`
- `phpunit` *(fails: missing WordPress test suite)*

------
https://chatgpt.com/codex/tasks/task_e_6876f279157083279088711b41d7f05a