### PR TITLE
Handle array seed keywords

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -2993,14 +2993,19 @@ TEXT;
         }
 
 
-        $seed_string = '';
+        $seed_value = '';
         if (!empty($data['seed_keywords'])) {
-            $seed_string = $data['seed_keywords'];
+            $seed_value = $data['seed_keywords'];
         } elseif (!empty($data['focus_keywords'])) {
-            $seed_string = $data['focus_keywords'];
+            $seed_value = $data['focus_keywords'];
         }
 
-        $seeds = array_filter(array_map('trim', explode(',', $seed_string)));
+        if (is_array($seed_value)) {
+            $seeds = array_filter(array_map('trim', $seed_value));
+        } else {
+            $seed_string = $seed_value;
+            $seeds = array_filter(array_map('trim', explode(',', $seed_string)));
+        }
 
         $final_focus = '';
         $final_long  = [];


### PR DESCRIPTION
## Summary
- allow array input for seed keywords
- store seed keywords consistently
- test handling of `seed_keywords` arrays

## Testing
- `php -l admin/Gm2_SEO_Admin.php`
- `php -l tests/test-ai-seo.php`
- `phpunit --configuration phpunit.xml` *(fails: missing WordPress test suite)*

------
https://chatgpt.com/codex/tasks/task_e_6881a6cf992483279d99243317bb6601