### PR TITLE
Fix quote escaping in sanitize_ai_json and add test

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1991,6 +1991,7 @@ class Gm2_SEO_Admin {
 
             $inner = substr($str, 1, -1);
             $inner = preg_replace('/(?<!\\\\)(\d+(?:\.\d+)?(?:-inch)?)"/', '$1\\"', $inner);
+            $inner = preg_replace('/(?<!\\)"/', '\\"', $inner);
 
             return '"' . $inner . '"';
         }, $json);

--- a/tests/test-ai-seo.php
+++ b/tests/test-ai-seo.php
@@ -204,6 +204,22 @@ class AiResearchAjaxTest extends WP_Ajax_UnitTestCase {
         $this->assertSame('Approx 17.5" screen', $data['size']);
     }
 
+    public function test_sanitize_ai_json_escapes_unescaped_quotes() {
+        $admin  = new Gm2_SEO_Admin();
+        $method = new ReflectionMethod(Gm2_SEO_Admin::class, 'sanitize_ai_json');
+        $method->setAccessible(true);
+
+        $raw  = '{ "seo_title":"New "Special" Title" }';
+        $clean = $method->invoke($admin, $raw);
+
+        $this->assertStringContainsString('New \"Special\" Title', $clean);
+
+        $data  = json_decode($clean, true);
+
+        $this->assertNotNull($data);
+        $this->assertSame('New "Special" Title', $data['seo_title']);
+    }
+
     public function test_sanitize_ai_json_strips_comments() {
         $admin  = new Gm2_SEO_Admin();
         $method = new ReflectionMethod(Gm2_SEO_Admin::class, 'sanitize_ai_json');


### PR DESCRIPTION
## Summary
- properly escape unescaped quotes in `sanitize_ai_json`
- add test for escaping of inner quotes within JSON strings

## Testing
- `DB_NAME=wp_test DB_USER=root DB_PASS=pass make test` *(fails: mysqladmin command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68819b9dd1648327abe156407cfeb85e