### PR TITLE
Update SEO context docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,7 @@ This release adds several new SEO and AI options:
 
 - **Project Description** and **Custom Prompts** fields under **SEO → Context**. The project description falls back to the site tagline or a snippet of post content if empty.
 - Each context field now includes a guiding question so users know what to enter.
+- Additional context fields: **Core Offerings**, **Geographic Focus**, **Keyword Data**, **Competitor Landscape**, **Success Metrics** and **Buyer Personas**.
 - Additional meta fields on post and taxonomy edit screens for Search Intent, Focus Keyword Limit, Number of Words and an "Improve Readability" checkbox.
 - New helper functions `gm2_get_project_description()` and `gm2_ai_send_prompt()` supporting custom language models (`gpt-3.5-turbo` or `gpt-4`) and temperature settings.
 

--- a/readme.txt
+++ b/readme.txt
@@ -181,6 +181,14 @@ Open the **Context** tab under **SEO** to store detailed business information us
 * **Primary Goal** – What is the website's main objective and which KPIs indicate success?
 * **Brand Voice** – Describe the desired style or tone (professional, casual, luxury, authoritative, playful, eco-friendly, etc.).
 * **Competitors** – List main online competitors and what makes your offer stronger or unique.
+* **Core Offerings** – What are the key products or services you provide?
+* **Geographic Focus** – Which regions or locations do you primarily target?
+* **Keyword Data** – Do you have existing keyword research or rankings to share?
+* **Competitor Landscape** – How would you describe the competitive landscape in your niche?
+* **Success Metrics** – How will you measure SEO success (sales, leads, traffic, rankings)?
+* **Buyer Personas** – Describe your ideal buyers and their pain points.
+* **Project Description** – Short summary of your project or website. Used when other fields are empty.
+* **Custom Prompts** – Default instructions appended to AI requests.
 
 == SEO Settings ==
 The SEO meta box appears when editing posts, pages, any public custom post types and taxonomy terms. In the


### PR DESCRIPTION
## Summary
- document additional SEO context fields
- list new fields briefly in the docs

## Testing
- `npm test`
- `phpunit` *(fails: WordPress test suite missing)*

------
https://chatgpt.com/codex/tasks/task_e_6877c8f1aa1c8327bdb5ae1a43c57a33