### PR TITLE
Rename AI Prompt to Business Context Prompt

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -833,10 +833,10 @@ class Gm2_SEO_Admin {
             }
             $val     = get_option( 'gm2_context_ai_prompt', '' );
             $enabled = get_option( 'gm2_enable_chatgpt', '1' ) === '1';
-            echo '<tr><th scope="row"><label for="gm2_context_ai_prompt">' . esc_html__( 'AI Prompt', 'gm2-wordpress-suite' ) . '</label></th><td>';
+            echo '<tr><th scope="row"><label for="gm2_context_ai_prompt">' . esc_html__( 'Business Context Prompt', 'gm2-wordpress-suite' ) . '</label></th><td>';
             echo '<textarea id="gm2_context_ai_prompt" name="gm2_context_ai_prompt" rows="4" class="large-text"' . disabled( $enabled, false, false ) . '>' . esc_textarea( $val ) . '</textarea>';
             if ( $enabled ) {
-                echo '<p><button type="button" class="button gm2-build-ai-prompt">' . esc_html__( 'Build AI Prompt', 'gm2-wordpress-suite' ) . '</button></p>';
+                echo '<p><button type="button" class="button gm2-build-ai-prompt">' . esc_html__( 'Generate AI Prompt', 'gm2-wordpress-suite' ) . '</button></p>';
             } else {
                 echo '<p><em>' . esc_html__( 'ChatGPT is disabled.', 'gm2-wordpress-suite' ) . '</em></p>';
             }

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 This release adds several new SEO and AI options:
 
 - **Project Description** and **Custom Prompts** fields under **SEO → Context**. The project description falls back to the site tagline or a snippet of post content if empty.
-- **AI Prompt** builder that compiles your Context answers into a single prompt for generating a short business summary.
+ - **Business Context Prompt** builder that compiles your Context answers into a single prompt for generating a short business summary.
 - Each context field now includes a guiding question so users know what to enter.
 - Additional context fields: **Core Offerings**, **Geographic Focus**, **Keyword Data**, **Competitor Landscape**, **Success Metrics** and **Buyer Personas**.
 - Additional meta fields on post and taxonomy edit screens for Search Intent, Focus Keyword Limit, Number of Words and an "Improve Readability" checkbox.
@@ -15,6 +15,6 @@ Existing prompt logic automatically includes these options via `gm2_get_seo_cont
 - The price section now uses flexbox by default and includes responsive **Horizontal** and **Vertical** alignment controls to adjust `justify-content` and `align-items`.
 - New **Wrap Options** control lets you enable flex wrapping so quantity buttons can stack on tablets and mobile.
 
-## Building the AI Prompt
+## Building the Business Context Prompt
 
-Before using the AI Prompt builder make sure the ChatGPT feature is enabled and your API key and model are configured under **Gm2 → ChatGPT**. Then open **SEO → Context** and click **Build AI Prompt** below the AI Prompt field. The plugin assembles a single prompt from all of your Context answers and sends it to ChatGPT. The resulting text appears in the textarea ready for review and editing.
+Before using the Business Context Prompt builder make sure the ChatGPT feature is enabled and your API key and model are configured under **Gm2 → ChatGPT**. Then open **SEO → Context** and click **Generate AI Prompt** below the Business Context Prompt field. The plugin assembles a single prompt from all of your Context answers and sends it to ChatGPT. The resulting text appears in the textarea ready for review and editing.

--- a/readme.txt
+++ b/readme.txt
@@ -198,9 +198,9 @@ Open the **Context** tab under **SEO** to store detailed business information us
 * **Buyer Personas** – Describe your ideal buyers and their pain points.
 * **Project Description** – Short summary of your project or website. Used when other fields are empty.
 * **Custom Prompts** – Default instructions appended to AI requests.
-* **AI Prompt** – One-click builder that combines your answers into a single prompt summarizing the business.
+* **Business Context Prompt** – One-click builder that combines your answers into a single prompt summarizing the business.
 
-To build the prompt, ensure the ChatGPT feature is enabled and save your API key and model under **Gm2 → ChatGPT**. Then return to **SEO → Context** and click **Build AI Prompt** below the AI Prompt field. The plugin merges all of your Context answers and sends them to ChatGPT. The response is inserted into the textarea so you can tweak it before saving.
+To build the prompt, ensure the ChatGPT feature is enabled and save your API key and model under **Gm2 → ChatGPT**. Then return to **SEO → Context** and click **Generate AI Prompt** below the Business Context Prompt field. The plugin merges all of your Context answers and sends them to ChatGPT. The response is inserted into the textarea so you can tweak it before saving.
 
 == SEO Settings ==
 The SEO meta box appears when editing posts, pages, any public custom post types and taxonomy terms. In the


### PR DESCRIPTION
## Summary
- rename "AI Prompt" field and button to business-focused language
- update documentation with new naming

## Testing
- `npm test`
- `phpunit` *(fails: WordPress test suite missing)*

------
https://chatgpt.com/codex/tasks/task_e_687fc8f407008327ad01f6b326421056