### PR TITLE
Ensure published status in product searches

### DIFF
--- a/admin/Gm2_Quantity_Discounts_Admin.php
+++ b/admin/Gm2_Quantity_Discounts_Admin.php
@@ -116,6 +116,7 @@ class Gm2_Quantity_Discounts_Admin {
             'post_type'      => 'product',
             'posts_per_page' => 20,
             's'              => $term,
+            'post_status'    => 'publish',
         ];
         if ( $cat ) {
             $args['tax_query'] = [
@@ -150,6 +151,7 @@ class Gm2_Quantity_Discounts_Admin {
         $args = [
             'post_type'      => 'product',
             'posts_per_page' => -1,
+            'post_status'    => 'publish',
             'tax_query'      => [
                 [
                     'taxonomy' => 'product_cat',


### PR DESCRIPTION
## Summary
- include `post_status => publish` when querying products for quantity discounts
- add PHPUnit tests for draft exclusions in AJAX handlers

## Testing
- `phpunit` *(fails: command not found)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687802c1c0a48327a135595e34707bb0