### PR TITLE
Show ChatGPT setup notice on SEO pages

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -29,6 +29,7 @@ class Gm2_Admin {
             add_action('admin_post_gm2_chatgpt_settings', [$this, 'handle_chatgpt_form']);
             add_action('wp_ajax_gm2_chatgpt_prompt', [$this, 'ajax_chatgpt_prompt']);
         }
+        add_action('admin_notices', [$this, 'maybe_show_chatgpt_notice']);
     }
 
     public function enqueue_admin_scripts($hook) {
@@ -566,5 +567,27 @@ class Gm2_Admin {
         }
 
         wp_send_json_success($resp);
+    }
+
+    public function maybe_show_chatgpt_notice() {
+        $key = trim(get_option('gm2_chatgpt_api_key', ''));
+        if ($this->chatgpt_enabled && $key !== '') {
+            return;
+        }
+        if (!function_exists('get_current_screen')) {
+            return;
+        }
+        $screen = get_current_screen();
+        $seo_pages = [
+            'gm2_page_gm2-seo',
+            'gm2_page_gm2-bulk-ai-review',
+        ];
+        if ($screen && in_array($screen->id, $seo_pages, true)) {
+            $url = admin_url('admin.php?page=gm2-chatgpt');
+            $link = '<a href="' . esc_url($url) . '">Gm2 &rarr; ChatGPT</a>';
+            echo '<div class="notice notice-warning"><p>' .
+                sprintf(esc_html__('Configure ChatGPT under %s.', 'gm2-wordpress-suite'), $link) .
+                '</p></div>';
+        }
     }
 }


### PR DESCRIPTION
## Summary
- warn SEO admins if ChatGPT is disabled or the API key is missing

## Testing
- `php -l admin/Gm2_Admin.php`
- `make test DB_NAME=wp_test DB_USER=root DB_PASS=pass` *(fails: mysqladmin command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d26e84ff4832799b9c3f10237891a