### PR TITLE
Enhance cart tracking

### DIFF
--- a/public/Gm2_Abandoned_Carts_Public.php
+++ b/public/Gm2_Abandoned_Carts_Public.php
@@ -51,7 +51,11 @@ class Gm2_Abandoned_Carts_Public {
         $table = $wpdb->prefix . 'wc_ac_carts';
         $row   = $wpdb->get_row($wpdb->prepare("SELECT id FROM $table WHERE cart_token = %s", $token));
         if ($row) {
-            $wpdb->update($table, [ 'email' => $email ], [ 'id' => $row->id ]);
+            $wpdb->update(
+                $table,
+                [ 'email' => $email ],
+                [ 'id' => $row->id ]
+            );
         } else {
             $wpdb->insert($table, [
                 'cart_token'    => $token,


### PR DESCRIPTION
## Summary
- expand abandoned cart table with tracking fields
- track IP, user agent, entry/exit URLs and totals when capturing cart
- record exit URL on every page load
- adjust AJAX email capture to use the `email` column

## Testing
- `npm test`
- `phpunit -c phpunit.xml` *(fails: missing wordpress test suite)*

------
https://chatgpt.com/codex/tasks/task_e_6882d76998248327b93d11b31f71ab81