### PR TITLE
Fix category dropdown overlay in discount admin

### DIFF
--- a/admin/js/gm2-quantity-discounts.js
+++ b/admin/js/gm2-quantity-discounts.js
@@ -76,6 +76,9 @@ jQuery(function($){
         $('.gm2-qd-cat').selectWoo({ width: '200px' });
     }
     renderGroups();
+    $(document).on('select2:unselect','.gm2-qd-cat',function(){
+        $(this).selectWoo('close');
+    });
     $('#gm2-qd-add-group').on('click',function(){
         var group = createGroup();
         $('#gm2-qd-groups').append(group);

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Gm2 WordPress Suite
  * Description:       A powerful suite of tools and features for WordPress, by Gm2.
- * Version:           1.6.10
+ * Version:           1.6.11
  * Author:            Your Name or Team Gm2
  * Author URI:        https://yourwebsite.com
  * License:           GPL-2.0+
@@ -15,7 +15,7 @@
 defined('ABSPATH') or die('No script kiddies please!');
 
 // Define constants
-define('GM2_VERSION', '1.6.10');
+define('GM2_VERSION', '1.6.11');
 define('GM2_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('GM2_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('GM2_CONTENT_RULES_VERSION', 2);

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: gm2team
 Tags: admin, tools, suite, performance
 Requires at least: 6.0
 Tested up to: 6.5
-Stable tag: 1.6.10
+Stable tag: 1.6.11
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -292,6 +292,8 @@ the last 100 missing URLs to help you create new redirects.
   `nofollow` or `sponsored` to outbound links.
 
 == Changelog ==
+= 1.6.11 =
+* Fixed category dropdown overlay after removing a selection in Quantity Discounts admin.
 = 1.6.10 =
 * Keyword research now falls back to ChatGPT when Ads credentials are missing or the Keyword Planner request fails. A notice explains that metrics are unavailable.
 = 1.6.9 =


### PR DESCRIPTION
## Summary
- fix select2 dropdown overlay after removing categories in quantity discounts
- bump version to 1.6.11
- update changelog

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878f0c260c48327946637ae76f6eae1