### PR TITLE
Add wrap option to Qnty Discounts widget

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,3 +12,4 @@ Existing prompt logic automatically includes these options via `gm2_get_seo_cont
 
 - The **Gm2 Qnty Discounts** widget now offers typography, color, shadow, padding and background controls for quantity labels and prices with Normal, Hover and Active tabs. Choose an icon for the currency symbol and style it alongside new box options for each quantity button, plus an **Icon Margin** option to control spacing around the currency icon. A new **Icon Color** style option lets you set colors for the currency icon in Normal, Hover and Active states.
 - The price section now uses flexbox by default and includes responsive **Horizontal** and **Vertical** alignment controls to adjust `justify-content` and `align-items`.
+- New **Wrap Options** control lets you enable flex wrapping so quantity buttons can stack on tablets and mobile.

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Gm2 WordPress Suite
  * Description:       A powerful suite of tools and features for WordPress, by Gm2.
- * Version:           1.6.13
+ * Version:           1.6.14
  * Author:            Your Name or Team Gm2
  * Author URI:        https://yourwebsite.com
  * License:           GPL-2.0+
@@ -15,7 +15,7 @@
 defined('ABSPATH') or die('No script kiddies please!');
 
 // Define constants
-define('GM2_VERSION', '1.6.13');
+define('GM2_VERSION', '1.6.14');
 define('GM2_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('GM2_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('GM2_CONTENT_RULES_VERSION', 2);

--- a/includes/widgets/class-gm2-qd-widget.php
+++ b/includes/widgets/class-gm2-qd-widget.php
@@ -24,6 +24,30 @@ class GM2_QD_Widget extends \Elementor\Widget_Base {
 
     protected function register_controls() {
         $this->start_controls_section(
+            'gm2_qd_container_style',
+            [
+                'label' => __( 'Options Container', 'gm2-wordpress-suite' ),
+                'tab'   => \Elementor\Controls_Manager::TAB_STYLE,
+            ]
+        );
+        $this->add_responsive_control(
+            'options_wrap',
+            [
+                'label'   => __( 'Wrap Options', 'gm2-wordpress-suite' ),
+                'type'    => \Elementor\Controls_Manager::SELECT,
+                'options' => [
+                    'nowrap' => __( 'No', 'gm2-wordpress-suite' ),
+                    'wrap'   => __( 'Yes', 'gm2-wordpress-suite' ),
+                ],
+                'default' => 'nowrap',
+                'selectors' => [
+                    '{{WRAPPER}} .gm2-qd-options' => 'flex-wrap: {{VALUE}};',
+                ],
+            ]
+        );
+        $this->end_controls_section();
+
+        $this->start_controls_section(
             'gm2_qd_style',
             [
                 'label' => __( 'Options Style', 'gm2-wordpress-suite' ),

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: gm2team
 Tags: admin, tools, suite, performance
 Requires at least: 6.0
 Tested up to: 6.5
-Stable tag: 1.6.13
+Stable tag: 1.6.14
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -292,6 +292,8 @@ the last 100 missing URLs to help you create new redirects.
   `nofollow` or `sponsored` to outbound links.
 
 == Changelog ==
+= 1.6.14 =
+* Added wrap option to the Gm2 Qnty Discounts widget so quantity buttons can wrap on smaller screens.
 = 1.6.13 =
 * Added icon color style options for the Gm2 Qnty Discounts widget currency icon.
 = 1.6.12 =

--- a/tests/js/gm2-qd-widget.test.js
+++ b/tests/js/gm2-qd-widget.test.js
@@ -153,3 +153,20 @@ test('vertical alignment modifies align-items', () => {
   price.removeClass('align-top').addClass('align-bottom');
   expect(price.css('align-items')).toBe('flex-end');
 });
+
+test('container wrap toggles flex-wrap', () => {
+  const dom = new JSDOM(`
+    <style>
+      .gm2-qd-options { display:flex; }
+      .wrap { flex-wrap:wrap; }
+      .nowrap { flex-wrap:nowrap; }
+    </style>
+    <div class="gm2-qd-options wrap"></div>
+  `, { url: 'http://localhost' });
+
+  const $ = jquery(dom.window);
+  const container = $('.gm2-qd-options');
+  expect(container.css('flex-wrap')).toBe('wrap');
+  container.removeClass('wrap').addClass('nowrap');
+  expect(container.css('flex-wrap')).toBe('nowrap');
+});


### PR DESCRIPTION
## Summary
- add responsive wrap control to Quantity Discounts widget
- document new widget feature
- update changelog and bump version to 1.6.14
- test flex wrap behavior in JSDOM

## Testing
- `npm test`
- `phpunit --configuration phpunit.xml` *(fails: WordPress test suite missing)*

------
https://chatgpt.com/codex/tasks/task_e_6879053302408327a5258d0f2baffc90