### PR TITLE
Add more SEO context fields

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -260,6 +260,18 @@ class Gm2_SEO_Admin {
         register_setting('gm2_seo_options', 'gm2_context_unique_selling_points', [
             'sanitize_callback' => 'sanitize_textarea_field',
         ]);
+        register_setting('gm2_seo_options', 'gm2_context_revenue_streams', [
+            'sanitize_callback' => 'sanitize_textarea_field',
+        ]);
+        register_setting('gm2_seo_options', 'gm2_context_primary_goal', [
+            'sanitize_callback' => 'sanitize_textarea_field',
+        ]);
+        register_setting('gm2_seo_options', 'gm2_context_brand_voice', [
+            'sanitize_callback' => 'sanitize_textarea_field',
+        ]);
+        register_setting('gm2_seo_options', 'gm2_context_competitors', [
+            'sanitize_callback' => 'sanitize_textarea_field',
+        ]);
         foreach ($this->get_supported_post_types() as $pt) {
             register_setting('gm2_seo_options', 'gm2_seo_guidelines_post_' . $pt, [
                 'sanitize_callback' => 'sanitize_textarea_field',
@@ -692,6 +704,10 @@ class Gm2_SEO_Admin {
                 'gm2_context_industry_category'     => [ 'label' => __( 'Industry Category', 'gm2-wordpress-suite' ), 'type' => 'text' ],
                 'gm2_context_target_audience'       => [ 'label' => __( 'Target Audience', 'gm2-wordpress-suite' ), 'type' => 'textarea' ],
                 'gm2_context_unique_selling_points' => [ 'label' => __( 'Unique Selling Points', 'gm2-wordpress-suite' ), 'type' => 'textarea' ],
+                'gm2_context_revenue_streams'       => [ 'label' => __( 'Revenue Streams', 'gm2-wordpress-suite' ), 'type' => 'textarea' ],
+                'gm2_context_primary_goal'          => [ 'label' => __( 'Primary Goal', 'gm2-wordpress-suite' ), 'type' => 'textarea' ],
+                'gm2_context_brand_voice'           => [ 'label' => __( 'Brand Voice', 'gm2-wordpress-suite' ), 'type' => 'textarea' ],
+                'gm2_context_competitors'           => [ 'label' => __( 'Competitors', 'gm2-wordpress-suite' ), 'type' => 'textarea' ],
             ];
             foreach ( $fields as $opt => $data ) {
                 $val = get_option( $opt, '' );
@@ -3043,7 +3059,7 @@ class Gm2_SEO_Admin {
             [
                 'id'      => 'gm2-seo-context',
                 'title'   => __( 'SEO Context', 'gm2-wordpress-suite' ),
-                'content' => '<p>' . __( 'Use the Context tab to describe your business model, industry, audience and unique selling points. Saved answers are automatically included in ChatGPT prompts for AI SEO.', 'gm2-wordpress-suite' ) . '</p>',
+                'content' => '<p>' . __( 'Use the Context tab to describe your business model, industry, audience, unique selling points and more. Saved answers are automatically included in ChatGPT prompts for AI SEO.', 'gm2-wordpress-suite' ) . '</p>',
             ]
         );
     }

--- a/includes/Gm2_SEO_Utils.php
+++ b/includes/Gm2_SEO_Utils.php
@@ -13,6 +13,10 @@ namespace {
             'industry_category'     => sanitize_text_field(get_option('gm2_context_industry_category', '')),
             'target_audience'       => sanitize_textarea_field(get_option('gm2_context_target_audience', '')),
             'unique_selling_points' => sanitize_textarea_field(get_option('gm2_context_unique_selling_points', '')),
+            'revenue_streams'       => sanitize_textarea_field(get_option('gm2_context_revenue_streams', '')),
+            'primary_goal'          => sanitize_textarea_field(get_option('gm2_context_primary_goal', '')),
+            'brand_voice'           => sanitize_textarea_field(get_option('gm2_context_brand_voice', '')),
+            'competitors'           => sanitize_textarea_field(get_option('gm2_context_competitors', '')),
         ];
         /**
          * Filter the assembled SEO context options.

--- a/readme.txt
+++ b/readme.txt
@@ -169,7 +169,7 @@ Example JSON response:
 ```
 
 == SEO Context ==
-Open the **Context** tab under **SEO** to store your business model, industry, target audience and unique selling points. These answers are automatically added to ChatGPT prompts so AI-generated titles, descriptions and keywords match your brand.
+Open the **Context** tab under **SEO** to store your business model, industry, audience, revenue streams, primary goal, brand voice and more. These answers are automatically added to ChatGPT prompts so AI-generated titles, descriptions and keywords match your brand.
 
 == SEO Settings ==
 The SEO meta box appears when editing posts, pages, any public custom post types and taxonomy terms. In the

--- a/tests/test-seo-context.php
+++ b/tests/test-seo-context.php
@@ -5,6 +5,10 @@ class SeoContextHelperTest extends WP_UnitTestCase {
         delete_option('gm2_context_industry_category');
         delete_option('gm2_context_target_audience');
         delete_option('gm2_context_unique_selling_points');
+        delete_option('gm2_context_revenue_streams');
+        delete_option('gm2_context_primary_goal');
+        delete_option('gm2_context_brand_voice');
+        delete_option('gm2_context_competitors');
         remove_all_filters('gm2_seo_context');
         parent::tearDown();
     }
@@ -14,6 +18,10 @@ class SeoContextHelperTest extends WP_UnitTestCase {
         update_option('gm2_context_industry_category', ' <i>Tech</i> ');
         update_option('gm2_context_target_audience', "Audience <script>bad()</script>");
         update_option('gm2_context_unique_selling_points', 'USP <span>great</span>');
+        update_option('gm2_context_revenue_streams', 'Ads <b>Subscriptions</b>');
+        update_option('gm2_context_primary_goal', '<i>Increase sales</i>');
+        update_option('gm2_context_brand_voice', 'Friendly <script>alert(1)</script>');
+        update_option('gm2_context_competitors', 'Comp <span>A</span>, CompB');
 
         $filtered = null;
         add_filter('gm2_seo_context', function($context) use (&$filtered) {
@@ -29,10 +37,18 @@ class SeoContextHelperTest extends WP_UnitTestCase {
         $this->assertSame(sanitize_text_field(' <i>Tech</i> '), $filtered['industry_category']);
         $this->assertSame(sanitize_textarea_field("Audience <script>bad()</script>"), $filtered['target_audience']);
         $this->assertSame(sanitize_textarea_field('USP <span>great</span>'), $filtered['unique_selling_points']);
+        $this->assertSame(sanitize_textarea_field('Ads <b>Subscriptions</b>'), $filtered['revenue_streams']);
+        $this->assertSame(sanitize_textarea_field('<i>Increase sales</i>'), $filtered['primary_goal']);
+        $this->assertSame(sanitize_textarea_field('Friendly <script>alert(1)</script>'), $filtered['brand_voice']);
+        $this->assertSame(sanitize_textarea_field('Comp <span>A</span>, CompB'), $filtered['competitors']);
 
         $this->assertSame('filtered', $context['industry_category']);
         $this->assertSame($filtered['business_model'], $context['business_model']);
         $this->assertSame($filtered['target_audience'], $context['target_audience']);
         $this->assertSame($filtered['unique_selling_points'], $context['unique_selling_points']);
+        $this->assertSame($filtered['revenue_streams'], $context['revenue_streams']);
+        $this->assertSame($filtered['primary_goal'], $context['primary_goal']);
+        $this->assertSame($filtered['brand_voice'], $context['brand_voice']);
+        $this->assertSame($filtered['competitors'], $context['competitors']);
     }
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -82,6 +82,10 @@ $option_names = array(
     'gm2_context_industry_category',
     'gm2_context_target_audience',
     'gm2_context_unique_selling_points',
+    'gm2_context_revenue_streams',
+    'gm2_context_primary_goal',
+    'gm2_context_brand_voice',
+    'gm2_context_competitors',
     'gm2_sc_query_limit',
     'gm2_analytics_days',
 );


### PR DESCRIPTION
## Summary
- expand SEO context settings with new fields
- display additional fields in Context tab
- include new options in helper
- remove new options on uninstall
- document extra Context items in readme

## Testing
- `make test DB_NAME=wp_test DB_USER=root DB_PASS=pass` *(fails: mysqladmin command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877a718df288327976e068c22db64c4