### PR TITLE
Fix cart totals for quantity discounts

### DIFF
--- a/public/Gm2_Quantity_Discounts_Public.php
+++ b/public/Gm2_Quantity_Discounts_Public.php
@@ -9,6 +9,7 @@ class Gm2_Quantity_Discounts_Public {
     public function run() {
         add_action('woocommerce_before_calculate_totals', [ $this, 'adjust_prices' ], 20);
         add_filter('woocommerce_add_cart_item_data', [ $this, 'add_cart_item_data' ], 10, 4);
+        add_action('woocommerce_add_to_cart', [ $this, 'recalculate_after_add' ], 20, 6);
         add_action('woocommerce_checkout_create_order_line_item', [ $this, 'add_order_item_meta' ], 10, 4);
         add_filter('woocommerce_display_item_meta', [ $this, 'display_item_meta' ], 10, 3);
         add_filter('woocommerce_email_order_item_meta', [ $this, 'display_item_meta' ], 10, 3);
@@ -61,6 +62,12 @@ class Gm2_Quantity_Discounts_Public {
             }
         }
         return $cart_item_data;
+    }
+
+    public function recalculate_after_add() {
+        if (function_exists('WC') && WC()->cart) {
+            WC()->cart->calculate_totals();
+        }
     }
 
     public function adjust_prices($cart) {


### PR DESCRIPTION
## Summary
- ensure totals recalc after WooCommerce add to cart

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878122cd28883278c38c0dbff87fba0