### PR TITLE
Sanitize term meta in taxonomy description prompt

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -108,6 +108,20 @@ class Gm2_SEO_Admin {
         return $taxonomies;
     }
 
+    /**
+     * Provide a short, human readable classification for a taxonomy.
+     *
+     * Returns one of the following labels based on the taxonomy's
+     * registered object types:
+     * - `post category` for the built in `category` taxonomy.
+     * - `product category` for WooCommerce's `product_cat` taxonomy.
+     * - `product taxonomy` if attached to the `product` post type.
+     * - `post taxonomy` when used only with posts.
+     * - `custom taxonomy` for anything else.
+     *
+     * @param string $taxonomy Taxonomy slug.
+     * @return string Taxonomy classification or empty string if unknown.
+     */
     private function describe_taxonomy_type($taxonomy) {
         $tax_obj = get_taxonomy($taxonomy);
         if (!$tax_obj) {
@@ -3334,6 +3348,31 @@ class Gm2_SEO_Admin {
             '{taxonomy}'   => $taxonomy,
             '{guidelines}' => $guidelines,
         ]);
+
+        $seo_title       = '';
+        $seo_description = '';
+        $focus_keywords  = '';
+        $canonical       = '';
+
+        if ($term_id) {
+            $seo_title       = sanitize_text_field(get_term_meta($term_id, '_gm2_title', true));
+            $seo_description = sanitize_text_field(get_term_meta($term_id, '_gm2_description', true));
+            $focus_keywords  = sanitize_text_field(get_term_meta($term_id, '_gm2_focus_keywords', true));
+            $canonical       = esc_url_raw(get_term_meta($term_id, '_gm2_canonical', true));
+        }
+
+        if ($seo_title !== '') {
+            $prompt .= "\nExisting SEO Title: {$seo_title}";
+        }
+        if ($seo_description !== '') {
+            $prompt .= "\nSEO Description: {$seo_description}";
+        }
+        if ($focus_keywords !== '') {
+            $prompt .= "\nFocus Keywords: {$focus_keywords}";
+        }
+        if ($canonical !== '') {
+            $prompt .= "\nCanonical: {$canonical}";
+        }
 
         $tax_type = $this->describe_taxonomy_type($taxonomy);
         if ($tax_type !== '') {

--- a/readme.txt
+++ b/readme.txt
@@ -250,12 +250,12 @@ Enabling **Auto-fill missing alt text** under **SEO → Performance** also uses
 ChatGPT to generate alt text for new images when none is provided. Enable
 **Clean Image Filenames** in the same section to automatically rename uploads
 using a sanitized version of the attachment title.
-
 On taxonomy edit screens you'll also find a **Generate Description** button next
 to the description field. The prompt can be customised via the
 `gm2_tax_desc_prompt` setting and includes any saved SEO guidelines for that
-taxonomy.
-The prompt now automatically notes whether the term is a post category, product category or other custom taxonomy.
+taxonomy. The prompt now automatically notes whether the term is a post
+category, product category or other custom taxonomy. Any existing SEO field
+values are cleaned before being sent to ChatGPT.
 
 
 The SEO Settings tab also lets you set `max-snippet`, `max-image-preview`, and

--- a/tests/test-tax-description.php
+++ b/tests/test-tax-description.php
@@ -23,6 +23,11 @@ class TaxDescriptionAjaxTest extends WP_Ajax_UnitTestCase {
 
         $term_id = self::factory()->term->create(['taxonomy' => 'category', 'name' => 'Books']);
 
+        update_term_meta($term_id, '_gm2_title', '  <b>Title</b>  ');
+        update_term_meta($term_id, '_gm2_description', " <em>Desc</em> ");
+        update_term_meta($term_id, '_gm2_focus_keywords', ' one, <i>two</i> ');
+        update_term_meta($term_id, '_gm2_canonical', ' https://example.com/cat ');
+
         $this->_setRole('administrator');
         $_POST['taxonomy'] = 'category';
         $_POST['term_id'] = $term_id;
@@ -39,6 +44,10 @@ class TaxDescriptionAjaxTest extends WP_Ajax_UnitTestCase {
         $this->assertSame('desc', $resp['data']);
         $term = get_term($term_id, 'category');
         $this->assertSame('desc', $term->description);
+        $this->assertStringContainsString('Title', $captured);
+        $this->assertStringContainsString('Desc', $captured);
+        $this->assertStringContainsString('one, two', $captured);
+        $this->assertStringContainsString('https://example.com/cat', $captured);
         $this->assertStringContainsString('Books', $captured);
         $this->assertStringContainsString('guidelines', $captured);
         $this->assertStringContainsString('Taxonomy type: post category', $captured);


### PR DESCRIPTION
## Summary
- document taxonomy type detection
- sanitize SEO metadata when building taxonomy description prompts
- test that sanitization occurs
- mention sanitization in README

## Testing
- `npm test`
- `phpunit` *(fails: WP test suite missing)*

------
https://chatgpt.com/codex/tasks/task_e_6882b29f4dec8327b17e617c174a66f3