### PR TITLE
Refactor admin to use discount manager

### DIFF
--- a/admin/Gm2_Quantity_Discounts_Admin.php
+++ b/admin/Gm2_Quantity_Discounts_Admin.php
@@ -45,7 +45,8 @@ class Gm2_Quantity_Discounts_Admin {
             GM2_VERSION,
             true
         );
-        $groups  = get_option( 'gm2_quantity_discount_groups', [] );
+        $manager = new Gm2_Quantity_Discount_Manager();
+        $groups  = $manager->get_groups();
         $titles  = [];
         foreach ( $groups as &$g ) {
             if ( empty( $g['products'] ) || ! is_array( $g['products'] ) ) {
@@ -220,7 +221,8 @@ class Gm2_Quantity_Discounts_Admin {
                 ];
             }
         }
-        update_option( 'gm2_quantity_discount_groups', $clean );
+        $manager = new Gm2_Quantity_Discount_Manager();
+        $manager->set_groups( $clean );
         wp_send_json_success( [ 'saved' => true ] );
     }
 }

--- a/includes/Gm2_Quantity_Discount_Manager.php
+++ b/includes/Gm2_Quantity_Discount_Manager.php
@@ -61,4 +61,17 @@ class Gm2_Quantity_Discount_Manager {
         });
         update_option($this->option_name, array_values($groups));
     }
+
+    /**
+     * Replace all groups with the provided array.
+     *
+     * @param array $groups Group data to store.
+     * @return void
+     */
+    public function set_groups($groups) {
+        if (!is_array($groups)) {
+            $groups = [];
+        }
+        update_option($this->option_name, $groups);
+    }
 }

--- a/tests/js/gm2-quantity-discounts.test.js
+++ b/tests/js/gm2-quantity-discounts.test.js
@@ -58,7 +58,8 @@ test('submits group data via ajax', async () => {
   await new Promise(r => setTimeout(r, 0));
 
   expect($.post).toHaveBeenCalled();
-  const data = $.post.mock.calls[0][1].groups[0];
+  const sent = $.post.mock.calls[0][1].groups;
+  const data = Array.isArray(sent) ? sent[0] : JSON.parse(sent)[0];
   expect(data.name).toBe('Test');
   expect(data.products[0]).toBe(55);
   expect(data.rules[0]).toEqual({ min: 2, label: 'First', type: 'percent', amount: 10 });


### PR DESCRIPTION
## Summary
- centralize quantity discount storage using manager
- refactor admin page to use the manager class
- fix JS test for JSON group payloads

## Testing
- `npm test`
- `phpunit` *(fails: WordPress test suite missing)*

------
https://chatgpt.com/codex/tasks/task_e_6879cc32bb188327a5375f5bc6205fe5