### PR TITLE
Fix AI JSON sanitization

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1971,6 +1971,10 @@ class Gm2_SEO_Admin {
             $json = $response;
         }
 
+        // Strip JavaScript-style comments before further processing.
+        $json = preg_replace('#/\*.*?\*/#s', '', $json);
+        $json = preg_replace('#//.*$#m', '', $json);
+
         $json = preg_replace_callback(
             '/:\s*\{\s*("(?:\\\\.|[^"\\])*"\s*(?:,\s*"(?:\\\\.|[^"\\])*"\s*)*)\}/s',
             function($m) {
@@ -1982,7 +1986,7 @@ class Gm2_SEO_Admin {
             $json
         );
 
-        return preg_replace_callback('/"(?:\\\\.|[^"\\\\])*"/s', function($matches) {
+        $json = preg_replace_callback('/"(?:\\\\.|[^"\\\\])*"/s', function($matches) {
             $str = str_replace("\n", "\\n", $matches[0]);
 
             $inner = substr($str, 1, -1);
@@ -1990,6 +1994,13 @@ class Gm2_SEO_Admin {
 
             return '"' . $inner . '"';
         }, $json);
+
+        $end = strrpos($json, '}');
+        if ($end !== false) {
+            $json = substr($json, 0, $end + 1);
+        }
+
+        return trim($json);
     }
 
     /**

--- a/tests/test-ai-seo.php
+++ b/tests/test-ai-seo.php
@@ -159,6 +159,19 @@ class AiResearchAjaxTest extends WP_Ajax_UnitTestCase {
         $this->assertSame('Approx 17.5" screen', $data['size']);
     }
 
+    public function test_sanitize_ai_json_strips_comments() {
+        $admin  = new Gm2_SEO_Admin();
+        $method = new ReflectionMethod(Gm2_SEO_Admin::class, 'sanitize_ai_json');
+        $method->setAccessible(true);
+
+        $raw  = "{ \"foo\": \"bar\" } /* c1 */ // c2\n\"";
+        $clean = $method->invoke($admin, $raw);
+        $data  = json_decode($clean, true);
+
+        $this->assertNotNull($data);
+        $this->assertSame('bar', $data['foo']);
+    }
+
     public function test_ai_research_invalid_json_returns_error() {
         update_option('gm2_chatgpt_api_key', 'key');
         $filter = function($pre, $args, $url) {


### PR DESCRIPTION
## Summary
- improve sanitize_ai_json to remove JS comments and trailing characters
- cover comment removal in tests

## Testing
- `./vendor/bin/phpunit` *(fails: Class declarations may not be nested in tests/test-quantity-discounts.php)*

------
https://chatgpt.com/codex/tasks/task_e_68818059f12c8327ae9a2bf414d77b59