### PR TITLE
Add spinner and inline feedback when saving Quantity Discounts

### DIFF
--- a/admin/Gm2_Quantity_Discounts_Admin.php
+++ b/admin/Gm2_Quantity_Discounts_Admin.php
@@ -102,8 +102,7 @@ class Gm2_Quantity_Discounts_Admin {
         echo '<h1 class="gm2-qd-title">' . esc_html__( 'Quantity Discounts', 'gm2-wordpress-suite' ) . '</h1>';
         echo '<form id="gm2-qd-form"><div id="gm2-qd-groups"></div>';
         echo '<p><button type="button" id="gm2-qd-add-group" class="button">' . esc_html__( 'Add Group', 'gm2-wordpress-suite' ) . '</button></p>';
-        echo '<div id="gm2-qd-msg" class="notice hidden"></div>';
-        submit_button( esc_html__( 'Save Changes', 'gm2-wordpress-suite' ) );
+        echo '<div class="gm2-qd-actions"><button type="submit" id="gm2-qd-save" class="button button-primary">' . esc_html__( 'Save Changes', 'gm2-wordpress-suite' ) . '</button> <span class="gm2-qd-spinner loading-spinner hidden"></span> <span id="gm2-qd-msg" class="notice hidden"></span></div>';
         echo '</form></div>';
     }
 

--- a/admin/css/gm2-quantity-discounts.css
+++ b/admin/css/gm2-quantity-discounts.css
@@ -78,6 +78,25 @@
     margin-top:10px;
 }
 
+.gm2-qd-actions{
+    display:flex;
+    align-items:center;
+    gap:8px;
+    margin-top:15px;
+}
+.gm2-qd-actions .loading-spinner{
+    width:1em;
+    height:1em;
+    border:2px solid currentColor;
+    border-top-color:transparent;
+    border-radius:50%;
+    animation:gm2-spin .6s linear infinite;
+}
+.gm2-qd-actions #gm2-qd-msg{
+    display:inline-block;
+    margin:0;
+}
+
 .select2-container--default .select2-search--inline {
     display: none;
 }

--- a/admin/js/gm2-quantity-discounts.js
+++ b/admin/js/gm2-quantity-discounts.js
@@ -229,6 +229,10 @@ jQuery(function($){
             data.push(obj);
         });
         var $msg=$('#gm2-qd-msg');
+        var $spinner=$('.gm2-qd-spinner');
+        var $btn=$('#gm2-qd-save');
+        $btn.prop('disabled',true);
+        $spinner.removeClass('hidden');
         $msg.removeClass('notice-success notice-error').addClass('hidden');
         $.post(gm2Qd.ajax_url,{action:'gm2_qd_save_groups',nonce:gm2Qd.nonce,groups:data}).done(function(res){
             if(res.success){$msg.text('Saved.').addClass('notice-success');}
@@ -236,6 +240,8 @@ jQuery(function($){
         }).fail(function(){
             $msg.text('Error').addClass('notice-error');
         }).always(function(){
+            $spinner.addClass('hidden');
+            $btn.prop('disabled',false);
             $msg.removeClass('hidden');
         });
     });


### PR DESCRIPTION
## Summary
- show "Save Changes" feedback beside the button
- disable button and show spinner while saving
- style save button row for new spinner and inline notice

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687902a5ff208327aa52c055b6bc51bc