### PR TITLE
Fix context placement in AI content rules

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -2363,17 +2363,18 @@ class Gm2_SEO_Admin {
             $prompt_target = sprintf('for the %s taxonomy', gm2_substr($target, 4));
         }
 
-        $prompt = sprintf(
-            'You are an SEO content strategist. Using the business context below, create actionable rules for %s in WordPress. ' .
+        $context = gm2_get_business_context_prompt();
+        $prompt  = '';
+        if ($context !== '') {
+            $prompt .= $context . "\n\n";
+        }
+        $prompt .= sprintf(
+            'You are an SEO content strategist. Using the business context above, create actionable rules for %s in WordPress. ' .
             'Cover SEO Title, SEO Description, Focus Keywords, Long Tail Keywords, Canonical URL, Content and General Cohesive SEO Rules. ' .
             'Use these categories: %s. Respond ONLY with JSON using those slugs as keys.',
             $prompt_target,
             $cats
         );
-        $context = gm2_get_business_context_prompt();
-        if ($context !== '') {
-            $prompt = $context . "\n\n" . $prompt;
-        }
         $chat   = new Gm2_ChatGPT();
         $resp   = $chat->query($prompt);
 


### PR DESCRIPTION
## Summary
- prepend business context before building the content rules prompt so the text 'using the business context above' matches

## Testing
- `npm test`
- `phpunit` *(fails: missing WordPress test suite)*

------
https://chatgpt.com/codex/tasks/task_e_687feabb0e3c8327a6fa0b77e093cff7