### PR TITLE
Improve snippet sanitization

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -2188,6 +2188,11 @@ class Gm2_SEO_Admin {
         $html = preg_replace('/(<br\s*\/?\s*>\s*)+/i', "\n", $html);
         $html = preg_replace('/\n{2,}/', "\n", $html);
 
+        // Decode entities and normalize whitespace.
+        $html = html_entity_decode($html, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $html = str_replace(["\xc2\xa0", '&nbsp;'], ' ', $html);
+        $html = preg_replace('/ {2,}/', ' ', $html);
+
         return trim($html);
     }
 

--- a/tests/SanitizeSnippetHtmlTest.php
+++ b/tests/SanitizeSnippetHtmlTest.php
@@ -14,4 +14,33 @@ class SanitizeSnippetHtmlTest extends WP_UnitTestCase {
         $this->assertStringNotContainsString('color:red', $sanitized);
         $this->assertStringNotContainsString('<style', $sanitized);
     }
+
+    public function test_nbsp_and_spaces_removed() {
+        $admin = new Gm2_SEO_Admin();
+        $method = new ReflectionMethod(Gm2_SEO_Admin::class, 'sanitize_snippet_html');
+        $method->setAccessible(true);
+
+        $html = '<p>Foo&nbsp;&nbsp; Bar&nbsp; &nbsp;Baz</p>';
+        $sanitized = $method->invoke($admin, $html);
+
+        $this->assertSame('<p>Foo Bar Baz</p>', $sanitized);
+    }
+
+    public function test_get_rendered_html_returns_clean_string() {
+        $post_id = self::factory()->post->create([
+            'post_title'   => 'Clean',
+            'post_content' => '<p>Foo&nbsp; &nbsp;Bar</p>'
+        ]);
+
+        $admin = new Gm2_SEO_Admin();
+        $method = new ReflectionMethod(Gm2_SEO_Admin::class, 'get_rendered_html');
+        $method->setAccessible(true);
+
+        $html = $method->invoke($admin, $post_id, 0, null);
+
+        $this->assertIsString($html);
+        $this->assertStringNotContainsString('&nbsp;', $html);
+        $this->assertStringNotContainsString("\xc2\xa0", $html);
+        $this->assertSame(0, preg_match('/ {2,}/', $html));
+    }
 }


### PR DESCRIPTION
## Summary
- decode HTML entities and remove `&nbsp;` in snippet sanitizer
- trim consecutive spaces during sanitization
- test snippet sanitizer for spacing
- ensure `get_rendered_html()` returns a clean string

## Testing
- `php -l admin/Gm2_SEO_Admin.php`
- `make test DB_NAME=wp_test DB_USER=root DB_PASS=pass` *(fails: Can't connect to MySQL server)*

------
https://chatgpt.com/codex/tasks/task_e_68826b16f5a883278db78e1d9e381167