### PR TITLE
Fix icon scaling in qd widget css

### DIFF
--- a/public/css/gm2-qd-widget.css
+++ b/public/css/gm2-qd-widget.css
@@ -2,6 +2,7 @@
 .gm2-qd-option{cursor:pointer;padding:4px 8px;border:1px solid #ccc;background:#f8f8f8;}
 .gm2-qd-label,.gm2-qd-price{display:block;}
 .gm2-qd-currency-icon{display:inline-block;margin-right:4px;}
+.gm2-qd-currency-icon i{width:1em;height:1em;}
 .gm2-qd-option.active{border-color:#007cba;background:#e7f1ff;}
 .gm2-qd-option.active .gm2-qd-currency-icon{color:#007cba;}
 .gm2-qd-option.loading{position:relative;opacity:.5;pointer-events:none;}


### PR DESCRIPTION
## Summary
- ensure icon `<i>` elements scale with font size in quantity discount widget

## Testing
- `npm test`
- `phpunit --configuration phpunit.xml` *(fails: missing WordPress test suite)*

------
https://chatgpt.com/codex/tasks/task_e_687850f30a108327af3d96590448a72b