### PR TITLE
Add icon size controls to discount widget

### DIFF
--- a/includes/widgets/class-gm2-qd-widget.php
+++ b/includes/widgets/class-gm2-qd-widget.php
@@ -231,6 +231,22 @@ class GM2_QD_Widget extends \Elementor\Widget_Base {
             'price_style_normal',
             [ 'label' => __( 'Normal', 'gm2-wordpress-suite' ) ]
         );
+        $this->add_responsive_control(
+            'icon_size',
+            [
+                'label' => __( 'Icon Size', 'gm2-wordpress-suite' ),
+                'type'  => \Elementor\Controls_Manager::SLIDER,
+                'size_units' => [ 'px', 'em', 'rem' ],
+                'range' => [
+                    'px'  => [ 'min' => 1,  'max' => 100 ],
+                    'em'  => [ 'min' => 0.1, 'max' => 10, 'step' => 0.1 ],
+                    'rem' => [ 'min' => 0.1, 'max' => 10, 'step' => 0.1 ],
+                ],
+                'selectors' => [
+                    '{{WRAPPER}} .gm2-qd-currency-icon' => 'font-size: {{SIZE}}{{UNIT}};',
+                ],
+            ]
+        );
         $this->add_control(
             'price_color',
             [
@@ -270,6 +286,22 @@ class GM2_QD_Widget extends \Elementor\Widget_Base {
             'price_style_hover',
             [ 'label' => __( 'Hover', 'gm2-wordpress-suite' ) ]
         );
+        $this->add_responsive_control(
+            'icon_size_hover',
+            [
+                'label' => __( 'Icon Size', 'gm2-wordpress-suite' ),
+                'type'  => \Elementor\Controls_Manager::SLIDER,
+                'size_units' => [ 'px', 'em', 'rem' ],
+                'range' => [
+                    'px'  => [ 'min' => 1,  'max' => 100 ],
+                    'em'  => [ 'min' => 0.1, 'max' => 10, 'step' => 0.1 ],
+                    'rem' => [ 'min' => 0.1, 'max' => 10, 'step' => 0.1 ],
+                ],
+                'selectors' => [
+                    '{{WRAPPER}} .gm2-qd-option:hover .gm2-qd-currency-icon' => 'font-size: {{SIZE}}{{UNIT}};',
+                ],
+            ]
+        );
         $this->add_control(
             'price_hover_color',
             [
@@ -308,6 +340,22 @@ class GM2_QD_Widget extends \Elementor\Widget_Base {
         $this->start_controls_tab(
             'price_style_active',
             [ 'label' => __( 'Active', 'gm2-wordpress-suite' ) ]
+        );
+        $this->add_responsive_control(
+            'icon_size_active',
+            [
+                'label' => __( 'Icon Size', 'gm2-wordpress-suite' ),
+                'type'  => \Elementor\Controls_Manager::SLIDER,
+                'size_units' => [ 'px', 'em', 'rem' ],
+                'range' => [
+                    'px'  => [ 'min' => 1,  'max' => 100 ],
+                    'em'  => [ 'min' => 0.1, 'max' => 10, 'step' => 0.1 ],
+                    'rem' => [ 'min' => 0.1, 'max' => 10, 'step' => 0.1 ],
+                ],
+                'selectors' => [
+                    '{{WRAPPER}} .gm2-qd-option:active .gm2-qd-currency-icon' => 'font-size: {{SIZE}}{{UNIT}};',
+                ],
+            ]
         );
         $this->add_control(
             'price_active_color',

--- a/public/css/gm2-qd-widget.css
+++ b/public/css/gm2-qd-widget.css
@@ -1,4 +1,4 @@
 .gm2-qd-options{display:flex;gap:6px;margin-bottom:10px;}
 .gm2-qd-option{cursor:pointer;padding:4px 8px;border:1px solid #ccc;background:#f8f8f8;}
 .gm2-qd-label,.gm2-qd-price{display:block;}
-.gm2-qd-currency-icon{margin-right:4px;}
+.gm2-qd-currency-icon{display:inline-block;margin-right:4px;font-size:1em;}


### PR DESCRIPTION
## Summary
- extend the Quantity Discounts widget to offer icon size controls
- style `.gm2-qd-currency-icon` using the new settings
- support icon sizing in the public CSS

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68780a8f5cdc832790906022d92e1023