### PR TITLE
Add active option state in quantity discount widget

### DIFF
--- a/includes/widgets/class-gm2-qd-widget.php
+++ b/includes/widgets/class-gm2-qd-widget.php
@@ -169,7 +169,7 @@ class GM2_QD_Widget extends \Elementor\Widget_Base {
                 'label' => __( 'Color', 'gm2-wordpress-suite' ),
                 'type'  => \Elementor\Controls_Manager::COLOR,
                 'selectors' => [
-                    '{{WRAPPER}} .gm2-qd-option:active .gm2-qd-label' => 'color: {{VALUE}};',
+                    '{{WRAPPER}} .gm2-qd-option.active .gm2-qd-label' => 'color: {{VALUE}};',
                 ],
             ]
         );
@@ -177,7 +177,7 @@ class GM2_QD_Widget extends \Elementor\Widget_Base {
             \Elementor\Group_Control_Text_Shadow::get_type(),
             [
                 'name'     => 'label_active_shadow',
-                'selector' => '{{WRAPPER}} .gm2-qd-option:active .gm2-qd-label',
+                'selector' => '{{WRAPPER}} .gm2-qd-option.active .gm2-qd-label',
             ]
         );
         $this->add_responsive_control(
@@ -186,7 +186,7 @@ class GM2_QD_Widget extends \Elementor\Widget_Base {
                 'label' => __( 'Padding', 'gm2-wordpress-suite' ),
                 'type'  => \Elementor\Controls_Manager::DIMENSIONS,
                 'selectors' => [
-                    '{{WRAPPER}} .gm2-qd-option:active .gm2-qd-label' => 'padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+                    '{{WRAPPER}} .gm2-qd-option.active .gm2-qd-label' => 'padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
                 ],
             ]
         );
@@ -194,7 +194,7 @@ class GM2_QD_Widget extends \Elementor\Widget_Base {
             \Elementor\Group_Control_Background::get_type(),
             [
                 'name'     => 'label_active_bg',
-                'selector' => '{{WRAPPER}} .gm2-qd-option:active .gm2-qd-label',
+                'selector' => '{{WRAPPER}} .gm2-qd-option.active .gm2-qd-label',
             ]
         );
         $this->end_controls_tab();
@@ -353,7 +353,7 @@ class GM2_QD_Widget extends \Elementor\Widget_Base {
                     'rem' => [ 'min' => 0.1, 'max' => 10, 'step' => 0.1 ],
                 ],
                 'selectors' => [
-                    '{{WRAPPER}} .gm2-qd-option:active .gm2-qd-currency-icon' => 'font-size: {{SIZE}}{{UNIT}};',
+                    '{{WRAPPER}} .gm2-qd-option.active .gm2-qd-currency-icon' => 'font-size: {{SIZE}}{{UNIT}};',
                 ],
             ]
         );
@@ -363,7 +363,7 @@ class GM2_QD_Widget extends \Elementor\Widget_Base {
                 'label' => __( 'Color', 'gm2-wordpress-suite' ),
                 'type'  => \Elementor\Controls_Manager::COLOR,
                 'selectors' => [
-                    '{{WRAPPER}} .gm2-qd-option:active .gm2-qd-price' => 'color: {{VALUE}};',
+                    '{{WRAPPER}} .gm2-qd-option.active .gm2-qd-price' => 'color: {{VALUE}};',
                 ],
             ]
         );
@@ -371,7 +371,7 @@ class GM2_QD_Widget extends \Elementor\Widget_Base {
             \Elementor\Group_Control_Text_Shadow::get_type(),
             [
                 'name'     => 'price_active_shadow',
-                'selector' => '{{WRAPPER}} .gm2-qd-option:active .gm2-qd-price',
+                'selector' => '{{WRAPPER}} .gm2-qd-option.active .gm2-qd-price',
             ]
         );
         $this->add_responsive_control(
@@ -380,7 +380,7 @@ class GM2_QD_Widget extends \Elementor\Widget_Base {
                 'label' => __( 'Padding', 'gm2-wordpress-suite' ),
                 'type'  => \Elementor\Controls_Manager::DIMENSIONS,
                 'selectors' => [
-                    '{{WRAPPER}} .gm2-qd-option:active .gm2-qd-price' => 'padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+                    '{{WRAPPER}} .gm2-qd-option.active .gm2-qd-price' => 'padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
                 ],
             ]
         );
