### PR TITLE
Bulk AI caching enhancements

### DIFF
--- a/admin/js/gm2-bulk-ai.js
+++ b/admin/js/gm2-bulk-ai.js
@@ -15,6 +15,16 @@ jQuery(function($){
         $('#gm2-bulk-progress-bar').val(val);
     }
 
+    function buildHtml(data,id){
+        var html='';
+        if(data.seo_title){html+='<p><label><input type="checkbox" class="gm2-apply" data-field="seo_title" data-value="'+data.seo_title.replace(/"/g,'&quot;')+'"> '+data.seo_title+'</label></p>';}
+        if(data.description){html+='<p><label><input type="checkbox" class="gm2-apply" data-field="seo_description" data-value="'+data.description.replace(/"/g,'&quot;')+'"> '+data.description+'</label></p>';}
+        if(data.slug){html+='<p><label><input type="checkbox" class="gm2-apply" data-field="slug" data-value="'+data.slug+'"> Slug: '+data.slug+'</label></p>';}
+        if(data.page_name){html+='<p><label><input type="checkbox" class="gm2-apply" data-field="title" data-value="'+data.page_name.replace(/"/g,'&quot;')+'"> Title: '+data.page_name+'</label></p>';}
+        html+='<p><button class="button gm2-apply-btn" data-id="'+id+'">Apply</button> <button class="button gm2-refresh-btn" data-id="'+id+'">Refresh</button> <button class="button gm2-clear-btn" data-id="'+id+'">Clear</button></p>';
+        return html;
+    }
+
     $('#gm2-bulk-ai').on('click','#gm2-bulk-select-all',function(){
         var c=$(this).prop('checked');
         $('#gm2-bulk-list .gm2-select').prop('checked',c);
@@ -72,12 +82,7 @@ jQuery(function($){
                     }
                 }
                 if(resp&&resp.success&&resp.data){
-                    var html='';
-                    if(resp.data.seo_title){html+='<p><label><input type="checkbox" class="gm2-apply" data-field="seo_title" data-value="'+resp.data.seo_title.replace(/"/g,'&quot;')+'"> '+resp.data.seo_title+'</label></p>';}
-                    if(resp.data.description){html+='<p><label><input type="checkbox" class="gm2-apply" data-field="seo_description" data-value="'+resp.data.description.replace(/"/g,'&quot;')+'"> '+resp.data.description+'</label></p>';}
-                    if(resp.data.slug){html+='<p><label><input type="checkbox" class="gm2-apply" data-field="slug" data-value="'+resp.data.slug+'"> Slug: '+resp.data.slug+'</label></p>';}
-                    if(resp.data.page_name){html+='<p><label><input type="checkbox" class="gm2-apply" data-field="title" data-value="'+resp.data.page_name.replace(/"/g,'&quot;')+'"> Title: '+resp.data.page_name+'</label></p>';}
-                    html+='<p><button class="button gm2-apply-btn" data-id="'+id+'">Apply</button></p>';
+                    var html = buildHtml(resp.data,id);
                     row.find('.gm2-result').html(html);
                     processed++;
                     updateProgress();
@@ -115,6 +120,52 @@ jQuery(function($){
             $('#gm2-row-'+id+' .gm2-result').append('<span> ✓</span>');
             applied++;
             updateBar(applied);
+        });
+    });
+
+    $('#gm2-bulk-list').on('click','.gm2-refresh-btn',function(e){
+        e.preventDefault();
+        var id=$(this).data('id');
+        var row=$('#gm2-row-'+id);
+        row.find('.gm2-result').text('...');
+        $.ajax({
+            url: gm2BulkAi.ajax_url,
+            method:'POST',
+            data:{action:'gm2_ai_research',post_id:id,refresh:1,_ajax_nonce:gm2BulkAi.nonce},
+            dataType:'json'
+        }).done(function(resp){
+            if(resp&&resp.success&&resp.data){
+                row.find('.gm2-result').html(buildHtml(resp.data,id));
+            }else{
+                var msg=(resp&&resp.data)?(resp.data.message||resp.data):'Error';
+                row.find('.gm2-result').text(msg);
+            }
+        }).fail(function(jqXHR,textStatus){
+            var msg=(jqXHR&&jqXHR.responseJSON&&jqXHR.responseJSON.data)?jqXHR.responseJSON.data:(jqXHR&&jqXHR.responseText?jqXHR.responseText:textStatus);
+            row.find('.gm2-result').text(msg||'Error');
+        });
+    });
+
+    $('#gm2-bulk-list').on('click','.gm2-clear-btn',function(e){
+        e.preventDefault();
+        var id=$(this).data('id');
+        var row=$('#gm2-row-'+id);
+        row.find('.gm2-result').text('...');
+        $.ajax({
+            url: gm2BulkAi.ajax_url,
+            method:'POST',
+            data:{action:'gm2_ai_research_clear',post_id:id,_ajax_nonce:gm2BulkAi.nonce},
+            dataType:'json'
+        }).done(function(resp){
+            if(resp&&resp.success){
+                row.find('.gm2-result').empty();
+            }else{
+                var msg=(resp&&resp.data)?(resp.data.message||resp.data):'Error';
+                row.find('.gm2-result').text(msg);
+            }
+        }).fail(function(jqXHR,textStatus){
+            var msg=(jqXHR&&jqXHR.responseJSON&&jqXHR.responseJSON.data)?jqXHR.responseJSON.data:(jqXHR&&jqXHR.responseText?jqXHR.responseText:textStatus);
+            row.find('.gm2-result').text(msg||'Error');
         });
     });
 

--- a/tests/test-ai-seo.php
+++ b/tests/test-ai-seo.php
@@ -739,6 +739,57 @@ class AiResearchPersistenceTest extends WP_Ajax_UnitTestCase {
     }
 }
 
+class AiResearchCacheTest extends WP_Ajax_UnitTestCase {
+    public function test_cached_results_returned_without_api_call() {
+        $post_id = self::factory()->post->create();
+        update_post_meta($post_id, '_gm2_ai_research', wp_json_encode(['seo_title' => 'Cached']));
+
+        $called = false;
+        $filter = function($pre, $args, $url) use (&$called) {
+            if ($url === 'https://api.openai.com/v1/chat/completions') {
+                $called = true;
+            }
+            return false;
+        };
+        add_filter('pre_http_request', $filter, 10, 3);
+
+        $this->_setRole('administrator');
+        $_POST['post_id'] = $post_id;
+        $_POST['_ajax_nonce'] = wp_create_nonce('gm2_ai_research');
+        $_REQUEST['_ajax_nonce'] = $_POST['_ajax_nonce'];
+        try { $this->_handleAjax('gm2_ai_research'); } catch (WPAjaxDieContinueException $e) {}
+        remove_filter('pre_http_request', $filter, 10);
+
+        $resp = json_decode($this->_last_response, true);
+        $this->assertTrue($resp['success']);
+        $this->assertSame('Cached', $resp['data']['seo_title']);
+        $this->assertFalse($called);
+    }
+
+    public function test_refresh_ignores_cache() {
+        update_option('gm2_chatgpt_api_key', 'key');
+        $post_id = self::factory()->post->create();
+        update_post_meta($post_id, '_gm2_ai_research', wp_json_encode(['seo_title' => 'Old']));
+        $filter = function($pre, $args, $url) {
+            if ($url === 'https://api.openai.com/v1/chat/completions') {
+                return [ 'response' => ['code' => 200], 'body' => json_encode(['choices' => [ ['message' => ['content' => json_encode(['seo_title' => 'New'])]] ]]) ];
+            }
+            return false;
+        };
+        add_filter('pre_http_request', $filter, 10, 3);
+        $this->_setRole('administrator');
+        $_POST['post_id'] = $post_id;
+        $_POST['refresh'] = 1;
+        $_POST['_ajax_nonce'] = wp_create_nonce('gm2_ai_research');
+        $_REQUEST['_ajax_nonce'] = $_POST['_ajax_nonce'];
+        try { $this->_handleAjax('gm2_ai_research'); } catch (WPAjaxDieContinueException $e) {}
+        remove_filter('pre_http_request', $filter, 10);
+        $resp = json_decode($this->_last_response, true);
+        $this->assertTrue($resp['success']);
+        $this->assertSame('New', $resp['data']['seo_title']);
+    }
+}
+
 class AiResearchKeywordSelectionTest extends WP_Ajax_UnitTestCase {
     public function test_seed_keywords_and_selection() {
         update_option('gm2_chatgpt_api_key', 'key');

--- a/tests/test-bulk-ai.php
+++ b/tests/test-bulk-ai.php
@@ -96,6 +96,22 @@ class BulkAiPaginationTest extends WP_UnitTestCase {
     }
 }
 
+class BulkAiCachedResultsTest extends WP_UnitTestCase {
+    public function test_cached_results_preloaded() {
+        $post_id = self::factory()->post->create(['post_title' => 'Post']);
+        update_post_meta($post_id, '_gm2_ai_research', wp_json_encode(['seo_title' => 'Cached Title']));
+
+        $admin = new Gm2_SEO_Admin();
+        $user  = self::factory()->user->create(['role' => 'administrator']);
+        wp_set_current_user($user);
+        ob_start();
+        $admin->display_bulk_ai_page();
+        $html = ob_get_clean();
+        $this->assertStringContainsString('Cached Title', $html);
+        $this->assertStringContainsString('gm2-refresh-btn', $html);
+    }
+}
+
 class BulkAiApplyBatchAjaxTest extends WP_Ajax_UnitTestCase {
     public function test_batch_apply_updates_posts() {
         $posts = self::factory()->post->create_many(2);


### PR DESCRIPTION
## Summary
- preload cached AI suggestions in bulk AI table
- allow refreshing or clearing cached AI research results
- avoid repeated AI research calls when cached data exists
- test cached result handling and new UI features

## Testing
- `npm install`
- `npm test`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_6887e33cd92c83279ad7d142e6d889a8