### PR TITLE
Add timeout to bulk AI highlight

### DIFF
--- a/admin/js/gm2-bulk-ai.js
+++ b/admin/js/gm2-bulk-ai.js
@@ -157,6 +157,9 @@ jQuery(function($){
                 hideSpinner($res);
                 row.find('.gm2-result').append('<span> ✓</span>');
                 row.addClass('gm2-applied');
+                setTimeout(function(){
+                    row.removeClass('gm2-applied');
+                },3000);
                 applied++;
                 updateBar(applied);
             })
@@ -249,6 +252,9 @@ jQuery(function($){
                     hideSpinner(row.find('.gm2-result'));
                     row.find('.gm2-result').append('<span> ✓</span>');
                     row.addClass('gm2-applied');
+                    setTimeout(function(){
+                        row.removeClass('gm2-applied');
+                    },3000);
                 });
                 $msg.text(window.gm2BulkAi && gm2BulkAi.i18n ? gm2BulkAi.i18n.done : 'Done');
                 applied += Object.keys(posts).length;


### PR DESCRIPTION
## Summary
- temporarily highlight a row after applying AI suggestions

## Testing
- `npm test`
- `phpunit` *(fails: missing WordPress test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68892b164c20832794345890ba8df449