### PR TITLE
Add log viewer for ChatGPT

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -536,6 +536,11 @@ class Gm2_Admin {
         echo '<p><button class="button">' . esc_html__( 'Send', 'gm2-wordpress-suite' ) . '</button></p>';
         echo '</form>';
         echo '<pre id="gm2-chatgpt-output"></pre>';
+        if (get_option('gm2_enable_chatgpt_logging', '0') === '1' && file_exists(GM2_CHATGPT_LOG_FILE)) {
+            echo '<h2>' . esc_html__( 'ChatGPT Logs', 'gm2-wordpress-suite' ) . '</h2>';
+            $logs = file_get_contents(GM2_CHATGPT_LOG_FILE);
+            echo '<textarea readonly rows="10" class="large-text">' . esc_textarea($logs) . '</textarea>';
+        }
         echo '</div>';
     }
 

--- a/tests/test-chatgpt.php
+++ b/tests/test-chatgpt.php
@@ -94,6 +94,20 @@ class ChatGPTTest extends WP_UnitTestCase {
 
         $this->assertSame('1', get_option('gm2_enable_chatgpt_logging'));
     }
+
+    public function test_chatgpt_page_shows_logs_when_file_exists() {
+        $admin = new Gm2_Admin();
+        update_option('gm2_enable_chatgpt_logging', '1');
+        file_put_contents(GM2_CHATGPT_LOG_FILE, 'log entry');
+        ob_start();
+        $admin->display_chatgpt_page();
+        $out = ob_get_clean();
+        @unlink(GM2_CHATGPT_LOG_FILE);
+        update_option('gm2_enable_chatgpt_logging', '0');
+        $this->assertStringContainsString('ChatGPT Logs', $out);
+        $this->assertStringContainsString('<textarea', $out);
+        $this->assertStringContainsString('log entry', $out);
+    }
 }
 
 class ChatGPTAjaxTest extends WP_Ajax_UnitTestCase {


### PR DESCRIPTION
## Summary
- display ChatGPT logs on the ChatGPT admin page when logging is enabled and a log file exists
- test that the logs textarea appears when the log file is present

## Testing
- `phpunit` *(fails: missing WordPress test DB)*

------
https://chatgpt.com/codex/tasks/task_e_688141de59a083278d0556b319ceacb8