### PR TITLE
Allow 1-minute abandoned cart cron interval

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -72,7 +72,7 @@ add_filter('cron_schedules', 'gm2_add_weekly_schedule');
 function gm2_add_ac_schedule($schedules) {
     $minutes = absint(apply_filters('gm2_ac_mark_abandoned_interval', (int) get_option('gm2_ac_mark_abandoned_interval', 5)));
     if ($minutes < 1) {
-        $minutes = 5;
+        $minutes = 1;
     }
     $schedules['gm2_ac_' . $minutes . '_mins'] = [
         'interval' => $minutes * MINUTE_IN_SECONDS,

--- a/includes/Gm2_Abandoned_Carts.php
+++ b/includes/Gm2_Abandoned_Carts.php
@@ -183,7 +183,7 @@ class Gm2_Abandoned_Carts {
     public static function schedule_event() {
         $minutes = absint(apply_filters('gm2_ac_mark_abandoned_interval', (int) get_option('gm2_ac_mark_abandoned_interval', 5)));
         if ($minutes < 1) {
-            $minutes = 5;
+            $minutes = 1;
         }
         $schedule = 'gm2_ac_' . $minutes . '_mins';
         $existing = wp_next_scheduled(self::CRON_HOOK);

--- a/readme.txt
+++ b/readme.txt
@@ -318,7 +318,7 @@ the last 100 missing URLs to help you create new redirects.
 
 == Changelog ==
 = 1.6.17 =
-* Abandoned cart checks now run every 5 minutes by default. Adjust the frequency via the `gm2_ac_mark_abandoned_interval` filter or `gm2_ac_mark_abandoned_interval` option.
+* Abandoned cart checks now run every 5 minutes by default. The interval can be lowered to one minute using the `gm2_ac_mark_abandoned_interval` filter or corresponding option.
 = 1.6.16 =
 * When multiple discount groups include the same product, the product now gets the highest available percentage.
 = 1.6.15 =


### PR DESCRIPTION
## Summary
- allow `gm2_add_ac_schedule()` to schedule events every minute
- adjust `Gm2_Abandoned_Carts::schedule_event()` to respect the new lower limit
- document the option/filter in the changelog

## Testing
- `npm test --silent` *(fails: jest not found)*
- `phpunit` *(fails: command not found)*
- `make test DB_NAME=wp_test DB_USER=root DB_PASS=pass` *(fails: mysqladmin command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688932bcbab88327bb6519d6e563e138