### PR TITLE
Add uninstall cleanup test for AI prompt option

### DIFF
--- a/tests/test-seo-context.php
+++ b/tests/test-seo-context.php
@@ -88,4 +88,17 @@ class SeoContextHelperTest extends WP_UnitTestCase {
             $this->assertSame($val, $context[$key]);
         }
     }
+
+    public function test_uninstall_removes_ai_prompt_option() {
+        update_option('gm2_context_ai_prompt', 'prompt');
+        $this->assertSame('prompt', get_option('gm2_context_ai_prompt'));
+
+        if (!defined('WP_UNINSTALL_PLUGIN')) {
+            define('WP_UNINSTALL_PLUGIN', true);
+        }
+
+        include dirname(__DIR__) . '/uninstall.php';
+
+        $this->assertFalse(get_option('gm2_context_ai_prompt'));
+    }
 }


### PR DESCRIPTION
## Summary
- extend `test-seo-context.php` with uninstall test
- ensure `gm2_context_ai_prompt` option is deleted after running uninstall script

## Testing
- `phpunit` *(fails: cannot locate WordPress test suite)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d180b0308832791bd0f6ac516f78a