### PR TITLE
Document SEO Context tab

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -3038,5 +3038,13 @@ class Gm2_SEO_Admin {
                 ) . '</p>',
             ]
         );
+
+        $screen->add_help_tab(
+            [
+                'id'      => 'gm2-seo-context',
+                'title'   => __( 'SEO Context', 'gm2-wordpress-suite' ),
+                'content' => '<p>' . __( 'Use the Context tab to describe your business model, industry, audience and unique selling points. Saved answers are automatically included in ChatGPT prompts for AI SEO.', 'gm2-wordpress-suite' ) . '</p>',
+            ]
+        );
     }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -160,6 +160,9 @@ Example JSON response:
 }
 ```
 
+== SEO Context ==
+Open the **Context** tab under **SEO** to store your business model, industry, target audience and unique selling points. These answers are automatically added to ChatGPT prompts so AI-generated titles, descriptions and keywords match your brand.
+
 == SEO Settings ==
 The SEO meta box appears when editing posts, pages, any public custom post types and taxonomy terms. In the
 **SEO Settings** tab you can enter a custom title and description, focus keywords and long tail keywords, toggle
@@ -180,11 +183,7 @@ Enable **Clean Slugs** from **SEO → General** to strip stopwords from new
 permalinks. Enter the words to remove in the accompanying field.
 
 == AI SEO ==
-While editing a post or taxonomy term, open the **AI SEO** tab in the SEO meta
-box. Click **AI Research** to run a two-step workflow. You'll first be asked
-whether to use any existing SEO field values. If all fields are empty and no
-site context is set under **SEO → Context**, you'll be prompted for a short
-description so ChatGPT has extra context.
+While editing a post or taxonomy term, open the **AI SEO** tab in the SEO meta box. Click **AI Research** to run a two-step workflow. You'll first be asked whether to use any existing SEO field values. If all fields are empty and no site context is set under **SEO → Context**, you'll be prompted for a short description so ChatGPT has extra context. Answers saved in the Context tab are automatically included in each prompt, so you only need to provide extra details when those fields are empty.
 
 Step one sends the post content to ChatGPT which returns a title, description
 and a list of seed keywords. If no seed keywords are returned, the plugin


### PR DESCRIPTION
## Summary
- document new SEO Context tab and how it feeds ChatGPT
- add admin help entry about SEO Context

## Testing
- `npm test`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_6876f4c442b88327b9ed5c8c4a9bd166