### PR TITLE
Add state-based option background styles

### DIFF
--- a/includes/widgets/class-gm2-qd-widget.php
+++ b/includes/widgets/class-gm2-qd-widget.php
@@ -31,13 +31,6 @@ class GM2_QD_Widget extends \Elementor\Widget_Base {
             ]
         );
         $this->add_group_control(
-            \Elementor\Group_Control_Background::get_type(),
-            [
-                'name'     => 'option_bg',
-                'selector' => '{{WRAPPER}} .gm2-qd-option',
-            ]
-        );
-        $this->add_group_control(
             \Elementor\Group_Control_Border::get_type(),
             [
                 'name'     => 'option_border',
@@ -64,6 +57,44 @@ class GM2_QD_Widget extends \Elementor\Widget_Base {
                 ],
             ]
         );
+        $this->start_controls_tabs( 'option_style_tabs' );
+        $this->start_controls_tab(
+            'option_style_normal',
+            [ 'label' => __( 'Normal', 'gm2-wordpress-suite' ) ]
+        );
+        $this->add_group_control(
+            \Elementor\Group_Control_Background::get_type(),
+            [
+                'name'     => 'option_bg_normal',
+                'selector' => '{{WRAPPER}} .gm2-qd-option',
+            ]
+        );
+        $this->end_controls_tab();
+        $this->start_controls_tab(
+            'option_style_hover',
+            [ 'label' => __( 'Hover', 'gm2-wordpress-suite' ) ]
+        );
+        $this->add_group_control(
+            \Elementor\Group_Control_Background::get_type(),
+            [
+                'name'     => 'option_bg_hover',
+                'selector' => '{{WRAPPER}} .gm2-qd-option:hover',
+            ]
+        );
+        $this->end_controls_tab();
+        $this->start_controls_tab(
+            'option_style_active',
+            [ 'label' => __( 'Active', 'gm2-wordpress-suite' ) ]
+        );
+        $this->add_group_control(
+            \Elementor\Group_Control_Background::get_type(),
+            [
+                'name'     => 'option_bg_active',
+                'selector' => '{{WRAPPER}} .gm2-qd-option.active',
+            ]
+        );
+        $this->end_controls_tab();
+        $this->end_controls_tabs();
         $this->end_controls_section();
 
         $this->start_controls_section(

--- a/tests/js/gm2-qd-widget.test.js
+++ b/tests/js/gm2-qd-widget.test.js
@@ -45,3 +45,20 @@ test('currency icon font size changes with active class', () => {
   $('.gm2-qd-option').addClass('active');
   expect($('.gm2-qd-option.active .gm2-qd-currency-icon').css('font-size')).toBe('20px');
 });
+
+test('option background colors apply for normal and active states', () => {
+  const dom = new JSDOM(`
+    <style>
+      .gm2-qd-option{background-color:red}
+      .gm2-qd-option:hover{background-color:green}
+      .gm2-qd-option.active{background-color:blue}
+    </style>
+    <button class="gm2-qd-option">Option</button>
+  `, { url: 'http://localhost' });
+
+  const $ = jquery(dom.window);
+
+  expect($('.gm2-qd-option').css('background-color')).toBe('rgb(255, 0, 0)');
+  $('.gm2-qd-option').addClass('active');
+  expect($('.gm2-qd-option.active').css('background-color')).toBe('rgb(0, 0, 255)');
+});


### PR DESCRIPTION
## Summary
- enhance option styling controls in `GM2_QD_Widget`
- add normal/hover/active background settings
- test widget background styles in js

## Testing
- `npm test`
- `phpunit` *(fails: database not configured)*

------
https://chatgpt.com/codex/tasks/task_e_6878447ef2f08327891eef4834bb2236