### PR TITLE
Add SEO context final prompt option

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -304,6 +304,9 @@ class Gm2_SEO_Admin {
         register_setting('gm2_seo_options', 'gm2_context_ai_prompt', [
             'sanitize_callback' => 'sanitize_textarea_field',
         ]);
+        register_setting('gm2_seo_options', 'gm2_context_final_prompt', [
+            'sanitize_callback' => 'sanitize_textarea_field',
+        ]);
         register_setting('gm2_seo_options', 'gm2_project_description', [
             'sanitize_callback' => 'sanitize_textarea_field',
         ]);
@@ -836,6 +839,12 @@ class Gm2_SEO_Admin {
             echo '<textarea id="gm2_context_ai_prompt" name="gm2_context_ai_prompt" rows="4" class="large-text">' . esc_textarea( $val ) . '</textarea>';
             echo '<p><button type="button" class="button gm2-build-ai-prompt">' . esc_html__( 'Build AI Prompt', 'gm2-wordpress-suite' ) . '</button></p>';
             echo '<p class="description">' . esc_html__( 'Creates a single prompt summarizing your answers above.', 'gm2-wordpress-suite' ) . '</p>';
+            echo '</td></tr>';
+            $val = get_option( 'gm2_context_final_prompt', '' );
+            echo '<tr><th scope="row"><label for="gm2_context_final_prompt">' . esc_html__( 'Context Prompt', 'gm2-wordpress-suite' ) . '</label></th><td>';
+            echo '<textarea id="gm2_context_final_prompt" name="gm2_context_final_prompt" rows="4" class="large-text">' . esc_textarea( $val ) . '</textarea>';
+            echo '<p><button type="button" class="button gm2-generate-context-prompt">' . esc_html__( 'Generate AI Prompt', 'gm2-wordpress-suite' ) . '</button></p>';
+            echo '<p class="description">' . esc_html__( 'Prepended to SEO tasks.', 'gm2-wordpress-suite' ) . '</p>';
             echo '</td></tr>';
             echo '</tbody></table>';
             submit_button( esc_html__( 'Save Context', 'gm2-wordpress-suite' ) );

--- a/admin/js/gm2-context-prompt.js
+++ b/admin/js/gm2-context-prompt.js
@@ -48,5 +48,11 @@ jQuery(function($){
             $('#gm2_context_ai_prompt').val(prompt);
         }
     });
+
+    $(document).on('click', '.gm2-generate-context-prompt', function(e){
+        e.preventDefault();
+        var val = $('#gm2_context_ai_prompt').val();
+        $('#gm2_context_final_prompt').val(val);
+    });
 });
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -101,6 +101,7 @@ $option_names = array(
     'gm2_context_project_description',
     'gm2_context_custom_prompts',
     'gm2_context_ai_prompt',
+    'gm2_context_final_prompt',
     'gm2_project_description',
     'gm2_sc_query_limit',
     'gm2_analytics_days',


### PR DESCRIPTION
## Summary
- register option `gm2_context_final_prompt`
- show Context Prompt textarea and generator button on SEO → Context page
- copy AI prompt text into the Context Prompt via JS
- remove option on uninstall

## Testing
- `npm test`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_687d19e28a70832790d207aaaaec1fa2