### PR TITLE
Add spinner during bulk AI operations

### DIFF
--- a/admin/css/gm2-seo.css
+++ b/admin/css/gm2-seo.css
@@ -27,3 +27,10 @@
 .gm2-applied {
     background:#f9f9f9;
 }
+
+/* Spinner for bulk AI actions */
+.gm2-ai-spinner.spinner{
+    float:none;
+    margin-left:4px;
+    vertical-align:middle;
+}


### PR DESCRIPTION
## Summary
- add `.gm2-ai-spinner.spinner` rule
- show a spinner while AJAX requests run in gm2-bulk-ai.js

## Testing
- `npm test`
- `phpunit` *(fails: missing WordPress test suite)*

------
https://chatgpt.com/codex/tasks/task_e_688927a487a88327aa1c1d162fd159bf