### PR TITLE
Highlight applied rows in bulk SEO tool

### DIFF
--- a/admin/css/gm2-seo.css
+++ b/admin/css/gm2-seo.css
@@ -24,3 +24,6 @@
 
 #gm2-elementor-seo-panel { padding:10px; }
 #elementor-panel-footer #gm2-elementor-seo-panel .gm2-tab-panel { border:none; }
+.gm2-applied {
+    background:#f9f9f9;
+}

--- a/admin/js/gm2-bulk-ai.js
+++ b/admin/js/gm2-bulk-ai.js
@@ -134,7 +134,9 @@ jQuery(function($){
             data[$(this).data('field')]= $(this).data('value');
         });
         $.post(gm2BulkAi.ajax_url,data).done(function(){
-            $('#gm2-row-'+id+' .gm2-result').append('<span> ✓</span>');
+            var row = $('#gm2-row-'+id);
+            row.find('.gm2-result').append('<span> ✓</span>');
+            row.addClass('gm2-applied');
             applied++;
             updateBar(applied);
         });
@@ -176,6 +178,7 @@ jQuery(function($){
         }).done(function(resp){
             if(resp&&resp.success){
                 row.find('.gm2-result').empty();
+                row.removeClass('gm2-applied');
             }else{
                 var msg=(resp&&resp.data)?(resp.data.message||resp.data):'Error';
                 row.find('.gm2-result').text(msg);
@@ -210,7 +213,9 @@ jQuery(function($){
         }).done(function(resp){
             if(resp&&resp.success){
                 $.each(posts,function(id){
-                    $('#gm2-row-'+id+' .gm2-result').append('<span> ✓</span>');
+                    var row = $('#gm2-row-'+id);
+                    row.find('.gm2-result').append('<span> ✓</span>');
+                    row.addClass('gm2-applied');
                 });
                 $msg.text(window.gm2BulkAi && gm2BulkAi.i18n ? gm2BulkAi.i18n.done : 'Done');
                 applied += Object.keys(posts).length;


### PR DESCRIPTION
## Summary
- indicate applied rows with a `.gm2-applied` class
- show `.gm2-applied` rows with a subtle background
- remove highlight when clearing results

## Testing
- `npm test`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_6887ffb70c848327b4d2d3c20c01f3d3