### PR TITLE
Handle curly quotes & trailing commas in sanitize

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1971,9 +1971,21 @@ class Gm2_SEO_Admin {
             $json = $response;
         }
 
+        // Normalize curly double quotes which often appear in AI output.
+        $json = str_replace(["\xE2\x80\x9C", "\xE2\x80\x9D"], '"', $json);
+
         // Strip JavaScript-style comments before further processing.
         $json = preg_replace('#/\*.*?\*/#s', '', $json);
         $json = preg_replace('#//.*$#m', '', $json);
+
+        // Remove trailing commas before closing braces or brackets.
+        $json = preg_replace_callback(
+            '/"(?:\\.|[^"\\])*"|,(?=\s*[}\]])/s',
+            function($m) {
+                return ($m[0][0] === '"') ? $m[0] : '';
+            },
+            $json
+        );
 
         $json = preg_replace_callback(
             '/:\s*\{\s*("(?:\\\\.|[^"\\])*"\s*(?:,\s*"(?:\\\\.|[^"\\])*"\s*)*)\}/s',

--- a/tests/test-ai-seo.php
+++ b/tests/test-ai-seo.php
@@ -245,6 +245,34 @@ class AiResearchAjaxTest extends WP_Ajax_UnitTestCase {
         $this->assertSame(['one' => 1], $data);
     }
 
+    public function test_sanitize_ai_json_normalizes_curly_quotes() {
+        $admin  = new Gm2_SEO_Admin();
+        $method = new ReflectionMethod(Gm2_SEO_Admin::class, 'sanitize_ai_json');
+        $method->setAccessible(true);
+
+        $raw  = "{ “seo_title”: “Curly” }";
+        $clean = $method->invoke($admin, $raw);
+        $data  = json_decode($clean, true);
+
+        $this->assertSame('Curly', $data['seo_title']);
+    }
+
+    public function test_sanitize_ai_json_removes_trailing_commas() {
+        $admin  = new Gm2_SEO_Admin();
+        $method = new ReflectionMethod(Gm2_SEO_Admin::class, 'sanitize_ai_json');
+        $method->setAccessible(true);
+
+        $raw  = '{ "x": 1, }';
+        $clean = $method->invoke($admin, $raw);
+        $data  = json_decode($clean, true);
+        $this->assertSame(['x' => 1], $data);
+
+        $raw  = '{ "arr": ["a","b",] }';
+        $clean = $method->invoke($admin, $raw);
+        $data  = json_decode($clean, true);
+        $this->assertSame(['arr' => ['a','b']], $data);
+    }
+
     public function test_ai_research_invalid_json_returns_error() {
         update_option('gm2_chatgpt_api_key', 'key');
         $filter = function($pre, $args, $url) {


### PR DESCRIPTION
## Summary
- extend `sanitize_ai_json` to normalize curly quotes and remove trailing commas
- add unit tests covering curly quotes and trailing commas

## Testing
- `./vendor/bin/phpunit` *(fails: WordPress tests not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6881a2bc05308327ba4a7876b0f56de7