### PR TITLE
Load qd widget in editor

### DIFF
--- a/public/Gm2_Public.php
+++ b/public/Gm2_Public.php
@@ -28,7 +28,12 @@ class Gm2_Public {
             true
         );
 
-        if (function_exists('is_product') && is_product()) {
+        $in_edit_mode = false;
+        if (class_exists('\\Elementor\\Plugin') && \Elementor\Plugin::$instance->editor) {
+            $in_edit_mode = \Elementor\Plugin::$instance->editor->is_edit_mode();
+        }
+
+        if ((function_exists('is_product') && is_product()) || $in_edit_mode) {
             wp_enqueue_style(
                 'gm2-qd-widget',
                 GM2_PLUGIN_URL . 'public/css/gm2-qd-widget.css',


### PR DESCRIPTION
## Summary
- make Gm2_Public aware of Elementor edit mode
- load quantity discount assets on product pages or in Elementor editor

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68781b8f7dcc8327975e7d8d2d58b6cc