### PR TITLE
Store selected rule meta in WooCommerce orders

### DIFF
--- a/public/Gm2_Quantity_Discounts_Public.php
+++ b/public/Gm2_Quantity_Discounts_Public.php
@@ -10,6 +10,15 @@ class Gm2_Quantity_Discounts_Public {
         add_action('woocommerce_before_calculate_totals', [ $this, 'adjust_prices' ], 20);
         add_filter('woocommerce_add_cart_item_data', [ $this, 'add_cart_item_data' ], 10, 4);
         add_action('woocommerce_checkout_create_order_line_item', [ $this, 'add_order_item_meta' ], 10, 4);
+        add_filter('woocommerce_display_item_meta', [ $this, 'display_item_meta' ], 10, 3);
+        add_filter('woocommerce_email_order_item_meta', [ $this, 'display_item_meta' ], 10, 3);
+    }
+
+    private function format_rule_desc($rule) {
+        if ($rule['type'] === 'percent') {
+            return sprintf('%d+ units: %s%% off', $rule['min'], $rule['amount']);
+        }
+        return sprintf('%d+ units: %s discount', $rule['min'], wc_price($rule['amount']));
     }
 
     private function get_applicable_rule($product_id, $qty) {
@@ -44,7 +53,8 @@ class Gm2_Quantity_Discounts_Public {
     public function add_cart_item_data($cart_item_data, $product_id, $variation_id, $quantity) {
         $rule = $this->get_applicable_rule($product_id, $quantity);
         if ($rule) {
-            $cart_item_data['gm2_qd_rule'] = $rule;
+            $cart_item_data['gm2_qd_rule']      = $rule;
+            $cart_item_data['gm2_qd_rule_desc'] = $this->format_rule_desc($rule);
             $product = wc_get_product($product_id);
             if ($product) {
                 $cart_item_data['gm2_qd_original_price'] = (float) $product->get_price('edit');
@@ -108,26 +118,40 @@ class Gm2_Quantity_Discounts_Public {
                 $product->set_price($new_price);
                 $cart->cart_contents[$key]['data'] = $product;
                 $cart->cart_contents[$key]['gm2_qd_rule']            = $applied;
+                $cart->cart_contents[$key]['gm2_qd_rule_desc']       = $this->format_rule_desc($applied);
                 $cart->cart_contents[$key]['gm2_qd_discounted_price'] = $new_price;
             } else {
-                unset($cart->cart_contents[$key]['gm2_qd_rule'], $cart->cart_contents[$key]['gm2_qd_discounted_price']);
+                unset($cart->cart_contents[$key]['gm2_qd_rule'], $cart->cart_contents[$key]['gm2_qd_rule_desc'], $cart->cart_contents[$key]['gm2_qd_discounted_price']);
             }
         }
     }
 
     public function add_order_item_meta($item, $cart_item_key, $values, $order) {
-        if (isset($values['gm2_qd_rule'])) {
-            $rule = $values['gm2_qd_rule'];
-            if ($rule['type'] === 'percent') {
-                $desc = sprintf('%d+ units: %s%% off', $rule['min'], $rule['amount']);
-            } else {
-                $desc = sprintf('%d+ units: %s discount', $rule['min'], wc_price($rule['amount']));
-            }
+        if (isset($values['gm2_qd_rule_desc'])) {
+            $desc = $values['gm2_qd_rule_desc'];
             $item->add_meta_data(__('Quantity Discount Rule', 'gm2-wordpress-suite'), $desc, true);
+        } elseif (isset($values['gm2_qd_rule'])) {
+            $item->add_meta_data(
+                __('Quantity Discount Rule', 'gm2-wordpress-suite'),
+                $this->format_rule_desc($values['gm2_qd_rule']),
+                true
+            );
         }
         $item->add_meta_data(__('Purchased Quantity', 'gm2-wordpress-suite'), $item->get_quantity(), true);
         if (isset($values['gm2_qd_discounted_price'])) {
             $item->add_meta_data(__('Discounted Price', 'gm2-wordpress-suite'), wc_price($values['gm2_qd_discounted_price']), true);
         }
+    }
+
+    public function display_item_meta($html, $item, $args) {
+        $qty   = $item->get_meta(__('Purchased Quantity', 'gm2-wordpress-suite'), true);
+        $price = $item->get_meta(__('Discounted Price', 'gm2-wordpress-suite'), true);
+        if ($qty) {
+            $html .= '<br><small>' . sprintf(__('Purchased Quantity: %s', 'gm2-wordpress-suite'), esc_html($qty)) . '</small>';
+        }
+        if ($price) {
+            $html .= '<br><small>' . sprintf(__('Discounted Price: %s', 'gm2-wordpress-suite'), wp_kses_post($price)) . '</small>';
+        }
+        return $html;
     }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -239,6 +239,8 @@ WooCommerce products. Define rules with minimum quantities and either percentage
 or fixed discounts. Discounts are applied automatically in the cart.
 When Elementor is active, use the **GM2 Quantity Options** widget on product
 pages to display buttons that preselect quantities before adding to the cart.
+Each selected rule, the purchased quantity and the discounted price are stored
+in the order item meta and shown in emails and the admin order screen.
 
 == Redirects ==
 Create 301 or 302 redirects from the **SEO → Redirects** tab. The plugin logs


### PR DESCRIPTION
## Summary
- store quantity rule description when adding to cart
- show purchased quantity and discounted price in order meta
- explain order item data in readme

## Testing
- `npm test`
- `phpunit` *(fails: Error establishing a database connection)*

------
https://chatgpt.com/codex/tasks/task_e_6877a74879688327b15943e3b7ec8da8