### PR TITLE
Fix sanitize_ai_json for braced lists

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1971,6 +1971,17 @@ class Gm2_SEO_Admin {
             $json = $response;
         }
 
+        $json = preg_replace_callback(
+            '/:\s*\{\s*("(?:\\\\.|[^"\\])*"\s*(?:,\s*"(?:\\\\.|[^"\\])*"\s*)*)\}/s',
+            function($m) {
+                if (strpos($m[1], ':') !== false) {
+                    return $m[0];
+                }
+                return ':[' . $m[1] . ']';
+            },
+            $json
+        );
+
         return preg_replace_callback('/"(?:\\\\.|[^"\\\\])*"/s', function($matches) {
             return str_replace("\n", "\\n", $matches[0]);
         }, $json);

--- a/tests/test-ai-seo.php
+++ b/tests/test-ai-seo.php
@@ -134,6 +134,18 @@ class AiResearchAjaxTest extends WP_Ajax_UnitTestCase {
         $this->assertSame("<p>line1\nline2</p>", $data['updated_html']);
     }
 
+    public function test_sanitize_ai_json_converts_braced_lists() {
+        $admin  = new Gm2_SEO_Admin();
+        $method = new ReflectionMethod(Gm2_SEO_Admin::class, 'sanitize_ai_json');
+        $method->setAccessible(true);
+
+        $raw  = '{ "content_suggestions": { "One", "Two" } }';
+        $clean = $method->invoke($admin, $raw);
+        $data  = json_decode($clean, true);
+
+        $this->assertSame(['One', 'Two'], $data['content_suggestions']);
+    }
+
     public function test_ai_research_invalid_json_returns_error() {
         update_option('gm2_chatgpt_api_key', 'key');
         $filter = function($pre, $args, $url) {


### PR DESCRIPTION
## Summary
- allow sanitize_ai_json() to convert `{ "A", "B" }` into an array
- cover this case with a new PHPUnit test

## Testing
- `phpunit --configuration phpunit.xml --dont-report-useless-tests --colors=never` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_688178280f3c83279c0b17156b1c835a