### PR TITLE
Add accordion for quantity discounts

### DIFF
--- a/admin/Gm2_Quantity_Discounts_Admin.php
+++ b/admin/Gm2_Quantity_Discounts_Admin.php
@@ -27,6 +27,12 @@ class Gm2_Quantity_Discounts_Admin {
         if ( $hook !== 'gm2_page_gm2-quantity-discounts' ) {
             return;
         }
+        wp_enqueue_style(
+            'gm2-quantity-discounts',
+            GM2_PLUGIN_URL . 'admin/css/gm2-quantity-discounts.css',
+            [],
+            GM2_VERSION
+        );
         wp_enqueue_script(
             'gm2-quantity-discounts',
             GM2_PLUGIN_URL . 'admin/js/gm2-quantity-discounts.js',

--- a/admin/css/gm2-quantity-discounts.css
+++ b/admin/css/gm2-quantity-discounts.css
@@ -1,0 +1,15 @@
+.gm2-qd-header {
+    background:#f1f1f1;
+    border:1px solid #ccc;
+    padding:6px 10px;
+    cursor:pointer;
+}
+.gm2-qd-accordion .gm2-qd-group {
+    border:1px solid #ccc;
+    border-top:0;
+    padding:10px;
+    display:none;
+}
+.gm2-qd-accordion.open .gm2-qd-group {
+    display:block;
+}

--- a/admin/js/gm2-quantity-discounts.js
+++ b/admin/js/gm2-quantity-discounts.js
@@ -12,8 +12,11 @@ jQuery(function($){
     }
     function createGroup(g){
         g = g || {name:'',products:[],rules:[]};
+        var accordion = $('<div class="gm2-qd-accordion open"></div>');
+        var header = $('<div class="gm2-qd-header"></div>');
+        header.append('<input type="text" class="gm2-qd-name" placeholder="Group name" value="'+(g.name||'')+'"> <button type="button" class="button gm2-qd-remove-group">&times;</button>');
+        accordion.append(header);
         var container = $('<div class="gm2-qd-group"></div>');
-        container.append('<h2><input type="text" class="gm2-qd-name" placeholder="Group name" value="'+(g.name||'')+'"> <button type="button" class="button gm2-qd-remove-group">&times;</button></h2>');
         var prodSection = $('<div class="gm2-qd-products"><select class="gm2-qd-cat"><option value="">All Categories</option></select> <input type="text" class="gm2-qd-search" placeholder="Search products"> <ul class="gm2-qd-results"></ul><ul class="gm2-qd-selected"></ul></div>');
         categories.forEach(function(c){prodSection.find('select').append('<option value="'+c.id+'">'+c.name+'</option>');});
         container.append(prodSection);
@@ -24,7 +27,8 @@ jQuery(function($){
         g.products.forEach(function(id){
             addSelectedProduct(container, {id:id,text:id});
         });
-        return container;
+        accordion.append(container);
+        return accordion;
     }
     function addSelectedProduct(group, item){
         var ul = group.find('.gm2-qd-selected');
@@ -40,7 +44,13 @@ jQuery(function($){
         $('#gm2-qd-groups').append(createGroup());
     });
     $(document).on('click','.gm2-qd-remove-group',function(){
-        $(this).closest('.gm2-qd-group').remove();
+        $(this).closest('.gm2-qd-accordion').remove();
+    });
+    $(document).on('click','.gm2-qd-header',function(e){
+        if($(e.target).closest('button').length) return;
+        var acc=$(this).closest('.gm2-qd-accordion');
+        acc.toggleClass('open');
+        acc.find('> .gm2-qd-group').toggle();
     });
     $(document).on('click','.gm2-qd-add-rule',function(){
         var group=$(this).closest('.gm2-qd-group');
@@ -69,8 +79,9 @@ jQuery(function($){
     $('#gm2-qd-form').on('submit',function(e){
         e.preventDefault();
         var data=[];
-        $('#gm2-qd-groups .gm2-qd-group').each(function(){
-            var g=$(this);var obj={name:g.find('.gm2-qd-name').val(),products:[],rules:[]};
+        $('#gm2-qd-groups .gm2-qd-accordion').each(function(){
+            var acc=$(this);var g=acc.find('> .gm2-qd-group');
+            var obj={name:acc.find('.gm2-qd-name').val(),products:[],rules:[]};
             g.find('.gm2-qd-selected li').each(function(){obj.products.push($(this).data('id'));});
             g.find('.gm2-qd-rules tbody tr').each(function(){
                 var min=parseInt($(this).find('.gm2-qd-min').val(),10)||0;

--- a/tests/js/gm2-quantity-discounts.test.js
+++ b/tests/js/gm2-quantity-discounts.test.js
@@ -18,6 +18,7 @@ test('renders groups from gm2Qd', async () => {
   await new Promise(r => setTimeout(r, 0));
 
   expect($('.gm2-qd-name').val()).toBe('Group A');
+  expect($('.gm2-qd-accordion').length).toBe(1);
 });
 
 test('submits group data via ajax', async () => {
@@ -51,4 +52,32 @@ test('submits group data via ajax', async () => {
   const data = $.post.mock.calls[0][1].groups[0];
   expect(data.name).toBe('Test');
   expect(data.rules[0]).toEqual({ min: 2, type: 'percent', amount: 10 });
+});
+
+test('accordion toggles visibility', async () => {
+  const dom = new JSDOM(`
+    <form id="gm2-qd-form">
+      <div id="gm2-qd-groups"></div>
+    </form>
+  `, { url: 'http://localhost' });
+  const $ = jquery(dom.window);
+  Object.assign(global, { window: dom.window, document: dom.window.document, jQuery: $, $ });
+  global.gm2Qd = { nonce: 'n', ajax_url: '/fake', groups: [{ name: 'A', products: [], rules: [] }], categories: [] };
+
+  jest.resetModules();
+  require('../../admin/js/gm2-quantity-discounts.js');
+  await new Promise(r => setTimeout(r, 0));
+  await new Promise(r => setTimeout(r, 0));
+
+  const accordion = $('.gm2-qd-accordion');
+  const body = accordion.find('.gm2-qd-group');
+  expect(body.css('display')).not.toBe('none');
+
+  accordion.find('.gm2-qd-header').trigger('click');
+  await new Promise(r => setTimeout(r, 0));
+  expect(body.css('display')).toBe('none');
+
+  accordion.find('.gm2-qd-header').trigger('click');
+  await new Promise(r => setTimeout(r, 0));
+  expect(body.css('display')).not.toBe('none');
 });


### PR DESCRIPTION
## Summary
- wrap quantity discount groups in accordion containers
- add JS toggle logic for groups
- style accordion sections
- enqueue quantity discount styles
- verify accordion behavior in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877bc0524988327b88f5298345ac577