### PR TITLE
Fix menu registration order

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -14,7 +14,7 @@ class Gm2_Admin {
         $this->diagnostics = new Gm2_Diagnostics();
         $this->diagnostics->run();
         $this->quantity_discounts = new Gm2_Quantity_Discounts_Admin();
-        add_action('admin_menu', [$this, 'add_admin_menu']);
+        add_action('admin_menu', [$this, 'add_admin_menu'], 9);
         $this->quantity_discounts->register_hooks();
         add_action('admin_enqueue_scripts', [$this, 'enqueue_admin_scripts']);
         add_action('wp_ajax_gm2_add_tariff', [$this, 'ajax_add_tariff']);


### PR DESCRIPTION
## Summary
- ensure the main admin menu registers before submenus by setting a lower priority

## Testing
- `npm test`
- `vendor/bin/phpunit` *(fails: missing WordPress test library)*

------
https://chatgpt.com/codex/tasks/task_e_6877f191e5408327a65a924e3b8c3ccc