### PR TITLE
Fix timezone handling for abandoned cart threshold

### DIFF
--- a/includes/Gm2_Abandoned_Carts.php
+++ b/includes/Gm2_Abandoned_Carts.php
@@ -144,7 +144,10 @@ class Gm2_Abandoned_Carts {
 
         // Mark carts without orders after timeout
         $timeout = absint(get_option('gm2_ac_timeout', 60));
-        $threshold = gmdate('Y-m-d H:i:s', time() - $timeout * 60);
+        $threshold = gmdate(
+            'Y-m-d H:i:s',
+            current_time('timestamp') - $timeout * 60
+        );
         $wpdb->query(
             $wpdb->prepare(
                 "UPDATE $table SET abandoned_at = %s WHERE abandoned_at IS NULL AND cart_contents <> '' AND created_at <= %s",


### PR DESCRIPTION
## Summary
- calculate abandoned cart timeout using WordPress timezone

## Testing
- `phpunit` *(fails: The PHPUnit Polyfills library is a requirement for running the WP test suite)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68880c9eb8cc8327afa43ab900a3c86e