### PR TITLE
Remove guidelines from taxonomy prompts

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -431,9 +431,9 @@ class Gm2_SEO_Admin {
             'gm2_tax_desc_prompt',
             'Taxonomy Description Prompt',
             function () {
-                $value = get_option('gm2_tax_desc_prompt', __( 'Write a short SEO description for the term "{name}". {guidelines}', 'gm2-wordpress-suite' ) );
+                $value = get_option('gm2_tax_desc_prompt', __( 'Write a short SEO description for the term "{name}".', 'gm2-wordpress-suite' ) );
                 echo '<textarea name="gm2_tax_desc_prompt" rows="3" class="large-text">' . esc_textarea($value) . '</textarea>';
-                echo '<p class="description">' . esc_html__( 'Available tags: {name}, {taxonomy}, {guidelines}', 'gm2-wordpress-suite' ) . '</p>';
+                echo '<p class="description">' . esc_html__( 'Available tags: {name}, {taxonomy}', 'gm2-wordpress-suite' ) . '</p>';
             },
             'gm2_seo',
             'gm2_seo_main'
@@ -3368,13 +3368,11 @@ class Gm2_SEO_Admin {
             }
         }
 
-        $guidelines = trim($this->build_guidelines_text('tax_' . $taxonomy));
-        $template   = get_option('gm2_tax_desc_prompt', 'Write a short SEO description for the term "{name}". {guidelines}');
+        $template = get_option('gm2_tax_desc_prompt', 'Write a short SEO description for the term "{name}".');
 
         $prompt = strtr($template, [
-            '{name}'       => $name,
-            '{taxonomy}'   => $taxonomy,
-            '{guidelines}' => $guidelines,
+            '{name}'     => $name,
+            '{taxonomy}' => $taxonomy,
         ]);
 
         $seo_title       = '';

--- a/readme.txt
+++ b/readme.txt
@@ -252,8 +252,7 @@ ChatGPT to generate alt text for new images when none is provided. Enable
 using a sanitized version of the attachment title.
 On taxonomy edit screens you'll also find a **Generate Description** button next
 to the description field. The prompt can be customised via the
-`gm2_tax_desc_prompt` setting and includes any saved SEO guidelines for that
-taxonomy. The prompt now automatically notes whether the term is a post
+`gm2_tax_desc_prompt` setting. The prompt automatically notes whether the term is a post
 category, product category or other custom taxonomy. Any existing SEO field
 values are cleaned before being sent to ChatGPT.
 

--- a/tests/test-tax-description.php
+++ b/tests/test-tax-description.php
@@ -5,7 +5,7 @@ class TaxDescriptionAjaxTest extends WP_Ajax_UnitTestCase {
     public function test_generate_tax_description_updates_term() {
         update_option('gm2_chatgpt_api_key', 'key');
         update_option('gm2_guideline_rules', ['tax_category' => ['general' => 'guidelines']]);
-        update_option('gm2_tax_desc_prompt', 'Prompt {name} {guidelines}');
+        update_option('gm2_tax_desc_prompt', 'Prompt {name}');
 
         $captured = null;
         $filter = function($pre, $args, $url) use (&$captured) {
@@ -49,7 +49,6 @@ class TaxDescriptionAjaxTest extends WP_Ajax_UnitTestCase {
         $this->assertStringContainsString('one, two', $captured);
         $this->assertStringContainsString('https://example.com/cat', $captured);
         $this->assertStringContainsString('Books', $captured);
-        $this->assertStringContainsString('guidelines', $captured);
         $this->assertStringContainsString('Taxonomy type: post category', $captured);
     }
 }


### PR DESCRIPTION
## Summary
- simplify default taxonomy description prompt
- show `{name}` and `{taxonomy}` tags only in settings help text
- stop appending guideline rules in the AJAX prompt generator
- adjust docs for new behaviour
- update unit test accordingly

## Testing
- `make test DB_NAME=wordpress_test DB_USER=root DB_PASS=pass` *(fails: mysqladmin not found)*
- `phpunit` *(fails: WordPress test suite missing)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882be39d1f88327b86e9c13cc61f215