### PR TITLE
Add guideline rules option

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -122,6 +122,13 @@ class Gm2_Admin {
                 filemtime(GM2_PLUGIN_DIR . 'admin/js/gm2-content-rules.js'),
                 true
             );
+            wp_enqueue_script(
+                'gm2-guideline-rules',
+                GM2_PLUGIN_URL . 'admin/js/gm2-guideline-rules.js',
+                ['jquery'],
+                filemtime(GM2_PLUGIN_DIR . 'admin/js/gm2-guideline-rules.js'),
+                true
+            );
             if ($this->chatgpt_enabled) {
                 wp_enqueue_script(
                     'gm2-context-prompt',
@@ -168,6 +175,16 @@ class Gm2_Admin {
                 'gm2ContentRules',
                 [
                     'nonce'      => wp_create_nonce('gm2_research_content_rules'),
+                    'ajax_url'   => admin_url('admin-ajax.php'),
+                    'categories' => 'seo_title, seo_description, focus_keywords, long_tail_keywords, canonical_url, content, general',
+                    'loading'    => __( 'Researching...', 'gm2-wordpress-suite' ),
+                ]
+            );
+            wp_localize_script(
+                'gm2-guideline-rules',
+                'gm2GuidelineRules',
+                [
+                    'nonce'      => wp_create_nonce('gm2_research_guideline_rules'),
                     'ajax_url'   => admin_url('admin-ajax.php'),
                     'categories' => 'seo_title, seo_description, focus_keywords, long_tail_keywords, canonical_url, content, general',
                     'loading'    => __( 'Researching...', 'gm2-wordpress-suite' ),

--- a/admin/js/gm2-guideline-rules.js
+++ b/admin/js/gm2-guideline-rules.js
@@ -1,0 +1,62 @@
+jQuery(function($){
+    function mapAlias(key){
+        var map = {
+            'content_in_post': 'content',
+            'content_in_page': 'content',
+            'content_in_custom_post': 'content',
+            'content_in_product': 'content'
+        };
+        return map[key] || key;
+    }
+    function flatten(val){
+        if($.isArray(val)){
+            return $.map(val, flatten).join("\n");
+        }else if(val && typeof val === "object"){
+            return $.map(Object.values(val), flatten).join("\n");
+        }
+        return String(val);
+    }
+    var ruleSlugs = [];
+    if(window.gm2GuidelineRules && gm2GuidelineRules.categories){
+        ruleSlugs = gm2GuidelineRules.categories.split(',').map(function(slug){
+            return slug.trim();
+        }).filter(Boolean);
+    }
+
+    $('.gm2-research-guideline-rules').on('click', function(e){
+        e.preventDefault();
+        if(!window.gm2GuidelineRules) return;
+        var $btn = $(this);
+        var base = $btn.data('base');
+        if(!base) return;
+        var cats = ruleSlugs.join(',');
+        var loadingText = gm2GuidelineRules.loading || 'Researching...';
+        var originalText = $btn.text();
+        $btn.prop('disabled', true).text(loadingText);
+        $.post(gm2GuidelineRules.ajax_url, {
+            action: 'gm2_research_guideline_rules',
+            target: base,
+            categories: cats,
+            _ajax_nonce: gm2GuidelineRules.nonce
+        }).done(function(resp){
+            if(resp && resp.success && typeof resp.data === 'object'){
+                if($.isEmptyObject(resp.data)){
+                    alert('No recognized rules returned. Check the categories or server logs.');
+                }else{
+                    $.each(resp.data, function(key,val){
+                        var selector = 'textarea[name="gm2_guideline_rules['+base+']['+mapAlias(key)+']"]';
+                        $(selector).val(flatten(val));
+                    });
+                }
+            }else if(resp && resp.data){
+                alert(resp.data);
+            }else{
+                alert('Error');
+            }
+        }).fail(function(){
+            alert('Request failed');
+        }).always(function(){
+            $btn.prop('disabled', false).text(originalText);
+        });
+    });
+});

--- a/tests/test-guideline-rules.php
+++ b/tests/test-guideline-rules.php
@@ -1,0 +1,220 @@
+<?php
+
+class GuidelineRulesFormTest extends WP_UnitTestCase {
+    public function test_form_flattens_arrays() {
+        $admin = new \Gm2\Gm2_SEO_Admin();
+        $user  = self::factory()->user->create(['role' => 'administrator']);
+        wp_set_current_user($user);
+
+        $_POST['gm2_guideline_rules_nonce'] = wp_create_nonce('gm2_guideline_rules_save');
+        $_POST['gm2_guideline_rules'] = [
+            'post_post' => [
+                'content' => ['First', 'Second']
+            ]
+        ];
+
+        $admin->handle_guideline_rules_form();
+
+        $rules = get_option('gm2_guideline_rules');
+        $this->assertIsString($rules['post_post']['content']);
+        $this->assertSame("First\nSecond", $rules['post_post']['content']);
+    }
+
+    public function test_form_flattens_nested_arrays() {
+        $admin = new \Gm2\Gm2_SEO_Admin();
+        $user  = self::factory()->user->create(['role' => 'administrator']);
+        wp_set_current_user($user);
+
+        $_POST['gm2_guideline_rules_nonce'] = wp_create_nonce('gm2_guideline_rules_save');
+        $_POST['gm2_guideline_rules'] = [
+            'post_post' => [
+                'canonical_url' => [[ 'Rule A' ], ['Rule B']]
+            ]
+        ];
+
+        $admin->handle_guideline_rules_form();
+
+        $rules = get_option('gm2_guideline_rules');
+        $this->assertSame("Rule A\nRule B", $rules['post_post']['canonical_url']);
+    }
+
+    public function test_form_flattens_scalar_value() {
+        $admin = new \Gm2\Gm2_SEO_Admin();
+        $user  = self::factory()->user->create(['role' => 'administrator']);
+        wp_set_current_user($user);
+
+        $_POST['gm2_guideline_rules_nonce'] = wp_create_nonce('gm2_guideline_rules_save');
+        $_POST['gm2_guideline_rules'] = [
+            'post_post' => 'One\nTwo'
+        ];
+
+        $admin->handle_guideline_rules_form();
+
+        $rules = get_option('gm2_guideline_rules');
+        $this->assertSame('One\nTwo', $rules['post_post']['general']);
+    }
+}
+
+class GuidelineRulesNormalizationTest extends WP_Ajax_UnitTestCase {
+    public function test_categories_with_spaces_or_hyphens_are_normalized() {
+        update_option('gm2_chatgpt_api_key', 'key');
+        $resp_data = [ 'SEO Title' => 'Title rule', 'seo-description' => 'Desc rule' ];
+        $filter = function($pre, $args, $url) use ($resp_data) {
+            if ($url === 'https://api.openai.com/v1/chat/completions') {
+                return [
+                    'response' => ['code' => 200],
+                    'body'     => json_encode([
+                        'choices' => [ ['message' => ['content' => json_encode($resp_data)]] ]
+                    ])
+                ];
+            }
+            return false;
+        };
+        add_filter('pre_http_request', $filter, 10, 3);
+
+        $this->_setRole('administrator');
+        $_POST['categories'] = 'SEO Title, seo-description';
+        $_POST['target'] = 'post_post';
+        $_POST['_ajax_nonce'] = wp_create_nonce('gm2_research_guideline_rules');
+        $_REQUEST['_ajax_nonce'] = $_POST['_ajax_nonce'];
+        try { $this->_handleAjax('gm2_research_guideline_rules'); } catch (WPAjaxDieContinueException $e) {}
+
+        remove_filter('pre_http_request', $filter, 10);
+
+        $resp = json_decode($this->_last_response, true);
+        $this->assertTrue($resp['success']);
+        $this->assertSame('Title rule', $resp['data']['seo_title']);
+        $this->assertSame('Desc rule', $resp['data']['seo_description']);
+        $rules = get_option('gm2_guideline_rules');
+        $this->assertSame('Title rule', $rules['post_post']['seo_title']);
+        $this->assertSame('Desc rule', $rules['post_post']['seo_description']);
+    }
+
+    public function test_unknown_categories_are_ignored() {
+        update_option('gm2_chatgpt_api_key', 'key');
+        $resp_data = [ 'unknown' => 'Rule', 'seo_title' => 'Title rule' ];
+        $filter = function($pre, $args, $url) use ($resp_data) {
+            if ($url === 'https://api.openai.com/v1/chat/completions') {
+                return [
+                    'response' => ['code' => 200],
+                    'body'     => json_encode([
+                        'choices' => [ ['message' => ['content' => json_encode($resp_data)]] ]
+                    ])
+                ];
+            }
+            return false;
+        };
+        add_filter('pre_http_request', $filter, 10, 3);
+
+        $this->_setRole('administrator');
+        $_POST['categories'] = 'unknown, seo_title';
+        $_POST['target'] = 'post_post';
+        $_POST['_ajax_nonce'] = wp_create_nonce('gm2_research_guideline_rules');
+        $_REQUEST['_ajax_nonce'] = $_POST['_ajax_nonce'];
+        try { $this->_handleAjax('gm2_research_guideline_rules'); } catch (WPAjaxDieContinueException $e) {}
+
+        remove_filter('pre_http_request', $filter, 10);
+
+        $resp = json_decode($this->_last_response, true);
+        $this->assertTrue($resp['success']);
+        $this->assertArrayHasKey('seo_title', $resp['data']);
+        $this->assertArrayNotHasKey('unknown', $resp['data']);
+        $rules = get_option('gm2_guideline_rules');
+        $this->assertArrayHasKey('seo_title', $rules['post_post']);
+        $this->assertArrayNotHasKey('unknown', $rules['post_post']);
+    }
+
+    public function test_nested_arrays_are_flattened_via_ajax() {
+        update_option('gm2_chatgpt_api_key', 'key');
+        $resp_data = [ 'canonical_url' => [[ 'Rule A' ], ['Rule B' ]] ];
+        $filter = function($pre, $args, $url) use ($resp_data) {
+            if ($url === 'https://api.openai.com/v1/chat/completions') {
+                return [
+                    'response' => ['code' => 200],
+                    'body'     => json_encode([
+                        'choices' => [ ['message' => ['content' => json_encode($resp_data)]] ]
+                    ])
+                ];
+            }
+            return false;
+        };
+        add_filter('pre_http_request', $filter, 10, 3);
+
+        $this->_setRole('administrator');
+        $_POST['categories'] = 'canonical_url';
+        $_POST['target'] = 'post_post';
+        $_POST['_ajax_nonce'] = wp_create_nonce('gm2_research_guideline_rules');
+        $_REQUEST['_ajax_nonce'] = $_POST['_ajax_nonce'];
+        try { $this->_handleAjax('gm2_research_guideline_rules'); } catch (WPAjaxDieContinueException $e) {}
+
+        remove_filter('pre_http_request', $filter, 10);
+
+        $resp = json_decode($this->_last_response, true);
+        $this->assertTrue($resp['success']);
+        $this->assertSame("Rule A\nRule B", $resp['data']['canonical_url']);
+        $rules = get_option('gm2_guideline_rules');
+        $this->assertSame("Rule A\nRule B", $rules['post_post']['canonical_url']);
+    }
+
+    public function test_synonym_categories_map_to_content() {
+        update_option('gm2_chatgpt_api_key', 'key');
+        $resp_data = [ 'content-in-post' => 'Mapped rule' ];
+        $filter = function($pre, $args, $url) use ($resp_data) {
+            if ($url === 'https://api.openai.com/v1/chat/completions') {
+                return [
+                    'response' => ['code' => 200],
+                    'body'     => json_encode([
+                        'choices' => [ ['message' => ['content' => json_encode($resp_data)]] ]
+                    ])
+                ];
+            }
+            return false;
+        };
+        add_filter('pre_http_request', $filter, 10, 3);
+
+        $this->_setRole('administrator');
+        $_POST['categories'] = 'content-in-post';
+        $_POST['target'] = 'post_post';
+        $_POST['_ajax_nonce'] = wp_create_nonce('gm2_research_guideline_rules');
+        $_REQUEST['_ajax_nonce'] = $_POST['_ajax_nonce'];
+        try { $this->_handleAjax('gm2_research_guideline_rules'); } catch (WPAjaxDieContinueException $e) {}
+
+        remove_filter('pre_http_request', $filter, 10);
+
+        $resp = json_decode($this->_last_response, true);
+        $this->assertTrue($resp['success']);
+        $this->assertSame('Mapped rule', $resp['data']['content']);
+        $rules = get_option('gm2_guideline_rules');
+        $this->assertSame('Mapped rule', $rules['post_post']['content']);
+    }
+
+    public function test_only_unknown_categories_returns_error() {
+        update_option('gm2_chatgpt_api_key', 'key');
+        $resp_data = [ 'weird' => 'Rule' ];
+        $filter = function($pre, $args, $url) use ($resp_data) {
+            if ($url === 'https://api.openai.com/v1/chat/completions') {
+                return [
+                    'response' => ['code' => 200],
+                    'body'     => json_encode([
+                        'choices' => [ ['message' => ['content' => json_encode($resp_data)]] ]
+                    ])
+                ];
+            }
+            return false;
+        };
+        add_filter('pre_http_request', $filter, 10, 3);
+
+        $this->_setRole('administrator');
+        $_POST['categories'] = 'weird';
+        $_POST['target'] = 'post_post';
+        $_POST['_ajax_nonce'] = wp_create_nonce('gm2_research_guideline_rules');
+        $_REQUEST['_ajax_nonce'] = $_POST['_ajax_nonce'];
+        try { $this->_handleAjax('gm2_research_guideline_rules'); } catch (WPAjaxDieContinueException $e) {}
+
+        remove_filter('pre_http_request', $filter, 10);
+
+        $resp = json_decode($this->_last_response, true);
+        $this->assertFalse($resp['success']);
+    }
+}
+?>

--- a/uninstall.php
+++ b/uninstall.php
@@ -27,6 +27,7 @@ $option_names = array(
     'gm2_suite_settings',
     'gm2_suite_version',
     'gm2_content_rules',
+    'gm2_guideline_rules',
     'gm2_ga_measurement_id',
     'gm2_search_console_verification',
     'gm2_gads_developer_token',


### PR DESCRIPTION
## Summary
- create `gm2_guideline_rules` option
- include initialization, migration, and admin notices for guideline rules
- add admin forms/handlers and AJAX endpoint to manage guideline rules
- expose new script `gm2-guideline-rules.js`
- extend uninstall routine and tests

## Testing
- `php -l gm2-wordpress-suite.php`
- `php -l admin/Gm2_Admin.php`
- `php -l admin/Gm2_SEO_Admin.php`
- `php -l uninstall.php`
- `phpunit -c phpunit.xml` *(fails: WordPress test library missing)*

------
https://chatgpt.com/codex/tasks/task_e_687ff9fda55c83279cbe3b9c7cd25271