### PR TITLE
Fix Elementor widget registration method

### DIFF
--- a/includes/Gm2_Elementor_Quantity_Discounts.php
+++ b/includes/Gm2_Elementor_Quantity_Discounts.php
@@ -26,8 +26,11 @@ class Gm2_Elementor_Quantity_Discounts {
         require_once GM2_PLUGIN_DIR . 'includes/widgets/class-gm2-qd-widget.php';
 
         if ( method_exists( $widgets_manager, 'register' ) ) {
+            // Elementor 3.5+ exposes a `register()` method on the
+            // widgets manager.
             $widgets_manager->register( new GM2_QD_Widget() );
-        } else {
+        } elseif ( method_exists( $widgets_manager, 'register_widget_type' ) ) {
+            // Older versions use `register_widget_type()` instead.
             $widgets_manager->register_widget_type( new GM2_QD_Widget() );
         }
     }

--- a/readme.txt
+++ b/readme.txt
@@ -37,7 +37,7 @@ Key features include:
    **SEO → Connect Google Account** page after connecting, or enter them
    manually on the SEO settings screen if needed.
 8. Activate WooCommerce to enable Quantity Discounts.
-9. Install and activate Elementor to use the Gm2 Qnty Discounts widget on product pages. The widget appears under the **WooCommerce** section when editing Single Product templates in Elementor.
+9. Install and activate Elementor **3.5** or later to use the Gm2 Qnty Discounts widget on product pages. The widget appears under the **WooCommerce** section when editing Single Product templates in Elementor.
 10. Open **Gm2 → Quantity Discounts** and create discount groups to define pricing rules.
 
 If you plan to distribute or manually upload the plugin, you can create a ZIP


### PR DESCRIPTION
## Summary
- update widget registration to handle both Elementor APIs
- note minimum Elementor version in readme

## Testing
- `npm install`
- `make test` *(fails: mysqladmin command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877d18755388327b6dd39409ab5385d