### PR TITLE
Update ChatGPT log test for table output

### DIFF
--- a/tests/test-chatgpt.php
+++ b/tests/test-chatgpt.php
@@ -107,8 +107,7 @@ class ChatGPTTest extends WP_UnitTestCase {
         update_option('gm2_enable_chatgpt_logging', '0');
         $this->assertStringContainsString('ChatGPT Logs', $out);
         $this->assertStringContainsString('<table', $out);
-        $this->assertStringContainsString('hi', $out);
-        $this->assertStringContainsString('there', $out);
+        $this->assertStringContainsString('<tr><td>hi</td><td>there</td></tr>', $out);
     }
 
     public function test_chatgpt_page_shows_no_logs_message() {


### PR DESCRIPTION
## Summary
- update ChatGPT log test to check for table rows

## Testing
- `npm test`
- `make test DB_NAME=wp_test DB_USER=root DB_PASS=pass` *(fails: Can't connect to MySQL server)*

------
https://chatgpt.com/codex/tasks/task_e_6881648e9fb883278e1f86efb7aa4323