### PR TITLE
Add icon color style control

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,5 +10,5 @@ This release adds several new SEO and AI options:
 
 Existing prompt logic automatically includes these options via `gm2_get_seo_context()`.
 
-- The **Gm2 Qnty Discounts** widget now offers typography, color, shadow, padding and background controls for quantity labels and prices with Normal, Hover and Active tabs. Choose an icon for the currency symbol and style it alongside new box options for each quantity button, plus an **Icon Margin** option to control spacing around the currency icon.
+- The **Gm2 Qnty Discounts** widget now offers typography, color, shadow, padding and background controls for quantity labels and prices with Normal, Hover and Active tabs. Choose an icon for the currency symbol and style it alongside new box options for each quantity button, plus an **Icon Margin** option to control spacing around the currency icon. A new **Icon Color** style option lets you set colors for the currency icon in Normal, Hover and Active states.
 - The price section now uses flexbox by default and includes responsive **Horizontal** and **Vertical** alignment controls to adjust `justify-content` and `align-items`.

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Gm2 WordPress Suite
  * Description:       A powerful suite of tools and features for WordPress, by Gm2.
- * Version:           1.6.12
+ * Version:           1.6.13
  * Author:            Your Name or Team Gm2
  * Author URI:        https://yourwebsite.com
  * License:           GPL-2.0+
@@ -15,7 +15,7 @@
 defined('ABSPATH') or die('No script kiddies please!');
 
 // Define constants
-define('GM2_VERSION', '1.6.12');
+define('GM2_VERSION', '1.6.13');
 define('GM2_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('GM2_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('GM2_CONTENT_RULES_VERSION', 2);

--- a/includes/widgets/class-gm2-qd-widget.php
+++ b/includes/widgets/class-gm2-qd-widget.php
@@ -339,6 +339,16 @@ class GM2_QD_Widget extends \Elementor\Widget_Base {
             ]
         );
         $this->add_control(
+            'icon_color',
+            [
+                'label' => __( 'Icon Color', 'gm2-wordpress-suite' ),
+                'type'  => \Elementor\Controls_Manager::COLOR,
+                'selectors' => [
+                    '{{WRAPPER}} .gm2-qd-currency-icon' => 'color: {{VALUE}};',
+                ],
+            ]
+        );
+        $this->add_control(
             'price_color',
             [
                 'label' => __( 'Color', 'gm2-wordpress-suite' ),
@@ -395,6 +405,16 @@ class GM2_QD_Widget extends \Elementor\Widget_Base {
             ]
         );
         $this->add_control(
+            'icon_hover_color',
+            [
+                'label' => __( 'Icon Color', 'gm2-wordpress-suite' ),
+                'type'  => \Elementor\Controls_Manager::COLOR,
+                'selectors' => [
+                    '{{WRAPPER}} .gm2-qd-option:hover .gm2-qd-currency-icon' => 'color: {{VALUE}};',
+                ],
+            ]
+        );
+        $this->add_control(
             'price_hover_color',
             [
                 'label' => __( 'Color', 'gm2-wordpress-suite' ),
@@ -447,6 +467,16 @@ class GM2_QD_Widget extends \Elementor\Widget_Base {
                 'selectors' => [
                     '{{WRAPPER}} .gm2-qd-option.active .gm2-qd-currency-icon'      => 'font-size: {{SIZE}}{{UNIT}} !important;',
                     '{{WRAPPER}} .gm2-qd-option.active .gm2-qd-currency-icon svg,\n                     {{WRAPPER}} .gm2-qd-option.active .gm2-qd-currency-icon.e-font-icon-svg,\n                     {{WRAPPER}} .gm2-qd-option.active .gm2-qd-currency-icon i' => 'width: {{SIZE}}{{UNIT}} !important; height: {{SIZE}}{{UNIT}} !important;',
+                ],
+            ]
+        );
+        $this->add_control(
+            'icon_active_color',
+            [
+                'label' => __( 'Icon Color', 'gm2-wordpress-suite' ),
+                'type'  => \Elementor\Controls_Manager::COLOR,
+                'selectors' => [
+                    '{{WRAPPER}} .gm2-qd-option.active .gm2-qd-currency-icon' => 'color: {{VALUE}};',
                 ],
             ]
         );

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: gm2team
 Tags: admin, tools, suite, performance
 Requires at least: 6.0
 Tested up to: 6.5
-Stable tag: 1.6.12
+Stable tag: 1.6.13
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -292,6 +292,8 @@ the last 100 missing URLs to help you create new redirects.
   `nofollow` or `sponsored` to outbound links.
 
 == Changelog ==
+= 1.6.13 =
+* Added icon color style options for the Gm2 Qnty Discounts widget currency icon.
 = 1.6.12 =
 * Improved dropdown behavior in Quantity Discounts admin.
 = 1.6.11 =

--- a/tests/js/gm2-qd-widget.test.js
+++ b/tests/js/gm2-qd-widget.test.js
@@ -46,6 +46,24 @@ test('currency icon font size changes with active class', () => {
   expect($('.gm2-qd-option.active .gm2-qd-currency-icon').css('font-size')).toBe('20px');
 });
 
+test('currency icon color changes with active class', () => {
+  const dom = new JSDOM(`
+    <style>
+      .gm2-qd-currency-icon{color:red}
+      .gm2-qd-option.active .gm2-qd-currency-icon{color:blue}
+    </style>
+    <div class="gm2-qd-option">
+      <span class="gm2-qd-currency-icon"></span>
+    </div>
+  `, { url: 'http://localhost' });
+
+  const $ = jquery(dom.window);
+
+  expect($('.gm2-qd-currency-icon').css('color')).toBe('rgb(255, 0, 0)');
+  $('.gm2-qd-option').addClass('active');
+  expect($('.gm2-qd-option.active .gm2-qd-currency-icon').css('color')).toBe('rgb(0, 0, 255)');
+});
+
 test('option background colors apply for normal and active states', () => {
   const dom = new JSDOM(`
     <style>


### PR DESCRIPTION
## Summary
- expose icon color controls for the quantity discounts widget
- document the new option
- update tests
- bump version to 1.6.13

## Testing
- `npm test`
- `~/.local/share/mise/installs/php/8.4.10/.composer/vendor/bin/phpunit` *(fails: missing WordPress test suite)*

------
https://chatgpt.com/codex/tasks/task_e_6878fd85df588327befa2774e4551211