### PR TITLE
Link titles in bulk AI view

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1042,7 +1042,9 @@ class Gm2_SEO_Admin {
             }
             echo '<tr id="gm2-row-' . intval($post->ID) . '">';
             echo '<th scope="row" class="check-column"><input type="checkbox" class="gm2-select" value="' . intval($post->ID) . '"></th>';
-            echo '<td>' . esc_html($post->post_title) . '</td>';
+            $edit_link = get_edit_post_link($post->ID);
+            $title     = $edit_link ? '<a href="' . esc_url($edit_link) . '" target="_blank">' . esc_html($post->post_title) . '</a>' : esc_html($post->post_title);
+            echo '<td>' . $title . '</td>';
             echo '<td>' . esc_html($seo_title) . '</td>';
             echo '<td>' . esc_html($description) . '</td>';
             echo '<td>' . esc_html($post->post_name) . '</td>';

--- a/tests/test-bulk-ai.php
+++ b/tests/test-bulk-ai.php
@@ -11,6 +11,19 @@ class BulkAiPageTest extends WP_UnitTestCase {
         $out = ob_get_clean();
         $this->assertStringContainsString('Permission denied', $out);
     }
+
+    public function test_titles_link_to_edit_page() {
+        $post_id = self::factory()->post->create(['post_title' => 'Linked']);
+        $admin   = new Gm2_SEO_Admin();
+        $user    = self::factory()->user->create(['role' => 'administrator']);
+        wp_set_current_user($user);
+        ob_start();
+        $admin->display_bulk_ai_page();
+        $html = ob_get_clean();
+        $edit_link = get_edit_post_link($post_id);
+        $this->assertStringContainsString('href="' . $edit_link . '"', $html);
+        $this->assertStringContainsString('target="_blank"', $html);
+    }
 }
 
 class BulkAiApplyAjaxTest extends WP_Ajax_UnitTestCase {


### PR DESCRIPTION
## Summary
- make post titles in the bulk AI page link to the editor
- open links in a new tab
- test new link markup

## Testing
- `make test` *(fails: Database credentials must be supplied)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688926039a6483279e092d5a6dc85a10