### PR TITLE
Handle widget preview product

### DIFF
--- a/includes/widgets/class-gm2-qd-widget.php
+++ b/includes/widgets/class-gm2-qd-widget.php
@@ -434,6 +434,12 @@ class GM2_QD_Widget extends \Elementor\Widget_Base {
             return;
         }
         global $product;
+        if ( ! $product && $in_edit_mode && function_exists( 'wc_get_product' ) ) {
+            $preview_id = get_the_ID();
+            if ( $preview_id ) {
+                $product = wc_get_product( $preview_id );
+            }
+        }
         if ( ! $product ) {
             return;
         }


### PR DESCRIPTION
## Summary
- allow quantity discount widget to load preview products in Elementor edit mode
- support ID retrieval in WC_Product stub
- test rendering with preview ID when no global product is set

## Testing
- `phpunit` *(fails: missing WordPress test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68782ff54f5483278cb663755489b9e9