### PR TITLE
Add gm2-chatgpt-table class to log markup

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -552,14 +552,20 @@ class Gm2_Admin {
                 echo '<p>' . esc_html__( 'No logs found.', 'gm2-wordpress-suite' ) . '</p>';
             } else {
                 echo '<div class="gm2-chatgpt-logs">';
+                echo '<table class="widefat fixed gm2-chatgpt-table"><thead><tr><th>' . esc_html__( 'Prompt', 'gm2-wordpress-suite' ) . '</th><th>' . esc_html__( 'Response', 'gm2-wordpress-suite' ) . '</th></tr></thead><tbody>';
                 foreach ($entries as $e) {
-                    echo '<div class="gm2-log-entry">';
+                    echo '<tr class="gm2-log-entry">';
+                    echo '<td>';
                     echo '<div class="gm2-log-toggle">' . esc_html__( 'Prompt sent', 'gm2-wordpress-suite' ) . '</div>';
                     echo '<pre class="gm2-log-content">' . esc_html($e['prompt']) . '</pre>';
+                    echo '</td>';
+                    echo '<td>';
                     echo '<div class="gm2-log-toggle">' . esc_html__( 'Response received', 'gm2-wordpress-suite' ) . '</div>';
                     echo '<pre class="gm2-log-content">' . esc_html($e['response']) . '</pre>';
-                    echo '</div>';
+                    echo '</td>';
+                    echo '</tr>';
                 }
+                echo '</tbody></table>';
                 echo '</div>';
             }
             if (file_exists(GM2_CHATGPT_LOG_FILE)) {


### PR DESCRIPTION
## Summary
- display ChatGPT logs in a `<table>` with the `gm2-chatgpt-table` class
- confirm stylesheet for ChatGPT page is enqueued

## Testing
- `npm install`
- `make test DB_NAME=wp_test DB_USER=root DB_PASS=pass` *(fails: Can't connect to MySQL server)*

------
https://chatgpt.com/codex/tasks/task_e_68816f8d193c8327b5e8042303f1ea4a