### PR TITLE
Add ChatGPT admin CSS

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -59,6 +59,12 @@ class Gm2_Admin {
         ];
 
         if ($hook === 'gm2_page_gm2-chatgpt') {
+            wp_enqueue_style(
+                'gm2-chatgpt-style',
+                GM2_PLUGIN_URL . 'admin/css/gm2-chatgpt.css',
+                [],
+                GM2_VERSION
+            );
             wp_enqueue_script(
                 'gm2-chatgpt',
                 GM2_PLUGIN_URL . 'admin/js/gm2-chatgpt.js',

--- a/admin/css/gm2-chatgpt.css
+++ b/admin/css/gm2-chatgpt.css
@@ -1,0 +1,15 @@
+.gm2-chatgpt-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.gm2-chatgpt-table th,
+.gm2-chatgpt-table td {
+    padding: 8px;
+    border: 1px solid #ccc;
+    text-align: left;
+}
+
+.gm2-chatgpt-table th {
+    background: #f1f1f1;
+}


### PR DESCRIPTION
## Summary
- add ChatGPT table stylesheet
- load the stylesheet when viewing the ChatGPT admin page

## Testing
- `npm test`
- `make test` *(fails: Database credentials must be supplied)*

------
https://chatgpt.com/codex/tasks/task_e_6881612e1e64832781d19db56ff1407f