### PR TITLE
Display formatted ChatGPT logs

### DIFF
--- a/tests/test-chatgpt.php
+++ b/tests/test-chatgpt.php
@@ -98,21 +98,35 @@ class ChatGPTTest extends WP_UnitTestCase {
     public function test_chatgpt_page_shows_logs_when_file_exists() {
         $admin = new Gm2_Admin();
         update_option('gm2_enable_chatgpt_logging', '1');
-        file_put_contents(GM2_CHATGPT_LOG_FILE, 'log entry');
+        $log = "ChatGPT prompt: hi\nChatGPT response: there\n";
+        file_put_contents(GM2_CHATGPT_LOG_FILE, $log);
         ob_start();
         $admin->display_chatgpt_page();
         $out = ob_get_clean();
         @unlink(GM2_CHATGPT_LOG_FILE);
         update_option('gm2_enable_chatgpt_logging', '0');
         $this->assertStringContainsString('ChatGPT Logs', $out);
-        $this->assertStringContainsString('<textarea', $out);
-        $this->assertStringContainsString('log entry', $out);
+        $this->assertStringContainsString('<table', $out);
+        $this->assertStringContainsString('hi', $out);
+        $this->assertStringContainsString('there', $out);
+    }
+
+    public function test_chatgpt_page_shows_no_logs_message() {
+        $admin = new Gm2_Admin();
+        update_option('gm2_enable_chatgpt_logging', '1');
+        @unlink(GM2_CHATGPT_LOG_FILE);
+        ob_start();
+        $admin->display_chatgpt_page();
+        $out = ob_get_clean();
+        update_option('gm2_enable_chatgpt_logging', '0');
+        $this->assertStringContainsString('No logs found.', $out);
     }
 
     public function test_chatgpt_page_contains_reset_button() {
         $admin = new Gm2_Admin();
         update_option('gm2_enable_chatgpt_logging', '1');
-        file_put_contents(GM2_CHATGPT_LOG_FILE, 'log entry');
+        $log = "ChatGPT prompt: hi\nChatGPT response: there\n";
+        file_put_contents(GM2_CHATGPT_LOG_FILE, $log);
         ob_start();
         $admin->display_chatgpt_page();
         $out = ob_get_clean();


### PR DESCRIPTION
## Summary
- parse `chatgpt.log` file into prompt/response pairs
- render log pairs in a table on the ChatGPT admin page
- show "No logs found." when log file is empty or missing
- update tests for the new markup

## Testing
- `make test DB_NAME=wp_test DB_USER=root DB_PASS=pass` *(fails: mysqladmin not found)*
- `npm test`
- `phpunit` *(fails: WordPress test suite missing)*

------
https://chatgpt.com/codex/tasks/task_e_68815d48271483278b698b23569b77c7