### PR TITLE
Update readme with Elementor Pro requirements

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -37,10 +37,10 @@ Key features include:
    **SEO → Connect Google Account** page after connecting, or enter them
    manually on the SEO settings screen if needed.
 8. Activate WooCommerce to enable Quantity Discounts.
-9. Install and activate Elementor **3.5** or later to use the Gm2 Qnty Discounts widget on product pages. The widget appears under the **WooCommerce** section when editing Single Product templates in Elementor.
+9. Install and activate Elementor **3.5** or later and ensure Elementor Pro is active. WooCommerce and Elementor Pro must be active for the **Gm2 Qnty Discounts** widget to appear under the **WooCommerce** category when editing Single Product templates in Elementor.
 10. Open **Gm2 → Quantity Discounts** and create discount groups to define pricing rules.
 
-**Note:** WooCommerce must be active and Elementor 3.5+ is recommended. Older versions are supported with a fallback.
+**Note:** WooCommerce and Elementor Pro must be active. Elementor 3.5+ is recommended and older versions are supported with a fallback.
 
 If you plan to distribute or manually upload the plugin, you can create a ZIP
 archive with `bash bin/build-plugin.sh`. This command packages the plugin with
@@ -255,9 +255,9 @@ add or edit tariffs. Enabled tariffs add a fee to the cart total during
 checkout.
 
 == Quantity Discounts ==
-After activating WooCommerce, open **Gm2 → Quantity Discounts** and click **Add Discount Group** to define bulk pricing rules. Choose the products or categories to apply, enter the minimum quantity and specify either a percentage or fixed discount. When customers meet the threshold the discount is applied automatically in the cart. Install Elementor to add the **Gm2 Qnty Discounts** widget on product pages, giving shoppers buttons for preset quantities that match your rules. The widget resides in the **WooCommerce** section. The selected rule and discounted price are saved in order item meta and appear in emails and on the admin order screen.
+After activating WooCommerce, open **Gm2 → Quantity Discounts** and click **Add Discount Group** to define bulk pricing rules. Choose the products or categories to apply, enter the minimum quantity and specify either a percentage or fixed discount. When customers meet the threshold the discount is applied automatically in the cart. Install Elementor to add the **Gm2 Qnty Discounts** widget on product pages, giving shoppers buttons for preset quantities that match your rules. WooCommerce and Elementor Pro must be active for the widget to appear under the **WooCommerce** category when editing Single Product templates. The selected rule and discounted price are saved in order item meta and appear in emails and on the admin order screen.
 
-**Note:** WooCommerce must be active and Elementor 3.5+ is recommended. Older versions are supported with a fallback.
+**Note:** WooCommerce and Elementor Pro must be active. Elementor 3.5+ is recommended and older versions are supported with a fallback.
 
 == Redirects ==
 Create 301 or 302 redirects from the **SEO → Redirects** tab. The plugin logs


### PR DESCRIPTION
## Summary
- clarify Elementor Pro requirement in installation notes
- note that WooCommerce and Elementor Pro must both be active for the Gm2 Qnty Discounts widget

## Testing
- `npm test`
- `phpunit` *(fails: WordPress test suite missing)*

------
https://chatgpt.com/codex/tasks/task_e_6877dc8d522c832784cfefe839a37da3