### PR TITLE
Update snippet sanitizer

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1985,6 +1985,39 @@ class Gm2_SEO_Admin {
             'pre' => [],
             'br' => [],
         ];
+
+        if (class_exists('\\DOMDocument') && function_exists('libxml_use_internal_errors')) {
+            $doc = new \DOMDocument();
+            libxml_use_internal_errors(true);
+            $doc->loadHTML('<?xml encoding="utf-8" ?>' . $html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+            libxml_clear_errors();
+
+            // Remove style and script tags.
+            foreach (['style', 'script'] as $tag) {
+                $nodes = $doc->getElementsByTagName($tag);
+                for ($i = $nodes->length - 1; $i >= 0; $i--) {
+                    $node = $nodes->item($i);
+                    $node->parentNode->removeChild($node);
+                }
+            }
+
+            // Remove HTML comments.
+            $xpath = new \DOMXPath($doc);
+            foreach ($xpath->query('//comment()') as $comment) {
+                $comment->parentNode->removeChild($comment);
+            }
+
+            $body = $doc->getElementsByTagName('body')->item(0);
+            $html = '';
+            if ($body) {
+                foreach ($body->childNodes as $child) {
+                    $html .= $doc->saveHTML($child);
+                }
+            } else {
+                $html = $doc->saveHTML();
+            }
+        }
+
         return wp_kses($html, $allowed);
     }
 

--- a/tests/SanitizeSnippetHtmlTest.php
+++ b/tests/SanitizeSnippetHtmlTest.php
@@ -1,0 +1,17 @@
+<?php
+use Gm2\Gm2_SEO_Admin;
+
+class SanitizeSnippetHtmlTest extends WP_UnitTestCase {
+    public function test_style_tags_removed() {
+        $admin = new Gm2_SEO_Admin();
+        $method = new ReflectionMethod(Gm2_SEO_Admin::class, 'sanitize_snippet_html');
+        $method->setAccessible(true);
+
+        $html = '<p>Text</p><style>.foo{color:red;}</style>';
+        $sanitized = $method->invoke($admin, $html);
+
+        $this->assertStringContainsString('<p>Text</p>', $sanitized);
+        $this->assertStringNotContainsString('color:red', $sanitized);
+        $this->assertStringNotContainsString('<style', $sanitized);
+    }
+}


### PR DESCRIPTION
## Summary
- sanitize `<style>` & `<script>` tags with DOMDocument in snippet HTML
- add PHPUnit test for snippet sanitizer

## Testing
- `php -l admin/Gm2_SEO_Admin.php`
- `make test` *(fails: PHPUnit Polyfills library missing)*

------
https://chatgpt.com/codex/tasks/task_e_6881562579f88327a90a1cabb0703a46