### PR TITLE
Add label field to quantity discount rules

### DIFF
--- a/admin/Gm2_Quantity_Discounts_Admin.php
+++ b/admin/Gm2_Quantity_Discounts_Admin.php
@@ -45,17 +45,25 @@ class Gm2_Quantity_Discounts_Admin {
         foreach ( $groups as &$g ) {
             if ( empty( $g['products'] ) || ! is_array( $g['products'] ) ) {
                 $g['products'] = [];
-                continue;
+            } else {
+                $info = [];
+                foreach ( $g['products'] as $pid ) {
+                    $info[] = [
+                        'id'    => (int) $pid,
+                        'title' => get_the_title( $pid ),
+                        'sku'   => get_post_meta( $pid, '_sku', true ),
+                    ];
+                }
+                $g['products'] = $info;
             }
-            $info = [];
-            foreach ( $g['products'] as $pid ) {
-                $info[] = [
-                    'id'    => (int) $pid,
-                    'title' => get_the_title( $pid ),
-                    'sku'   => get_post_meta( $pid, '_sku', true ),
-                ];
+            if ( ! empty( $g['rules'] ) && is_array( $g['rules'] ) ) {
+                foreach ( $g['rules'] as &$r ) {
+                    if ( ! isset( $r['label'] ) ) {
+                        $r['label'] = '';
+                    }
+                }
+                unset( $r );
             }
-            $g['products'] = $info;
         }
         unset( $g );
         $cats   = [];
@@ -173,10 +181,12 @@ class Gm2_Quantity_Discounts_Admin {
                     $min    = intval( $r['min'] ?? 1 );
                     $type   = $r['type'] === 'fixed' ? 'fixed' : 'percent';
                     $amount = floatval( $r['amount'] ?? 0 );
+                    $label  = sanitize_text_field( $r['label'] ?? '' );
                     $rules[] = [
                         'min'    => $min,
                         'type'   => $type,
                         'amount' => $amount,
+                        'label'  => $label,
                     ];
                 }
             }

--- a/admin/js/gm2-quantity-discounts.js
+++ b/admin/js/gm2-quantity-discounts.js
@@ -7,9 +7,10 @@ jQuery(function($){
         return l;
     }
     function createRuleRow(rule){
-        rule = rule || {min:'',type:'percent',amount:''};
+        rule = rule || {min:'',label:'',type:'percent',amount:''};
         var row = $('<tr class="gm2-qd-rule">\
             <td><input type="number" class="gm2-qd-min" value="'+rule.min+'" min="1"></td>\
+            <td><input type="text" class="gm2-qd-label" value="'+(rule.label||'')+'"></td>\
             <td><input type="number" step="0.01" class="gm2-qd-percent" '+(rule.type==='percent'?'' : 'disabled')+' value="'+(rule.type==='percent'?rule.amount:'')+'"></td>\
             <td><input type="number" step="0.01" class="gm2-qd-fixed" '+(rule.type==='fixed'?'' : 'disabled')+' value="'+(rule.type==='fixed'?rule.amount:'')+'"></td>\
             <td><button type="button" class="button gm2-qd-remove-rule">&times;</button></td></tr>');
@@ -25,7 +26,7 @@ jQuery(function($){
         var prodSection = $('<div class="gm2-qd-products"><select class="gm2-qd-cat"><option value="">All Categories</option></select> <input type="text" class="gm2-qd-search" placeholder="Search products"> <button type="button" class="button gm2-qd-search-btn">Search</button> <div class="gm2-qd-cat-products"></div><ul class="gm2-qd-results"></ul><ul class="gm2-qd-selected"></ul><p class="gm2-qd-remove-actions"><button type="button" class="button gm2-qd-remove-selected">Remove selected products</button> <button type="button" class="button gm2-qd-remove-all">Remove all</button></p></div>');
         categories.forEach(function(c){prodSection.find('select').append('<option value="'+c.id+'">'+c.name+'</option>');});
         container.append(prodSection);
-        var table = $('<table class="widefat gm2-qd-rules"><thead><tr><th>Min Qty</th><th>% Off</th><th>Fixed Off</th><th></th></tr></thead><tbody></tbody></table>');
+        var table = $('<table class="widefat gm2-qd-rules"><thead><tr><th>Min Qty</th><th>Label</th><th>% Off</th><th>Fixed Off</th><th></th></tr></thead><tbody></tbody></table>');
         g.rules.forEach(function(r){table.find('tbody').append(createRuleRow(r));});
         container.append(table);
         container.append('<p><button type="button" class="button gm2-qd-add-rule">Add Rule</button></p>');
@@ -140,11 +141,12 @@ jQuery(function($){
             g.find('.gm2-qd-selected li').each(function(){obj.products.push($(this).data('id'));});
             g.find('.gm2-qd-rules tbody tr').each(function(){
                 var min=parseInt($(this).find('.gm2-qd-min').val(),10)||0;
+                var label=$(this).find('.gm2-qd-label').val();
                 var percent=$(this).find('.gm2-qd-percent').val();
                 var fixed=$(this).find('.gm2-qd-fixed').val();
                 var type='percent';var amount=parseFloat(percent)||0;
                 if(fixed){type='fixed';amount=parseFloat(fixed)||0;}
-                obj.rules.push({min:min,type:type,amount:amount});
+                obj.rules.push({min:min,label:label,type:type,amount:amount});
             });
             data.push(obj);
         });

--- a/tests/js/gm2-quantity-discounts.test.js
+++ b/tests/js/gm2-quantity-discounts.test.js
@@ -46,6 +46,7 @@ test('submits group data via ajax', async () => {
   $('.gm2-qd-add-rule').trigger('click');
   $('.gm2-qd-name').val('Test');
   $('.gm2-qd-min').val('2');
+  $('.gm2-qd-label').val('First');
   $('.gm2-qd-percent').val('10');
   $('.gm2-qd-selected').append('<li data-id="55"><label><input type="checkbox" class="gm2-qd-selected-chk"> Prod</label></li>');
 
@@ -56,7 +57,7 @@ test('submits group data via ajax', async () => {
   const data = $.post.mock.calls[0][1].groups[0];
   expect(data.name).toBe('Test');
   expect(data.products[0]).toBe(55);
-  expect(data.rules[0]).toEqual({ min: 2, type: 'percent', amount: 10 });
+  expect(data.rules[0]).toEqual({ min: 2, label: 'First', type: 'percent', amount: 10 });
 });
 
 test('accordion toggles visibility', async () => {

--- a/tests/test-quantity-discounts-admin.php
+++ b/tests/test-quantity-discounts-admin.php
@@ -52,4 +52,24 @@ class QuantityDiscountsAdminAjaxTest extends WP_Ajax_UnitTestCase {
         $this->assertTrue($resp['success']);
         $this->assertSame('FSKU', $resp['data'][0]['sku']);
     }
+
+    public function test_save_groups_persists_label() {
+        $admin = new Gm2_Quantity_Discounts_Admin();
+        $admin->register_hooks();
+
+        $this->_setRole('administrator');
+        $_POST['nonce'] = wp_create_nonce('gm2_qd_nonce');
+        $_POST['groups'] = [
+            [
+                'name'     => 'G',
+                'products' => [1],
+                'rules'    => [ [ 'min' => 1, 'type' => 'percent', 'amount' => 5, 'label' => 'First' ] ],
+            ],
+        ];
+        try { $this->_handleAjax('gm2_qd_save_groups'); } catch (WPAjaxDieContinueException $e) {}
+        $resp = json_decode($this->_last_response, true);
+        $this->assertTrue($resp['success']);
+        $saved = get_option('gm2_quantity_discount_groups');
+        $this->assertSame('First', $saved[0]['rules'][0]['label']);
+    }
 }


### PR DESCRIPTION
## Summary
- support custom rule labels in the quantity discounts admin
- sanitize and store the new label value via AJAX
- include labels when localizing script data
- persist rule labels when saving
- test new label functionality

## Testing
- `npm test`
- `phpunit` *(fails: cannot find WordPress test suite)*

------
https://chatgpt.com/codex/tasks/task_e_6877f6da22048327a0f09e2c06fb5a61