### PR TITLE
Honor SEO toggle in diagnostics

### DIFF
--- a/admin/Gm2_Diagnostics.php
+++ b/admin/Gm2_Diagnostics.php
@@ -23,6 +23,9 @@ class Gm2_Diagnostics {
     }
 
     private function check_plugins() {
+        if (get_option('gm2_enable_seo', '1') !== '1') {
+            return;
+        }
         $active    = (array) get_option('active_plugins');
         $patterns  = ['wordpress-seo', 'all-in-one-seo', 'aioseo', 'rank-math', 'seopress'];
         foreach ($active as $plugin) {

--- a/readme.txt
+++ b/readme.txt
@@ -91,7 +91,7 @@ If AI Research fails or returns unexpected results, enable WordPress debugging a
 The AI features depend on the DOM/LibXML extension. Verify it is installed by running `php -m | grep -i dom` before using AI Research.
 
 == Diagnostics ==
-As a first step, open **Gm2 → Diagnostics** to detect plugin conflicts, missing files or theme customizations that may disable SEO output. Any detected issues are listed as an admin notice with steps to resolve them.
+As a first step, open **Gm2 → Diagnostics** to detect plugin conflicts, missing files or theme customizations that may disable SEO output. Any detected issues are listed as an admin notice with steps to resolve them. Diagnostics run only when the SEO module is enabled on the **Gm2 Suite** page.
 
 == Breadcrumbs ==
 Display a breadcrumb trail anywhere using the `[gm2_breadcrumbs]` shortcode. The output

--- a/tests/test-diagnostics.php
+++ b/tests/test-diagnostics.php
@@ -1,0 +1,25 @@
+<?php
+use Gm2\Gm2_Diagnostics;
+class DiagnosticsTest extends WP_UnitTestCase {
+    public function test_conflicts_hidden_when_seo_disabled() {
+        update_option('gm2_enable_seo', '0');
+        update_option('active_plugins', ['wordpress-seo/wp-seo.php']);
+        $diag = new Gm2_Diagnostics();
+        $diag->diagnose();
+        ob_start();
+        $diag->display_notice();
+        $output = ob_get_clean();
+        $this->assertSame('', $output);
+    }
+
+    public function test_conflicts_shown_when_seo_enabled() {
+        update_option('gm2_enable_seo', '1');
+        update_option('active_plugins', ['wordpress-seo/wp-seo.php']);
+        $diag = new Gm2_Diagnostics();
+        $diag->diagnose();
+        ob_start();
+        $diag->display_notice();
+        $output = ob_get_clean();
+        $this->assertStringContainsString('Conflicting SEO plugins', $output);
+    }
+}


### PR DESCRIPTION
## Summary
- bail out of diagnostics check_plugins when SEO is disabled
- add tests ensuring the warning is shown only when SEO is enabled
- document that diagnostics require the SEO module

## Testing
- `make test DB_NAME=wp_test DB_USER=root DB_PASS=pass` *(fails: PHPUnit Polyfills library missing)*

------
https://chatgpt.com/codex/tasks/task_e_6881799fb5a88327978da3db8dcc01c5