### PR TITLE
Init categories with selectWoo

### DIFF
--- a/admin/Gm2_Quantity_Discounts_Admin.php
+++ b/admin/Gm2_Quantity_Discounts_Admin.php
@@ -34,6 +34,8 @@ class Gm2_Quantity_Discounts_Admin {
             [],
             GM2_VERSION
         );
+        wp_enqueue_script( 'selectWoo' );
+        wp_enqueue_style( 'select2' );
         wp_enqueue_script(
             'gm2-quantity-discounts',
             GM2_PLUGIN_URL . 'admin/js/gm2-quantity-discounts.js',

--- a/admin/js/gm2-quantity-discounts.js
+++ b/admin/js/gm2-quantity-discounts.js
@@ -73,10 +73,13 @@ jQuery(function($){
     function renderGroups(){
         var holder = $('#gm2-qd-groups').empty();
         groups.forEach(function(g){holder.append(createGroup(g));});
+        $('.gm2-qd-cat').selectWoo({ width: '200px' });
     }
     renderGroups();
     $('#gm2-qd-add-group').on('click',function(){
-        $('#gm2-qd-groups').append(createGroup());
+        var group = createGroup();
+        $('#gm2-qd-groups').append(group);
+        group.find('.gm2-qd-cat').selectWoo({ width: '200px' });
     });
     $(document).on('click','.gm2-qd-remove-group',function(){
         $(this).closest('.gm2-qd-accordion').remove();

--- a/tests/js/gm2-quantity-discounts.test.js
+++ b/tests/js/gm2-quantity-discounts.test.js
@@ -10,12 +10,14 @@ test('renders groups from gm2Qd', async () => {
   `, { url: 'http://localhost' });
   const $ = jquery(dom.window);
   Object.assign(global, { window: dom.window, document: dom.window.document, jQuery: $, $ });
+  $.fn.selectWoo = jest.fn(function(){ return this; });
   global.gm2Qd = { nonce: 'n', ajax_url: '/fake', groups: [{ name: 'Group A', products: [{ id: 1, title: 'Prod', sku: 'P1' }], rules: [] }], categories: [], productTitles: { 1: 'Prod' } };
 
   jest.resetModules();
   require('../../admin/js/gm2-quantity-discounts.js');
   await new Promise(r => setTimeout(r, 0));
   await new Promise(r => setTimeout(r, 0));
+  expect($.fn.selectWoo).toHaveBeenCalled();
 
   expect($('.gm2-qd-name').val()).toBe('Group A');
   expect($('.gm2-qd-accordion').length).toBe(1);
@@ -35,6 +37,7 @@ test('submits group data via ajax', async () => {
   `, { url: 'http://localhost' });
   const $ = jquery(dom.window);
   Object.assign(global, { window: dom.window, document: dom.window.document, jQuery: $, $ });
+  $.fn.selectWoo = jest.fn(function(){ return this; });
   global.gm2Qd = { nonce: 'n', ajax_url: '/fake', groups: [], categories: [], productTitles: {} };
   $.post = jest.fn(() => $.Deferred().resolve({ success: true }));
 
@@ -69,6 +72,7 @@ test('accordion toggles visibility', async () => {
   `, { url: 'http://localhost' });
   const $ = jquery(dom.window);
   Object.assign(global, { window: dom.window, document: dom.window.document, jQuery: $, $ });
+  $.fn.selectWoo = jest.fn(function(){ return this; });
   global.gm2Qd = { nonce: 'n', ajax_url: '/fake', groups: [{ name: 'A', products: [], rules: [] }], categories: [], productTitles: {} };
 
   jest.resetModules();
@@ -97,6 +101,7 @@ test('search results use checkboxes and add selected button', async () => {
   `, { url: 'http://localhost' });
   const $ = jquery(dom.window);
   Object.assign(global, { window: dom.window, document: dom.window.document, jQuery: $, $ });
+  $.fn.selectWoo = jest.fn(function(){ return this; });
   global.gm2Qd = {
     nonce: 'n',
     ajax_url: '/fake',


### PR DESCRIPTION
## Summary
- enqueue WordPress selectWoo assets for quantity discounts admin
- initialize selectWoo on category selects when rendering or adding groups
- test selectWoo initialization using a mock

## Testing
- `npm test`
- `phpunit` *(fails: WordPress test suite missing)*

------
https://chatgpt.com/codex/tasks/task_e_68782314e0e083279622011ea872ab38