### PR TITLE
Add cron job for marking abandoned carts

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -118,6 +118,8 @@ function gm2_deactivate_plugin() {
     if ($ts) {
         wp_unschedule_event($ts, 'gm2_pagespeed_check');
     }
+
+    \Gm2\Gm2_Abandoned_Carts::clear_scheduled_event();
 }
 register_deactivation_hook(__FILE__, 'gm2_deactivate_plugin');
 
@@ -323,6 +325,15 @@ function gm2_run_pagespeed_check() {
     }
 }
 add_action('gm2_pagespeed_check', 'gm2_run_pagespeed_check');
+
+function gm2_handle_ac_option_change($old, $new) {
+    if ($new === '1') {
+        \Gm2\Gm2_Abandoned_Carts::schedule_event();
+    } else {
+        \Gm2\Gm2_Abandoned_Carts::clear_scheduled_event();
+    }
+}
+add_action('update_option_gm2_enable_abandoned_carts', 'gm2_handle_ac_option_change', 10, 2);
 
 function gm2_maybe_migrate_content_rules() {
     $current = (int) get_option('gm2_content_rules_version', 1);


### PR DESCRIPTION
## Summary
- ensure abandoned carts get marked even without page loads
- schedule hourly `gm2_ac_mark_abandoned` cron hook in the Abandoned Carts module
- clean up scheduled event when the module is disabled or plugin deactivated

## Testing
- `npm test`
- `make test DB_NAME=wp_test DB_USER=root DB_PASS=pass` *(fails: Can't connect to MySQL server)*

------
https://chatgpt.com/codex/tasks/task_e_68880d76850c8327b194fddd6ead08f2