### PR TITLE
Fix content rules prompt wording

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -2364,7 +2364,7 @@ class Gm2_SEO_Admin {
         }
 
         $prompt = sprintf(
-            'You are an SEO content strategist. Using the business context below, create actionable rules for %s in WordPress. ' .
+            'You are an SEO content strategist. Using the business context provided, create actionable rules for %s in WordPress. ' .
             'Cover SEO Title, SEO Description, Focus Keywords, Long Tail Keywords, Canonical URL, Content and General Cohesive SEO Rules. ' .
             'Use these categories: %s. Respond ONLY with JSON using those slugs as keys.',
             $prompt_target,


### PR DESCRIPTION
## Summary
- rephrase the content rules prompt so it accurately references the business context string

## Testing
- `npm test`
- `phpunit` *(fails: missing WordPress test suite)*

------
https://chatgpt.com/codex/tasks/task_e_687feabb0e3c8327a6fa0b77e093cff7