### PR TITLE
Add abandoned cart email capture

### DIFF
--- a/public/Gm2_Abandoned_Carts_Public.php
+++ b/public/Gm2_Abandoned_Carts_Public.php
@@ -8,9 +8,60 @@ if (!defined('ABSPATH')) {
 class Gm2_Abandoned_Carts_Public {
     public function run() {
         add_action('wp_enqueue_scripts', [ $this, 'enqueue_scripts' ]);
+        add_action('wp_ajax_gm2_ac_email_capture', [ $this, 'handle_email_capture' ]);
+        add_action('wp_ajax_nopriv_gm2_ac_email_capture', [ $this, 'handle_email_capture' ]);
     }
 
     public function enqueue_scripts() {
-        // Placeholder for guest email capture or exit intent
+        wp_enqueue_script(
+            'gm2-ac-email-capture',
+            GM2_PLUGIN_URL . 'public/js/gm2-ac-email-capture.js',
+            [ 'jquery' ],
+            GM2_VERSION,
+            true
+        );
+        wp_localize_script(
+            'gm2-ac-email-capture',
+            'gm2AcEmailCapture',
+            [
+                'ajax_url' => admin_url('admin-ajax.php'),
+                'nonce'    => wp_create_nonce('gm2_ac_email_capture'),
+            ]
+        );
+    }
+
+    public function handle_email_capture() {
+        check_ajax_referer('gm2_ac_email_capture', 'nonce');
+
+        $email = sanitize_email($_POST['email'] ?? '');
+        if (empty($email)) {
+            wp_send_json_error('empty_email');
+        }
+
+        $token = '';
+        if (class_exists('WC_Session') && WC()->session) {
+            $token = WC()->session->get_customer_id();
+        }
+
+        if (empty($token)) {
+            wp_send_json_error('no_cart');
+        }
+
+        global $wpdb;
+        $table = $wpdb->prefix . 'wc_ac_carts';
+        $row   = $wpdb->get_row($wpdb->prepare("SELECT id FROM $table WHERE cart_token = %s", $token));
+        if ($row) {
+            $wpdb->update($table, [ 'email' => $email ], [ 'id' => $row->id ]);
+        } else {
+            $wpdb->insert($table, [
+                'cart_token'    => $token,
+                'user_id'       => get_current_user_id(),
+                'cart_contents' => '',
+                'created_at'    => current_time('mysql'),
+                'email'         => $email,
+            ]);
+        }
+
+        wp_send_json_success();
     }
 }

--- a/public/js/gm2-ac-email-capture.js
+++ b/public/js/gm2-ac-email-capture.js
@@ -1,0 +1,22 @@
+jQuery(function($){
+    var $email = $('#billing_email');
+    if(!$email.length){
+        return;
+    }
+    var timer;
+    var postEmail = function(){
+        var val = $email.val();
+        if(!val){
+            return;
+        }
+        $.post(gm2AcEmailCapture.ajax_url, {
+            action: 'gm2_ac_email_capture',
+            nonce: gm2AcEmailCapture.nonce,
+            email: val
+        });
+    };
+    $email.on('change input', function(){
+        clearTimeout(timer);
+        timer = setTimeout(postEmail, 500);
+    });
+});


### PR DESCRIPTION
## Summary
- enqueue a new email capture script in `Gm2_Abandoned_Carts_Public`
- implement `handle_email_capture` AJAX handler
- add `public/js/gm2-ac-email-capture.js` to post checkout email via AJAX

## Testing
- `npm test`
- `phpunit` *(fails: WordPress test suite missing)*

------
https://chatgpt.com/codex/tasks/task_e_6882d4884ab8832788b6c9c0593ca70a