### PR TITLE
Ensure newline formatting in log table

### DIFF
--- a/tests/test-chatgpt.php
+++ b/tests/test-chatgpt.php
@@ -112,8 +112,14 @@ class ChatGPTTest extends WP_UnitTestCase {
         $this->assertStringContainsString('gm2-log-entry', $out);
         $this->assertStringContainsString('Prompt sent', $out);
         $this->assertStringContainsString('Response received', $out);
-        $this->assertStringContainsString('hi', $out);
-        $this->assertStringContainsString("there\nbuddy", $out);
+        $this->assertStringContainsString(
+            '<pre class="gm2-log-content">hi</pre>',
+            $out
+        );
+        $this->assertStringContainsString(
+            "<pre class=\"gm2-log-content\">there\nbuddy</pre>",
+            $out
+        );
     }
 
     public function test_chatgpt_page_shows_no_logs_message() {


### PR DESCRIPTION
## Summary
- verify logs show up wrapped in `<pre>` tags via tests

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688171f14a50832784d6eb9c8c514791