### PR TITLE
Update SEO rule prompts

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -2457,7 +2457,15 @@ class Gm2_SEO_Admin {
         $prompt .= sprintf(
             'You are an SEO content strategist. Using the business context above, create actionable rules for %s in WordPress. ' .
             'Cover SEO Title, SEO Description, Focus Keywords, Long Tail Keywords, Canonical URL, Content and General Cohesive SEO Rules. ' .
-            'Use these categories: %s. Respond ONLY with JSON using those slugs as keys.',
+            "Here are example guidelines:\n" .
+            "- SEO Title: keep under 60 characters and include the focus keyword.\n" .
+            "- SEO Description: keep under 160 characters and include the focus keyword.\n" .
+            "- Focus Keywords: list 1-3 target keywords.\n" .
+            "- Long-Tail Keywords: list 1-3 longer keyword phrases.\n" .
+            "- Canonical URL: specify the canonical link to avoid duplicates.\n" .
+            "- Content: use headings and short paragraphs with keywords naturally.\n" .
+            "- General Cohesive SEO Rules: maintain consistent tone and avoid keyword stuffing.\n" .
+            'Provide an array of short, measurable rules. Use these categories: %s. Respond ONLY with JSON using those slugs as keys.',
             $prompt_target,
             $cats
         );
@@ -2499,6 +2507,19 @@ class Gm2_SEO_Admin {
             'content_in_product'     => 'content',
         ];
 
+        $requested_slugs = [];
+        foreach (array_filter(array_map('trim', explode(',', strtolower($cats)))) as $req) {
+            $r = str_replace([' ', '-'], '_', $req);
+            $r = preg_replace('/[^a-z0-9_]/', '', $r);
+            if (isset($alias_map[$r])) {
+                $r = $alias_map[$r];
+            }
+            if (in_array($r, $valid_slugs, true)) {
+                $requested_slugs[] = $r;
+            }
+        }
+        $requested_slugs = array_unique($requested_slugs);
+
         $formatted = [];
         foreach ($data as $cat => $text) {
             $key = strtolower(str_replace([' ', '-'], '_', $cat));
@@ -2507,7 +2528,7 @@ class Gm2_SEO_Admin {
                 $key = $alias_map[$key];
             }
 
-            if (!in_array($key, $valid_slugs, true)) {
+            if (!in_array($key, $valid_slugs, true) || !in_array($key, $requested_slugs, true)) {
                 if (defined('WP_DEBUG') && WP_DEBUG) {
                     error_log('Discarded content rule category: ' . $key);
                 }
@@ -2572,7 +2593,15 @@ class Gm2_SEO_Admin {
         $prompt .= sprintf(
             'You are an SEO content strategist. Using the business context above, create actionable guidelines for %s in WordPress. ' .
             'Cover SEO Title, SEO Description, Focus Keywords, Long Tail Keywords, Canonical URL, Content and General Cohesive SEO Rules. ' .
-            'Use these categories: %s. Respond ONLY with JSON using those slugs as keys.',
+            "Here are example guidelines:\n" .
+            "- SEO Title: keep under 60 characters and include the focus keyword.\n" .
+            "- SEO Description: keep under 160 characters and include the focus keyword.\n" .
+            "- Focus Keywords: list 1-3 target keywords.\n" .
+            "- Long-Tail Keywords: list 1-3 longer keyword phrases.\n" .
+            "- Canonical URL: specify the canonical link to avoid duplicates.\n" .
+            "- Content: use headings and short paragraphs with keywords naturally.\n" .
+            "- General Cohesive SEO Rules: maintain consistent tone and avoid keyword stuffing.\n" .
+            'Provide an array of short, measurable rules. Use these categories: %s. Respond ONLY with JSON using those slugs as keys.',
             $prompt_target,
             $cats
         );
@@ -2614,6 +2643,19 @@ class Gm2_SEO_Admin {
             'content_in_product'     => 'content',
         ];
 
+        $requested_slugs = [];
+        foreach (array_filter(array_map('trim', explode(',', strtolower($cats)))) as $req) {
+            $r = str_replace([' ', '-'], '_', $req);
+            $r = preg_replace('/[^a-z0-9_]/', '', $r);
+            if (isset($alias_map[$r])) {
+                $r = $alias_map[$r];
+            }
+            if (in_array($r, $valid_slugs, true)) {
+                $requested_slugs[] = $r;
+            }
+        }
+        $requested_slugs = array_unique($requested_slugs);
+
         $formatted = [];
         foreach ($data as $cat => $text) {
             $key = strtolower(str_replace([' ', '-'], '_', $cat));
@@ -2622,7 +2664,7 @@ class Gm2_SEO_Admin {
                 $key = $alias_map[$key];
             }
 
-            if (!in_array($key, $valid_slugs, true)) {
+            if (!in_array($key, $valid_slugs, true) || !in_array($key, $requested_slugs, true)) {
                 if (defined('WP_DEBUG') && WP_DEBUG) {
                     error_log('Discarded guideline rule category: ' . $key);
                 }


### PR DESCRIPTION
## Summary
- add example guidelines to the ChatGPT prompt for content rules
- add example guidelines to the prompt for guideline rules
- only save/return requested rule categories when generating rules

## Testing
- `npm test`
- `make test` *(fails: Database credentials must be supplied)*

------
https://chatgpt.com/codex/tasks/task_e_6880001d8d788327a3fc77662bca47a4