### PR TITLE
Adjust currency icon to inherit font size

### DIFF
--- a/public/css/gm2-qd-widget.css
+++ b/public/css/gm2-qd-widget.css
@@ -1,7 +1,7 @@
 .gm2-qd-options{display:flex;gap:6px;margin-bottom:10px;}
 .gm2-qd-option{cursor:pointer;padding:4px 8px;border:1px solid #ccc;background:#f8f8f8;}
 .gm2-qd-label,.gm2-qd-price{display:block;}
-.gm2-qd-currency-icon{display:inline-block;margin-right:4px;font-size:1em;}
+.gm2-qd-currency-icon{display:inline-block;margin-right:4px;font-size:inherit;}
 .gm2-qd-option.active{border-color:#007cba;background:#e7f1ff;}
 .gm2-qd-option.active .gm2-qd-currency-icon{color:#007cba;}
 .gm2-qd-option.loading{position:relative;opacity:.5;pointer-events:none;}


### PR DESCRIPTION
## Summary
- allow the quantity discount currency icon font size to inherit from parent

## Testing
- `npm test`
- `phpunit` *(fails: PHPUnit Polyfills library missing)*

------
https://chatgpt.com/codex/tasks/task_e_68783c76c1608327aee4f09c495d4c01