### PR TITLE
Fix currency icon sizing

### DIFF
--- a/includes/widgets/class-gm2-qd-widget.php
+++ b/includes/widgets/class-gm2-qd-widget.php
@@ -274,7 +274,8 @@ class GM2_QD_Widget extends \Elementor\Widget_Base {
                     'rem' => [ 'min' => 0.1, 'max' => 10, 'step' => 0.1 ],
                 ],
                 'selectors' => [
-                    '{{WRAPPER}} .gm2-qd-currency-icon' => 'font-size: {{SIZE}}{{UNIT}};',
+                    '{{WRAPPER}} .gm2-qd-currency-icon'      => 'font-size: {{SIZE}}{{UNIT}} !important;',
+                    '{{WRAPPER}} .gm2-qd-currency-icon svg,\n                     {{WRAPPER}} .gm2-qd-currency-icon i' => 'width: {{SIZE}}{{UNIT}} !important; height: {{SIZE}}{{UNIT}} !important;',
                 ],
             ]
         );
@@ -329,7 +330,8 @@ class GM2_QD_Widget extends \Elementor\Widget_Base {
                     'rem' => [ 'min' => 0.1, 'max' => 10, 'step' => 0.1 ],
                 ],
                 'selectors' => [
-                    '{{WRAPPER}} .gm2-qd-option:hover .gm2-qd-currency-icon' => 'font-size: {{SIZE}}{{UNIT}};',
+                    '{{WRAPPER}} .gm2-qd-option:hover .gm2-qd-currency-icon'      => 'font-size: {{SIZE}}{{UNIT}} !important;',
+                    '{{WRAPPER}} .gm2-qd-option:hover .gm2-qd-currency-icon svg,\n                     {{WRAPPER}} .gm2-qd-option:hover .gm2-qd-currency-icon i' => 'width: {{SIZE}}{{UNIT}} !important; height: {{SIZE}}{{UNIT}} !important;',
                 ],
             ]
         );
@@ -384,7 +386,8 @@ class GM2_QD_Widget extends \Elementor\Widget_Base {
                     'rem' => [ 'min' => 0.1, 'max' => 10, 'step' => 0.1 ],
                 ],
                 'selectors' => [
-                    '{{WRAPPER}} .gm2-qd-option.active .gm2-qd-currency-icon' => 'font-size: {{SIZE}}{{UNIT}};',
+                    '{{WRAPPER}} .gm2-qd-option.active .gm2-qd-currency-icon'      => 'font-size: {{SIZE}}{{UNIT}} !important;',
+                    '{{WRAPPER}} .gm2-qd-option.active .gm2-qd-currency-icon svg,\n                     {{WRAPPER}} .gm2-qd-option.active .gm2-qd-currency-icon i' => 'width: {{SIZE}}{{UNIT}} !important; height: {{SIZE}}{{UNIT}} !important;',
                 ],
             ]
         );


### PR DESCRIPTION
## Summary
- ensure icon size controls override theme or Font Awesome defaults

## Testing
- `make test DB_NAME=wp_test DB_USER=root DB_PASS=pass` *(fails: Can't connect to MySQL server)*

------
https://chatgpt.com/codex/tasks/task_e_68784f60805c83278cf66b71e1a6d256