### PR TITLE
Add ChatGPT log file constant and update logging

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -18,6 +18,7 @@ defined('ABSPATH') or die('No script kiddies please!');
 define('GM2_VERSION', '1.6.16');
 define('GM2_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('GM2_PLUGIN_URL', plugin_dir_url(__FILE__));
+define('GM2_CHATGPT_LOG_FILE', GM2_PLUGIN_DIR . 'chatgpt.log');
 define('GM2_CONTENT_RULES_VERSION', 2);
 define('GM2_GUIDELINE_RULES_VERSION', 2);
 if (!defined('GM2_GCLOUD_PROJECT_ID')) {

--- a/includes/Gm2_ChatGPT.php
+++ b/includes/Gm2_ChatGPT.php
@@ -79,8 +79,8 @@ class Gm2_ChatGPT {
 
         if (get_option('gm2_enable_chatgpt_logging', '0') === '1') {
             $log_resp = is_wp_error($result) ? $result->get_error_message() : $result;
-            error_log('ChatGPT prompt: ' . $prompt);
-            error_log('ChatGPT response: ' . $log_resp);
+            error_log('ChatGPT prompt: ' . $prompt . PHP_EOL, 3, GM2_CHATGPT_LOG_FILE);
+            error_log('ChatGPT response: ' . $log_resp . PHP_EOL, 3, GM2_CHATGPT_LOG_FILE);
         }
 
         return $result;

--- a/includes/Gm2_SEO_Utils.php
+++ b/includes/Gm2_SEO_Utils.php
@@ -134,8 +134,8 @@ namespace {
 
         if (get_option('gm2_enable_chatgpt_logging', '0') === '1') {
             $log_resp = is_wp_error($result) ? $result->get_error_message() : $result;
-            error_log('ChatGPT prompt: ' . $prompt);
-            error_log('ChatGPT response: ' . $log_resp);
+            error_log('ChatGPT prompt: ' . $prompt . PHP_EOL, 3, GM2_CHATGPT_LOG_FILE);
+            error_log('ChatGPT response: ' . $log_resp . PHP_EOL, 3, GM2_CHATGPT_LOG_FILE);
         }
 
         return $result;

--- a/uninstall.php
+++ b/uninstall.php
@@ -122,3 +122,7 @@ global $wpdb;
 $table_name = $wpdb->prefix . 'gm2_suite_data';
 $wpdb->query( "DROP TABLE IF EXISTS {$table_name}" );
 
+if (defined('GM2_CHATGPT_LOG_FILE') && file_exists(GM2_CHATGPT_LOG_FILE)) {
+    @unlink(GM2_CHATGPT_LOG_FILE);
+}
+


### PR DESCRIPTION
## Summary
- log ChatGPT prompts and responses to a plugin log file
- clean up the log file on uninstall

## Testing
- `npm test`
- `make test DB_NAME=wp_test DB_USER=root DB_PASS=pass` *(fails: Can't connect to MySQL server)*

------
https://chatgpt.com/codex/tasks/task_e_68813e3481f4832797da374a173e3a59