### PR TITLE
Add configurable abandoned cart cron schedule

### DIFF
--- a/includes/Gm2_Abandoned_Carts.php
+++ b/includes/Gm2_Abandoned_Carts.php
@@ -177,8 +177,20 @@ class Gm2_Abandoned_Carts {
     }
 
     public static function schedule_event() {
-        if (!wp_next_scheduled(self::CRON_HOOK)) {
-            wp_schedule_event(time(), 'hourly', self::CRON_HOOK);
+        $minutes = absint(apply_filters('gm2_ac_mark_abandoned_interval', (int) get_option('gm2_ac_mark_abandoned_interval', 5)));
+        if ($minutes < 1) {
+            $minutes = 5;
+        }
+        $schedule = 'gm2_ac_' . $minutes . '_mins';
+        $existing = wp_next_scheduled(self::CRON_HOOK);
+        if ($existing) {
+            $current = wp_get_schedule(self::CRON_HOOK);
+            if ($current !== $schedule) {
+                self::clear_scheduled_event();
+                wp_schedule_event(time(), $schedule, self::CRON_HOOK);
+            }
+        } else {
+            wp_schedule_event(time(), $schedule, self::CRON_HOOK);
         }
     }
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: gm2team
 Tags: admin, tools, suite, performance
 Requires at least: 6.0
 Tested up to: 6.5
-Stable tag: 1.6.16
+Stable tag: 1.6.17
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -317,6 +317,8 @@ the last 100 missing URLs to help you create new redirects.
   `nofollow` or `sponsored` to outbound links.
 
 == Changelog ==
+= 1.6.17 =
+* Abandoned cart checks now run every 5 minutes by default. Adjust the frequency via the `gm2_ac_mark_abandoned_interval` filter or `gm2_ac_mark_abandoned_interval` option.
 = 1.6.16 =
 * When multiple discount groups include the same product, the product now gets the highest available percentage.
 = 1.6.15 =


### PR DESCRIPTION
## Summary
- run `gm2_ac_mark_abandoned` every five minutes by default
- allow the interval to be changed via a filter or option
- reschedule the event when the interval is updated
- document new interval in the changelog

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68892c6da8b483279f86ab29f089d646