### PR TITLE
Rename Elementor widget for quantity discounts

### DIFF
--- a/includes/Gm2_Elementor_Quantity_Discounts.php
+++ b/includes/Gm2_Elementor_Quantity_Discounts.php
@@ -30,7 +30,7 @@ class GM2_QD_Widget extends \Elementor\Widget_Base {
         return 'gm2_quantity_discounts';
     }
     public function get_title() {
-        return __( 'GM2 Quantity Options', 'gm2-wordpress-suite' );
+        return __( 'Gm2 Qnty Discounts', 'gm2-wordpress-suite' );
     }
     public function get_icon() {
         return 'eicon-cart-medium';

--- a/readme.txt
+++ b/readme.txt
@@ -37,7 +37,7 @@ Key features include:
    **SEO → Connect Google Account** page after connecting, or enter them
    manually on the SEO settings screen if needed.
 8. Activate WooCommerce to enable Quantity Discounts.
-9. Install and activate Elementor to use the Quantity Options widget on product pages.
+9. Install and activate Elementor to use the Gm2 Qnty Discounts widget on product pages.
 10. Open **Gm2 → Quantity Discounts** and create discount groups to define pricing rules.
 
 If you plan to distribute or manually upload the plugin, you can create a ZIP
@@ -245,7 +245,7 @@ add or edit tariffs. Enabled tariffs add a fee to the cart total during
 checkout.
 
 == Quantity Discounts ==
-After activating WooCommerce, open **Gm2 → Quantity Discounts** and click **Add Discount Group** to define bulk pricing rules. Choose the products or categories to apply, enter the minimum quantity and specify either a percentage or fixed discount. When customers meet the threshold the discount is applied automatically in the cart. Install Elementor to add the **GM2 Quantity Options** widget on product pages, giving shoppers buttons for preset quantities that match your rules. The selected rule and discounted price are saved in order item meta and appear in emails and on the admin order screen.
+After activating WooCommerce, open **Gm2 → Quantity Discounts** and click **Add Discount Group** to define bulk pricing rules. Choose the products or categories to apply, enter the minimum quantity and specify either a percentage or fixed discount. When customers meet the threshold the discount is applied automatically in the cart. Install Elementor to add the **Gm2 Qnty Discounts** widget on product pages, giving shoppers buttons for preset quantities that match your rules. The selected rule and discounted price are saved in order item meta and appear in emails and on the admin order screen.
 
 == Redirects ==
 Create 301 or 302 redirects from the **SEO → Redirects** tab. The plugin logs


### PR DESCRIPTION
## Summary
- rename the quantity discounts widget shown in Elementor to `Gm2 Qnty Discounts`
- update documentation to reference the new widget name

## Testing
- `npm test`
- `phpunit` *(fails: missing WordPress test library)*

------
https://chatgpt.com/codex/tasks/task_e_6877c59197bc8327949d2526924bf64d