### PR TITLE
Fix term HTML rendering

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1904,17 +1904,6 @@ class Gm2_SEO_Admin {
             wp_reset_postdata();
             $post = $prev_post;
 
-            $url = get_term_link($term_id, $taxonomy);
-            if (!is_wp_error($url)) {
-                $response = wp_remote_get($url, ['timeout' => 10]);
-                if (!is_wp_error($response)) {
-                    $body = wp_remote_retrieve_body($response);
-                    if ($body !== '') {
-                        $html .= "\n" . $body;
-                    }
-                }
-            }
-
             return $html;
         }
         return '';


### PR DESCRIPTION
## Summary
- remove wp_remote_get page fetch for taxonomy descriptions
- return filtered description HTML for terms only

## Testing
- `make test DB_NAME=wp_test DB_USER=wp DB_PASS=pass DB_HOST=127.0.0.1` *(fails: Class declarations may not be nested in tests/test-quantity-discounts.php)*

------
https://chatgpt.com/codex/tasks/task_e_68814aa118008327b1fe22714f8285ab