### PR TITLE
Add progress bar to Bulk AI tools

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1053,6 +1053,7 @@ class Gm2_SEO_Admin {
         echo '<p><button type="button" class="button" id="gm2-bulk-analyze">' . esc_html__( 'Analyze Selected', 'gm2-wordpress-suite' ) . '</button> ' .
             '<button type="button" class="button" id="gm2-bulk-apply-all">' . esc_html__( 'Apply All', 'gm2-wordpress-suite' ) . '</button> ' .
             '<span id="gm2-bulk-apply-msg"></span></p>';
+        echo '<p><progress id="gm2-bulk-progress-bar" value="0" max="100" style="width:100%;display:none"></progress></p>';
         echo '</div>';
     }
 


### PR DESCRIPTION
## Summary
- add a `progress` element on the Bulk AI review page
- refresh the progress bar while posts are analyzed and when changes are applied

## Testing
- `npm test`
- `phpunit` *(fails: /tmp/wordpress-tests-lib missing)*

------
https://chatgpt.com/codex/tasks/task_e_6887e151dfb883279857fb571e25cbbd