### PR TITLE
Add currency icon margin control

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,4 +10,4 @@ This release adds several new SEO and AI options:
 
 Existing prompt logic automatically includes these options via `gm2_get_seo_context()`.
 
-- The **Gm2 Qnty Discounts** widget now offers typography, color, shadow, padding and background controls for quantity labels and prices with Normal, Hover and Active tabs. Choose an icon for the currency symbol and style it alongside new box options for each quantity button.
+ - The **Gm2 Qnty Discounts** widget now offers typography, color, shadow, padding and background controls for quantity labels and prices with Normal, Hover and Active tabs. Choose an icon for the currency symbol and style it alongside new box options for each quantity button, plus an **Icon Margin** option to control spacing around the currency icon.

--- a/includes/widgets/class-gm2-qd-widget.php
+++ b/includes/widgets/class-gm2-qd-widget.php
@@ -250,6 +250,17 @@ class GM2_QD_Widget extends \Elementor\Widget_Base {
                 ],
             ]
         );
+        $this->add_responsive_control(
+            'currency_icon_margin',
+            [
+                'label' => __( 'Icon Margin', 'gm2-wordpress-suite' ),
+                'type'  => \Elementor\Controls_Manager::DIMENSIONS,
+                'default' => [ 'top' => '0', 'right' => '4', 'bottom' => '0', 'left' => '0', 'unit' => 'px' ],
+                'selectors' => [
+                    '{{WRAPPER}} .gm2-qd-currency-icon' => 'margin: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+                ],
+            ]
+        );
         $this->add_group_control(
             \Elementor\Group_Control_Typography::get_type(),
             [

--- a/public/css/gm2-qd-widget.css
+++ b/public/css/gm2-qd-widget.css
@@ -1,7 +1,7 @@
 .gm2-qd-options{display:flex;gap:6px;margin-bottom:10px;}
 .gm2-qd-option{cursor:pointer;padding:4px 8px;border:1px solid #ccc;background:#f8f8f8;}
 .gm2-qd-label,.gm2-qd-price{display:block;}
-.gm2-qd-currency-icon{display:inline-block;margin-right:4px;}
+.gm2-qd-currency-icon{display:inline-block;}
 .gm2-qd-currency-icon i{width:1em;height:1em;}
 .gm2-qd-currency-icon svg{width:1em;height:1em;}
 .gm2-qd-currency-icon.e-font-icon-svg{width:1em;height:1em;}

--- a/tests/js/gm2-qd-widget.test.js
+++ b/tests/js/gm2-qd-widget.test.js
@@ -80,3 +80,19 @@ test('svg currency icon width and height follow CSS rules', () => {
   expect($('.gm2-qd-currency-icon svg').css('height')).toBe('10px');
   expect($('.gm2-qd-currency-icon.e-font-icon-svg').css('height')).toBe('10px');
 });
+
+test('currency icon margin can be customized', () => {
+  const dom = new JSDOM(`
+    <style>
+      .gm2-qd-currency-icon { margin: 2px 3px 4px 5px; }
+    </style>
+    <span class="gm2-qd-currency-icon"></span>
+  `, { url: 'http://localhost' });
+
+  const $ = jquery(dom.window);
+
+  expect($('.gm2-qd-currency-icon').css('margin-top')).toBe('2px');
+  expect($('.gm2-qd-currency-icon').css('margin-right')).toBe('3px');
+  expect($('.gm2-qd-currency-icon').css('margin-bottom')).toBe('4px');
+  expect($('.gm2-qd-currency-icon').css('margin-left')).toBe('5px');
+});


### PR DESCRIPTION
## Summary
- allow customizing margin around price icon
- adjust QD widget CSS to not force margin
- document "Icon Margin" option
- test that custom margins apply

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878f451e624832780a76eb5ff5b5bc2