### PR TITLE
Fix abandoned cart time comparisons

### DIFF
--- a/includes/Gm2_Abandoned_Carts.php
+++ b/includes/Gm2_Abandoned_Carts.php
@@ -149,10 +149,10 @@ class Gm2_Abandoned_Carts {
         }
 
         // Mark carts without orders after timeout
-        $timeout = absint(get_option('gm2_ac_timeout', 60));
-        $threshold = gmdate(
+        $timeout   = absint(get_option('gm2_ac_timeout', 60));
+        $threshold = date(
             'Y-m-d H:i:s',
-            current_time('timestamp') - $timeout * 60
+            strtotime(current_time('mysql')) - $timeout * 60
         );
         $wpdb->query(
             $wpdb->prepare(


### PR DESCRIPTION
## Summary
- compute abandoned cart timeout using site's timezone

## Testing
- `npm test`
- `make test` *(fails: Database credentials must be supplied)*

------
https://chatgpt.com/codex/tasks/task_e_688928140d588327a11a81c430d9f73a