### PR TITLE
Add loading spinner for category product fetch

### DIFF
--- a/admin/css/gm2-quantity-discounts.css
+++ b/admin/css/gm2-quantity-discounts.css
@@ -45,6 +45,23 @@
 .gm2-qd-cat-products {
     display:none;
 }
+.gm2-qd-cat-products.loading{
+    position:relative;
+    min-height:1em;
+}
+.gm2-qd-cat-products.loading .loading-spinner{
+    position:absolute;
+    top:50%;
+    left:50%;
+    width:1em;
+    height:1em;
+    margin-top:-.5em;
+    margin-left:-.5em;
+    border:2px solid currentColor;
+    border-top-color:transparent;
+    border-radius:50%;
+    animation:gm2-spin .6s linear infinite;
+}
 .gm2-qd-selected input[type=checkbox] {
     margin-right:4px;
 }
@@ -74,4 +91,8 @@
 
 .gm2-qd-cat + .select2 .select2-selection__choice {
     padding-right: 8px;
+}
+
+@keyframes gm2-spin{
+    to{transform:rotate(360deg);}
 }

--- a/admin/js/gm2-quantity-discounts.js
+++ b/admin/js/gm2-quantity-discounts.js
@@ -56,7 +56,10 @@ jQuery(function($){
     function loadCategoryProducts(group, cats){
         var box = group.find('.gm2-qd-cat-products').empty().hide();
         if(!cats || !cats.length){ return; }
+        var spinner = $('<span class="loading-spinner"></span>');
+        box.append(spinner).addClass('loading').show();
         $.get(gm2Qd.ajax_url,{action:'gm2_qd_get_category_products',nonce:gm2Qd.nonce,'categories[]':cats}).done(function(res){
+            box.removeClass('loading').empty();
             if(!res.success || !res.data || !res.data.length) return;
             var html = '<label><input type="checkbox" class="gm2-qd-select-all"> Select all</label><ul class="gm2-qd-checkboxes"></ul><p><button type="button" class="button gm2-qd-add-selected">Add selected products</button></p>';
             box.append(html).show();
@@ -68,6 +71,8 @@ jQuery(function($){
                 }
                 list.append(li);
             });
+        }).fail(function(){
+            box.removeClass('loading').empty();
         });
     }
     function renderGroups(){


### PR DESCRIPTION
## Summary
- show a loading spinner while category products load in Quantity Discounts admin

## Testing
- `npm test`
- `phpunit` *(fails: WordPress test suite missing)*

------
https://chatgpt.com/codex/tasks/task_e_6878fb6f219883278e81eda60ab0e512