### PR TITLE
Standardize seed_keywords array format

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -26,3 +26,15 @@ When logging is enabled, the **Gm2 → ChatGPT** page shows a table of recent pr
 Each log row now includes small expand/collapse controls. Click the **Prompt sent** or **Response received** label to toggle the full text of that entry. This makes it easier to browse long conversations without leaving the page cluttered.
 
 If you need to clear the log and start over, click the **Reset Logs** button below the table.
+
+## Seed Keywords Format
+
+The first AI SEO response should return the `seed_keywords` value as an array of strings:
+
+```json
+{
+  "seed_keywords": ["alpha", "beta"]
+}
+```
+
+These seed keywords are refined with Google Ads data before the final results are presented.

--- a/tests/test-ai-seo.php
+++ b/tests/test-ai-seo.php
@@ -125,7 +125,7 @@ class AiResearchAjaxTest extends WP_Ajax_UnitTestCase {
     public function test_ai_research_second_response_with_newlines_and_comments() {
         update_option('gm2_chatgpt_api_key', 'key');
 
-        $first = ['seed_keywords' => 'alpha'];
+        $first = ['seed_keywords' => ['alpha']];
         $second_raw = "{ \"seo_title\": \"Line1\nLine2\", \"description\": \"Desc\" } // comment";
         $step = 0;
         $filter = function($pre, $args, $url) use (&$step, $first, $second_raw) {
@@ -577,7 +577,7 @@ class AiResearchKeywordSelectionTest extends WP_Ajax_UnitTestCase {
         update_option('gm2_google_access_token', 'access');
         update_option('gm2_google_expires_at', time() + 3600);
 
-        $first = ['seed_keywords' => 'alpha,beta'];
+        $first = ['seed_keywords' => ['alpha', 'beta']];
         $second = ['seo_title' => 'Final'];
         $kwp = [
             'results' => [
@@ -682,7 +682,7 @@ class AiResearchErrorHandlingTest extends WP_Ajax_UnitTestCase {
             if ($url === 'https://api.openai.com/v1/chat/completions') {
                 if ($step === 0) {
                     $step++;
-                    return [ 'response' => ['code' => 200], 'body' => json_encode(['choices' => [ ['message' => ['content' => json_encode(['seed_keywords' => 'alpha'])]] ]]) ];
+                    return [ 'response' => ['code' => 200], 'body' => json_encode(['choices' => [ ['message' => ['content' => json_encode(['seed_keywords' => ['alpha']])]] ]]) ];
                 }
                 return [ 'response' => ['code' => 200], 'body' => json_encode(['choices' => [ ['message' => ['content' => '{}']] ]]) ];
             }
@@ -722,7 +722,7 @@ class AiResearchErrorHandlingTest extends WP_Ajax_UnitTestCase {
             if ($url === 'https://api.openai.com/v1/chat/completions') {
                 if ($step === 0) {
                     $step++;
-                    return [ 'response' => ['code' => 200], 'body' => json_encode(['choices' => [ ['message' => ['content' => json_encode(['seed_keywords' => 'alpha'])]] ]]) ];
+                    return [ 'response' => ['code' => 200], 'body' => json_encode(['choices' => [ ['message' => ['content' => json_encode(['seed_keywords' => ['alpha']])]] ]]) ];
                 }
                 return [ 'response' => ['code' => 200], 'body' => json_encode(['choices' => [ ['message' => ['content' => '{}']] ]]) ];
             }
@@ -756,7 +756,7 @@ class AiResearchErrorHandlingTest extends WP_Ajax_UnitTestCase {
             if ($url === 'https://api.openai.com/v1/chat/completions') {
                 if ($step === 0) {
                     $step++;
-                    return [ 'response' => ['code' => 200], 'body' => json_encode(['choices' => [ ['message' => ['content' => json_encode(['seed_keywords' => 'alpha,beta'])]] ]]) ];
+                    return [ 'response' => ['code' => 200], 'body' => json_encode(['choices' => [ ['message' => ['content' => json_encode(['seed_keywords' => ['alpha','beta']])]] ]]) ];
                 }
                 return [ 'response' => ['code' => 200], 'body' => json_encode(['choices' => [ ['message' => ['content' => '{}']] ]]) ];
             }


### PR DESCRIPTION
## Summary
- clarify that seed_keywords must be returned as an array
- adjust AI SEO tests to use the array form
- document the expected response format in docs/index.md

## Testing
- `npm test`
- `phpunit -c phpunit.xml` *(fails: missing wordpress-tests-lib)*

------
https://chatgpt.com/codex/tasks/task_e_6881a83fc2b083278dddc269f344920f