### PR TITLE
Improve Generate Description UX

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -3724,6 +3724,7 @@ class Gm2_SEO_Admin {
                 'ajax_url' => admin_url('admin-ajax.php'),
                 'term_id'  => isset($_GET['tag_ID']) ? absint($_GET['tag_ID']) : 0,
                 'taxonomy' => $screen->taxonomy,
+                'loading'  => __( 'Researching...', 'gm2-wordpress-suite' ),
             ]
         );
         wp_enqueue_style(

--- a/admin/js/gm2-tax-desc.js
+++ b/admin/js/gm2-tax-desc.js
@@ -13,6 +13,9 @@ jQuery(function($){
         var $btn = $(this);
         var $ta = $btn.closest('p').prev('textarea');
         var name = $('#tag-name').val() || $('#name').val() || '';
+        var loadingText = (window.gm2TaxDesc && gm2TaxDesc.loading) ? gm2TaxDesc.loading : 'Researching...';
+        var originalText = $btn.text();
+        $btn.prop('disabled', true).text(loadingText);
         $.post(gm2TaxDesc.ajax_url, {
             action: 'gm2_ai_generate_tax_description',
             term_id: gm2TaxDesc.term_id,
@@ -29,6 +32,8 @@ jQuery(function($){
             }
         }).fail(function(){
             alert('Request failed');
+        }).always(function(){
+            $btn.prop('disabled', false).text(originalText);
         });
     });
 });


### PR DESCRIPTION
## Summary
- add `loading` string when localizing gm2-tax-desc script
- disable Generate Description button while researching and restore text on completion

## Testing
- `npm test`
- `phpunit` *(fails: wordpress-tests-lib missing)*

------
https://chatgpt.com/codex/tasks/task_e_6882c6a0730083278b9d13aa1f80c65d