### PR TITLE
Add loading spinner for QD widget

### DIFF
--- a/public/css/gm2-qd-widget.css
+++ b/public/css/gm2-qd-widget.css
@@ -2,3 +2,6 @@
 .gm2-qd-option{cursor:pointer;padding:4px 8px;border:1px solid #ccc;background:#f8f8f8;}
 .gm2-qd-label,.gm2-qd-price{display:block;}
 .gm2-qd-currency-icon{display:inline-block;margin-right:4px;font-size:1em;}
+.gm2-qd-option.loading{position:relative;opacity:.5;pointer-events:none;}
+.gm2-qd-option.loading .loading-spinner{position:absolute;top:50%;left:50%;width:1em;height:1em;margin-top:-.5em;margin-left:-.5em;border:2px solid currentColor;border-top-color:transparent;border-radius:50%;animation:gm2-spin .6s linear infinite;}
+@keyframes gm2-spin{to{transform:rotate(360deg);}}

--- a/public/js/gm2-qd-widget.js
+++ b/public/js/gm2-qd-widget.js
@@ -13,9 +13,12 @@ jQuery(function($){
             if($btn.length){
                 $btn.addClass('loading');
                 $option.addClass('loading');
+                var $spinner = $('<span class="loading-spinner"></span>');
+                $option.append($spinner);
                 $form.one('ajaxComplete', function(){
                     $btn.removeClass('loading');
                     $option.removeClass('loading');
+                    $spinner.remove();
                 });
                 $btn.trigger('click');
             }


### PR DESCRIPTION
## Summary
- style gm2-qd-option.loading similar to WooCommerce buttons
- append a loading spinner during ajax add-to-cart

## Testing
- `npm test`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_6878252661788327804c4495973fd409