### PR TITLE
Fix AI keyword array parsing

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -3010,18 +3010,17 @@ TEXT;
         }
 
 
-        $seed_value = '';
-        if (!empty($data['seed_keywords'])) {
+        $seed_value = [];
+        if (isset($data['seed_keywords'])) {
             $seed_value = $data['seed_keywords'];
-        } elseif (!empty($data['focus_keywords'])) {
+        } elseif (isset($data['focus_keywords'])) {
             $seed_value = $data['focus_keywords'];
         }
 
         if (is_array($seed_value)) {
             $seeds = array_filter(array_map('trim', $seed_value));
         } else {
-            $seed_string = $seed_value;
-            $seeds = array_filter(array_map('trim', explode(',', $seed_string)));
+            $seeds = array_filter(array_map('trim', explode(',', (string) $seed_value)));
         }
 
         $final_focus = '';

--- a/tests/test-ai-seo.php
+++ b/tests/test-ai-seo.php
@@ -886,4 +886,50 @@ class AiResearchErrorHandlingTest extends WP_Ajax_UnitTestCase {
         $this->assertContains('b', $resp['data']['long_tail_keywords']);
         $this->assertSame('a, b', $resp['data']['seed_keywords']);
     }
+
+    public function test_focus_and_seed_keyword_arrays_are_accepted() {
+        update_option('gm2_chatgpt_api_key', 'key');
+
+        $step = 0;
+        $filter = function($pre, $args, $url) use (&$step) {
+            if ($url === 'https://api.openai.com/v1/chat/completions') {
+                if ($step === 0) {
+                    $step++;
+                    return [
+                        'response' => ['code' => 200],
+                        'body' => json_encode([
+                            'choices' => [ ['message' => ['content' => json_encode([
+                                'seed_keywords' => ['a','b'],
+                                'focus_keywords' => ['a','b'],
+                            ])]] ]
+                        ])
+                    ];
+                }
+                return [
+                    'response' => ['code' => 200],
+                    'body' => json_encode([
+                        'choices' => [ ['message' => ['content' => json_encode(['seo_title' => 'Title'])]] ]
+                    ])
+                ];
+            }
+            return false;
+        };
+        add_filter('pre_http_request', $filter, 10, 3);
+
+        $post_id = self::factory()->post->create(['post_title' => 'Post', 'post_content' => 'Content']);
+
+        $this->_setRole('administrator');
+        $_POST['post_id'] = $post_id;
+        $_POST['_ajax_nonce'] = wp_create_nonce('gm2_ai_research');
+        $_REQUEST['_ajax_nonce'] = $_POST['_ajax_nonce'];
+        try { $this->_handleAjax('gm2_ai_research'); } catch (WPAjaxDieContinueException $e) {}
+        remove_filter('pre_http_request', $filter, 10);
+
+        $resp = json_decode($this->_last_response, true);
+        $this->assertTrue($resp['success']);
+        $this->assertSame('Title', $resp['data']['seo_title']);
+        $this->assertSame('a', $resp['data']['focus_keywords']);
+        $this->assertContains('b', $resp['data']['long_tail_keywords']);
+        $this->assertSame('a, b', $resp['data']['seed_keywords']);
+    }
 }


### PR DESCRIPTION
## Summary
- handle array returns for `focus_keywords` and `seed_keywords`
- test that arrays are accepted for both fields

## Testing
- `phpunit --bootstrap tests/bootstrap.php --filter test_focus_and_seed_keyword_arrays_are_accepted tests/test-ai-seo.php` *(fails: Class test-ai-seo could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_6881ac61fca883279fe62cc88ce249ec