### PR TITLE
Extend bulk AI filters

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -291,6 +291,12 @@ class Gm2_SEO_Admin {
         register_setting('gm2_seo_options', 'gm2_bulk_ai_term', [
             'sanitize_callback' => 'sanitize_text_field',
         ]);
+        register_setting('gm2_seo_options', 'gm2_bulk_ai_missing_title', [
+            'sanitize_callback' => 'sanitize_text_field',
+        ]);
+        register_setting('gm2_seo_options', 'gm2_bulk_ai_missing_description', [
+            'sanitize_callback' => 'sanitize_text_field',
+        ]);
         register_setting('gm2_seo_options', 'gm2_context_business_model', [
             'sanitize_callback' => 'sanitize_textarea_field',
         ]);
@@ -955,10 +961,12 @@ class Gm2_SEO_Admin {
             return;
         }
 
-        $page_size = max(1, absint(get_option('gm2_bulk_ai_page_size', 10)));
-        $status    = get_option('gm2_bulk_ai_status', 'publish');
-        $post_type = get_option('gm2_bulk_ai_post_type', 'all');
-        $term      = get_option('gm2_bulk_ai_term', '');
+        $page_size  = max(1, absint(get_option('gm2_bulk_ai_page_size', 10)));
+        $status     = get_option('gm2_bulk_ai_status', 'publish');
+        $post_type  = get_option('gm2_bulk_ai_post_type', 'all');
+        $term       = get_option('gm2_bulk_ai_term', '');
+        $missing_title = get_option('gm2_bulk_ai_missing_title', '0');
+        $missing_desc  = get_option('gm2_bulk_ai_missing_description', '0');
         $current_page = isset($_GET['paged']) ? max(1, absint($_GET['paged'])) : 1;
 
         if (isset($_POST['gm2_bulk_ai_save']) && check_admin_referer('gm2_bulk_ai_settings')) {
@@ -966,10 +974,14 @@ class Gm2_SEO_Admin {
             $status    = sanitize_key($_POST['status'] ?? 'publish');
             $post_type = sanitize_key($_POST['gm2_post_type'] ?? 'all');
             $term      = sanitize_text_field($_POST['term'] ?? '');
+            $missing_title = isset($_POST['gm2_missing_title']) ? '1' : '0';
+            $missing_desc  = isset($_POST['gm2_missing_description']) ? '1' : '0';
             update_option('gm2_bulk_ai_page_size', $page_size);
             update_option('gm2_bulk_ai_status', $status);
             update_option('gm2_bulk_ai_post_type', $post_type);
             update_option('gm2_bulk_ai_term', $term);
+            update_option('gm2_bulk_ai_missing_title', $missing_title);
+            update_option('gm2_bulk_ai_missing_description', $missing_desc);
         }
 
         $types = $this->get_supported_post_types();
@@ -986,12 +998,33 @@ class Gm2_SEO_Admin {
             list($tax, $id) = explode(':', $term);
             $taxonomies = $this->get_supported_taxonomies();
             if (in_array($tax, $taxonomies, true)) {
-                $args['tax_query'] = [[
-                    'taxonomy' => $tax,
-                    'field'    => 'term_id',
-                    'terms'    => absint($id),
-                ]];
+                $args['tax_query'] = [
+                    [
+                        'taxonomy' => $tax,
+                        'field'    => 'term_id',
+                        'terms'    => absint($id),
+                    ],
+                ];
             }
+        }
+
+        $meta_query = [];
+        if ($missing_title === '1') {
+            $meta_query[] = [
+                'relation' => 'OR',
+                [ 'key' => '_gm2_title', 'compare' => 'NOT EXISTS' ],
+                [ 'key' => '_gm2_title', 'value' => '', 'compare' => '=' ],
+            ];
+        }
+        if ($missing_desc === '1') {
+            $meta_query[] = [
+                'relation' => 'OR',
+                [ 'key' => '_gm2_description', 'compare' => 'NOT EXISTS' ],
+                [ 'key' => '_gm2_description', 'value' => '', 'compare' => '=' ],
+            ];
+        }
+        if ($meta_query) {
+            $args['meta_query'] = array_merge(['relation' => 'AND'], $meta_query);
         }
         $query = new \WP_Query($args);
 
@@ -1026,6 +1059,8 @@ class Gm2_SEO_Admin {
             echo '<option value="' . esc_attr($value) . '"' . selected($term, $value, false) . '>' . esc_html($label) . '</option>';
         }
         echo '</select></label> ';
+        echo '<label><input type="checkbox" name="gm2_missing_title" value="1" ' . checked($missing_title, '1', false) . '> ' . esc_html__( 'Only posts missing SEO Title', 'gm2-wordpress-suite' ) . '</label> ';
+        echo '<label><input type="checkbox" name="gm2_missing_description" value="1" ' . checked($missing_desc, '1', false) . '> ' . esc_html__( 'Only posts missing Description', 'gm2-wordpress-suite' ) . '</label> ';
         submit_button( esc_html__( 'Save', 'gm2-wordpress-suite' ), 'secondary', 'gm2_bulk_ai_save', false );
         echo '</p></form>';
 

--- a/tests/test-bulk-ai.php
+++ b/tests/test-bulk-ai.php
@@ -89,6 +89,36 @@ class BulkAiFilterTest extends WP_UnitTestCase {
         $this->assertStringContainsString('In', $html);
         $this->assertStringNotContainsString('Out', $html);
     }
+
+    public function test_missing_title_filter_limits_results() {
+        $has = self::factory()->post->create(['post_title' => 'Has']);
+        update_post_meta($has, '_gm2_title', 't');
+        $missing = self::factory()->post->create(['post_title' => 'Missing']);
+        update_option('gm2_bulk_ai_missing_title', '1');
+        $admin = new Gm2_SEO_Admin();
+        $user  = self::factory()->user->create(['role' => 'administrator']);
+        wp_set_current_user($user);
+        ob_start();
+        $admin->display_bulk_ai_page();
+        $html = ob_get_clean();
+        $this->assertStringContainsString('Missing', $html);
+        $this->assertStringNotContainsString('Has', $html);
+    }
+
+    public function test_missing_description_filter_limits_results() {
+        $has = self::factory()->post->create(['post_title' => 'HasD']);
+        update_post_meta($has, '_gm2_description', 'd');
+        $missing = self::factory()->post->create(['post_title' => 'MissingD']);
+        update_option('gm2_bulk_ai_missing_description', '1');
+        $admin = new Gm2_SEO_Admin();
+        $user  = self::factory()->user->create(['role' => 'administrator']);
+        wp_set_current_user($user);
+        ob_start();
+        $admin->display_bulk_ai_page();
+        $html = ob_get_clean();
+        $this->assertStringContainsString('MissingD', $html);
+        $this->assertStringNotContainsString('HasD', $html);
+    }
 }
 
 class BulkAiPaginationTest extends WP_UnitTestCase {

--- a/uninstall.php
+++ b/uninstall.php
@@ -82,6 +82,8 @@ $option_names = array(
     'gm2_bulk_ai_status',
     'gm2_bulk_ai_post_type',
     'gm2_bulk_ai_term',
+    'gm2_bulk_ai_missing_title',
+    'gm2_bulk_ai_missing_description',
     'gm2_clean_slugs',
     'gm2_slug_stopwords',
     'gm2_tax_desc_prompt',


### PR DESCRIPTION
## Summary
- allow filtering posts with missing SEO title or description in bulk AI review
- add new settings to uninstall
- test bulk AI filter by missing fields

## Testing
- `npm test`
- `phpunit` *(fails: WordPress test suite missing)*

------
https://chatgpt.com/codex/tasks/task_e_68892e8a4b4083278708a269a73aa722