### PR TITLE
Update abandoned carts docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,21 @@ option on the **SEO → Sitemap** settings page.
 
 ## Abandoned Carts Module
 
-When enabled from the Gm2 dashboard, the plugin tracks WooCommerce carts and
-sends recovery emails after a configurable timeout. Configure the timeout and
-message schedule under **Gm2 → Abandoned Carts**.
+Enable this feature from **Gm2 → Dashboard** to create two database tables used
+for tracking carts and queuing recovery emails. The cart table stores the cart
+contents along with the shopper's email address, IP, detected location and
+device type, the first and last URLs visited, and the cart total. A small
+JavaScript file captures the email as soon as it is entered on the checkout
+page so the address is available even if the customer never completes the
+order.
+
+The admin screen under **Gm2 → Abandoned Carts** displays a table of abandoned
+carts showing the IP address, email, location, device, products, cart value,
+entry and exit URLs, and the abandonment time. Recovery emails are added to a
+queue which is processed hourly by WP&nbsp;Cron via the `gm2_ac_process_queue`
+action. Developers can hook `gm2_ac_send_message` to send the actual email
+content. The cart timeout in minutes can be configured on the same settings
+page.
 
 
 

--- a/readme.txt
+++ b/readme.txt
@@ -14,7 +14,7 @@ Key features include:
 * SEO tools with breadcrumbs, caching and structured data
 * ChatGPT-powered content generation and keyword research
 * WooCommerce quantity discounts with a dedicated Elementor widget (requires WooCommerce)
-* Abandoned cart tracking and recovery emails
+* Abandoned cart tracking with email capture and recovery emails
 * Tariff management and redirects
 * Expanded SEO Context feeds AI prompts with business details
 * Focus keywords are tracked to prevent duplicates in AI suggestions
@@ -275,6 +275,11 @@ checkout.
 == Quantity Discounts ==
 This feature requires WooCommerce to be active.
 After activating WooCommerce, open **Gm2 → Quantity Discounts** and click **Add Discount Group** to define bulk pricing rules. Choose the products or categories to apply, enter the minimum quantity and specify either a percentage or fixed discount. When customers meet the threshold the discount is applied automatically in the cart. Install Elementor to add the **Gm2 Qnty Discounts** widget on product pages, giving shoppers buttons for preset quantities that match your rules. If Elementor Pro is active the widget lives in the **WooCommerce** section; otherwise it appears in **General**. The selected rule and discounted price are saved in order item meta and appear in emails and on the admin order screen.
+
+== Abandoned Carts ==
+Enable this module from **Gm2 → Dashboard** to create tables that record the cart contents, email address, IP, location, device type, entry and exit URLs and cart value. A small JavaScript snippet captures the email field on the checkout page so you can reach customers who abandon their cart before placing an order.
+
+Open **Gm2 → Abandoned Carts** to configure the abandonment timeout and view a table listing each cart's IP address, email, location, device, products, value, entry and exit URLs and the time it was abandoned. Recovery messages are queued using WP&nbsp;Cron via the `gm2_ac_process_queue` action. Developers can hook `gm2_ac_send_message` to send the actual emails.
 
 == Redirects ==
 Create 301 or 302 redirects from the **SEO → Redirects** tab. The plugin logs


### PR DESCRIPTION
## Summary
- expand README abandoned carts explanation
- note WP Cron queue and hook
- add details on abandoned carts in the WP plugin readme

## Testing
- `make test DB_NAME=wp_test DB_USER=root DB_PASS=pass` *(fails: `mysqladmin command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6883922ca53c832798633ddebf70560c