### PR TITLE
Add Select None option to bulk AI

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1098,6 +1098,7 @@ class Gm2_SEO_Admin {
             echo '<div class="tablenav"><div class="tablenav-pages">' . $links . '</div></div>';
         }
         echo '<p><button type="button" class="button" id="gm2-bulk-analyze" aria-label="' . esc_attr__( 'Analyze Selected', 'gm2-wordpress-suite' ) . '">' . esc_html__( 'Analyze Selected', 'gm2-wordpress-suite' ) . '</button> ' .
+            '<button type="button" class="button" id="gm2-select-none">' . esc_html__( 'Select None', 'gm2-wordpress-suite' ) . '</button> ' .
             '<button type="button" class="button" id="gm2-bulk-cancel">' . esc_html__( 'Cancel', 'gm2-wordpress-suite' ) . '</button> ' .
             '<button type="button" class="button" id="gm2-bulk-apply-all">' . esc_html__( 'Apply All', 'gm2-wordpress-suite' ) . '</button> ' .
             '<span id="gm2-bulk-apply-msg"></span></p>';

--- a/admin/js/gm2-bulk-ai.js
+++ b/admin/js/gm2-bulk-ai.js
@@ -50,6 +50,11 @@ jQuery(function($){
         var c=$(this).prop('checked');
         $('#gm2-bulk-list .gm2-select').prop('checked',c);
     });
+    $('#gm2-bulk-ai').on('click','#gm2-select-none',function(e){
+        e.preventDefault();
+        $('#gm2-bulk-select-all').prop('checked',false);
+        $('#gm2-bulk-list .gm2-select').prop('checked',false);
+    });
     $('#gm2-bulk-list').on('click','.gm2-row-select-all',function(){
         var checked=$(this).prop('checked');
         $(this).closest('.gm2-result').find('.gm2-apply').prop('checked',checked);


### PR DESCRIPTION
## Summary
- add a **Select None** button to Bulk AI admin table
- allow clearing all selections via new JS handler

## Testing
- `npm test`
- `phpunit` *(fails: WordPress test suite missing)*

------
https://chatgpt.com/codex/tasks/task_e_68894aaf79d8832786a54a61d0f3a2a1