### PR TITLE
Handle svg icons in quantity discount widget

### DIFF
--- a/includes/widgets/class-gm2-qd-widget.php
+++ b/includes/widgets/class-gm2-qd-widget.php
@@ -275,7 +275,7 @@ class GM2_QD_Widget extends \Elementor\Widget_Base {
                 ],
                 'selectors' => [
                     '{{WRAPPER}} .gm2-qd-currency-icon'      => 'font-size: {{SIZE}}{{UNIT}} !important;',
-                    '{{WRAPPER}} .gm2-qd-currency-icon svg,\n                     {{WRAPPER}} .gm2-qd-currency-icon i' => 'width: {{SIZE}}{{UNIT}} !important; height: {{SIZE}}{{UNIT}} !important;',
+                    '{{WRAPPER}} .gm2-qd-currency-icon svg,\n                     {{WRAPPER}} .gm2-qd-currency-icon.e-font-icon-svg,\n                     {{WRAPPER}} .gm2-qd-currency-icon i' => 'width: {{SIZE}}{{UNIT}} !important; height: {{SIZE}}{{UNIT}} !important;',
                 ],
             ]
         );
@@ -331,7 +331,7 @@ class GM2_QD_Widget extends \Elementor\Widget_Base {
                 ],
                 'selectors' => [
                     '{{WRAPPER}} .gm2-qd-option:hover .gm2-qd-currency-icon'      => 'font-size: {{SIZE}}{{UNIT}} !important;',
-                    '{{WRAPPER}} .gm2-qd-option:hover .gm2-qd-currency-icon svg,\n                     {{WRAPPER}} .gm2-qd-option:hover .gm2-qd-currency-icon i' => 'width: {{SIZE}}{{UNIT}} !important; height: {{SIZE}}{{UNIT}} !important;',
+                    '{{WRAPPER}} .gm2-qd-option:hover .gm2-qd-currency-icon svg,\n                     {{WRAPPER}} .gm2-qd-option:hover .gm2-qd-currency-icon.e-font-icon-svg,\n                     {{WRAPPER}} .gm2-qd-option:hover .gm2-qd-currency-icon i' => 'width: {{SIZE}}{{UNIT}} !important; height: {{SIZE}}{{UNIT}} !important;',
                 ],
             ]
         );
@@ -387,7 +387,7 @@ class GM2_QD_Widget extends \Elementor\Widget_Base {
                 ],
                 'selectors' => [
                     '{{WRAPPER}} .gm2-qd-option.active .gm2-qd-currency-icon'      => 'font-size: {{SIZE}}{{UNIT}} !important;',
-                    '{{WRAPPER}} .gm2-qd-option.active .gm2-qd-currency-icon svg,\n                     {{WRAPPER}} .gm2-qd-option.active .gm2-qd-currency-icon i' => 'width: {{SIZE}}{{UNIT}} !important; height: {{SIZE}}{{UNIT}} !important;',
+                    '{{WRAPPER}} .gm2-qd-option.active .gm2-qd-currency-icon svg,\n                     {{WRAPPER}} .gm2-qd-option.active .gm2-qd-currency-icon.e-font-icon-svg,\n                     {{WRAPPER}} .gm2-qd-option.active .gm2-qd-currency-icon i' => 'width: {{SIZE}}{{UNIT}} !important; height: {{SIZE}}{{UNIT}} !important;',
                 ],
             ]
         );

--- a/public/css/gm2-qd-widget.css
+++ b/public/css/gm2-qd-widget.css
@@ -3,6 +3,8 @@
 .gm2-qd-label,.gm2-qd-price{display:block;}
 .gm2-qd-currency-icon{display:inline-block;margin-right:4px;}
 .gm2-qd-currency-icon i{width:1em;height:1em;}
+.gm2-qd-currency-icon svg{width:1em;height:1em;}
+.gm2-qd-currency-icon.e-font-icon-svg{width:1em;height:1em;}
 .gm2-qd-option.active{border-color:#007cba;background:#e7f1ff;}
 .gm2-qd-option.active .gm2-qd-currency-icon{color:#007cba;}
 .gm2-qd-option.loading{position:relative;opacity:.5;pointer-events:none;}

--- a/tests/js/gm2-qd-widget.test.js
+++ b/tests/js/gm2-qd-widget.test.js
@@ -62,3 +62,21 @@ test('option background colors apply for normal and active states', () => {
   $('.gm2-qd-option').addClass('active');
   expect($('.gm2-qd-option.active').css('background-color')).toBe('rgb(0, 0, 255)');
 });
+
+test('svg currency icon width and height follow CSS rules', () => {
+  const dom = new JSDOM(`
+    <style>
+      .gm2-qd-currency-icon svg,
+      .gm2-qd-currency-icon.e-font-icon-svg { width:10px; height:10px; }
+    </style>
+    <span class="gm2-qd-currency-icon"><svg></svg></span>
+    <span class="gm2-qd-currency-icon e-font-icon-svg"></span>
+  `, { url: 'http://localhost' });
+
+  const $ = jquery(dom.window);
+
+  expect($('.gm2-qd-currency-icon svg').css('width')).toBe('10px');
+  expect($('.gm2-qd-currency-icon.e-font-icon-svg').css('width')).toBe('10px');
+  expect($('.gm2-qd-currency-icon svg').css('height')).toBe('10px');
+  expect($('.gm2-qd-currency-icon.e-font-icon-svg').css('height')).toBe('10px');
+});


### PR DESCRIPTION
## Summary
- ensure `.e-font-icon-svg` class has default sizing in QD CSS
- support `.e-font-icon-svg` icons in elementor controls
- test that svg icons pick up width & height rules

## Testing
- `npm test`
- `phpunit` *(fails: missing WordPress test suite)*


------
https://chatgpt.com/codex/tasks/task_e_6878f00d6cac832785b975a969a3a54a