### PR TITLE
Wrap quantity discount descriptions in translations

### DIFF
--- a/public/Gm2_Quantity_Discounts_Public.php
+++ b/public/Gm2_Quantity_Discounts_Public.php
@@ -19,9 +19,17 @@ class Gm2_Quantity_Discounts_Public {
 
     private function format_rule_desc($rule) {
         if ($rule['type'] === 'percent') {
-            return sprintf('%d+ units: %s%% off', $rule['min'], $rule['amount']);
+            return sprintf(
+                __('%d+ units: %s%% off', 'gm2-wordpress-suite'),
+                $rule['min'],
+                $rule['amount']
+            );
         }
-        return sprintf('%d+ units: %s discount', $rule['min'], wc_price($rule['amount']));
+        return sprintf(
+            __('%d+ units: %s discount', 'gm2-wordpress-suite'),
+            $rule['min'],
+            wc_price($rule['amount'])
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary
- expose quantity discount text to translators by wrapping it with `__()`

## Testing
- `phpunit` *(fails: missing WordPress test suite)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687a768ea2508327a172e905fcf635ad