### PR TITLE
Add row select-all checkbox for bulk AI suggestions

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -210,6 +210,7 @@ class Gm2_Admin {
                             'apply'        => __( 'Apply', 'gm2-wordpress-suite' ),
                             'refresh'      => __( 'Refresh', 'gm2-wordpress-suite' ),
                             'clear'        => __( 'Clear', 'gm2-wordpress-suite' ),
+                            'selectAll'    => __( 'Select all', 'gm2-wordpress-suite' ),
                         ],
                     ]
                 );

--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1067,24 +1067,30 @@ class Gm2_SEO_Admin {
     }
 
     private function render_bulk_ai_result($data, $post_id) {
-        $html = '';
+        $html        = '';
+        $suggestions = '';
+
         if (!empty($data['seo_title'])) {
-            $html .= '<p><label><input type="checkbox" class="gm2-apply" data-field="seo_title" data-value="' . esc_attr($data['seo_title']) . '"> ' . esc_html($data['seo_title']) . '</label></p>';
+            $suggestions .= '<p><label><input type="checkbox" class="gm2-apply" data-field="seo_title" data-value="' . esc_attr($data['seo_title']) . '"> ' . esc_html($data['seo_title']) . '</label></p>';
         }
         if (!empty($data['description'])) {
-            $html .= '<p><label><input type="checkbox" class="gm2-apply" data-field="seo_description" data-value="' . esc_attr($data['description']) . '"> ' . esc_html($data['description']) . '</label></p>';
+            $suggestions .= '<p><label><input type="checkbox" class="gm2-apply" data-field="seo_description" data-value="' . esc_attr($data['description']) . '"> ' . esc_html($data['description']) . '</label></p>';
         }
         if (!empty($data['slug'])) {
-            $html .= '<p><label><input type="checkbox" class="gm2-apply" data-field="slug" data-value="' . esc_attr($data['slug']) . '"> ' . esc_html__( 'Slug', 'gm2-wordpress-suite' ) . ': ' . esc_html($data['slug']) . '</label></p>';
+            $suggestions .= '<p><label><input type="checkbox" class="gm2-apply" data-field="slug" data-value="' . esc_attr($data['slug']) . '"> ' . esc_html__( 'Slug', 'gm2-wordpress-suite' ) . ': ' . esc_html($data['slug']) . '</label></p>';
         }
         if (!empty($data['page_name'])) {
-            $html .= '<p><label><input type="checkbox" class="gm2-apply" data-field="title" data-value="' . esc_attr($data['page_name']) . '"> ' . esc_html__( 'Title', 'gm2-wordpress-suite' ) . ': ' . esc_html($data['page_name']) . '</label></p>';
+            $suggestions .= '<p><label><input type="checkbox" class="gm2-apply" data-field="title" data-value="' . esc_attr($data['page_name']) . '"> ' . esc_html__( 'Title', 'gm2-wordpress-suite' ) . ': ' . esc_html($data['page_name']) . '</label></p>';
         }
-        if ($html !== '') {
+
+        if ($suggestions !== '') {
+            $html .= '<p><label><input type="checkbox" class="gm2-row-select-all"> ' . esc_html__( 'Select all', 'gm2-wordpress-suite' ) . '</label></p>';
+            $html .= $suggestions;
             $html .= '<p><button class="button gm2-apply-btn" data-id="' . intval($post_id) . '">' . esc_html__( 'Apply', 'gm2-wordpress-suite' ) . '</button> ';
-            $html .= '<button class="button gm2-refresh-btn" data-id="' . intval($post_id) . '">' . esc_html__( 'Refresh', 'gm2-wordpress-suite' ) . '</button> ';
+            $html .= '<button class="button gm2-refresh-btn" data-id="' . intval($post_id) . '">' . esc_html__( 'Refresh', 'gm2-wordpress-suite' ) . '</button>';
             $html .= '<button class="button gm2-clear-btn" data-id="' . intval($post_id) . '">' . esc_html__( 'Clear', 'gm2-wordpress-suite' ) . '</button></p>';
         }
+
         return $html;
     }
 

--- a/admin/js/gm2-bulk-ai.js
+++ b/admin/js/gm2-bulk-ai.js
@@ -16,7 +16,8 @@ jQuery(function($){
     }
 
     function buildHtml(data,id){
-        var html='';
+        var selectLabel = window.gm2BulkAi && gm2BulkAi.i18n ? gm2BulkAi.i18n.selectAll : 'Select all';
+        var html='<p><label><input type="checkbox" class="gm2-row-select-all"> '+selectLabel+'</label></p>';
         if(data.seo_title){html+='<p><label><input type="checkbox" class="gm2-apply" data-field="seo_title" data-value="'+data.seo_title.replace(/"/g,'&quot;')+'"> '+data.seo_title+'</label></p>';}
         if(data.description){html+='<p><label><input type="checkbox" class="gm2-apply" data-field="seo_description" data-value="'+data.description.replace(/"/g,'&quot;')+'"> '+data.description+'</label></p>';}
         if(data.slug){
@@ -35,6 +36,10 @@ jQuery(function($){
     $('#gm2-bulk-ai').on('click','#gm2-bulk-select-all',function(){
         var c=$(this).prop('checked');
         $('#gm2-bulk-list .gm2-select').prop('checked',c);
+    });
+    $('#gm2-bulk-list').on('click','.gm2-row-select-all',function(){
+        var checked=$(this).prop('checked');
+        $(this).closest('.gm2-result').find('.gm2-apply').prop('checked',checked);
     });
     $('#gm2-bulk-ai').on('click','#gm2-bulk-analyze',function(e){
         e.preventDefault();


### PR DESCRIPTION
## Summary
- add row-level select-all checkbox in bulk AI suggestions
- toggle suggestion checkboxes with new JS handler
- localize label via `gm2BulkAi.i18n`

## Testing
- `npm test`
- `phpunit` *(fails: WordPress test suite missing)*

------
https://chatgpt.com/codex/tasks/task_e_6887fb16860883278e40338036f98a92