### PR TITLE
Improve AI JSON sanitization

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1991,9 +1991,24 @@ class Gm2_SEO_Admin {
         // Normalize curly double quotes which often appear in AI output.
         $json = str_replace(["\xE2\x80\x9C", "\xE2\x80\x9D"], '"', $json);
 
+        // Convert single-quoted keys and values to standard double quotes.
+        $json = preg_replace_callback(
+            "#'(?:\\\\.|[^'\\\\])*'#s",
+            function($m) {
+                $inner = substr($m[0], 1, -1);
+                $inner = str_replace("\\'", "'", $inner);
+                $inner = str_replace('"', '\\"', $inner);
+                return '"' . $inner . '"';
+            },
+            $json
+        );
+
         // Strip JavaScript-style comments before further processing.
         $json = preg_replace('#/\*.*?\*/#s', '', $json);
         $json = preg_replace('#//.*$#m', '', $json);
+
+        // Remove ellipses or stray characters after JSON strings.
+        $json = preg_replace('/("(?:\\\\.|[^"\\])*")\s*[^,:}\]]+(?=\s*[},\]])/u', '$1', $json);
 
         // Remove trailing commas before closing braces or brackets.
         $json = preg_replace_callback(

--- a/tests/test-ai-seo.php
+++ b/tests/test-ai-seo.php
@@ -286,6 +286,30 @@ class AiResearchAjaxTest extends WP_Ajax_UnitTestCase {
         $this->assertSame(['arr' => ['a','b']], $data);
     }
 
+    public function test_sanitize_ai_json_removes_chars_after_string() {
+        $admin  = new Gm2_SEO_Admin();
+        $method = new ReflectionMethod(Gm2_SEO_Admin::class, 'sanitize_ai_json');
+        $method->setAccessible(true);
+
+        $raw  = '{ "updated_html": "<p>text</p>"... }';
+        $clean = $method->invoke($admin, $raw);
+        $data  = json_decode($clean, true);
+
+        $this->assertSame('<p>text</p>', $data['updated_html']);
+    }
+
+    public function test_sanitize_ai_json_converts_single_quotes() {
+        $admin  = new Gm2_SEO_Admin();
+        $method = new ReflectionMethod(Gm2_SEO_Admin::class, 'sanitize_ai_json');
+        $method->setAccessible(true);
+
+        $raw  = "{ 'seo_title': 'Single' }";
+        $clean = $method->invoke($admin, $raw);
+        $data  = json_decode($clean, true);
+
+        $this->assertSame('Single', $data['seo_title']);
+    }
+
     public function test_ai_research_invalid_json_returns_error() {
         update_option('gm2_chatgpt_api_key', 'key');
         $filter = function($pre, $args, $url) {


### PR DESCRIPTION
## Summary
- sanitize single-quoted JSON strings in AI responses
- trim ellipses after JSON string values
- test handling of trailing characters and single quotes in AI SEO JSON

## Testing
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_68825a198a208327bbc87c9fa2bd2357