### PR TITLE
Add early return test and docs for SEO conflict notice

### DIFF
--- a/admin/Gm2_Diagnostics.php
+++ b/admin/Gm2_Diagnostics.php
@@ -23,6 +23,7 @@ class Gm2_Diagnostics {
     }
 
     private function check_plugins() {
+        // Skip conflict checks when the SEO module is disabled.
         if (get_option('gm2_enable_seo', '1') !== '1') {
             return;
         }

--- a/readme.txt
+++ b/readme.txt
@@ -79,6 +79,7 @@ If you see errors when connecting your Google account:
 * **Viewing debug logs** – Add `define('WP_DEBUG', true);` and `define('WP_DEBUG_LOG', true);` to your `wp-config.php` file, then check `wp-content/debug.log` for errors.
 * **Check DOM extension** – Run `php -m | grep -i dom` to verify the DOM/LibXML extension is loaded. The plugin requires this for HTML analysis.
 * **Gm2 Qnty Discounts widget missing** – Ensure Elementor is active and loads before this plugin, or deactivate and reactivate plugins so Elementor triggers the `elementor/loaded` action.
+* **Leftover SEO conflict warning** – Re-save the **Gm2 Suite** settings or update to version 1.6.16 or higher to clear outdated notices.
 
 === WP Debugging ===
 If AI Research fails or returns unexpected results, enable WordPress debugging and check for PHP errors:

--- a/tests/test-diagnostics.php
+++ b/tests/test-diagnostics.php
@@ -22,4 +22,18 @@ class DiagnosticsTest extends WP_UnitTestCase {
         $output = ob_get_clean();
         $this->assertStringContainsString('Conflicting SEO plugins', $output);
     }
+
+    public function test_check_plugins_returns_early_when_seo_disabled() {
+        update_option('gm2_enable_seo', '0');
+        update_option('active_plugins', ['wordpress-seo/wp-seo.php']);
+        $diag = new Gm2_Diagnostics();
+
+        $reflect   = new ReflectionMethod($diag, 'check_plugins');
+        $reflect->setAccessible(true);
+        $reflect->invoke($diag);
+
+        $prop = new ReflectionProperty($diag, 'conflicts');
+        $prop->setAccessible(true);
+        $this->assertSame([], $prop->getValue($diag));
+    }
 }


### PR DESCRIPTION
## Summary
- clarify skip logic in `check_plugins()`
- test early return when SEO module disabled
- document clearing leftover notices in troubleshooting

## Testing
- `make test DB_NAME=wp_test DB_USER=root DB_PASS=pass` *(fails: mysqladmin command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68817d23f6248327a8216006917826c5