### PR TITLE
Refactor quantity discounts widget loading

### DIFF
--- a/includes/Gm2_Elementor_Quantity_Discounts.php
+++ b/includes/Gm2_Elementor_Quantity_Discounts.php
@@ -19,101 +19,16 @@ class Gm2_Elementor_Quantity_Discounts {
             return;
         }
         add_action('elementor/widgets/register', [ $this, 'register_widget' ]);
+        add_action('elementor/widgets/widgets_registered', [ $this, 'register_widget' ]);
     }
 
     public function register_widget( $widgets_manager ) {
-        $widgets_manager->register( new GM2_QD_Widget() );
-    }
-}
+        require_once GM2_PLUGIN_DIR . 'includes/widgets/class-gm2-qd-widget.php';
 
-if ( class_exists( '\\Elementor\\Widget_Base' ) ) {
-class GM2_QD_Widget extends \Elementor\Widget_Base {
-    public function get_name() {
-        return 'gm2_quantity_discounts';
-    }
-    public function get_title() {
-        return __( 'Gm2 Qnty Discounts', 'gm2-wordpress-suite' );
-    }
-    public function get_icon() {
-        return 'eicon-cart-medium';
-    }
-    public function get_categories() {
-        // Show the widget with other WooCommerce elements so
-        // it's easier to find when building product templates.
-        return [ 'woocommerce' ];
-    }
-
-    protected function register_controls() {
-        $this->start_controls_section(
-            'gm2_qd_style',
-            [
-                'label' => __( 'Options Style', 'gm2-wordpress-suite' ),
-                'tab'   => \Elementor\Controls_Manager::TAB_STYLE,
-            ]
-        );
-        $this->add_control(
-            'text_color',
-            [
-                'label' => __( 'Text Color', 'gm2-wordpress-suite' ),
-                'type'  => \Elementor\Controls_Manager::COLOR,
-                'selectors' => [
-                    '{{WRAPPER}} .gm2-qd-option' => 'color: {{VALUE}};',
-                ],
-            ]
-        );
-        $this->add_control(
-            'bg_color',
-            [
-                'label' => __( 'Background', 'gm2-wordpress-suite' ),
-                'type'  => \Elementor\Controls_Manager::COLOR,
-                'selectors' => [
-                    '{{WRAPPER}} .gm2-qd-option' => 'background-color: {{VALUE}};',
-                ],
-            ]
-        );
-        $this->add_control(
-            'font_size',
-            [
-                'label' => __( 'Font Size', 'gm2-wordpress-suite' ),
-                'type'  => \Elementor\Controls_Manager::NUMBER,
-                'selectors' => [
-                    '{{WRAPPER}} .gm2-qd-option' => 'font-size: {{VALUE}}px;',
-                ],
-            ]
-        );
-        $this->end_controls_section();
-    }
-
-    protected function render() {
-        if ( ! function_exists( 'is_product' ) || ! is_product() ) {
-            return;
+        if ( method_exists( $widgets_manager, 'register' ) ) {
+            $widgets_manager->register( new GM2_QD_Widget() );
+        } else {
+            $widgets_manager->register_widget_type( new GM2_QD_Widget() );
         }
-        global $product;
-        if ( ! $product ) {
-            return;
-        }
-        $rules = $this->get_rules( $product->get_id() );
-        if ( empty( $rules ) ) {
-            return;
-        }
-        echo '<div class="gm2-qd-options">';
-        foreach ( $rules as $rule ) {
-            $qty   = intval( $rule['min'] );
-            $label = sprintf( __( 'Qty: %d', 'gm2-wordpress-suite' ), $qty );
-            echo '<button type="button" class="gm2-qd-option" data-qty="' . esc_attr( $qty ) . '">' . esc_html( $label ) . '</button>';
-        }
-        echo '</div>';
     }
-
-    private function get_rules( $product_id ) {
-        $m = new Gm2_Quantity_Discount_Manager();
-        $groups = $m->get_groups();
-        foreach ( $groups as $g ) {
-            if ( ! empty( $g['products'] ) && in_array( $product_id, $g['products'], true ) ) {
-                return $g['rules'] ?? [];
-            }
-        }
-        return [];
-    }
-}
 }

--- a/includes/widgets/class-gm2-qd-widget.php
+++ b/includes/widgets/class-gm2-qd-widget.php
@@ -1,0 +1,96 @@
+<?php
+namespace Gm2;
+
+if (!defined('ABSPATH')) { exit; }
+
+if ( class_exists( '\\Elementor\\Widget_Base' ) ) {
+class GM2_QD_Widget extends \Elementor\Widget_Base {
+    public function get_name() {
+        return 'gm2_quantity_discounts';
+    }
+    public function get_title() {
+        return __( 'Gm2 Qnty Discounts', 'gm2-wordpress-suite' );
+    }
+    public function get_icon() {
+        return 'eicon-cart-medium';
+    }
+    public function get_categories() {
+        // Show the widget with other WooCommerce elements so
+        // it's easier to find when building product templates.
+        return [ 'woocommerce' ];
+    }
+
+    protected function register_controls() {
+        $this->start_controls_section(
+            'gm2_qd_style',
+            [
+                'label' => __( 'Options Style', 'gm2-wordpress-suite' ),
+                'tab'   => \Elementor\Controls_Manager::TAB_STYLE,
+            ]
+        );
+        $this->add_control(
+            'text_color',
+            [
+                'label' => __( 'Text Color', 'gm2-wordpress-suite' ),
+                'type'  => \Elementor\Controls_Manager::COLOR,
+                'selectors' => [
+                    '{{WRAPPER}} .gm2-qd-option' => 'color: {{VALUE}};',
+                ],
+            ]
+        );
+        $this->add_control(
+            'bg_color',
+            [
+                'label' => __( 'Background', 'gm2-wordpress-suite' ),
+                'type'  => \Elementor\Controls_Manager::COLOR,
+                'selectors' => [
+                    '{{WRAPPER}} .gm2-qd-option' => 'background-color: {{VALUE}};',
+                ],
+            ]
+        );
+        $this->add_control(
+            'font_size',
+            [
+                'label' => __( 'Font Size', 'gm2-wordpress-suite' ),
+                'type'  => \Elementor\Controls_Manager::NUMBER,
+                'selectors' => [
+                    '{{WRAPPER}} .gm2-qd-option' => 'font-size: {{VALUE}}px;',
+                ],
+            ]
+        );
+        $this->end_controls_section();
+    }
+
+    protected function render() {
+        if ( ! function_exists( 'is_product' ) || ! is_product() ) {
+            return;
+        }
+        global $product;
+        if ( ! $product ) {
+            return;
+        }
+        $rules = $this->get_rules( $product->get_id() );
+        if ( empty( $rules ) ) {
+            return;
+        }
+        echo '<div class="gm2-qd-options">';
+        foreach ( $rules as $rule ) {
+            $qty   = intval( $rule['min'] );
+            $label = sprintf( __( 'Qty: %d', 'gm2-wordpress-suite' ), $qty );
+            echo '<button type="button" class="gm2-qd-option" data-qty="' . esc_attr( $qty ) . '\">' . esc_html( $label ) . '</button>';
+        }
+        echo '</div>';
+    }
+
+    private function get_rules( $product_id ) {
+        $m = new Gm2_Quantity_Discount_Manager();
+        $groups = $m->get_groups();
+        foreach ( $groups as $g ) {
+            if ( ! empty( $g['products'] ) && in_array( $product_id, $g['products'], true ) ) {
+                return $g['rules'] ?? [];
+            }
+        }
+        return [];
+    }
+}
+}


### PR DESCRIPTION
## Summary
- move `GM2_QD_Widget` class to `includes/widgets/class-gm2-qd-widget.php`
- load new file from `register_widget()`
- support older Elementor versions

## Testing
- `make test` *(fails: Database credentials must be supplied)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6877cf7d6d708327a500caa1639157ba