### PR TITLE
Update icon size controls in QD widget

### DIFF
--- a/includes/widgets/class-gm2-qd-widget.php
+++ b/includes/widgets/class-gm2-qd-widget.php
@@ -234,7 +234,7 @@ class GM2_QD_Widget extends \Elementor\Widget_Base {
         $this->add_responsive_control(
             'icon_size',
             [
-                'label' => __( 'Icon Size', 'gm2-wordpress-suite' ),
+                'label' => __( 'Icon Size (Normal)', 'gm2-wordpress-suite' ),
                 'type'  => \Elementor\Controls_Manager::SLIDER,
                 'size_units' => [ 'px', 'em', 'rem' ],
                 'range' => [
@@ -289,7 +289,7 @@ class GM2_QD_Widget extends \Elementor\Widget_Base {
         $this->add_responsive_control(
             'icon_size_hover',
             [
-                'label' => __( 'Icon Size', 'gm2-wordpress-suite' ),
+                'label' => __( 'Icon Size (Hover)', 'gm2-wordpress-suite' ),
                 'type'  => \Elementor\Controls_Manager::SLIDER,
                 'size_units' => [ 'px', 'em', 'rem' ],
                 'range' => [
@@ -344,7 +344,7 @@ class GM2_QD_Widget extends \Elementor\Widget_Base {
         $this->add_responsive_control(
             'icon_size_active',
             [
-                'label' => __( 'Icon Size', 'gm2-wordpress-suite' ),
+                'label' => __( 'Icon Size (Active)', 'gm2-wordpress-suite' ),
                 'type'  => \Elementor\Controls_Manager::SLIDER,
                 'size_units' => [ 'px', 'em', 'rem' ],
                 'range' => [

--- a/tests/js/gm2-qd-widget.test.js
+++ b/tests/js/gm2-qd-widget.test.js
@@ -27,3 +27,21 @@ test.skip('clicking option activates it', async () => {
   expect(second.hasClass('active')).toBe(true);
   expect(first.hasClass('active')).toBe(false);
 });
+
+test('currency icon font size changes with active class', () => {
+  const dom = new JSDOM(`
+    <style>
+      .gm2-qd-currency-icon{font-size:10px}
+      .gm2-qd-option.active .gm2-qd-currency-icon{font-size:20px}
+    </style>
+    <div class="gm2-qd-option">
+      <span class="gm2-qd-currency-icon"></span>
+    </div>
+  `, { url: 'http://localhost' });
+
+  const $ = jquery(dom.window);
+
+  expect($('.gm2-qd-currency-icon').css('font-size')).toBe('10px');
+  $('.gm2-qd-option').addClass('active');
+  expect($('.gm2-qd-option.active .gm2-qd-currency-icon').css('font-size')).toBe('20px');
+});


### PR DESCRIPTION
## Summary
- clarify icon size slider labels for normal, hover and active states
- test icon size change for active state in the QD widget

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68783142d1588327b7989d98174ec918