### PR TITLE
Handle inch symbol in sanitize_ai_json

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1983,7 +1983,12 @@ class Gm2_SEO_Admin {
         );
 
         return preg_replace_callback('/"(?:\\\\.|[^"\\\\])*"/s', function($matches) {
-            return str_replace("\n", "\\n", $matches[0]);
+            $str = str_replace("\n", "\\n", $matches[0]);
+
+            $inner = substr($str, 1, -1);
+            $inner = preg_replace('/(?<!\\\\)(\d+(?:\.\d+)?(?:-inch)?)"/', '$1\\"', $inner);
+
+            return '"' . $inner . '"';
         }, $json);
     }
 

--- a/tests/test-ai-seo.php
+++ b/tests/test-ai-seo.php
@@ -146,6 +146,19 @@ class AiResearchAjaxTest extends WP_Ajax_UnitTestCase {
         $this->assertSame(['One', 'Two'], $data['content_suggestions']);
     }
 
+    public function test_sanitize_ai_json_escapes_inch_quotes() {
+        $admin  = new Gm2_SEO_Admin();
+        $method = new ReflectionMethod(Gm2_SEO_Admin::class, 'sanitize_ai_json');
+        $method->setAccessible(true);
+
+        $raw  = '{ "size": "Approx 17.5" screen" }';
+        $clean = $method->invoke($admin, $raw);
+        $data  = json_decode($clean, true);
+
+        $this->assertNotNull($data);
+        $this->assertSame('Approx 17.5" screen', $data['size']);
+    }
+
     public function test_ai_research_invalid_json_returns_error() {
         update_option('gm2_chatgpt_api_key', 'key');
         $filter = function($pre, $args, $url) {


### PR DESCRIPTION
## Summary
- escape numeric inch quotes in `sanitize_ai_json`
- test inch quote handling

## Testing
- `phpunit` *(fails: wordpress-tests-lib missing)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68817b3e4558832782094e3834ae878f