### PR TITLE
Allow <br> tags in quantity discount labels

### DIFF
--- a/admin/Gm2_Quantity_Discounts_Admin.php
+++ b/admin/Gm2_Quantity_Discounts_Admin.php
@@ -191,7 +191,7 @@ class Gm2_Quantity_Discounts_Admin {
                     $min    = intval( $r['min'] ?? 1 );
                     $type   = $r['type'] === 'fixed' ? 'fixed' : 'percent';
                     $amount = floatval( $r['amount'] ?? 0 );
-                    $label  = sanitize_text_field( $r['label'] ?? '' );
+                    $label  = wp_kses( $r['label'] ?? '', [ 'br' => [] ] );
                     $rules[] = [
                         'min'    => $min,
                         'type'   => $type,

--- a/includes/widgets/class-gm2-qd-widget.php
+++ b/includes/widgets/class-gm2-qd-widget.php
@@ -611,7 +611,7 @@ class GM2_QD_Widget extends \Elementor\Widget_Base {
             $price     = wc_price( $price_raw, [ 'currency' => '', 'price_format' => '%2$s' ] );
 
             echo '<button class="gm2-qd-option" data-qty="' . esc_attr( $qty ) . '">';
-            echo '<span class="gm2-qd-label">' . esc_html( $label ) . '</span>';
+            echo '<span class="gm2-qd-label">' . wp_kses( $label, [ 'br' => [] ] ) . '</span>';
             echo '<span class="gm2-qd-price">';
             if ( ! empty( $settings['currency_icon']['value'] ) ) {
                 Icons_Manager::render_icon( $settings['currency_icon'], [ 'aria-hidden' => 'true', 'class' => 'gm2-qd-currency-icon' ] );

--- a/tests/test-quantity-discounts-admin.php
+++ b/tests/test-quantity-discounts-admin.php
@@ -74,6 +74,24 @@ class QuantityDiscountsAdminAjaxTest extends WP_Ajax_UnitTestCase {
         $this->assertSame('First', $saved[0]['rules'][0]['label']);
     }
 
+    public function test_save_groups_preserves_br_tag() {
+        $admin = new Gm2_Quantity_Discounts_Admin();
+        $admin->register_hooks();
+
+        $this->_setRole('administrator');
+        $_POST['nonce'] = wp_create_nonce('gm2_qd_nonce');
+        $_POST['groups'] = [
+            [
+                'name'     => 'G',
+                'products' => [1],
+                'rules'    => [ [ 'min' => 1, 'type' => 'percent', 'amount' => 5, 'label' => 'Line1<br>Line2' ] ],
+            ],
+        ];
+        try { $this->_handleAjax('gm2_qd_save_groups'); } catch (WPAjaxDieContinueException $e) {}
+        $saved = get_option('gm2_quantity_discount_groups');
+        $this->assertSame('Line1<br>Line2', $saved[0]['rules'][0]['label']);
+    }
+
     public function test_search_products_excludes_drafts() {
         $published = self::factory()->post->create([
             'post_type'   => 'product',

--- a/tests/test-quantity-discounts.php
+++ b/tests/test-quantity-discounts.php
@@ -201,6 +201,35 @@ class QuantityDiscountsTest extends WP_UnitTestCase {
         $this->assertStringContainsString('gm2-qd-options', $out);
     }
 
+    public function test_widget_outputs_br_in_label() {
+        require_once GM2_PLUGIN_DIR . 'includes/widgets/class-gm2-qd-widget.php';
+
+        if ( ! class_exists( '\\Elementor\\Plugin' ) ) {
+            eval('namespace Elementor; class Plugin { public static $instance; public $editor; public function __construct(){ self::$instance = $this; $this->editor = new class { public function is_edit_mode(){ return true; } }; } }');
+        } else {
+            \Elementor\Plugin::$instance = new class { public $editor; public function __construct(){ $this->editor = new class { public function is_edit_mode(){ return true; } }; } };
+        }
+
+        if ( ! class_exists( 'WC_Product_With_ID' ) ) {
+            class WC_Product_With_ID extends WC_Product { public function get_id() { return 1; } }
+        }
+        global $product;
+        $product = new WC_Product_With_ID(100);
+
+        $m = new Gm2_Quantity_Discount_Manager();
+        $m->add_group([
+            'name'     => 'Test',
+            'products' => [1],
+            'rules'    => [ [ 'min' => 1, 'type' => 'percent', 'amount' => 10, 'label' => 'Line1<br>Line2' ] ],
+        ]);
+
+        ob_start();
+        $widget = new \Gm2\GM2_QD_Widget();
+        $widget->render();
+        $out = ob_get_clean();
+        $this->assertStringContainsString('Line1<br>Line2', $out);
+    }
+
     public function test_ajax_recalculate_updates_fragments() {
         $m = new Gm2_Quantity_Discount_Manager();
         $m->add_group([


### PR DESCRIPTION
## Summary
- permit `<br>` tags when saving quantity discount labels
- render labels with `<br>` tags in the QD widget
- test preservation of `<br>` tags in admin save handler
- test widget output with `<br>` labels

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68792b18d6c883279c63691f894ee69a