### PR TITLE
Improve ChatGPT logging format

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -578,6 +578,13 @@ class Gm2_Admin {
         $resp_prefix   = 'ChatGPT response: ';
         $prompt = null;
         foreach ($lines as $line) {
+            $data = json_decode($line, true);
+            if (is_array($data) && isset($data['prompt']) && isset($data['response'])) {
+                $pairs[] = [ 'prompt' => $data['prompt'], 'response' => $data['response'] ];
+                continue;
+            }
+
+            // Fallback for legacy two-line log format
             if (strpos($line, $prompt_prefix) === 0) {
                 $prompt = substr($line, strlen($prompt_prefix));
             } elseif (strpos($line, $resp_prefix) === 0 && $prompt !== null) {

--- a/includes/Gm2_ChatGPT.php
+++ b/includes/Gm2_ChatGPT.php
@@ -79,8 +79,11 @@ class Gm2_ChatGPT {
 
         if (get_option('gm2_enable_chatgpt_logging', '0') === '1') {
             $log_resp = is_wp_error($result) ? $result->get_error_message() : $result;
-            error_log('ChatGPT prompt: ' . $prompt . PHP_EOL, 3, GM2_CHATGPT_LOG_FILE);
-            error_log('ChatGPT response: ' . $log_resp . PHP_EOL, 3, GM2_CHATGPT_LOG_FILE);
+            $entry = wp_json_encode([
+                'prompt'   => $prompt,
+                'response' => $log_resp,
+            ]);
+            error_log($entry . PHP_EOL, 3, GM2_CHATGPT_LOG_FILE);
         }
 
         return $result;

--- a/includes/Gm2_SEO_Utils.php
+++ b/includes/Gm2_SEO_Utils.php
@@ -134,8 +134,11 @@ namespace {
 
         if (get_option('gm2_enable_chatgpt_logging', '0') === '1') {
             $log_resp = is_wp_error($result) ? $result->get_error_message() : $result;
-            error_log('ChatGPT prompt: ' . $prompt . PHP_EOL, 3, GM2_CHATGPT_LOG_FILE);
-            error_log('ChatGPT response: ' . $log_resp . PHP_EOL, 3, GM2_CHATGPT_LOG_FILE);
+            $entry = wp_json_encode([
+                'prompt'   => $prompt,
+                'response' => $log_resp,
+            ]);
+            error_log($entry . PHP_EOL, 3, GM2_CHATGPT_LOG_FILE);
         }
 
         return $result;

--- a/tests/test-chatgpt.php
+++ b/tests/test-chatgpt.php
@@ -98,8 +98,11 @@ class ChatGPTTest extends WP_UnitTestCase {
     public function test_chatgpt_page_shows_logs_when_file_exists() {
         $admin = new Gm2_Admin();
         update_option('gm2_enable_chatgpt_logging', '1');
-        $log = "ChatGPT prompt: hi\nChatGPT response: there\n";
-        file_put_contents(GM2_CHATGPT_LOG_FILE, $log);
+        $entry = json_encode([
+            'prompt'   => 'hi',
+            'response' => "there\nbuddy",
+        ]) . "\n";
+        file_put_contents(GM2_CHATGPT_LOG_FILE, $entry);
         ob_start();
         $admin->display_chatgpt_page();
         $out = ob_get_clean();
@@ -107,7 +110,7 @@ class ChatGPTTest extends WP_UnitTestCase {
         update_option('gm2_enable_chatgpt_logging', '0');
         $this->assertStringContainsString('ChatGPT Logs', $out);
         $this->assertStringContainsString('<table', $out);
-        $this->assertStringContainsString('<tr><td>hi</td><td>there</td></tr>', $out);
+        $this->assertStringContainsString("<tr><td>hi</td><td>there\nbuddy</td></tr>", $out);
     }
 
     public function test_chatgpt_page_shows_no_logs_message() {
@@ -124,8 +127,8 @@ class ChatGPTTest extends WP_UnitTestCase {
     public function test_chatgpt_page_contains_reset_button() {
         $admin = new Gm2_Admin();
         update_option('gm2_enable_chatgpt_logging', '1');
-        $log = "ChatGPT prompt: hi\nChatGPT response: there\n";
-        file_put_contents(GM2_CHATGPT_LOG_FILE, $log);
+        $entry = json_encode(['prompt' => 'hi', 'response' => 'there']) . "\n";
+        file_put_contents(GM2_CHATGPT_LOG_FILE, $entry);
         ob_start();
         $admin->display_chatgpt_page();
         $out = ob_get_clean();


### PR DESCRIPTION
## Summary
- store each ChatGPT prompt/response pair in a single JSON log line
- handle new JSON log format when reading the log
- update tests for JSON log parsing and multi-line responses

## Testing
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `npm test` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_688169eda9dc8327b16fbce31c235aa1