### PR TITLE
Fix quantity discount group save via JSON

### DIFF
--- a/admin/Gm2_Quantity_Discounts_Admin.php
+++ b/admin/Gm2_Quantity_Discounts_Admin.php
@@ -182,7 +182,17 @@ class Gm2_Quantity_Discounts_Admin {
             wp_send_json_error( __( 'Permission denied', 'gm2-wordpress-suite' ) );
         }
         check_ajax_referer( 'gm2_qd_nonce', 'nonce' );
-        $groups = isset( $_POST['groups'] ) && is_array( $_POST['groups'] ) ? $_POST['groups'] : [];
+        $groups = [];
+        if ( isset( $_POST['groups'] ) ) {
+            if ( is_string( $_POST['groups'] ) ) {
+                $decoded = json_decode( wp_unslash( $_POST['groups'] ), true );
+                if ( is_array( $decoded ) ) {
+                    $groups = $decoded;
+                }
+            } elseif ( is_array( $_POST['groups'] ) ) {
+                $groups = $_POST['groups'];
+            }
+        }
         $clean  = [];
         foreach ( $groups as $g ) {
             $name     = sanitize_text_field( $g['name'] ?? '' );

--- a/admin/js/gm2-quantity-discounts.js
+++ b/admin/js/gm2-quantity-discounts.js
@@ -239,7 +239,7 @@ jQuery(function($){
         $btn.prop('disabled',true);
         $spinner.removeClass('hidden');
         $msg.removeClass('notice-success notice-error').addClass('hidden');
-        $.post(gm2Qd.ajax_url,{action:'gm2_qd_save_groups',nonce:gm2Qd.nonce,groups:data}).done(function(res){
+        $.post(gm2Qd.ajax_url,{action:'gm2_qd_save_groups',nonce:gm2Qd.nonce,groups:JSON.stringify(data)}).done(function(res){
             if(res.success){$msg.text('Saved.').addClass('notice-success');}
             else{$msg.text(res.data&&res.data.message?res.data.message:'Error').addClass('notice-error');}
         }).fail(function(){

--- a/tests/test-quantity-discounts-admin.php
+++ b/tests/test-quantity-discounts-admin.php
@@ -92,6 +92,26 @@ class QuantityDiscountsAdminAjaxTest extends WP_Ajax_UnitTestCase {
         $this->assertSame('Line1<br>Line2', $saved[0]['rules'][0]['label']);
     }
 
+    public function test_save_groups_accepts_json() {
+        $admin = new Gm2_Quantity_Discounts_Admin();
+        $admin->register_hooks();
+
+        $this->_setRole('administrator');
+        $_POST['nonce'] = wp_create_nonce('gm2_qd_nonce');
+        $_POST['groups'] = json_encode([
+            [
+                'name'     => 'J',
+                'products' => [1, 2],
+                'rules'    => [ [ 'min' => 1, 'type' => 'percent', 'amount' => 5 ] ],
+            ],
+        ]);
+        try { $this->_handleAjax('gm2_qd_save_groups'); } catch (WPAjaxDieContinueException $e) {}
+        $resp = json_decode($this->_last_response, true);
+        $this->assertTrue($resp['success']);
+        $saved = get_option('gm2_quantity_discount_groups');
+        $this->assertSame(['J', [1,2]], [$saved[0]['name'], $saved[0]['products']]);
+    }
+
     public function test_search_products_excludes_drafts() {
         $published = self::factory()->post->create([
             'post_type'   => 'product',


### PR DESCRIPTION
## Summary
- support JSON payloads when saving quantity discount groups
- send groups as JSON from admin script
- test JSON submission handling

## Testing
- `npm test` *(fails: jest not found)*
- `phpunit` *(fails: phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6879c33aa8ec8327b27c797edfb7b86c