### PR TITLE
Hide select2 inline search input

### DIFF
--- a/admin/css/gm2-quantity-discounts.css
+++ b/admin/css/gm2-quantity-discounts.css
@@ -60,3 +60,7 @@
 .gm2-qd-selected-title {
     margin-top:10px;
 }
+
+.select2-container--default .select2-search--inline {
+    display: none;
+}


### PR DESCRIPTION
## Summary
- hide select2 inline search field on quantity discounts screen so only the main search field shows

## Testing
- `npm test`
- `phpunit` *(fails: failed to open /tmp/wordpress-tests-lib/includes/functions.php)*

------
https://chatgpt.com/codex/tasks/task_e_68784659bc988327bb63ebf3a51e13af