### PR TITLE
Improve JSON extraction logic and add test

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1965,8 +1965,25 @@ class Gm2_SEO_Admin {
      * @return string Clean JSON string ready for decoding.
      */
     private function sanitize_ai_json($response) {
-        if (preg_match('/\{(?:[^{}]|(?R))*\}/s', $response, $m)) {
-            $json = $m[0];
+        $start = strpos($response, '{');
+        $end   = strrpos($response, '}');
+
+        if ($start !== false && $end !== false && $end > $start) {
+            $json    = substr($response, $start, $end - $start + 1);
+            $trimmed = $json;
+
+            while ($trimmed !== '') {
+                json_decode($trimmed);
+                if (json_last_error() === JSON_ERROR_NONE) {
+                    $json = $trimmed;
+                    break;
+                }
+                $pos = strrpos($trimmed, '}');
+                if ($pos === false) {
+                    break;
+                }
+                $trimmed = substr($trimmed, 0, $pos);
+            }
         } else {
             $json = $response;
         }

--- a/tests/test-ai-seo.php
+++ b/tests/test-ai-seo.php
@@ -179,6 +179,19 @@ class AiResearchAjaxTest extends WP_Ajax_UnitTestCase {
         $this->assertSame("<p>line1\nline2</p>", $data['updated_html']);
     }
 
+    public function test_sanitize_ai_json_handles_braces_in_quotes() {
+        $admin  = new Gm2_SEO_Admin();
+        $method = new ReflectionMethod(Gm2_SEO_Admin::class, 'sanitize_ai_json');
+        $method->setAccessible(true);
+
+        $raw  = '{ "updated_html": "<p>{example}</p>" }';
+        $clean = $method->invoke($admin, $raw);
+        $data  = json_decode($clean, true);
+
+        $this->assertNotNull($data);
+        $this->assertSame('<p>{example}</p>', $data['updated_html']);
+    }
+
     public function test_sanitize_ai_json_converts_braced_lists() {
         $admin  = new Gm2_SEO_Admin();
         $method = new ReflectionMethod(Gm2_SEO_Admin::class, 'sanitize_ai_json');


### PR DESCRIPTION
## Summary
- robustly extract JSON in `sanitize_ai_json` using first/last braces and decode attempts
- cover braces inside quoted HTML with new unit test

## Testing
- `php -l admin/Gm2_SEO_Admin.php`
- `php -l tests/test-ai-seo.php`
- `phpunit` *(fails: missing WordPress test suite)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881ab6f7d608327aa2d7470cccc0714