### PR TITLE
Support gpt-4-turbo model

### DIFF
--- a/includes/Gm2_SEO_Utils.php
+++ b/includes/Gm2_SEO_Utils.php
@@ -73,7 +73,7 @@ namespace {
         if ($api_key === '') {
             return new \WP_Error('no_api_key', 'ChatGPT API key not set');
         }
-        $model = in_array($args['language-model'], ['gpt-3.5-turbo', 'gpt-4'], true) ? $args['language-model'] : 'gpt-3.5-turbo';
+        $model = in_array($args['language-model'], ['gpt-3.5-turbo', 'gpt-4', 'gpt-4-turbo'], true) ? $args['language-model'] : 'gpt-3.5-turbo';
         $temperature = floatval($args['temperature']);
 
         $payload = [

--- a/tests/test-ai-utils.php
+++ b/tests/test-ai-utils.php
@@ -1,0 +1,21 @@
+<?php
+use function Gm2\gm2_ai_send_prompt;
+
+class AiUtilsTest extends WP_UnitTestCase {
+    public function test_gpt4_turbo_model_selected() {
+        update_option('gm2_chatgpt_api_key', 'key');
+        $captured = null;
+        $filter = function($pre, $args, $url) use (&$captured) {
+            $captured = json_decode($args['body'], true)['model'];
+            return [
+                'response' => ['code' => 200],
+                'body'     => json_encode(['choices' => [ ['message' => ['content' => 'ok']] ] ])
+            ];
+        };
+        add_filter('pre_http_request', $filter, 10, 3);
+        $result = gm2_ai_send_prompt('hi', ['language-model' => 'gpt-4-turbo']);
+        remove_filter('pre_http_request', $filter, 10);
+        $this->assertSame('ok', $result);
+        $this->assertSame('gpt-4-turbo', $captured);
+    }
+}


### PR DESCRIPTION
## Summary
- allow `gpt-4-turbo` in language model validation
- test that `gm2_ai_send_prompt` uses `gpt-4-turbo` when requested

## Testing
- `vendor/bin/phpunit` *(fails: Class declarations may not be nested)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687951a647008327b9f1ab7cd315ed9e