### PR TITLE
Fix Elementor load handling

### DIFF
--- a/includes/Gm2_Loader.php
+++ b/includes/Gm2_Loader.php
@@ -33,9 +33,14 @@ class Gm2_Loader {
         $seo_public = new Gm2_SEO_Public();
         $seo_public->run();
 
-        if (class_exists('Elementor\\Plugin') && class_exists('Elementor\\Widget_Base')) {
+        if (did_action('elementor/loaded')) {
             new Gm2_Elementor_SEO();
             new Gm2_Elementor_Quantity_Discounts();
+        } else {
+            add_action('elementor/loaded', function () {
+                new Gm2_Elementor_SEO();
+                new Gm2_Elementor_Quantity_Discounts();
+            });
         }
     }
 }


### PR DESCRIPTION
## Summary
- load Elementor integration after Elementor is initialized

## Testing
- `phpunit` *(fails: WordPress test suite missing)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877e871e8608327b340aaa272fffa67