### PR TITLE
Add collapsible selected products list

### DIFF
--- a/admin/css/gm2-quantity-discounts.css
+++ b/admin/css/gm2-quantity-discounts.css
@@ -76,6 +76,25 @@
 }
 .gm2-qd-selected-title {
     margin-top:10px;
+    cursor:pointer;
+    position:relative;
+    padding-right:20px;
+}
+.gm2-qd-selected-title .gm2-qd-selected-toggle{
+    position:absolute;
+    right:0;
+    top:0;
+    font-weight:bold;
+}
+
+.gm2-qd-selected-wrap .gm2-qd-selected,
+.gm2-qd-selected-wrap .gm2-qd-remove-actions{
+    display:none;
+}
+
+.gm2-qd-selected-wrap.open .gm2-qd-selected,
+.gm2-qd-selected-wrap.open .gm2-qd-remove-actions{
+    display:block;
 }
 
 .gm2-qd-actions{

--- a/admin/js/gm2-quantity-discounts.js
+++ b/admin/js/gm2-quantity-discounts.js
@@ -35,7 +35,7 @@ jQuery(function($){
         header.append('<input type="text" class="gm2-qd-name" placeholder="Group name" value="'+(g.name||'')+'"> <button type="button" class="button gm2-qd-remove-group">&times;</button><span class="gm2-qd-toggle">&#9650;</span>');
         accordion.append(header);
         var container = $('<div class="gm2-qd-group"></div>');
-        var prodSection = $('<div class="gm2-qd-products"><select class="gm2-qd-cat" multiple><option value="">All Categories</option></select> <input type="text" class="gm2-qd-search" placeholder="Search products"> <button type="button" class="button gm2-qd-search-btn">Search</button> <div class="gm2-qd-cat-products"></div><ul class="gm2-qd-results"></ul><h4 class="gm2-qd-selected-title">Selected products</h4><ul class="gm2-qd-selected"></ul><p class="gm2-qd-remove-actions"><button type="button" class="button gm2-qd-remove-selected">Remove selected products</button> <button type="button" class="button gm2-qd-remove-all">Remove all</button></p></div>');
+        var prodSection = $('<div class="gm2-qd-products"><select class="gm2-qd-cat" multiple><option value="">All Categories</option></select> <input type="text" class="gm2-qd-search" placeholder="Search products"> <button type="button" class="button gm2-qd-search-btn">Search</button> <div class="gm2-qd-cat-products"></div><ul class="gm2-qd-results"></ul><div class="gm2-qd-selected-wrap open"><h4 class="gm2-qd-selected-title">Selected products <span class="gm2-qd-selected-toggle">&#9650;</span></h4><ul class="gm2-qd-selected"></ul><p class="gm2-qd-remove-actions"><button type="button" class="button gm2-qd-remove-selected">Remove selected products</button> <button type="button" class="button gm2-qd-remove-all">Remove all</button></p></div></div>');
         categories.forEach(function(c){prodSection.find('select').append('<option value="'+c.id+'">'+c.name+'</option>');});
         container.append(prodSection);
         var table = $('<table class="widefat gm2-qd-rules"><thead><tr><th>Min Qty</th><th>Label</th><th>% Off</th><th>Fixed Off</th><th></th></tr></thead><tbody></tbody></table>');
@@ -209,6 +209,11 @@ jQuery(function($){
     });
     $(document).on('click','.gm2-qd-selected .remove',function(){
         $(this).closest('li').remove();
+    });
+    $(document).on('click','.gm2-qd-selected-title',function(e){
+        var wrap=$(this).closest('.gm2-qd-selected-wrap');
+        wrap.toggleClass('open');
+        $(this).find('.gm2-qd-selected-toggle').html(wrap.hasClass('open')?'\u25B2':'\u25BC');
     });
     $('#gm2-qd-form').on('submit',function(e){
         e.preventDefault();

--- a/tests/js/gm2-quantity-discounts.test.js
+++ b/tests/js/gm2-quantity-discounts.test.js
@@ -21,7 +21,7 @@ test('renders groups from gm2Qd', async () => {
 
   expect($('.gm2-qd-name').val()).toBe('Group A');
   expect($('.gm2-qd-accordion').length).toBe(1);
-  expect($('.gm2-qd-selected-title').text()).toBe('Selected products');
+  expect($('.gm2-qd-selected-title').text()).toBe('Selected products ▲');
   const text = $('.gm2-qd-selected li').text();
   expect(text).toContain('Prod');
   expect(text).toContain('P1');
@@ -252,6 +252,34 @@ test('remove button deletes entire list item', async () => {
   await new Promise(r => setTimeout(r, 0));
 
   expect($('.gm2-qd-selected li').length).toBe(0);
+});
+
+test('selected product list toggles visibility', async () => {
+  const dom = new JSDOM(`
+    <form id="gm2-qd-form">
+      <div id="gm2-qd-groups"></div>
+    </form>
+  `, { url: 'http://localhost' });
+  const $ = jquery(dom.window);
+  Object.assign(global, { window: dom.window, document: dom.window.document, jQuery: $, $ });
+  $.fn.selectWoo = jest.fn(function(){ return this; });
+  global.gm2Qd = { nonce: 'n', ajax_url: '/fake', groups: [{ name: 'A', products: [], rules: [] }], categories: [], productTitles: {} };
+
+  jest.resetModules();
+  require('../../admin/js/gm2-quantity-discounts.js');
+  await new Promise(r => setTimeout(r, 0));
+  await new Promise(r => setTimeout(r, 0));
+
+  const wrap = $('.gm2-qd-selected-wrap');
+  expect(wrap.hasClass('open')).toBe(true);
+
+  wrap.find('.gm2-qd-selected-title').trigger('click');
+  await new Promise(r => setTimeout(r, 0));
+  expect(wrap.hasClass('open')).toBe(false);
+
+  wrap.find('.gm2-qd-selected-title').trigger('click');
+  await new Promise(r => setTimeout(r, 0));
+  expect(wrap.hasClass('open')).toBe(true);
 });
 
 test('category dropdown closes on select2 unselect', async () => {


### PR DESCRIPTION
## Summary
- make selected product list an accordion with toggle arrow
- update styling to show/hide selected items
- update JS tests for new markup and add toggle behavior test

## Testing
- `npm test`
- `phpunit` *(fails: missing WordPress test suite)*

------
https://chatgpt.com/codex/tasks/task_e_6879a0026208832782957a34b1d65b8f