### PR TITLE
Fix AI research JSON parsing

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -3091,8 +3091,9 @@ TEXT;
             wp_send_json_error(__('AI request failed', 'gm2-wordpress-suite'));
         }
 
+        $resp2_clean = $this->sanitize_ai_json($resp2);
         try {
-            $data2 = json_decode($resp2, true, 512, JSON_THROW_ON_ERROR);
+            $data2 = json_decode($resp2_clean, true, 512, JSON_THROW_ON_ERROR);
         } catch (\Throwable $e) {
             if (defined('WP_DEBUG') && WP_DEBUG) {
                 error_log('AI Research JSON decode failed: ' . $resp2);


### PR DESCRIPTION
## Summary
- sanitize the second AI research response before decoding
- keep fallback parsing for malformed JSON
- test that AI research handles newlines and comments in second response

## Testing
- `npm test`
- `phpunit` *(fails: Missing WordPress test library)*

------
https://chatgpt.com/codex/tasks/task_e_68819a5b56148327a74ef3f7f9d36e3a