### PR TITLE
Handle truncated AI JSON

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -3148,14 +3148,24 @@ TEXT;
                 error_log('AI Research JSON decode failed: ' . $resp2);
                 error_log('AI Research JSON error: ' . json_last_error_msg());
             }
-            if (preg_match('/\{(?:[^{}]|(?R))*\}/s', $resp2, $m)) {
-                try {
-                    $data2 = json_decode($m[0], true, 512, JSON_THROW_ON_ERROR);
-                } catch (\Throwable $e2) {
-                    error_log('AI Research JSON decode failed after extraction: ' . $m[0]);
-                    wp_send_json_error(__('Invalid AI response', 'gm2-wordpress-suite'));
+
+            $trimmed = rtrim($resp2_clean);
+            $data2   = null;
+            while ($trimmed !== '') {
+                $result = json_decode($trimmed, true);
+                if (json_last_error() === JSON_ERROR_NONE && is_array($result)) {
+                    $data2 = $result;
+                    break;
                 }
-            } else {
+                $pos = strrpos($trimmed, '}');
+                if ($pos === false) {
+                    $trimmed = substr($trimmed, 0, -1);
+                } else {
+                    $trimmed = substr($trimmed, 0, $pos);
+                }
+            }
+
+            if ($data2 === null) {
                 wp_send_json_error(__('Invalid AI response', 'gm2-wordpress-suite'));
             }
         }

--- a/tests/test-ai-seo.php
+++ b/tests/test-ai-seo.php
@@ -528,6 +528,34 @@ class AiResearchAjaxTest extends WP_Ajax_UnitTestCase {
         $this->assertTrue($resp['success']);
         $this->assertStringContainsString('URL: \n', $captured);
     }
+
+    public function test_ai_research_truncated_json_is_handled() {
+        update_option('gm2_chatgpt_api_key', 'key');
+        $raw = '{"seo_title":"Truncated {brace}", "description":"Desc"}{';
+        $filter = function($pre, $args, $url) use ($raw) {
+            if ($url === 'https://api.openai.com/v1/chat/completions') {
+                return [
+                    'response' => ['code' => 200],
+                    'body' => json_encode(['choices' => [ ['message' => ['content' => $raw]] ]])
+                ];
+            }
+            return false;
+        };
+        add_filter('pre_http_request', $filter, 10, 3);
+
+        $post_id = self::factory()->post->create(['post_title' => 'Post', 'post_content' => 'Content']);
+
+        $this->_setRole('administrator');
+        $_POST['post_id'] = $post_id;
+        $_POST['_ajax_nonce'] = wp_create_nonce('gm2_ai_research');
+        $_REQUEST['_ajax_nonce'] = $_POST['_ajax_nonce'];
+        try { $this->_handleAjax('gm2_ai_research'); } catch (WPAjaxDieContinueException $e) {}
+        remove_filter('pre_http_request', $filter, 10);
+
+        $resp = json_decode($this->_last_response, true);
+        $this->assertTrue($resp['success']);
+        $this->assertSame('Truncated {brace}', $resp['data']['seo_title']);
+    }
 }
 
 class AdminTabsTest extends WP_UnitTestCase {


### PR DESCRIPTION
## Summary
- gracefully parse incomplete JSON responses in ajax_ai_research
- test truncated responses containing braces inside strings

## Testing
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `bash bin/install-wp-tests.sh wordpress_test root '' localhost latest` *(fails: Can't connect to MySQL server)*

------
https://chatgpt.com/codex/tasks/task_e_68825b6ab95c83278be3469c730c3ade