### PR TITLE
Update quantity discount icon size

### DIFF
--- a/admin/css/gm2-quantity-discounts.css
+++ b/admin/css/gm2-quantity-discounts.css
@@ -10,6 +10,7 @@
     top:6px;
     right:6px;
     font-weight:bold;
+    font-size:20px;
 }
 .gm2-qd-accordion .gm2-qd-group {
     border:1px solid #ccc;


### PR DESCRIPTION
## Summary
- enlarge the quantity discount header toggle icon

## Testing
- `npm test`
- `phpunit` *(fails: missing WordPress test suite)*

------
https://chatgpt.com/codex/tasks/task_e_6877ed0ba5f08327918290bccb7f6ecb