### PR TITLE
Add toggleable ChatGPT log display

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -551,11 +551,16 @@ class Gm2_Admin {
             if (empty($entries)) {
                 echo '<p>' . esc_html__( 'No logs found.', 'gm2-wordpress-suite' ) . '</p>';
             } else {
-                echo '<table class="widefat fixed"><thead><tr><th>' . esc_html__( 'Prompt', 'gm2-wordpress-suite' ) . '</th><th>' . esc_html__( 'Response', 'gm2-wordpress-suite' ) . '</th></tr></thead><tbody>';
+                echo '<div class="gm2-chatgpt-logs">';
                 foreach ($entries as $e) {
-                    echo '<tr><td>' . esc_html($e['prompt']) . '</td><td>' . esc_html($e['response']) . '</td></tr>';
+                    echo '<div class="gm2-log-entry">';
+                    echo '<div class="gm2-log-toggle">' . esc_html__( 'Prompt sent', 'gm2-wordpress-suite' ) . '</div>';
+                    echo '<pre class="gm2-log-content">' . esc_html($e['prompt']) . '</pre>';
+                    echo '<div class="gm2-log-toggle">' . esc_html__( 'Response received', 'gm2-wordpress-suite' ) . '</div>';
+                    echo '<pre class="gm2-log-content">' . esc_html($e['response']) . '</pre>';
+                    echo '</div>';
                 }
-                echo '</tbody></table>';
+                echo '</div>';
             }
             if (file_exists(GM2_CHATGPT_LOG_FILE)) {
                 echo '<form method="post" action="' . admin_url('admin-post.php') . '">';

--- a/admin/css/gm2-chatgpt.css
+++ b/admin/css/gm2-chatgpt.css
@@ -13,3 +13,21 @@
 .gm2-chatgpt-table th {
     background: #f1f1f1;
 }
+
+/* Log toggle styles */
+.gm2-log-toggle {
+    cursor: pointer;
+    color: #0073aa;
+    text-decoration: underline;
+    margin-bottom: 4px;
+    display: inline-block;
+}
+
+.gm2-log-content {
+    display: none;
+    white-space: pre-wrap;
+    background: #f9f9f9;
+    padding: 8px;
+    border: 1px solid #ddd;
+    margin-bottom: 10px;
+}

--- a/admin/js/gm2-chatgpt.js
+++ b/admin/js/gm2-chatgpt.js
@@ -15,4 +15,9 @@ jQuery(function($){
             }
         });
     });
+
+    // Toggle log visibility for prompt/response entries
+    $('.gm2-log-toggle').on('click', function(){
+        $(this).next('.gm2-log-content').toggle();
+    });
 });

--- a/tests/test-chatgpt.php
+++ b/tests/test-chatgpt.php
@@ -109,8 +109,11 @@ class ChatGPTTest extends WP_UnitTestCase {
         @unlink(GM2_CHATGPT_LOG_FILE);
         update_option('gm2_enable_chatgpt_logging', '0');
         $this->assertStringContainsString('ChatGPT Logs', $out);
-        $this->assertStringContainsString('<table', $out);
-        $this->assertStringContainsString("<tr><td>hi</td><td>there\nbuddy</td></tr>", $out);
+        $this->assertStringContainsString('gm2-log-entry', $out);
+        $this->assertStringContainsString('Prompt sent', $out);
+        $this->assertStringContainsString('Response received', $out);
+        $this->assertStringContainsString('hi', $out);
+        $this->assertStringContainsString("there\nbuddy", $out);
     }
 
     public function test_chatgpt_page_shows_no_logs_message() {


### PR DESCRIPTION
## Summary
- style log toggles in ChatGPT admin CSS
- add jQuery logic to reveal prompt/response text
- output ChatGPT logs with expandable containers
- update PHPUnit tests for new markup

## Testing
- `npm test`
- `phpunit` *(fails: missing WordPress test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68816e2fb7648327bb25441ddac7c27a