### PR TITLE
Add taxonomy type to description prompt

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -108,6 +108,27 @@ class Gm2_SEO_Admin {
         return $taxonomies;
     }
 
+    private function describe_taxonomy_type($taxonomy) {
+        $tax_obj = get_taxonomy($taxonomy);
+        if (!$tax_obj) {
+            return '';
+        }
+        if ($taxonomy === 'category') {
+            return 'post category';
+        }
+        if ($taxonomy === 'product_cat') {
+            return 'product category';
+        }
+        $objects = (array) $tax_obj->object_type;
+        if (in_array('product', $objects, true)) {
+            return 'product taxonomy';
+        }
+        if ($objects === ['post']) {
+            return 'post taxonomy';
+        }
+        return 'custom taxonomy';
+    }
+
     public function register_taxonomy_hooks() {
         $taxonomies = $this->get_supported_taxonomies();
         foreach ($taxonomies as $tax) {
@@ -3313,6 +3334,11 @@ class Gm2_SEO_Admin {
             '{taxonomy}'   => $taxonomy,
             '{guidelines}' => $guidelines,
         ]);
+
+        $tax_type = $this->describe_taxonomy_type($taxonomy);
+        if ($tax_type !== '') {
+            $prompt .= "\nTaxonomy type: " . $tax_type;
+        }
 
         $context_parts = array_filter(array_map('trim', gm2_get_seo_context()));
         if ($context_parts) {

--- a/readme.txt
+++ b/readme.txt
@@ -255,6 +255,7 @@ On taxonomy edit screens you'll also find a **Generate Description** button next
 to the description field. The prompt can be customised via the
 `gm2_tax_desc_prompt` setting and includes any saved SEO guidelines for that
 taxonomy.
+The prompt now automatically notes whether the term is a post category, product category or other custom taxonomy.
 
 
 The SEO Settings tab also lets you set `max-snippet`, `max-image-preview`, and

--- a/tests/test-tax-description.php
+++ b/tests/test-tax-description.php
@@ -41,5 +41,6 @@ class TaxDescriptionAjaxTest extends WP_Ajax_UnitTestCase {
         $this->assertSame('desc', $term->description);
         $this->assertStringContainsString('Books', $captured);
         $this->assertStringContainsString('guidelines', $captured);
+        $this->assertStringContainsString('Taxonomy type: post category', $captured);
     }
 }


### PR DESCRIPTION
## Summary
- differentiate taxonomy types via new `describe_taxonomy_type()` helper
- include taxonomy type in description prompt
- document new behaviour in `readme.txt`
- test taxonomy type note in generated prompt

## Testing
- `npm test`
- `phpunit` *(fails: `require_once(/tmp/wordpress-tests-lib/includes/functions.php): Failed to open stream`)*

------
https://chatgpt.com/codex/tasks/task_e_68829eeec2a883279e12d00666292059