### PR TITLE
Improve quantity discount product titles

### DIFF
--- a/admin/Gm2_Quantity_Discounts_Admin.php
+++ b/admin/Gm2_Quantity_Discounts_Admin.php
@@ -41,16 +41,22 @@ class Gm2_Quantity_Discounts_Admin {
             GM2_VERSION,
             true
         );
-        $groups = get_option( 'gm2_quantity_discount_groups', [] );
+        $groups  = get_option( 'gm2_quantity_discount_groups', [] );
+        $titles  = [];
         foreach ( $groups as &$g ) {
             if ( empty( $g['products'] ) || ! is_array( $g['products'] ) ) {
                 $g['products'] = [];
             } else {
                 $info = [];
                 foreach ( $g['products'] as $pid ) {
+                    $title = get_the_title( $pid );
+                    if ( '' === $title ) {
+                        $title = (string) $pid;
+                    }
+                    $titles[ (int) $pid ] = $title;
                     $info[] = [
                         'id'    => (int) $pid,
-                        'title' => get_the_title( $pid ),
+                        'title' => $title,
                         'sku'   => get_post_meta( $pid, '_sku', true ),
                     ];
                 }
@@ -80,10 +86,11 @@ class Gm2_Quantity_Discounts_Admin {
             'gm2-quantity-discounts',
             'gm2Qd',
             [
-                'nonce'      => wp_create_nonce( 'gm2_qd_nonce' ),
-                'ajax_url'   => admin_url( 'admin-ajax.php' ),
-                'groups'     => $groups,
-                'categories' => $cats,
+                'nonce'         => wp_create_nonce( 'gm2_qd_nonce' ),
+                'ajax_url'      => admin_url( 'admin-ajax.php' ),
+                'groups'        => $groups,
+                'categories'    => $cats,
+                'productTitles' => $titles,
             ]
         );
     }

--- a/admin/js/gm2-quantity-discounts.js
+++ b/admin/js/gm2-quantity-discounts.js
@@ -31,7 +31,16 @@ jQuery(function($){
         container.append(table);
         container.append('<p><button type="button" class="button gm2-qd-add-rule">Add Rule</button></p>');
         g.products.forEach(function(p){
-            if(typeof p!=='object'){p={id:p};}
+            if(typeof p!=='object'){
+                var t=null;
+                if(gm2Qd && gm2Qd.productTitles && gm2Qd.productTitles[p]){
+                    t=gm2Qd.productTitles[p];
+                }
+                p={id:p};
+                if(t){p.title=t;}
+            }else if(!p.title && gm2Qd && gm2Qd.productTitles && gm2Qd.productTitles[p.id]){
+                p.title=gm2Qd.productTitles[p.id];
+            }
             addSelectedProduct(container, p);
         });
         accordion.append(container);

--- a/tests/js/gm2-quantity-discounts.test.js
+++ b/tests/js/gm2-quantity-discounts.test.js
@@ -10,7 +10,7 @@ test('renders groups from gm2Qd', async () => {
   `, { url: 'http://localhost' });
   const $ = jquery(dom.window);
   Object.assign(global, { window: dom.window, document: dom.window.document, jQuery: $, $ });
-  global.gm2Qd = { nonce: 'n', ajax_url: '/fake', groups: [{ name: 'Group A', products: [{ id: 1, title: 'Prod', sku: 'P1' }], rules: [] }], categories: [] };
+  global.gm2Qd = { nonce: 'n', ajax_url: '/fake', groups: [{ name: 'Group A', products: [{ id: 1, title: 'Prod', sku: 'P1' }], rules: [] }], categories: [], productTitles: { 1: 'Prod' } };
 
   jest.resetModules();
   require('../../admin/js/gm2-quantity-discounts.js');
@@ -34,7 +34,7 @@ test('submits group data via ajax', async () => {
   `, { url: 'http://localhost' });
   const $ = jquery(dom.window);
   Object.assign(global, { window: dom.window, document: dom.window.document, jQuery: $, $ });
-  global.gm2Qd = { nonce: 'n', ajax_url: '/fake', groups: [], categories: [] };
+  global.gm2Qd = { nonce: 'n', ajax_url: '/fake', groups: [], categories: [], productTitles: {} };
   $.post = jest.fn(() => $.Deferred().resolve({ success: true }));
 
   jest.resetModules();
@@ -68,7 +68,7 @@ test('accordion toggles visibility', async () => {
   `, { url: 'http://localhost' });
   const $ = jquery(dom.window);
   Object.assign(global, { window: dom.window, document: dom.window.document, jQuery: $, $ });
-  global.gm2Qd = { nonce: 'n', ajax_url: '/fake', groups: [{ name: 'A', products: [], rules: [] }], categories: [] };
+  global.gm2Qd = { nonce: 'n', ajax_url: '/fake', groups: [{ name: 'A', products: [], rules: [] }], categories: [], productTitles: {} };
 
   jest.resetModules();
   require('../../admin/js/gm2-quantity-discounts.js');


### PR DESCRIPTION
## Summary
- gather product titles during admin script enqueue
- expose a `productTitles` map via `gm2Qd`
- ensure groups display product names when rendering
- update tests for new data

## Testing
- `npm test`
- `phpunit` *(fails: missing WordPress test suite)*
- `make test DB_NAME=wp_test DB_USER=root DB_PASS=pass` *(fails: install error)*

------
https://chatgpt.com/codex/tasks/task_e_687800d24a2883278019b7b8d9cfd5f7