### PR TITLE
Clarify quantity discount widget location

### DIFF
--- a/includes/Gm2_Elementor_Quantity_Discounts.php
+++ b/includes/Gm2_Elementor_Quantity_Discounts.php
@@ -5,7 +5,9 @@ if (!defined('ABSPATH')) { exit; }
 
 class Gm2_Elementor_Quantity_Discounts {
     public function __construct() {
-        add_action('init', [ $this, 'init' ]);
+        // Register the widget after Elementor initializes so the
+        // `elementor/widgets/register` hook is available.
+        add_action('elementor/init', [ $this, 'init' ]);
     }
 
     public function init() {
@@ -30,13 +32,15 @@ class GM2_QD_Widget extends \Elementor\Widget_Base {
         return 'gm2_quantity_discounts';
     }
     public function get_title() {
-        return __( 'GM2 Quantity Options', 'gm2-wordpress-suite' );
+        return __( 'Gm2 Qnty Discounts', 'gm2-wordpress-suite' );
     }
     public function get_icon() {
         return 'eicon-cart-medium';
     }
     public function get_categories() {
-        return [ 'general' ];
+        // Show the widget with other WooCommerce elements so
+        // it's easier to find when building product templates.
+        return [ 'woocommerce' ];
     }
 
     protected function register_controls() {

--- a/readme.txt
+++ b/readme.txt
@@ -37,7 +37,7 @@ Key features include:
    **SEO → Connect Google Account** page after connecting, or enter them
    manually on the SEO settings screen if needed.
 8. Activate WooCommerce to enable Quantity Discounts.
-9. Install and activate Elementor to use the Quantity Options widget on product pages.
+9. Install and activate Elementor to use the Gm2 Qnty Discounts widget on product pages. The widget appears under the **WooCommerce** section when editing Single Product templates in Elementor.
 10. Open **Gm2 → Quantity Discounts** and create discount groups to define pricing rules.
 
 If you plan to distribute or manually upload the plugin, you can create a ZIP
@@ -245,7 +245,7 @@ add or edit tariffs. Enabled tariffs add a fee to the cart total during
 checkout.
 
 == Quantity Discounts ==
-After activating WooCommerce, open **Gm2 → Quantity Discounts** and click **Add Discount Group** to define bulk pricing rules. Choose the products or categories to apply, enter the minimum quantity and specify either a percentage or fixed discount. When customers meet the threshold the discount is applied automatically in the cart. Install Elementor to add the **GM2 Quantity Options** widget on product pages, giving shoppers buttons for preset quantities that match your rules. The selected rule and discounted price are saved in order item meta and appear in emails and on the admin order screen.
+After activating WooCommerce, open **Gm2 → Quantity Discounts** and click **Add Discount Group** to define bulk pricing rules. Choose the products or categories to apply, enter the minimum quantity and specify either a percentage or fixed discount. When customers meet the threshold the discount is applied automatically in the cart. Install Elementor to add the **Gm2 Qnty Discounts** widget on product pages, giving shoppers buttons for preset quantities that match your rules. The widget resides in the **WooCommerce** section. The selected rule and discounted price are saved in order item meta and appear in emails and on the admin order screen.
 
 == Redirects ==
 Create 301 or 302 redirects from the **SEO → Redirects** tab. The plugin logs


### PR DESCRIPTION
## Summary
- place quantity discount widget under the WooCommerce category
- update installation docs about widget location in Elementor

## Testing
- `npm test` *(fails: jest not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877c59197bc8327949d2526924bf64d