### PR TITLE
Fix HTML entity display in Quantity Discounts

### DIFF
--- a/admin/js/gm2-quantity-discounts.js
+++ b/admin/js/gm2-quantity-discounts.js
@@ -2,8 +2,19 @@ jQuery(function($){
     var groups = gm2Qd.groups || [];
     var categories = gm2Qd.categories || [];
     let activeSearch = null;
+
+    function decodeEntities(str){
+        if(!str) return '';
+        var txt = document.createElement('textarea');
+        txt.innerHTML = str;
+        return txt.value;
+    }
+
     function labelFor(item){
         var l = item.title || item.text || item.id;
+        if(typeof l === 'string'){
+            l = decodeEntities(l);
+        }
         if(item.sku){ l += ' ('+item.sku+')'; }
         return l;
     }

--- a/tests/js/gm2-quantity-discounts.test.js
+++ b/tests/js/gm2-quantity-discounts.test.js
@@ -183,6 +183,47 @@ test('product titles with quotes display correctly when added', async () => {
   expect(text).toContain('Prod "Special"');
 });
 
+test('product titles with HTML entities are decoded', async () => {
+  const dom = new JSDOM(`
+    <form id="gm2-qd-form">
+      <div id="gm2-qd-groups"></div>
+    </form>
+  `, { url: 'http://localhost' });
+  const $ = jquery(dom.window);
+  Object.assign(global, { window: dom.window, document: dom.window.document, jQuery: $, $ });
+  $.fn.selectWoo = jest.fn(function(){ return this; });
+  global.gm2Qd = {
+    nonce: 'n',
+    ajax_url: '/fake',
+    groups: [{ name: 'A', products: [], rules: [] }],
+    categories: [],
+    productTitles: {}
+  };
+  $.get = jest.fn(() => $.Deferred().resolve({
+    success: true,
+    data: [
+      { id: 1, title: 'Prod 6&#8243;', sku: 'S1' }
+    ]
+  }));
+
+  jest.resetModules();
+  require('../../admin/js/gm2-quantity-discounts.js');
+  await new Promise(r => setTimeout(r, 0));
+  await new Promise(r => setTimeout(r, 0));
+
+  const group = $('.gm2-qd-group');
+  group.find('.gm2-qd-search').val('pr');
+  group.find('.gm2-qd-search-btn').trigger('click');
+  await new Promise(r => setTimeout(r, 0));
+
+  group.find('.gm2-qd-product-chk').prop('checked', true);
+  group.find('.gm2-qd-add-selected').trigger('click');
+  await new Promise(r => setTimeout(r, 0));
+
+  const text = group.find('.gm2-qd-selected li').text();
+  expect(text).toContain('Prod 6″');
+});
+
 test('remove button deletes entire list item', async () => {
   const dom = new JSDOM(`
     <form id="gm2-qd-form">


### PR DESCRIPTION
## Summary
- decode HTML entities when rendering product titles in Quantity Discounts admin
- add unit test verifying entity decoding

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878fce4c54483279e814f39a949dda0