### PR TITLE
Improve multibyte substr handling

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -2328,9 +2328,9 @@ class Gm2_SEO_Admin {
         }
 
         if (strpos($target, 'post_') === 0) {
-            $prompt_target = sprintf('for the %s post type', substr($target, 5));
+            $prompt_target = sprintf('for the %s post type', gm2_substr($target, 5));
         } else {
-            $prompt_target = sprintf('for the %s taxonomy', substr($target, 4));
+            $prompt_target = sprintf('for the %s taxonomy', gm2_substr($target, 4));
         }
 
         $prompt = sprintf(

--- a/includes/Gm2_ChatGPT.php
+++ b/includes/Gm2_ChatGPT.php
@@ -60,7 +60,7 @@ class Gm2_ChatGPT {
 
         if ($status !== 200) {
             if (defined('WP_DEBUG') && WP_DEBUG) {
-                $snippet = substr($body, 0, 200);
+                $snippet = gm2_substr($body, 0, 200);
                 error_log(sprintf('Gm2_ChatGPT HTTP %s: %s', $status, $snippet));
             }
             $data    = json_decode($body, true);

--- a/includes/Gm2_Keyword_Planner.php
+++ b/includes/Gm2_Keyword_Planner.php
@@ -100,7 +100,7 @@ class Gm2_Keyword_Planner {
 
         if ($code < 200 || $code >= 300 || (!empty($data['error']['message']))) {
             if (defined('WP_DEBUG') && WP_DEBUG) {
-                $snippet = substr($body, 0, 200);
+                $snippet = gm2_substr($body, 0, 200);
                 error_log(sprintf('Keyword Planner HTTP %s: %s', $code, $snippet));
             }
             $msg = $data['error']['message'] ?? "HTTP $code response";

--- a/includes/Gm2_SEO_Utils.php
+++ b/includes/Gm2_SEO_Utils.php
@@ -56,9 +56,19 @@ namespace {
         }
         if ($desc === '' && isset($GLOBALS['post']) && $GLOBALS['post'] instanceof \WP_Post) {
             $clean = wp_strip_all_tags($GLOBALS['post']->post_content);
-            $desc  = substr($clean, 0, 160);
+            $desc  = gm2_substr($clean, 0, 160);
         }
         return $desc;
+    }
+
+    /**
+     * Multibyte-safe substring helper.
+     */
+    function gm2_substr($string, $start, $length = null) {
+        if (function_exists('mb_substr')) {
+            return mb_substr($string, $start, $length, 'UTF-8');
+        }
+        return $length === null ? substr($string, $start) : substr($string, $start, $length);
     }
 
     function gm2_ai_send_prompt($prompt, $args = []) {

--- a/includes/autoload.php
+++ b/includes/autoload.php
@@ -4,7 +4,13 @@ spl_autoload_register(function ($class) {
         return;
     }
 
-    $name = substr($class, 4); // class name without namespace
+    if (function_exists('gm2_substr')) {
+        $name = gm2_substr($class, 4); // class name without namespace
+    } elseif (function_exists('mb_substr')) {
+        $name = mb_substr($class, 4, null, 'UTF-8');
+    } else {
+        $name = substr($class, 4);
+    }
     foreach (['includes', 'admin', 'public'] as $dir) {
         $file = GM2_PLUGIN_DIR . $dir . '/' . $name . '.php';
         if (file_exists($file)) {

--- a/tests/test-mb-substr.php
+++ b/tests/test-mb-substr.php
@@ -1,0 +1,7 @@
+<?php
+class MbSubstrTest extends WP_UnitTestCase {
+    public function test_multibyte_substring() {
+        $str = 'こんにちは世界';
+        $this->assertSame('こんにちは', gm2_substr($str, 0, 5));
+    }
+}


### PR DESCRIPTION
## Summary
- add `gm2_substr` helper using `mb_substr` with fallback
- update uses of `substr` to call the helper
- include fallback logic in autoloader
- test handling of multibyte strings

## Testing
- `phpunit`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687955759144832797a43732bbea6f76