### PR TITLE
Display product SKUs in quantity discounts

### DIFF
--- a/admin/Gm2_Quantity_Discounts_Admin.php
+++ b/admin/Gm2_Quantity_Discounts_Admin.php
@@ -42,6 +42,22 @@ class Gm2_Quantity_Discounts_Admin {
             true
         );
         $groups = get_option( 'gm2_quantity_discount_groups', [] );
+        foreach ( $groups as &$g ) {
+            if ( empty( $g['products'] ) || ! is_array( $g['products'] ) ) {
+                $g['products'] = [];
+                continue;
+            }
+            $info = [];
+            foreach ( $g['products'] as $pid ) {
+                $info[] = [
+                    'id'    => (int) $pid,
+                    'title' => get_the_title( $pid ),
+                    'sku'   => get_post_meta( $pid, '_sku', true ),
+                ];
+            }
+            $g['products'] = $info;
+        }
+        unset( $g );
         $cats   = [];
         if ( taxonomy_exists( 'product_cat' ) ) {
             $terms = get_terms( [
@@ -98,8 +114,10 @@ class Gm2_Quantity_Discounts_Admin {
         $result = [];
         foreach ( $q->posts as $p ) {
             $result[] = [
-                'id'   => $p->ID,
-                'text' => $p->post_title,
+                'id'    => $p->ID,
+                'text'  => $p->post_title,
+                'title' => $p->post_title,
+                'sku'   => get_post_meta( $p->ID, '_sku', true ),
             ];
         }
         wp_send_json_success( $result );
@@ -129,7 +147,12 @@ class Gm2_Quantity_Discounts_Admin {
         $q      = new \WP_Query( $args );
         $result = [];
         foreach ( $q->posts as $p ) {
-            $result[] = [ 'id' => $p->ID, 'text' => $p->post_title ];
+            $result[] = [
+                'id'    => $p->ID,
+                'text'  => $p->post_title,
+                'title' => $p->post_title,
+                'sku'   => get_post_meta( $p->ID, '_sku', true ),
+            ];
         }
         wp_send_json_success( $result );
     }

--- a/admin/js/gm2-quantity-discounts.js
+++ b/admin/js/gm2-quantity-discounts.js
@@ -1,6 +1,11 @@
 jQuery(function($){
     var groups = gm2Qd.groups || [];
     var categories = gm2Qd.categories || [];
+    function labelFor(item){
+        var l = item.title || item.text || item.id;
+        if(item.sku){ l += ' ('+item.sku+')'; }
+        return l;
+    }
     function createRuleRow(rule){
         rule = rule || {min:'',type:'percent',amount:''};
         var row = $('<tr class="gm2-qd-rule">\
@@ -24,8 +29,9 @@ jQuery(function($){
         g.rules.forEach(function(r){table.find('tbody').append(createRuleRow(r));});
         container.append(table);
         container.append('<p><button type="button" class="button gm2-qd-add-rule">Add Rule</button></p>');
-        g.products.forEach(function(id){
-            addSelectedProduct(container, {id:id,text:id});
+        g.products.forEach(function(p){
+            if(typeof p!=='object'){p={id:p};}
+            addSelectedProduct(container, p);
         });
         accordion.append(container);
         return accordion;
@@ -33,7 +39,7 @@ jQuery(function($){
     function addSelectedProduct(group, item){
         var ul = group.find('.gm2-qd-selected');
         if( ul.find('li[data-id="'+item.id+'"]').length ) return;
-        ul.append('<li data-id="'+item.id+'"><label><input type="checkbox" class="gm2-qd-selected-chk"> '+item.text+' <span class="remove">x</span></label></li>');
+        ul.append('<li data-id="'+item.id+'"><label><input type="checkbox" class="gm2-qd-selected-chk"> '+labelFor(item)+' <span class="remove">x</span></label></li>');
     }
 
     function loadCategoryProducts(group, cat){
@@ -45,7 +51,7 @@ jQuery(function($){
             box.append(html);
             var list = box.find('.gm2-qd-checkboxes');
             res.data.forEach(function(p){
-                var li = $('<li><label><input type="checkbox" class="gm2-qd-product-chk" value="'+p.id+'"> '+p.text+'</label></li>');
+                var li = $('<li><label><input type="checkbox" class="gm2-qd-product-chk" value="'+p.id+'" data-title="'+p.title+'" data-sku="'+p.sku+'"> '+labelFor(p)+'</label></li>');
                 if(group.find('.gm2-qd-selected li[data-id="'+p.id+'"]').length){
                     li.find('input').prop('checked',true);
                 }
@@ -92,8 +98,7 @@ jQuery(function($){
         var group=$(this).closest('.gm2-qd-group');
         group.find('.gm2-qd-product-chk:checked').each(function(){
             var id=$(this).val();
-            var name=$(this).closest('label').text().trim();
-            addSelectedProduct(group,{id:id,text:name});
+            addSelectedProduct(group,{id:id,title:$(this).data('title'),sku:$(this).data('sku')});
         });
     });
     function searchProducts(group){
@@ -102,7 +107,7 @@ jQuery(function($){
         if(term.length<2){group.find('.gm2-qd-results').empty();return;}
         $.get(gm2Qd.ajax_url,{action:'gm2_qd_search_products',nonce:gm2Qd.nonce,term:term,category:cat}).done(function(res){
             var ul=group.find('.gm2-qd-results').empty();
-            if(res.success){res.data.forEach(function(i){ul.append('<li data-id="'+i.id+'">'+i.text+'</li>');});}
+            if(res.success){res.data.forEach(function(i){ul.append('<li data-id="'+i.id+'" data-title="'+i.title+'" data-sku="'+i.sku+'">'+labelFor(i)+'</li>');});}
         });
     }
     $(document).on('click','.gm2-qd-search-btn',function(){
@@ -111,7 +116,7 @@ jQuery(function($){
     });
     $(document).on('click','.gm2-qd-results li',function(){
         var group=$(this).closest('.gm2-qd-group');
-        addSelectedProduct(group,{id:$(this).data('id'),text:$(this).text()});
+        addSelectedProduct(group,{id:$(this).data('id'),title:$(this).data('title'),sku:$(this).data('sku')});
     });
     $(document).on('click','.gm2-qd-remove-selected',function(){
         var group=$(this).closest('.gm2-qd-products');

--- a/tests/js/gm2-quantity-discounts.test.js
+++ b/tests/js/gm2-quantity-discounts.test.js
@@ -10,7 +10,7 @@ test('renders groups from gm2Qd', async () => {
   `, { url: 'http://localhost' });
   const $ = jquery(dom.window);
   Object.assign(global, { window: dom.window, document: dom.window.document, jQuery: $, $ });
-  global.gm2Qd = { nonce: 'n', ajax_url: '/fake', groups: [{ name: 'Group A', products: [], rules: [] }], categories: [] };
+  global.gm2Qd = { nonce: 'n', ajax_url: '/fake', groups: [{ name: 'Group A', products: [{ id: 1, title: 'Prod', sku: 'P1' }], rules: [] }], categories: [] };
 
   jest.resetModules();
   require('../../admin/js/gm2-quantity-discounts.js');
@@ -19,6 +19,9 @@ test('renders groups from gm2Qd', async () => {
 
   expect($('.gm2-qd-name').val()).toBe('Group A');
   expect($('.gm2-qd-accordion').length).toBe(1);
+  const text = $('.gm2-qd-selected li').text();
+  expect(text).toContain('Prod');
+  expect(text).toContain('P1');
 });
 
 test('submits group data via ajax', async () => {
@@ -44,6 +47,7 @@ test('submits group data via ajax', async () => {
   $('.gm2-qd-name').val('Test');
   $('.gm2-qd-min').val('2');
   $('.gm2-qd-percent').val('10');
+  $('.gm2-qd-selected').append('<li data-id="55"><label><input type="checkbox" class="gm2-qd-selected-chk"> Prod</label></li>');
 
   $('#gm2-qd-form').trigger('submit');
   await new Promise(r => setTimeout(r, 0));
@@ -51,6 +55,7 @@ test('submits group data via ajax', async () => {
   expect($.post).toHaveBeenCalled();
   const data = $.post.mock.calls[0][1].groups[0];
   expect(data.name).toBe('Test');
+  expect(data.products[0]).toBe(55);
   expect(data.rules[0]).toEqual({ min: 2, type: 'percent', amount: 10 });
 });
 

--- a/tests/test-quantity-discounts-admin.php
+++ b/tests/test-quantity-discounts-admin.php
@@ -13,6 +13,9 @@ class QuantityDiscountsAdminAjaxTest extends WP_Ajax_UnitTestCase {
         $p1 = self::factory()->post->create(['post_type' => 'product', 'post_title' => 'One']);
         $p2 = self::factory()->post->create(['post_type' => 'product', 'post_title' => 'Two']);
         $p3 = self::factory()->post->create(['post_type' => 'product', 'post_title' => 'Three']);
+        update_post_meta($p1, '_sku', 'S1');
+        update_post_meta($p2, '_sku', 'S2');
+        update_post_meta($p3, '_sku', 'S3');
         wp_set_object_terms($p1, [$cat], 'product_cat');
         wp_set_object_terms($p2, [$cat], 'product_cat');
 
@@ -25,9 +28,28 @@ class QuantityDiscountsAdminAjaxTest extends WP_Ajax_UnitTestCase {
         try { $this->_handleAjax('gm2_qd_get_category_products'); } catch (WPAjaxDieContinueException $e) {}
         $resp = json_decode($this->_last_response, true);
         $this->assertTrue($resp['success']);
+        foreach ($resp['data'] as $item) {
+            $this->assertArrayHasKey('sku', $item);
+        }
         $ids = array_map(function($i){return $i['id'];}, $resp['data']);
         $this->assertContains($p1, $ids);
         $this->assertContains($p2, $ids);
         $this->assertNotContains($p3, $ids);
+    }
+
+    public function test_search_products_returns_sku() {
+        $p = self::factory()->post->create(['post_type' => 'product', 'post_title' => 'Find']);
+        update_post_meta($p, '_sku', 'FSKU');
+
+        $admin = new Gm2_Quantity_Discounts_Admin();
+        $admin->register_hooks();
+
+        $this->_setRole('administrator');
+        $_GET['term'] = 'Fi';
+        $_GET['nonce'] = wp_create_nonce('gm2_qd_nonce');
+        try { $this->_handleAjax('gm2_qd_search_products'); } catch (WPAjaxDieContinueException $e) {}
+        $resp = json_decode($this->_last_response, true);
+        $this->assertTrue($resp['success']);
+        $this->assertSame('FSKU', $resp['data'][0]['sku']);
     }
 }


### PR DESCRIPTION
## Summary
- include product titles and SKUs when localizing saved discount groups
- show title and SKU for search and category results
- carry SKU information in JS selected lists
- return SKU from product search and category AJAX endpoints
- adjust Jest and PHPUnit tests for SKU fields

## Testing
- `npm test`
- `phpunit` *(fails: missing WordPress test suite)*

------
https://chatgpt.com/codex/tasks/task_e_6877ee630b348327a2e49ff8a57945a1