### PR TITLE
Fix AI JSON extraction

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1965,7 +1965,7 @@ class Gm2_SEO_Admin {
      * @return string Clean JSON string ready for decoding.
      */
     private function sanitize_ai_json($response) {
-        if (preg_match('/\{.*\}/s', $response, $m)) {
+        if (preg_match('/\{(?:[^{}]|(?R))*\}/s', $response, $m)) {
             $json = $m[0];
         } else {
             $json = $response;
@@ -3100,7 +3100,7 @@ TEXT;
                 error_log('AI Research JSON decode failed: ' . $resp2);
                 error_log('AI Research JSON error: ' . json_last_error_msg());
             }
-            if (preg_match('/\{.*\}/s', $resp2, $m)) {
+            if (preg_match('/\{(?:[^{}]|(?R))*\}/s', $resp2, $m)) {
                 try {
                     $data2 = json_decode($m[0], true, 512, JSON_THROW_ON_ERROR);
                 } catch (\Throwable $e2) {

--- a/tests/test-ai-seo.php
+++ b/tests/test-ai-seo.php
@@ -233,6 +233,18 @@ class AiResearchAjaxTest extends WP_Ajax_UnitTestCase {
         $this->assertSame('bar', $data['foo']);
     }
 
+    public function test_sanitize_ai_json_extracts_first_object() {
+        $admin  = new Gm2_SEO_Admin();
+        $method = new ReflectionMethod(Gm2_SEO_Admin::class, 'sanitize_ai_json');
+        $method->setAccessible(true);
+
+        $raw  = '{ "one": 1 } { "two": 2 }';
+        $clean = $method->invoke($admin, $raw);
+        $data  = json_decode($clean, true);
+
+        $this->assertSame(['one' => 1], $data);
+    }
+
     public function test_ai_research_invalid_json_returns_error() {
         update_option('gm2_chatgpt_api_key', 'key');
         $filter = function($pre, $args, $url) {


### PR DESCRIPTION
## Summary
- parse only the first JSON block using a recursive regex
- add unit test to ensure only the first JSON object is returned

## Testing
- `make test` *(fails: WordPress test suite missing)*

------
https://chatgpt.com/codex/tasks/task_e_68819dafe42c83279d3f29c6a1daa4b3