### PR TITLE
Improve bulk AI Ajax handler

### DIFF
--- a/admin/js/gm2-bulk-ai.js
+++ b/admin/js/gm2-bulk-ai.js
@@ -10,8 +10,20 @@ jQuery(function($){
         if(!ids.length) return;
         ids.forEach(function(id){
             var row=$('#gm2-row-'+id);row.find('.gm2-result').text('...');
-            $.post(gm2BulkAi.ajax_url,{action:'gm2_ai_research',post_id:id,_ajax_nonce:gm2BulkAi.nonce})
+            // Use $.ajax so jQuery handles JSON parsing for us
+            $.ajax({
+                url: gm2BulkAi.ajax_url,
+                method: 'POST',
+                data: {action:'gm2_ai_research',post_id:id,_ajax_nonce:gm2BulkAi.nonce},
+                dataType: 'json'
+            })
             .done(function(resp){
+                if(typeof resp === 'string'){
+                    try{ resp = JSON.parse(resp); }catch(e){
+                        row.find('.gm2-result').text('Invalid JSON response');
+                        return;
+                    }
+                }
                 if(resp&&resp.success&&resp.data){
                     var html='';
                     if(resp.data.seo_title){html+='<p><label><input type="checkbox" class="gm2-apply" data-field="seo_title" data-value="'+resp.data.seo_title.replace(/"/g,'&quot;')+'"> '+resp.data.seo_title+'</label></p>';}
@@ -26,6 +38,9 @@ jQuery(function($){
                 var msg = (jqXHR && jqXHR.responseJSON && jqXHR.responseJSON.data)
                     ? jqXHR.responseJSON.data
                     : (jqXHR && jqXHR.responseText ? jqXHR.responseText : textStatus);
+                if(textStatus === 'parsererror'){
+                    msg = 'Invalid JSON response';
+                }
                 row.find('.gm2-result').text(msg || 'Error');
             });
         });

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@ Existing prompt logic automatically includes these options via `gm2_get_seo_cont
 - The **Gm2 Qnty Discounts** widget now offers typography, color, shadow, padding and background controls for quantity labels and prices with Normal, Hover and Active tabs. Choose an icon for the currency symbol and style it alongside new box options for each quantity button, plus an **Icon Margin** option to control spacing around the currency icon. A new **Icon Color** style option lets you set colors for the currency icon in Normal, Hover and Active states.
 - The price section now uses flexbox by default and includes responsive **Horizontal** and **Vertical** alignment controls to adjust `justify-content` and `align-items`.
 - New **Wrap Options** control lets you enable flex wrapping so quantity buttons can stack on tablets and mobile.
+- Bulk AI research requests now use JSON-formatted AJAX calls for more robust error handling.
 
 ## Building the Business Context Prompt
 


### PR DESCRIPTION
## Summary
- use `$.ajax()` for bulk AI requests so responses are parsed as JSON
- handle invalid JSON responses gracefully
- document that Bulk AI now uses JSON Ajax calls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882c1b0c1c88327a7f412e35f43830e