### PR TITLE
Improve AI Research prompt

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1878,7 +1878,11 @@ class Gm2_SEO_Admin {
                 $prev_post = $post;
                 $post      = $post_obj;
                 setup_postdata($post);
-                $html = apply_filters('the_content', $post_obj->post_content);
+                $content = $post_obj->post_content;
+                if ($post_obj->post_excerpt !== '') {
+                    $content = $post_obj->post_excerpt . "\n\n" . $content;
+                }
+                $html = apply_filters('the_content', $content);
                 wp_reset_postdata();
                 $post = $prev_post;
                 return $html;
@@ -1899,6 +1903,18 @@ class Gm2_SEO_Admin {
             $html = apply_filters('the_content', $desc);
             wp_reset_postdata();
             $post = $prev_post;
+
+            $url = get_term_link($term_id, $taxonomy);
+            if (!is_wp_error($url)) {
+                $response = wp_remote_get($url, ['timeout' => 10]);
+                if (!is_wp_error($response)) {
+                    $body = wp_remote_retrieve_body($response);
+                    if ($body !== '') {
+                        $html .= "\n" . $body;
+                    }
+                }
+            }
+
             return $html;
         }
         return '';
@@ -2713,10 +2729,8 @@ class Gm2_SEO_Admin {
         }
 
         $html        = $this->get_rendered_html($post_id, $term_id, $taxonomy);
-        $focus_main  = trim(explode(',', $focus)[0]);
-        $html_issues = $this->detect_html_issues($html, $canonical, $focus_main);
-        $clean_html  = wp_strip_all_tags($html);
-        $snippet     = $this->safe_truncate($clean_html, 400);
+        $html_issues = [];
+        $snippet     = trim($html);
 
         $guidelines = '';
         if ($post_id && !empty($post)) {
@@ -2726,16 +2740,6 @@ class Gm2_SEO_Admin {
         }
         $guidelines = trim($guidelines);
 
-        $context_parts = array_filter(array_map('trim', gm2_get_seo_context()));
-        $context_block = '';
-        if ($context_parts) {
-            $pairs = [];
-            foreach ($context_parts as $k => $v) {
-                $pairs[] = ucfirst(str_replace('_', ' ', $k)) . ': ' . $v;
-            }
-            $context_block = 'Site context: ' . implode('; ', $pairs);
-        }
-
         $prompt  = '';
         if ($guidelines !== '') {
             $prompt .= "SEO guidelines:\n" . $guidelines . "\n\n";
@@ -2743,16 +2747,13 @@ class Gm2_SEO_Admin {
         $prompt .= "Page title: {$title}\nURL: {$url}\n";
         $prompt .= "Existing SEO Title: {$seo_title}\nSEO Description: {$seo_description}\n";
         $prompt .= "Focus Keywords: {$focus}\nCanonical: {$canonical}\n";
-        if ($context_block !== '') {
-            $prompt .= $context_block . "\n";
-        }
         if ($extra_context !== '') {
             $prompt .= "Extra context: {$extra_context}\n";
         }
         if ($snippet !== '') {
-            $prompt .= "Content snippet: {$snippet}\n";
+            $prompt .= "Page HTML: {$snippet}\n";
         }
-        $prompt .= "Provide JSON with keys seo_title, description, focus_keywords, long_tail_keywords, seed_keywords, canonical, page_name, slug, content_suggestions, html_issues.";
+        $prompt .= "Check the above HTML and metadata for SEO best practices using the focus keywords and suggest improvements without removing existing information. Provide JSON with keys seo_title, description, focus_keywords, long_tail_keywords, seed_keywords, canonical, page_name, slug, updated_html, content_suggestions, html_issues.";
 
         $context = gm2_get_business_context_prompt();
         if ($context !== '') {
@@ -2876,16 +2877,13 @@ class Gm2_SEO_Admin {
         if ($final_long) {
             $prompt2 .= "Long-tail Keywords: " . implode(', ', $final_long) . "\n";
         }
-        if ($context_block !== '') {
-            $prompt2 .= $context_block . "\n";
-        }
         if ($extra_context !== '') {
             $prompt2 .= "Extra context: {$extra_context}\n";
         }
         if ($snippet !== '') {
-            $prompt2 .= "Content snippet: {$snippet}\n";
+            $prompt2 .= "Page HTML: {$snippet}\n";
         }
-        $prompt2 .= "Provide JSON with keys seo_title, description, focus_keywords, long_tail_keywords, canonical, page_name, slug, content_suggestions, html_issues.";
+        $prompt2 .= "Check the above HTML for SEO best practices and suggest improvements without removing meaning. Provide JSON with keys seo_title, description, focus_keywords, long_tail_keywords, canonical, page_name, slug, updated_html, content_suggestions, html_issues.";
 
         $context = gm2_get_business_context_prompt();
         if ($context !== '') {

--- a/admin/js/gm2-ai-seo.js
+++ b/admin/js/gm2-ai-seo.js
@@ -131,7 +131,8 @@ jQuery(function($){
             focus_keywords: labels.focusKeywords || 'Focus Keywords',
             long_tail_keywords: labels.longTailKeywords || 'Long Tail Keywords',
             canonical: labels.canonical || 'Canonical URL',
-            page_name: labels.pageName || 'Page Name'
+            page_name: labels.pageName || 'Page Name',
+            updated_html: labels.updatedHtml || 'Updated HTML'
         };
         if(typeof data.slug !== 'undefined'){
             fields.slug = labels.slug || 'Slug';


### PR DESCRIPTION
## Summary
- use full HTML content without truncation for AI prompts
- rely on business AI prompt for context
- tweak prompts to request updated HTML suggestions
- include excerpt in rendered content
- show Updated HTML suggestion in UI

## Testing
- `npm test` *(fails: jest not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ea10a5a088327a21f9b76c7aa724d