### PR TITLE
Add new AI SEO options and context fields

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -272,6 +272,15 @@ class Gm2_SEO_Admin {
         register_setting('gm2_seo_options', 'gm2_context_competitors', [
             'sanitize_callback' => 'sanitize_textarea_field',
         ]);
+        register_setting('gm2_seo_options', 'gm2_context_project_description', [
+            'sanitize_callback' => 'sanitize_textarea_field',
+        ]);
+        register_setting('gm2_seo_options', 'gm2_context_custom_prompts', [
+            'sanitize_callback' => 'sanitize_textarea_field',
+        ]);
+        register_setting('gm2_seo_options', 'gm2_project_description', [
+            'sanitize_callback' => 'sanitize_textarea_field',
+        ]);
         foreach ($this->get_supported_post_types() as $pt) {
             register_setting('gm2_seo_options', 'gm2_seo_guidelines_post_' . $pt, [
                 'sanitize_callback' => 'sanitize_textarea_field',
@@ -708,6 +717,8 @@ class Gm2_SEO_Admin {
                 'gm2_context_primary_goal'          => [ 'label' => __( 'Primary Goal', 'gm2-wordpress-suite' ), 'type' => 'textarea' ],
                 'gm2_context_brand_voice'           => [ 'label' => __( 'Brand Voice', 'gm2-wordpress-suite' ), 'type' => 'textarea' ],
                 'gm2_context_competitors'           => [ 'label' => __( 'Competitors', 'gm2-wordpress-suite' ), 'type' => 'textarea' ],
+                'gm2_context_project_description'   => [ 'label' => __( 'Project Description', 'gm2-wordpress-suite' ), 'type' => 'textarea' ],
+                'gm2_context_custom_prompts'        => [ 'label' => __( 'Custom Prompts', 'gm2-wordpress-suite' ), 'type' => 'textarea' ],
             ];
             foreach ( $fields as $opt => $data ) {
                 $val = get_option( $opt, '' );
@@ -1070,6 +1081,10 @@ class Gm2_SEO_Admin {
         $canonical           = '';
         $focus_keywords      = '';
         $long_tail_keywords  = '';
+        $search_intent       = '';
+        $focus_limit         = '';
+        $number_of_words     = '';
+        $improve_readability = '1';
         $max_snippet         = '';
         $max_image_preview   = '';
         $max_video_preview   = '';
@@ -1083,6 +1098,10 @@ class Gm2_SEO_Admin {
             $canonical        = get_term_meta($term->term_id, '_gm2_canonical', true);
             $focus_keywords   = get_term_meta($term->term_id, '_gm2_focus_keywords', true);
             $long_tail_keywords = get_term_meta($term->term_id, '_gm2_long_tail_keywords', true);
+            $search_intent    = get_term_meta($term->term_id, '_gm2_search_intent', true);
+            $focus_limit      = get_term_meta($term->term_id, '_gm2_focus_keyword_limit', true);
+            $number_of_words  = get_term_meta($term->term_id, '_gm2_number_of_words', true);
+            $improve_readability = get_term_meta($term->term_id, '_gm2_improve_readability', true);
             $max_snippet      = get_term_meta($term->term_id, '_gm2_max_snippet', true);
             $max_image_preview = get_term_meta($term->term_id, '_gm2_max_image_preview', true);
             $max_video_preview = get_term_meta($term->term_id, '_gm2_max_video_preview', true);
@@ -1140,6 +1159,24 @@ class Gm2_SEO_Admin {
         echo '<input type="text" id="gm2_focus_keywords" name="gm2_focus_keywords" value="' . esc_attr($focus_keywords) . '" class="widefat" /></p>';
         echo '<p><label for="gm2_long_tail_keywords">' . esc_html__( 'Long Tail Keywords (comma separated)', 'gm2-wordpress-suite' ) . '</label>';
         echo '<input type="text" id="gm2_long_tail_keywords" name="gm2_long_tail_keywords" value="' . esc_attr($long_tail_keywords) . '" class="widefat" /></p>';
+        $search_intent = get_post_meta($post->ID, '_gm2_search_intent', true);
+        $focus_limit   = get_post_meta($post->ID, '_gm2_focus_keyword_limit', true);
+        $number_of_words = get_post_meta($post->ID, '_gm2_number_of_words', true);
+        $improve_readability = get_post_meta($post->ID, '_gm2_improve_readability', true);
+        echo '<p><label for="gm2_search_intent">' . esc_html__( 'Search Intent', 'gm2-wordpress-suite' ) . '</label>';
+        echo '<input type="text" id="gm2_search_intent" name="gm2_search_intent" value="' . esc_attr($search_intent) . '" class="widefat" /></p>';
+        echo '<p><label for="gm2_focus_keyword_limit">' . esc_html__( 'Focus Keyword Limit', 'gm2-wordpress-suite' ) . '</label>';
+        echo '<input type="number" id="gm2_focus_keyword_limit" name="gm2_focus_keyword_limit" value="' . esc_attr($focus_limit) . '" class="small-text" min="1" /></p>';
+        echo '<p><label for="gm2_number_of_words">' . esc_html__( 'Number of Words', 'gm2-wordpress-suite' ) . '</label>';
+        echo '<input type="number" id="gm2_number_of_words" name="gm2_number_of_words" value="' . esc_attr($number_of_words) . '" class="small-text" min="0" /></p>';
+        echo '<p><label><input type="checkbox" id="gm2_improve_readability" name="gm2_improve_readability" value="1" ' . checked($improve_readability, '1', false) . '> ' . esc_html__( 'Improve Readability', 'gm2-wordpress-suite' ) . '</label></p>';
+        echo '<p><label for="gm2_search_intent">' . esc_html__( 'Search Intent', 'gm2-wordpress-suite' ) . '</label>';
+        echo '<input type="text" id="gm2_search_intent" name="gm2_search_intent" value="' . esc_attr($search_intent) . '" class="widefat" /></p>';
+        echo '<p><label for="gm2_focus_keyword_limit">' . esc_html__( 'Focus Keyword Limit', 'gm2-wordpress-suite' ) . '</label>';
+        echo '<input type="number" id="gm2_focus_keyword_limit" name="gm2_focus_keyword_limit" value="' . esc_attr($focus_limit) . '" class="small-text" min="1" /></p>';
+        echo '<p><label for="gm2_number_of_words">' . esc_html__( 'Number of Words', 'gm2-wordpress-suite' ) . '</label>';
+        echo '<input type="number" id="gm2_number_of_words" name="gm2_number_of_words" value="' . esc_attr($number_of_words) . '" class="small-text" min="0" /></p>';
+        echo '<p><label><input type="checkbox" id="gm2_improve_readability" name="gm2_improve_readability" value="1" ' . checked($improve_readability, '1', false) . '> ' . esc_html__( 'Improve Readability', 'gm2-wordpress-suite' ) . '</label></p>';
         echo '<p><label><input type="checkbox" name="gm2_noindex" value="1" ' . checked($noindex, '1', false) . '> ' . esc_html__( 'noindex', 'gm2-wordpress-suite' ) . '</label></p>';
         echo '<p><label><input type="checkbox" name="gm2_nofollow" value="1" ' . checked($nofollow, '1', false) . '> ' . esc_html__( 'nofollow', 'gm2-wordpress-suite' ) . '</label></p>';
         echo '<p><label for="gm2_canonical_url">' . esc_html__( 'Canonical URL', 'gm2-wordpress-suite' ) . '</label>';
@@ -1220,6 +1257,10 @@ class Gm2_SEO_Admin {
         $canonical      = isset($_POST['gm2_canonical_url']) ? esc_url_raw($_POST['gm2_canonical_url']) : '';
         $focus_keywords   = isset($_POST['gm2_focus_keywords']) ? sanitize_text_field($_POST['gm2_focus_keywords']) : '';
         $long_tail_keywords = isset($_POST['gm2_long_tail_keywords']) ? sanitize_text_field($_POST['gm2_long_tail_keywords']) : '';
+        $search_intent    = isset($_POST['gm2_search_intent']) ? sanitize_text_field($_POST['gm2_search_intent']) : '';
+        $focus_limit      = isset($_POST['gm2_focus_keyword_limit']) ? absint($_POST['gm2_focus_keyword_limit']) : 0;
+        $number_of_words  = isset($_POST['gm2_number_of_words']) ? absint($_POST['gm2_number_of_words']) : 0;
+        $improve_readability = isset($_POST['gm2_improve_readability']) ? '1' : '0';
         $max_snippet      = isset($_POST['gm2_max_snippet']) ? sanitize_text_field($_POST['gm2_max_snippet']) : '';
         $max_image_preview = isset($_POST['gm2_max_image_preview']) ? sanitize_text_field($_POST['gm2_max_image_preview']) : '';
         $max_video_preview = isset($_POST['gm2_max_video_preview']) ? sanitize_text_field($_POST['gm2_max_video_preview']) : '';
@@ -1235,6 +1276,10 @@ class Gm2_SEO_Admin {
         update_post_meta($post_id, '_gm2_canonical', $canonical);
         update_post_meta($post_id, '_gm2_focus_keywords', $focus_keywords);
         update_post_meta($post_id, '_gm2_long_tail_keywords', $long_tail_keywords);
+        update_post_meta($post_id, '_gm2_search_intent', $search_intent);
+        update_post_meta($post_id, '_gm2_focus_keyword_limit', $focus_limit);
+        update_post_meta($post_id, '_gm2_number_of_words', $number_of_words);
+        update_post_meta($post_id, '_gm2_improve_readability', $improve_readability);
         update_post_meta($post_id, '_gm2_max_snippet', $max_snippet);
         update_post_meta($post_id, '_gm2_max_image_preview', $max_image_preview);
         update_post_meta($post_id, '_gm2_max_video_preview', $max_video_preview);
@@ -1256,6 +1301,10 @@ class Gm2_SEO_Admin {
         $canonical      = isset($_POST['gm2_canonical_url']) ? esc_url_raw($_POST['gm2_canonical_url']) : '';
         $focus_keywords   = isset($_POST['gm2_focus_keywords']) ? sanitize_text_field($_POST['gm2_focus_keywords']) : '';
         $long_tail_keywords = isset($_POST['gm2_long_tail_keywords']) ? sanitize_text_field($_POST['gm2_long_tail_keywords']) : '';
+        $search_intent    = isset($_POST['gm2_search_intent']) ? sanitize_text_field($_POST['gm2_search_intent']) : '';
+        $focus_limit      = isset($_POST['gm2_focus_keyword_limit']) ? absint($_POST['gm2_focus_keyword_limit']) : 0;
+        $number_of_words  = isset($_POST['gm2_number_of_words']) ? absint($_POST['gm2_number_of_words']) : 0;
+        $improve_readability = isset($_POST['gm2_improve_readability']) ? '1' : '0';
         $max_snippet      = isset($_POST['gm2_max_snippet']) ? sanitize_text_field($_POST['gm2_max_snippet']) : '';
         $max_image_preview = isset($_POST['gm2_max_image_preview']) ? sanitize_text_field($_POST['gm2_max_image_preview']) : '';
         $max_video_preview = isset($_POST['gm2_max_video_preview']) ? sanitize_text_field($_POST['gm2_max_video_preview']) : '';
@@ -1267,6 +1316,10 @@ class Gm2_SEO_Admin {
         update_term_meta($term_id, '_gm2_canonical', $canonical);
         update_term_meta($term_id, '_gm2_focus_keywords', $focus_keywords);
         update_term_meta($term_id, '_gm2_long_tail_keywords', $long_tail_keywords);
+        update_term_meta($term_id, '_gm2_search_intent', $search_intent);
+        update_term_meta($term_id, '_gm2_focus_keyword_limit', $focus_limit);
+        update_term_meta($term_id, '_gm2_number_of_words', $number_of_words);
+        update_term_meta($term_id, '_gm2_improve_readability', $improve_readability);
         update_term_meta($term_id, '_gm2_max_snippet', $max_snippet);
         update_term_meta($term_id, '_gm2_max_image_preview', $max_image_preview);
         update_term_meta($term_id, '_gm2_max_video_preview', $max_video_preview);
@@ -2907,6 +2960,10 @@ class Gm2_SEO_Admin {
         $canonical      = get_post_meta($post->ID, '_gm2_canonical', true);
         $focus_keywords      = get_post_meta($post->ID, '_gm2_focus_keywords', true);
         $long_tail_keywords  = get_post_meta($post->ID, '_gm2_long_tail_keywords', true);
+        $search_intent       = get_post_meta($post->ID, '_gm2_search_intent', true);
+        $focus_limit         = get_post_meta($post->ID, '_gm2_focus_keyword_limit', true);
+        $number_of_words     = get_post_meta($post->ID, '_gm2_number_of_words', true);
+        $improve_readability = get_post_meta($post->ID, '_gm2_improve_readability', true);
         $max_snippet         = get_post_meta($post->ID, '_gm2_max_snippet', true);
         $max_image_preview   = get_post_meta($post->ID, '_gm2_max_image_preview', true);
         $max_video_preview   = get_post_meta($post->ID, '_gm2_max_video_preview', true);

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,9 @@
+# Gm2 WordPress Suite Updates
+
+This release adds several new SEO and AI options:
+
+- **Project Description** and **Custom Prompts** fields under **SEO → Context**. The project description falls back to the site tagline or a snippet of post content if empty.
+- Additional meta fields on post and taxonomy edit screens for Search Intent, Focus Keyword Limit, Number of Words and an "Improve Readability" checkbox.
+- New helper functions `gm2_get_project_description()` and `gm2_ai_send_prompt()` supporting custom language models (`gpt-3.5-turbo` or `gpt-4`) and temperature settings.
+
+Existing prompt logic automatically includes these options via `gm2_get_seo_context()`.

--- a/includes/Gm2_SEO_Utils.php
+++ b/includes/Gm2_SEO_Utils.php
@@ -17,7 +17,13 @@ namespace {
             'primary_goal'          => sanitize_textarea_field(get_option('gm2_context_primary_goal', '')),
             'brand_voice'           => sanitize_textarea_field(get_option('gm2_context_brand_voice', '')),
             'competitors'           => sanitize_textarea_field(get_option('gm2_context_competitors', '')),
+            'project_description'   => sanitize_textarea_field(get_option('gm2_context_project_description', '')),
+            'custom_prompts'        => sanitize_textarea_field(get_option('gm2_context_custom_prompts', '')),
         ];
+
+        if ($context['project_description'] === '') {
+            $context['project_description'] = gm2_get_project_description();
+        }
         /**
          * Filter the assembled SEO context options.
          *
@@ -25,5 +31,72 @@ namespace {
          */
         $context = apply_filters('gm2_seo_context', $context);
         return $context;
+    }
+
+    function gm2_get_project_description() {
+        $desc = sanitize_textarea_field(get_option('gm2_project_description', ''));
+        if ($desc === '') {
+            $desc = sanitize_textarea_field(get_bloginfo('description'));
+        }
+        if ($desc === '' && isset($GLOBALS['post']) && $GLOBALS['post'] instanceof \WP_Post) {
+            $clean = wp_strip_all_tags($GLOBALS['post']->post_content);
+            $desc  = substr($clean, 0, 160);
+        }
+        return $desc;
+    }
+
+    function gm2_ai_send_prompt($prompt, $args = []) {
+        $defaults = [
+            'language-model' => 'gpt-3.5-turbo',
+            'temperature'    => 1.0,
+            'number-of-words'=> 0,
+        ];
+        $args = wp_parse_args($args, $defaults);
+
+        $api_key = get_option('gm2_chatgpt_api_key', '');
+        if ($api_key === '') {
+            return new \WP_Error('no_api_key', 'ChatGPT API key not set');
+        }
+        $model = in_array($args['language-model'], ['gpt-3.5-turbo', 'gpt-4'], true) ? $args['language-model'] : 'gpt-3.5-turbo';
+        $temperature = floatval($args['temperature']);
+
+        $payload = [
+            'model'       => $model,
+            'messages'    => [ [ 'role' => 'user', 'content' => $prompt ] ],
+            'temperature' => $temperature,
+        ];
+        if ($args['number-of-words']) {
+            $payload['max_tokens'] = intval($args['number-of-words']);
+        }
+
+        $endpoint = get_option('gm2_chatgpt_endpoint', 'https://api.openai.com/v1/chat/completions');
+        $http_args = [
+            'headers' => [
+                'Authorization' => 'Bearer ' . $api_key,
+                'Content-Type'  => 'application/json',
+            ],
+            'body'    => wp_json_encode($payload),
+            'timeout' => 20,
+        ];
+
+        $response = wp_remote_post($endpoint, $http_args);
+
+        if (is_wp_error($response)) {
+            return $response;
+        }
+
+        $status = wp_remote_retrieve_response_code($response);
+        $body   = wp_remote_retrieve_body($response);
+        if ($status !== 200) {
+            $data    = json_decode($body, true);
+            $message = $data['error']['message'] ?? 'Non-200 response';
+            return new \WP_Error('api_error', $message);
+        }
+
+        if ($body === '') {
+            return '';
+        }
+        $data = json_decode($body, true);
+        return $data['choices'][0]['message']['content'] ?? '';
     }
 }

--- a/tests/test-seo-context.php
+++ b/tests/test-seo-context.php
@@ -9,6 +9,9 @@ class SeoContextHelperTest extends WP_UnitTestCase {
         delete_option('gm2_context_primary_goal');
         delete_option('gm2_context_brand_voice');
         delete_option('gm2_context_competitors');
+        delete_option('gm2_context_project_description');
+        delete_option('gm2_context_custom_prompts');
+        delete_option('gm2_project_description');
         remove_all_filters('gm2_seo_context');
         parent::tearDown();
     }
@@ -22,6 +25,8 @@ class SeoContextHelperTest extends WP_UnitTestCase {
         update_option('gm2_context_primary_goal', '<i>Increase sales</i>');
         update_option('gm2_context_brand_voice', 'Friendly <script>alert(1)</script>');
         update_option('gm2_context_competitors', 'Comp <span>A</span>, CompB');
+        update_option('gm2_context_project_description', '<b>Desc</b>');
+        update_option('gm2_context_custom_prompts', 'Prompt');
 
         $filtered = null;
         add_filter('gm2_seo_context', function($context) use (&$filtered) {
@@ -41,6 +46,8 @@ class SeoContextHelperTest extends WP_UnitTestCase {
         $this->assertSame(sanitize_textarea_field('<i>Increase sales</i>'), $filtered['primary_goal']);
         $this->assertSame(sanitize_textarea_field('Friendly <script>alert(1)</script>'), $filtered['brand_voice']);
         $this->assertSame(sanitize_textarea_field('Comp <span>A</span>, CompB'), $filtered['competitors']);
+        $this->assertSame(sanitize_textarea_field('<b>Desc</b>'), $filtered['project_description']);
+        $this->assertSame(sanitize_textarea_field('Prompt'), $filtered['custom_prompts']);
 
         $this->assertSame('filtered', $context['industry_category']);
         $this->assertSame($filtered['business_model'], $context['business_model']);
@@ -50,5 +57,7 @@ class SeoContextHelperTest extends WP_UnitTestCase {
         $this->assertSame($filtered['primary_goal'], $context['primary_goal']);
         $this->assertSame($filtered['brand_voice'], $context['brand_voice']);
         $this->assertSame($filtered['competitors'], $context['competitors']);
+        $this->assertSame($filtered['project_description'], $context['project_description']);
+        $this->assertSame($filtered['custom_prompts'], $context['custom_prompts']);
     }
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -86,6 +86,9 @@ $option_names = array(
     'gm2_context_primary_goal',
     'gm2_context_brand_voice',
     'gm2_context_competitors',
+    'gm2_context_project_description',
+    'gm2_context_custom_prompts',
+    'gm2_project_description',
     'gm2_sc_query_limit',
     'gm2_analytics_days',
 );


### PR DESCRIPTION
## Summary
- support project description fallback and custom prompts
- expose search intent, focus limit, number of words and readability fields
- implement `gm2_ai_send_prompt` with model and temperature options
- document the updates

## Testing
- `npm install`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `make test` *(fails: Database credentials must be supplied)*

------
https://chatgpt.com/codex/tasks/task_e_6877af586af883279c68a25a63f9df4d