### PR TITLE
Support preview mode in QD widget

### DIFF
--- a/includes/widgets/class-gm2-qd-widget.php
+++ b/includes/widgets/class-gm2-qd-widget.php
@@ -435,7 +435,13 @@ class GM2_QD_Widget extends \Elementor\Widget_Base {
         }
         global $product;
         if ( ! $product && $in_edit_mode && function_exists( 'wc_get_product' ) ) {
-            $preview_id = get_the_ID();
+            $preview_id = 0;
+            if ( function_exists( 'get_post_meta' ) ) {
+                $preview_id = intval( get_post_meta( get_the_ID(), '_elementor_preview_id', true ) );
+            }
+            if ( ! $preview_id && isset( $_GET['preview_id'] ) ) {
+                $preview_id = intval( $_GET['preview_id'] );
+            }
             if ( $preview_id ) {
                 $product = wc_get_product( $preview_id );
             }

--- a/tests/test-quantity-discounts.php
+++ b/tests/test-quantity-discounts.php
@@ -182,13 +182,15 @@ class QuantityDiscountsTest extends WP_UnitTestCase {
         global $product, $post;
         $product = null;
 
-        $post_id = self::factory()->post->create();
-        $post    = get_post( $post_id );
+        $template_id = self::factory()->post->create();
+        $product_id  = self::factory()->post->create();
+        $post        = get_post( $template_id );
+        update_post_meta( $template_id, '_elementor_preview_id', $product_id );
 
         $m = new Gm2_Quantity_Discount_Manager();
         $m->add_group([
             'name'     => 'Test',
-            'products' => [ $post_id ],
+            'products' => [ $product_id ],
             'rules'    => [ [ 'min' => 1, 'type' => 'percent', 'amount' => 10, 'label' => 'L' ] ],
         ]);
 


### PR DESCRIPTION
## Summary
- allow preview product ID for the quantity discount widget
- adjust quantity discount widget test for preview mode

## Testing
- `make test DB_NAME=wp_test DB_USER=root DB_PASS=root` *(fails: `mysqladmin command not found`)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68783b733718832782feed9d5edfc557