### PR TITLE
Add AI prompt builder for SEO context

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -121,6 +121,13 @@ class Gm2_Admin {
                 GM2_VERSION,
                 true
             );
+            wp_enqueue_script(
+                'gm2-context-prompt',
+                GM2_PLUGIN_URL . 'admin/js/gm2-context-prompt.js',
+                ['jquery'],
+                GM2_VERSION,
+                true
+            );
             $gads_ready = trim(get_option('gm2_gads_developer_token', '')) !== '' &&
                 trim(get_option('gm2_gads_customer_id', '')) !== '' &&
                 get_option('gm2_google_refresh_token', '') !== '';

--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -301,6 +301,9 @@ class Gm2_SEO_Admin {
         register_setting('gm2_seo_options', 'gm2_context_custom_prompts', [
             'sanitize_callback' => 'sanitize_textarea_field',
         ]);
+        register_setting('gm2_seo_options', 'gm2_context_ai_prompt', [
+            'sanitize_callback' => 'sanitize_textarea_field',
+        ]);
         register_setting('gm2_seo_options', 'gm2_project_description', [
             'sanitize_callback' => 'sanitize_textarea_field',
         ]);
@@ -828,6 +831,12 @@ class Gm2_SEO_Admin {
                 }
                 echo '</td></tr>';
             }
+            $val = get_option( 'gm2_context_ai_prompt', '' );
+            echo '<tr><th scope="row"><label for="gm2_context_ai_prompt">' . esc_html__( 'AI Prompt', 'gm2-wordpress-suite' ) . '</label></th><td>';
+            echo '<textarea id="gm2_context_ai_prompt" name="gm2_context_ai_prompt" rows="4" class="large-text">' . esc_textarea( $val ) . '</textarea>';
+            echo '<p><button type="button" class="button gm2-build-ai-prompt">' . esc_html__( 'Build AI Prompt', 'gm2-wordpress-suite' ) . '</button></p>';
+            echo '<p class="description">' . esc_html__( 'Creates a single prompt summarizing your answers above.', 'gm2-wordpress-suite' ) . '</p>';
+            echo '</td></tr>';
             echo '</tbody></table>';
             submit_button( esc_html__( 'Save Context', 'gm2-wordpress-suite' ) );
             echo '</form>';

--- a/admin/js/gm2-context-prompt.js
+++ b/admin/js/gm2-context-prompt.js
@@ -1,0 +1,35 @@
+jQuery(function($){
+    $(document).on('click', '.gm2-build-ai-prompt', function(e){
+        e.preventDefault();
+        var prompt = [
+            'You are a strategic SEO assistant. Based on the detailed business information below, summarize the company\u2019s background into a concise, 1-paragraph context that can be prefixed to other SEO prompts. This context summary should:',
+            '',
+            '- Clearly define the business model, industry, offerings, and audience.',
+            '- Highlight unique selling points and primary goals.',
+            '- Mention tone/brand voice and geographic focus.',
+            '- Be formatted in natural language, suitable for pasting into the beginning of SEO prompts.',
+            '- Keep it under 150 words.',
+            '',
+            'Here is the business information:',
+            '',
+            'Business Model: ' + $('#gm2_context_business_model').val(),
+            'Industry Category: ' + $('#gm2_context_industry_category').val(),
+            'Target Audience: ' + $('#gm2_context_target_audience').val(),
+            'Unique Selling Points: ' + $('#gm2_context_unique_selling_points').val(),
+            'Revenue Streams: ' + $('#gm2_context_revenue_streams').val(),
+            'Primary Goal: ' + $('#gm2_context_primary_goal').val(),
+            'Brand Voice: ' + $('#gm2_context_brand_voice').val(),
+            'Competitors: ' + $('#gm2_context_competitors').val(),
+            'Core Offerings: ' + $('#gm2_context_core_offerings').val(),
+            'Geographic Focus: ' + $('#gm2_context_geographic_focus').val(),
+            'Keyword Data: ' + $('#gm2_context_keyword_data').val(),
+            'Competitor Landscape: ' + $('#gm2_context_competitor_landscape').val(),
+            'Success Metrics: ' + $('#gm2_context_success_metrics').val(),
+            'Buyer Personas: ' + $('#gm2_context_buyer_personas').val(),
+            'Project Description: ' + $('#gm2_context_project_description').val(),
+            'Custom Prompts: ' + $('#gm2_context_custom_prompts').val()
+        ].join('\n');
+        $('#gm2_context_ai_prompt').val(prompt);
+    });
+});
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,7 @@
 This release adds several new SEO and AI options:
 
 - **Project Description** and **Custom Prompts** fields under **SEO → Context**. The project description falls back to the site tagline or a snippet of post content if empty.
+- **AI Prompt** builder that compiles your Context answers into a single prompt for generating a short business summary.
 - Each context field now includes a guiding question so users know what to enter.
 - Additional context fields: **Core Offerings**, **Geographic Focus**, **Keyword Data**, **Competitor Landscape**, **Success Metrics** and **Buyer Personas**.
 - Additional meta fields on post and taxonomy edit screens for Search Intent, Focus Keyword Limit, Number of Words and an "Improve Readability" checkbox.

--- a/readme.txt
+++ b/readme.txt
@@ -198,6 +198,7 @@ Open the **Context** tab under **SEO** to store detailed business information us
 * **Buyer Personas** – Describe your ideal buyers and their pain points.
 * **Project Description** – Short summary of your project or website. Used when other fields are empty.
 * **Custom Prompts** – Default instructions appended to AI requests.
+* **AI Prompt** – One-click builder that combines your answers into a single prompt summarizing the business.
 
 == SEO Settings ==
 The SEO meta box appears when editing posts, pages, any public custom post types and taxonomy terms. In the

--- a/tests/test-seo-context.php
+++ b/tests/test-seo-context.php
@@ -17,6 +17,7 @@ class SeoContextHelperTest extends WP_UnitTestCase {
         delete_option('gm2_context_buyer_personas');
         delete_option('gm2_context_project_description');
         delete_option('gm2_context_custom_prompts');
+        delete_option('gm2_context_ai_prompt');
         delete_option('gm2_project_description');
         remove_all_filters('gm2_seo_context');
         parent::tearDown();

--- a/uninstall.php
+++ b/uninstall.php
@@ -100,6 +100,7 @@ $option_names = array(
     'gm2_context_buyer_personas',
     'gm2_context_project_description',
     'gm2_context_custom_prompts',
+    'gm2_context_ai_prompt',
     'gm2_project_description',
     'gm2_sc_query_limit',
     'gm2_analytics_days',


### PR DESCRIPTION
## Summary
- add setting for AI prompt
- build `gm2-context-prompt.js` to generate summary prompt from context answers
- display AI Prompt textarea and button in SEO Context tab
- enqueue new script on SEO admin pages
- document AI Prompt feature in docs and readme
- clean up on uninstall and in tests

## Testing
- `phpunit` *(fails: command not found)*
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d02fc500c8327a431b1d2fbd2d2f1