### PR TITLE
Fix AI JSON regex

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -2007,8 +2007,18 @@ class Gm2_SEO_Admin {
         $json = preg_replace('#/\*.*?\*/#s', '', $json);
         $json = preg_replace('#//.*$#m', '', $json);
 
+        $json = preg_replace_callback('/"(?:\\\\.|[^"\\\\])*"/s', function($matches) {
+            $str = str_replace("\n", "\\n", $matches[0]);
+
+            $inner = substr($str, 1, -1);
+            $inner = preg_replace('/(?<!\\\\)(\d+(?:\.\d+)?(?:-inch)?)"/', '$1\\"', $inner);
+            $inner = preg_replace('/(?<!\\)"/', '\\"', $inner);
+
+            return '"' . $inner . '"';
+        }, $json);
+
         // Remove ellipses or stray characters after JSON strings.
-        $json = preg_replace('/("(?:\\\\.|[^"\\])*")\s*[^,:}\]]+(?=\s*[},\]])/u', '$1', $json);
+        $json = preg_replace('/("(?:\\.|[^"\\])*")\s*[^,:}\]]+(?=\s*[}\]])/u', '$1', $json);
 
         // Remove trailing commas before closing braces or brackets.
         $json = preg_replace_callback(
@@ -2030,15 +2040,6 @@ class Gm2_SEO_Admin {
             $json
         );
 
-        $json = preg_replace_callback('/"(?:\\\\.|[^"\\\\])*"/s', function($matches) {
-            $str = str_replace("\n", "\\n", $matches[0]);
-
-            $inner = substr($str, 1, -1);
-            $inner = preg_replace('/(?<!\\\\)(\d+(?:\.\d+)?(?:-inch)?)"/', '$1\\"', $inner);
-            $inner = preg_replace('/(?<!\\)"/', '\\"', $inner);
-
-            return '"' . $inner . '"';
-        }, $json);
 
         $end = strrpos($json, '}');
         if ($end !== false) {

--- a/tests/test-ai-seo.php
+++ b/tests/test-ai-seo.php
@@ -217,6 +217,20 @@ class AiResearchAjaxTest extends WP_Ajax_UnitTestCase {
         $this->assertSame('Approx 17.5" screen', $data['size']);
     }
 
+    public function test_sanitize_ai_json_allows_steel_wheels_string() {
+        $admin  = new Gm2_SEO_Admin();
+        $method = new ReflectionMethod(Gm2_SEO_Admin::class, 'sanitize_ai_json');
+        $method->setAccessible(true);
+
+        $raw  = '{ "spec": "17.5" steel wheels" }';
+        $clean = $method->invoke($admin, $raw);
+        $data  = json_decode($clean, true);
+
+        $this->assertSame(JSON_ERROR_NONE, json_last_error());
+        $this->assertNotNull($data);
+        $this->assertSame('17.5" steel wheels', $data['spec']);
+    }
+
     public function test_sanitize_ai_json_escapes_unescaped_quotes() {
         $admin  = new Gm2_SEO_Admin();
         $method = new ReflectionMethod(Gm2_SEO_Admin::class, 'sanitize_ai_json');


### PR DESCRIPTION
## Summary
- fix regex for stray text after quoted strings
- escape inches before removing stray text
- test parsing 17.5" steel wheels

## Testing
- `phpunit --configuration phpunit.xml` *(fails: Error in bootstrap script)*

------
https://chatgpt.com/codex/tasks/task_e_6882620f91dc83278680685e7ffda3cd