### PR TITLE
Bump version to 1.6.12

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Gm2 WordPress Suite
  * Description:       A powerful suite of tools and features for WordPress, by Gm2.
- * Version:           1.6.11
+ * Version:           1.6.12
  * Author:            Your Name or Team Gm2
  * Author URI:        https://yourwebsite.com
  * License:           GPL-2.0+
@@ -15,7 +15,7 @@
 defined('ABSPATH') or die('No script kiddies please!');
 
 // Define constants
-define('GM2_VERSION', '1.6.11');
+define('GM2_VERSION', '1.6.12');
 define('GM2_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('GM2_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('GM2_CONTENT_RULES_VERSION', 2);

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: gm2team
 Tags: admin, tools, suite, performance
 Requires at least: 6.0
 Tested up to: 6.5
-Stable tag: 1.6.11
+Stable tag: 1.6.12
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -292,6 +292,8 @@ the last 100 missing URLs to help you create new redirects.
   `nofollow` or `sponsored` to outbound links.
 
 == Changelog ==
+= 1.6.12 =
+* Improved dropdown behavior in Quantity Discounts admin.
 = 1.6.11 =
 * Fixed category dropdown overlay after removing a selection in Quantity Discounts admin.
 = 1.6.10 =


### PR DESCRIPTION
## Summary
- bump plugin header and constant to 1.6.12
- update stable tag
- document improved dropdown behavior

## Testing
- `npm test`
- `phpunit` *(fails: missing wordpress test suite)*

------
https://chatgpt.com/codex/tasks/task_e_6878f8491d1883279887ec218b3a8685