### PR TITLE
Fix crash when Elementor missing

### DIFF
--- a/includes/Gm2_Elementor_Quantity_Discounts.php
+++ b/includes/Gm2_Elementor_Quantity_Discounts.php
@@ -9,7 +9,11 @@ class Gm2_Elementor_Quantity_Discounts {
     }
 
     public function init() {
-        if (!class_exists('Elementor\\Plugin') || !class_exists('WooCommerce')) {
+        if (
+            ! class_exists('Elementor\\Plugin') ||
+            ! class_exists('WooCommerce') ||
+            ! class_exists('Elementor\\Widget_Base')
+        ) {
             return;
         }
         add_action('elementor/widgets/register', [ $this, 'register_widget' ]);
@@ -20,6 +24,7 @@ class Gm2_Elementor_Quantity_Discounts {
     }
 }
 
+if ( class_exists( '\\Elementor\\Widget_Base' ) ) {
 class GM2_QD_Widget extends \Elementor\Widget_Base {
     public function get_name() {
         return 'gm2_quantity_discounts';
@@ -106,4 +111,5 @@ class GM2_QD_Widget extends \Elementor\Widget_Base {
         }
         return [];
     }
+}
 }

--- a/includes/Gm2_Loader.php
+++ b/includes/Gm2_Loader.php
@@ -33,7 +33,7 @@ class Gm2_Loader {
         $seo_public = new Gm2_SEO_Public();
         $seo_public->run();
 
-        if (class_exists('Elementor\\Plugin')) {
+        if (class_exists('Elementor\\Plugin') && class_exists('Elementor\\Widget_Base')) {
             new Gm2_Elementor_SEO();
             new Gm2_Elementor_Quantity_Discounts();
         }


### PR DESCRIPTION
## Summary
- avoid instantiating Elementor integrations when Elementor widget base is missing
- guard elementor quantity discount widget behind class check

## Testing
- `php -l includes/Gm2_Elementor_Quantity_Discounts.php`
- `php -l includes/Gm2_Loader.php`
- `find . -name '*.php' -print0 | xargs -0 -I{} php -l {}`
- `make test` *(fails: Database credentials must be supplied via DB_NAME, DB_USER and DB_PASS)*

------
https://chatgpt.com/codex/tasks/task_e_6876f763e7748327a1afa73261e5b681