### PR TITLE
Add meta keywords tag

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Gm2 WordPress Suite
  * Description:       A powerful suite of tools and features for WordPress, by Gm2.
- * Version:           1.6.14
+ * Version:           1.6.15
  * Author:            Your Name or Team Gm2
  * Author URI:        https://yourwebsite.com
  * License:           GPL-2.0+
@@ -15,7 +15,7 @@
 defined('ABSPATH') or die('No script kiddies please!');
 
 // Define constants
-define('GM2_VERSION', '1.6.14');
+define('GM2_VERSION', '1.6.15');
 define('GM2_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('GM2_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('GM2_CONTENT_RULES_VERSION', 2);

--- a/public/Gm2_SEO_Public.php
+++ b/public/Gm2_SEO_Public.php
@@ -161,7 +161,9 @@ class Gm2_SEO_Public {
      *     canonical:string,
      *     max_snippet:string,
      *     max_image_preview:string,
-     *     max_video_preview:string
+     *     max_video_preview:string,
+     *     focus_keywords:string,
+     *     long_tail_keywords:string
      * }
      */
     private function get_seo_meta() {
@@ -174,6 +176,8 @@ class Gm2_SEO_Public {
         $max_snippet       = '';
         $max_image_preview = '';
         $max_video_preview = '';
+        $focus_keywords    = '';
+        $long_tail_keywords = '';
 
         if (is_singular()) {
             $post_id    = get_queried_object_id();
@@ -186,6 +190,8 @@ class Gm2_SEO_Public {
             $max_snippet       = get_post_meta($post_id, '_gm2_max_snippet', true);
             $max_image_preview = get_post_meta($post_id, '_gm2_max_image_preview', true);
             $max_video_preview = get_post_meta($post_id, '_gm2_max_video_preview', true);
+            $focus_keywords    = get_post_meta($post_id, '_gm2_focus_keywords', true);
+            $long_tail_keywords = get_post_meta($post_id, '_gm2_long_tail_keywords', true);
 
             if (class_exists('WooCommerce') && function_exists('is_product') && is_product()) {
                 $product = wc_get_product($post_id);
@@ -216,6 +222,8 @@ class Gm2_SEO_Public {
                 $max_snippet       = get_term_meta($term->term_id, '_gm2_max_snippet', true);
                 $max_image_preview = get_term_meta($term->term_id, '_gm2_max_image_preview', true);
                 $max_video_preview = get_term_meta($term->term_id, '_gm2_max_video_preview', true);
+                $focus_keywords    = get_term_meta($term->term_id, '_gm2_focus_keywords', true);
+                $long_tail_keywords = get_term_meta($term->term_id, '_gm2_long_tail_keywords', true);
             }
         }
 
@@ -247,6 +255,8 @@ class Gm2_SEO_Public {
             'max_snippet' => $max_snippet,
             'max_image_preview' => $max_image_preview,
             'max_video_preview' => $max_video_preview,
+            'focus_keywords'    => $focus_keywords,
+            'long_tail_keywords' => $long_tail_keywords,
         ];
     }
 
@@ -266,6 +276,23 @@ class Gm2_SEO_Public {
         if ($data['max_video_preview'] !== '') {
             $robots[] = 'max-video-preview:' . $data['max_video_preview'];
         }
+        $keywords = '';
+        $fw = trim($data['focus_keywords']);
+        $lt = trim($data['long_tail_keywords']);
+        if ($fw !== '' || $lt !== '') {
+            $parts = [];
+            foreach ([$fw, $lt] as $list) {
+                if ($list !== '') {
+                    foreach (explode(',', $list) as $k) {
+                        $k = trim($k);
+                        if ($k !== '') {
+                            $parts[] = $k;
+                        }
+                    }
+                }
+            }
+            $keywords = implode(', ', array_unique($parts));
+        }
         $canonical   = $data['canonical'];
         $og_image_id = $data['og_image'];
         if (!$og_image_id && is_singular()) {
@@ -283,6 +310,9 @@ class Gm2_SEO_Public {
         }
         echo '<meta name="description" content="' . esc_attr($description) . '" />' . "\n";
         echo '<meta name="robots" content="' . esc_attr(implode(',', $robots)) . '" />' . "\n";
+        if ($keywords !== '') {
+            echo '<meta name="keywords" content="' . esc_attr($keywords) . '" />' . "\n";
+        }
 
         $url  = $canonical;
         $type = is_singular() ? 'article' : 'website';

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: gm2team
 Tags: admin, tools, suite, performance
 Requires at least: 6.0
 Tested up to: 6.5
-Stable tag: 1.6.14
+Stable tag: 1.6.15
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -202,7 +202,7 @@ Open the **Context** tab under **SEO** to store detailed business information us
 == SEO Settings ==
 The SEO meta box appears when editing posts, pages, any public custom post types and taxonomy terms. In the
 **SEO Settings** tab you can enter a custom title and description, focus keywords and long tail keywords, toggle
-`noindex` or `nofollow`, and upload an Open Graph image. Click **Select Image**
+`noindex` or `nofollow`, and upload an Open Graph image. Focus and long tail keywords are combined into a `<meta name="keywords">` tag on the front end. Click **Select Image**
 to open the WordPress media library and choose a picture for the `og:image` and
 `twitter:image` tags. When inserting a link, you can pick `nofollow` or `sponsored`
 from the link dialog and the plugin will automatically apply the attribute.
@@ -300,6 +300,8 @@ the last 100 missing URLs to help you create new redirects.
   `nofollow` or `sponsored` to outbound links.
 
 == Changelog ==
+= 1.6.15 =
+* Combined focus and long tail keywords into a `<meta name="keywords">` tag on the front end.
 = 1.6.14 =
 * Added wrap option to the Gm2 Qnty Discounts widget so quantity buttons can wrap on smaller screens.
 = 1.6.13 =

--- a/tests/test-meta-tags.php
+++ b/tests/test-meta-tags.php
@@ -157,6 +157,40 @@ class MetaTagsTest extends WP_UnitTestCase {
         $this->assertStringContainsString('max-video-preview:10', $output);
     }
 
+    public function test_keywords_meta_tag_outputs_when_present() {
+        $post_id = self::factory()->post->create([
+            'post_title'   => 'KW Post',
+            'post_content' => 'Content',
+        ]);
+        update_post_meta($post_id, '_gm2_focus_keywords', 'alpha, beta');
+        update_post_meta($post_id, '_gm2_long_tail_keywords', 'gamma');
+
+        $seo = new Gm2_SEO_Public();
+        $this->go_to(get_permalink($post_id));
+        setup_postdata(get_post($post_id));
+        ob_start();
+        $seo->output_meta_tags();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('<meta name="keywords" content="alpha, beta, gamma"', $output);
+    }
+
+    public function test_keywords_meta_tag_omitted_when_empty() {
+        $post_id = self::factory()->post->create([
+            'post_title'   => 'No KW',
+            'post_content' => 'Content',
+        ]);
+
+        $seo = new Gm2_SEO_Public();
+        $this->go_to(get_permalink($post_id));
+        setup_postdata(get_post($post_id));
+        ob_start();
+        $seo->output_meta_tags();
+        $output = ob_get_clean();
+
+        $this->assertStringNotContainsString('name="keywords"', $output);
+    }
+
     public function test_custom_og_image_in_meta_tags() {
         $post_id = self::factory()->post->create([
             'post_title'   => 'Image Post',


### PR DESCRIPTION
## Summary
- fetch focus keywords and long tail keywords in public SEO class
- output `<meta name="keywords">` tag when keywords exist
- add tests for meta keywords
- document the new tag and bump version

## Testing
- `npm test`
- `make test DB_NAME=wp_test DB_USER=root DB_PASS=pass` *(fails: Can't connect to MySQL server)*

------
https://chatgpt.com/codex/tasks/task_e_68794b7e18ec8327a5fe034092cd3747