### PR TITLE
Fix menu registration order

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -14,8 +14,8 @@ class Gm2_Admin {
         $this->diagnostics = new Gm2_Diagnostics();
         $this->diagnostics->run();
         $this->quantity_discounts = new Gm2_Quantity_Discounts_Admin();
-        $this->quantity_discounts->register_hooks();
         add_action('admin_menu', [$this, 'add_admin_menu']);
+        $this->quantity_discounts->register_hooks();
         add_action('admin_enqueue_scripts', [$this, 'enqueue_admin_scripts']);
         add_action('wp_ajax_gm2_add_tariff', [$this, 'ajax_add_tariff']);
         add_action('wp_ajax_nopriv_gm2_add_tariff', [$this, 'ajax_add_tariff']);


### PR DESCRIPTION
## Summary
- ensure main admin menu registers before submenus

## Testing
- `npm test`
- `phpunit` *(fails: missing WordPress test suite)*

------
https://chatgpt.com/codex/tasks/task_e_6877b35d685c83278cd9a3b2278e08e0