### PR TITLE
Add Bulk AI CSV export feature

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -52,6 +52,7 @@ require_once GM2_PLUGIN_DIR . 'public/Gm2_SEO_Public.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_Sitemap.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_PageSpeed.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_SEO_Utils.php';
+require_once GM2_PLUGIN_DIR . 'includes/Gm2_CSV_Helper.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_Abandoned_Carts.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_Abandoned_Carts_Messaging.php';
 require_once GM2_PLUGIN_DIR . 'admin/Gm2_Abandoned_Carts_Admin.php';

--- a/includes/Gm2_CSV_Helper.php
+++ b/includes/Gm2_CSV_Helper.php
@@ -1,0 +1,17 @@
+<?php
+namespace Gm2;
+if (!defined('ABSPATH')) {
+    exit;
+}
+class Gm2_CSV_Helper {
+    public static function output(array $rows, $filename = 'export.csv') {
+        nocache_headers();
+        header('Content-Type: text/csv; charset=utf-8');
+        header('Content-Disposition: attachment; filename="' . $filename . '"');
+        $out = fopen('php://output', 'w');
+        foreach ($rows as $row) {
+            fputcsv($out, $row);
+        }
+        fclose($out);
+    }
+}

--- a/tests/test-bulk-ai.php
+++ b/tests/test-bulk-ai.php
@@ -176,3 +176,26 @@ class BulkAiApplyBatchAjaxTest extends WP_Ajax_UnitTestCase {
         $this->assertSame('Two', $post2->post_title);
     }
 }
+
+class BulkAiExportTest extends WP_UnitTestCase {
+    public function test_csv_export_contains_suggestions() {
+        $post_id = self::factory()->post->create(['post_title' => 'Post']);
+        update_post_meta($post_id, '_gm2_ai_research', wp_json_encode([
+            'seo_title'  => 'Suggested Title',
+            'description'=> 'Suggested Desc',
+            'slug'       => 'suggested-slug',
+            'page_name'  => 'Suggested Name',
+        ]));
+
+        $admin = new Gm2_SEO_Admin();
+        $user  = self::factory()->user->create(['role' => 'administrator']);
+        wp_set_current_user($user);
+
+        ob_start();
+        $admin->handle_bulk_ai_export();
+        $csv = ob_get_clean();
+
+        $this->assertStringContainsString('Suggested Title', $csv);
+        $this->assertStringContainsString('suggested-slug', $csv);
+    }
+}


### PR DESCRIPTION
## Summary
- add CSV helper utility
- support CSV export action for Bulk AI Review
- show **Export CSV** button on Bulk AI Review page
- test CSV export output

## Testing
- `make test DB_NAME=wp_test DB_USER=root DB_PASS=pass` *(fails: mysqladmin command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889500ea18c8327b96c8773e52eaff2