### PR TITLE
Add taxonomy type to description prompt

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -108,6 +108,27 @@ class Gm2_SEO_Admin {
         return $taxonomies;
     }
 
+    private function describe_taxonomy_type($taxonomy) {
+        $tax_obj = get_taxonomy($taxonomy);
+        if (!$tax_obj) {
+            return '';
+        }
+        if ($taxonomy === 'category') {
+            return 'post category';
+        }
+        if ($taxonomy === 'product_cat') {
+            return 'product category';
+        }
+        $objects = (array) $tax_obj->object_type;
+        if (in_array('product', $objects, true)) {
+            return 'product taxonomy';
+        }
+        if ($objects === ['post']) {
+            return 'post taxonomy';
+        }
+        return 'custom taxonomy';
+    }
+
     public function register_taxonomy_hooks() {
         $taxonomies = $this->get_supported_taxonomies();
         foreach ($taxonomies as $tax) {
@@ -3313,6 +3334,40 @@ class Gm2_SEO_Admin {
             '{taxonomy}'   => $taxonomy,
             '{guidelines}' => $guidelines,
         ]);
+
+        $seo_title          = '';
+        $seo_description    = '';
+        $focus_keywords     = '';
+        $long_tail_keywords = '';
+        $canonical          = '';
+        if ($term_id) {
+            $seo_title          = get_term_meta($term_id, '_gm2_title', true);
+            $seo_description    = get_term_meta($term_id, '_gm2_description', true);
+            $focus_keywords     = get_term_meta($term_id, '_gm2_focus_keywords', true);
+            $long_tail_keywords = get_term_meta($term_id, '_gm2_long_tail_keywords', true);
+            $canonical          = get_term_meta($term_id, '_gm2_canonical', true);
+        }
+
+        $tax_type = $this->describe_taxonomy_type($taxonomy);
+        if ($tax_type !== '') {
+            $prompt .= "\nTaxonomy type: " . $tax_type;
+        }
+
+        if ($seo_title !== '') {
+            $prompt .= "\nSEO Title: " . $seo_title;
+        }
+        if ($seo_description !== '') {
+            $prompt .= "\nSEO Description: " . $seo_description;
+        }
+        if ($focus_keywords !== '') {
+            $prompt .= "\nFocus Keywords: " . $focus_keywords;
+        }
+        if ($long_tail_keywords !== '') {
+            $prompt .= "\nLong-tail Keywords: " . $long_tail_keywords;
+        }
+        if ($canonical !== '') {
+            $prompt .= "\nCanonical URL: " . $canonical;
+        }
 
         $context_parts = array_filter(array_map('trim', gm2_get_seo_context()));
         if ($context_parts) {

--- a/readme.txt
+++ b/readme.txt
@@ -254,7 +254,10 @@ using a sanitized version of the attachment title.
 On taxonomy edit screens you'll also find a **Generate Description** button next
 to the description field. The prompt can be customised via the
 `gm2_tax_desc_prompt` setting and includes any saved SEO guidelines for that
-taxonomy.
+taxonomy. The prompt now automatically notes whether the term is a post category,
+product category or other custom taxonomy. If the taxonomy already has SEO
+metadata (title, description, keywords, long-tail keywords or a canonical URL)
+those values are also included in the prompt sent to ChatGPT.
 
 
 The SEO Settings tab also lets you set `max-snippet`, `max-image-preview`, and

--- a/tests/test-tax-description.php
+++ b/tests/test-tax-description.php
@@ -22,6 +22,11 @@ class TaxDescriptionAjaxTest extends WP_Ajax_UnitTestCase {
         add_filter('pre_http_request', $filter, 10, 3);
 
         $term_id = self::factory()->term->create(['taxonomy' => 'category', 'name' => 'Books']);
+        update_term_meta($term_id, '_gm2_title', 'SEO T');
+        update_term_meta($term_id, '_gm2_description', 'SEO D');
+        update_term_meta($term_id, '_gm2_focus_keywords', 'focus');
+        update_term_meta($term_id, '_gm2_long_tail_keywords', 'long');
+        update_term_meta($term_id, '_gm2_canonical', 'https://ex.com');
 
         $this->_setRole('administrator');
         $_POST['taxonomy'] = 'category';
@@ -41,5 +46,11 @@ class TaxDescriptionAjaxTest extends WP_Ajax_UnitTestCase {
         $this->assertSame('desc', $term->description);
         $this->assertStringContainsString('Books', $captured);
         $this->assertStringContainsString('guidelines', $captured);
+        $this->assertStringContainsString('Taxonomy type: post category', $captured);
+        $this->assertStringContainsString('SEO Title: SEO T', $captured);
+        $this->assertStringContainsString('SEO Description: SEO D', $captured);
+        $this->assertStringContainsString('Focus Keywords: focus', $captured);
+        $this->assertStringContainsString('Long-tail Keywords: long', $captured);
+        $this->assertStringContainsString('Canonical URL: https://ex.com', $captured);
     }
 }


### PR DESCRIPTION
## Summary
- differentiate taxonomy types via new `describe_taxonomy_type()` helper
- include taxonomy type in description prompt
- document new behaviour in `readme.txt`
- test taxonomy type note in generated prompt
- include SEO meta in taxonomy description prompt

## Testing
- `npm test`
- `phpunit` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68829eeec2a883279e12d00666292059