### PR TITLE
Disable AI Prompt without ChatGPT

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -121,13 +121,15 @@ class Gm2_Admin {
                 GM2_VERSION,
                 true
             );
-            wp_enqueue_script(
-                'gm2-context-prompt',
-                GM2_PLUGIN_URL . 'admin/js/gm2-context-prompt.js',
-                ['jquery'],
-                GM2_VERSION,
-                true
-            );
+            if ($this->chatgpt_enabled) {
+                wp_enqueue_script(
+                    'gm2-context-prompt',
+                    GM2_PLUGIN_URL . 'admin/js/gm2-context-prompt.js',
+                    ['jquery'],
+                    GM2_VERSION,
+                    true
+                );
+            }
             $gads_ready = trim(get_option('gm2_gads_developer_token', '')) !== '' &&
                 trim(get_option('gm2_gads_customer_id', '')) !== '' &&
                 get_option('gm2_google_refresh_token', '') !== '';

--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -831,11 +831,16 @@ class Gm2_SEO_Admin {
                 }
                 echo '</td></tr>';
             }
-            $val = get_option( 'gm2_context_ai_prompt', '' );
+            $val     = get_option( 'gm2_context_ai_prompt', '' );
+            $enabled = get_option( 'gm2_enable_chatgpt', '1' ) === '1';
             echo '<tr><th scope="row"><label for="gm2_context_ai_prompt">' . esc_html__( 'AI Prompt', 'gm2-wordpress-suite' ) . '</label></th><td>';
-            echo '<textarea id="gm2_context_ai_prompt" name="gm2_context_ai_prompt" rows="4" class="large-text">' . esc_textarea( $val ) . '</textarea>';
-            echo '<p><button type="button" class="button gm2-build-ai-prompt">' . esc_html__( 'Build AI Prompt', 'gm2-wordpress-suite' ) . '</button></p>';
-            echo '<p class="description">' . esc_html__( 'Creates a single prompt summarizing your answers above.', 'gm2-wordpress-suite' ) . '</p>';
+            echo '<textarea id="gm2_context_ai_prompt" name="gm2_context_ai_prompt" rows="4" class="large-text"' . disabled( $enabled, false, false ) . '>' . esc_textarea( $val ) . '</textarea>';
+            if ( $enabled ) {
+                echo '<p><button type="button" class="button gm2-build-ai-prompt">' . esc_html__( 'Build AI Prompt', 'gm2-wordpress-suite' ) . '</button></p>';
+            } else {
+                echo '<p><em>' . esc_html__( 'ChatGPT is disabled.', 'gm2-wordpress-suite' ) . '</em></p>';
+            }
+            echo '<p class="description">' . esc_html__( 'Creates a single prompt summarizing your answers above. ChatGPT must be enabled and configured.', 'gm2-wordpress-suite' ) . '</p>';
             echo '</td></tr>';
             echo '</tbody></table>';
             submit_button( esc_html__( 'Save Context', 'gm2-wordpress-suite' ) );
@@ -3229,7 +3234,7 @@ class Gm2_SEO_Admin {
             [
                 'id'      => 'gm2-seo-context',
                 'title'   => __( 'SEO Context', 'gm2-wordpress-suite' ),
-                'content' => '<p>' . __( 'Use the Context tab to describe your business model, industry, audience, unique selling points and more. Saved answers are automatically included in ChatGPT prompts for AI SEO.', 'gm2-wordpress-suite' ) . '</p>',
+                'content' => '<p>' . __( 'Use the Context tab to describe your business model, industry, audience, unique selling points and more. Saved answers are automatically included in ChatGPT prompts for AI SEO. ChatGPT must be enabled and configured.', 'gm2-wordpress-suite' ) . '</p>',
             ]
         );
     }

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,4 +17,4 @@ Existing prompt logic automatically includes these options via `gm2_get_seo_cont
 
 ## Building the AI Prompt
 
-Before using the AI Prompt builder make sure your ChatGPT API key and model are configured under **Gm2 → ChatGPT**. Then open **SEO → Context** and click **Build AI Prompt** below the AI Prompt field. The plugin assembles a single prompt from all of your Context answers and sends it to ChatGPT. The resulting text appears in the textarea ready for review and editing.
+Before using the AI Prompt builder make sure the ChatGPT feature is enabled and your API key and model are configured under **Gm2 → ChatGPT**. Then open **SEO → Context** and click **Build AI Prompt** below the AI Prompt field. The plugin assembles a single prompt from all of your Context answers and sends it to ChatGPT. The resulting text appears in the textarea ready for review and editing.

--- a/readme.txt
+++ b/readme.txt
@@ -200,7 +200,7 @@ Open the **Context** tab under **SEO** to store detailed business information us
 * **Custom Prompts** – Default instructions appended to AI requests.
 * **AI Prompt** – One-click builder that combines your answers into a single prompt summarizing the business.
 
-To build the prompt, first save your API key and model under **Gm2 → ChatGPT**. Then return to **SEO → Context** and click **Build AI Prompt** below the AI Prompt field. The plugin merges all of your Context answers and sends them to ChatGPT. The response is inserted into the textarea so you can tweak it before saving.
+To build the prompt, ensure the ChatGPT feature is enabled and save your API key and model under **Gm2 → ChatGPT**. Then return to **SEO → Context** and click **Build AI Prompt** below the AI Prompt field. The plugin merges all of your Context answers and sends them to ChatGPT. The response is inserted into the textarea so you can tweak it before saving.
 
 == SEO Settings ==
 The SEO meta box appears when editing posts, pages, any public custom post types and taxonomy terms. In the


### PR DESCRIPTION
## Summary
- hide the SEO context AI prompt field when ChatGPT is disabled
- update help text to mention ChatGPT must be configured
- only enqueue the context prompt script when ChatGPT is enabled
- document the requirement for enabling ChatGPT

## Testing
- `npm test`
- `phpunit` *(fails: wordpress-tests-lib missing)*


------
https://chatgpt.com/codex/tasks/task_e_687d2032af6c83279ae5b098a4f6014c