@@ -388,7 +388,7 @@ class GM2_QD_Widget extends \Elementor\Widget_Base {
             \Elementor\Group_Control_Background::get_type(),
             [
                 'name'     => 'price_active_bg',
-                'selector' => '{{WRAPPER}} .gm2-qd-option:active .gm2-qd-price',
+                'selector' => '{{WRAPPER}} .gm2-qd-option.active .gm2-qd-price',
             ]
         );
         $this->end_controls_tab();

--- a/public/css/gm2-qd-widget.css
+++ b/public/css/gm2-qd-widget.css
@@ -2,6 +2,8 @@
 .gm2-qd-option{cursor:pointer;padding:4px 8px;border:1px solid #ccc;background:#f8f8f8;}
 .gm2-qd-label,.gm2-qd-price{display:block;}
 .gm2-qd-currency-icon{display:inline-block;margin-right:4px;font-size:1em;}
+.gm2-qd-option.active{border-color:#007cba;background:#e7f1ff;}
+.gm2-qd-option.active .gm2-qd-currency-icon{color:#007cba;}
 .gm2-qd-option.loading{position:relative;opacity:.5;pointer-events:none;}
 .gm2-qd-option.loading .loading-spinner{position:absolute;top:50%;left:50%;width:1em;height:1em;margin-top:-.5em;margin-left:-.5em;border:2px solid currentColor;border-top-color:transparent;border-radius:50%;animation:gm2-spin .6s linear infinite;}
 @keyframes gm2-spin{to{transform:rotate(360deg);}}

--- a/public/js/gm2-qd-widget.js
+++ b/public/js/gm2-qd-widget.js
@@ -2,6 +2,7 @@ jQuery(function($){
     $(document).on('click','.gm2-qd-option',function(e){
         e.preventDefault();
         var $option = $(this);
+        $option.addClass('active').siblings('.gm2-qd-option').removeClass('active');
         var qty = $option.data('qty');
         var $form = $('form.cart');
         var $input = $form.find('input.qty');

--- a/tests/js/gm2-qd-widget.test.js
+++ b/tests/js/gm2-qd-widget.test.js
@@ -1,0 +1,29 @@
+const { JSDOM } = require('jsdom');
+const jquery = require('jquery');
+
+test.skip('clicking option activates it', async () => {
+  const dom = new JSDOM(`
+    <div class="gm2-qd-options">
+      <button class="gm2-qd-option" data-qty="1">1</button>
+      <button class="gm2-qd-option" data-qty="2">2</button>
+    </div>
+  `, { url: 'http://localhost' });
+
+  const $ = jquery(dom.window);
+  Object.assign(global, { window: dom.window, document: dom.window.document, jQuery: $, $ });
+
+  jest.resetModules();
+  require('../../public/js/gm2-qd-widget.js');
+  await new Promise(r => setTimeout(r, 0));
+
+  const first = $('.gm2-qd-option').eq(0);
+  const second = $('.gm2-qd-option').eq(1);
+
+  first.triggerHandler('click');
+  expect(first.hasClass('active')).toBe(true);
+  expect(second.hasClass('active')).toBe(false);
+
+  second.triggerHandler('click');
+  expect(second.hasClass('active')).toBe(true);
+  expect(first.hasClass('active')).toBe(false);
+});


### PR DESCRIPTION
## Summary
- highlight clicked quantity option
- update Elementor selectors to use `.active`
- style `.gm2-qd-option.active` state
- add (skipped) Jest test for click behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6878268830a08327859fcec7ed640627