### PR TITLE
Switch bulk AI settings to user meta

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -965,10 +965,11 @@ class Gm2_SEO_Admin {
             return;
         }
 
-        $page_size     = max(1, absint(get_option('gm2_bulk_ai_page_size', 10)));
-        $status        = get_option('gm2_bulk_ai_status', 'publish');
-        $post_type     = get_option('gm2_bulk_ai_post_type', 'all');
-        $term          = get_option('gm2_bulk_ai_term', '');
+        $user_id       = get_current_user_id();
+        $page_size     = max(1, absint(get_user_meta($user_id, 'gm2_bulk_ai_page_size', true) ?: 10));
+        $status        = get_user_meta($user_id, 'gm2_bulk_ai_status', true) ?: 'publish';
+        $post_type     = get_user_meta($user_id, 'gm2_bulk_ai_post_type', true) ?: 'all';
+        $term          = get_user_meta($user_id, 'gm2_bulk_ai_term', true) ?: '';
         $missing_title = get_option('gm2_bulk_ai_missing_title', '0');
         $missing_desc  = get_option('gm2_bulk_ai_missing_description', '0');
         $search_title  = get_option('gm2_bulk_ai_search_title', '');
@@ -982,10 +983,10 @@ class Gm2_SEO_Admin {
             $missing_title = isset($_POST['gm2_missing_title']) ? '1' : '0';
             $missing_desc  = isset($_POST['gm2_missing_description']) ? '1' : '0';
             $search_title  = sanitize_text_field($_POST['gm2_search_title'] ?? '');
-            update_option('gm2_bulk_ai_page_size', $page_size);
-            update_option('gm2_bulk_ai_status', $status);
-            update_option('gm2_bulk_ai_post_type', $post_type);
-            update_option('gm2_bulk_ai_term', $term);
+            update_user_meta($user_id, 'gm2_bulk_ai_page_size', $page_size);
+            update_user_meta($user_id, 'gm2_bulk_ai_status', $status);
+            update_user_meta($user_id, 'gm2_bulk_ai_post_type', $post_type);
+            update_user_meta($user_id, 'gm2_bulk_ai_term', $term);
             update_option('gm2_bulk_ai_missing_title', $missing_title);
             update_option('gm2_bulk_ai_missing_description', $missing_desc);
             update_option('gm2_bulk_ai_search_title', $search_title);
@@ -1151,10 +1152,11 @@ class Gm2_SEO_Admin {
             wp_die( esc_html__( 'Permission denied', 'gm2-wordpress-suite' ) );
         }
 
-        $page_size     = max(1, absint(get_option('gm2_bulk_ai_page_size', 10)));
-        $status        = get_option('gm2_bulk_ai_status', 'publish');
-        $post_type     = get_option('gm2_bulk_ai_post_type', 'all');
-        $term          = get_option('gm2_bulk_ai_term', '');
+        $user_id       = get_current_user_id();
+        $page_size     = max(1, absint(get_user_meta($user_id, 'gm2_bulk_ai_page_size', true) ?: 10));
+        $status        = get_user_meta($user_id, 'gm2_bulk_ai_status', true) ?: 'publish';
+        $post_type     = get_user_meta($user_id, 'gm2_bulk_ai_post_type', true) ?: 'all';
+        $term          = get_user_meta($user_id, 'gm2_bulk_ai_term', true) ?: '';
         $missing_title = get_option('gm2_bulk_ai_missing_title', '0');
         $missing_desc  = get_option('gm2_bulk_ai_missing_description', '0');
         $search_title  = get_option('gm2_bulk_ai_search_title', '');

--- a/tests/test-bulk-ai.php
+++ b/tests/test-bulk-ai.php
@@ -62,9 +62,9 @@ class BulkAiFilterTest extends WP_UnitTestCase {
     public function test_post_type_filter_limits_results() {
         $post1 = self::factory()->post->create(['post_title' => 'Post One']);
         $page1 = self::factory()->post->create(['post_type' => 'page', 'post_title' => 'Page One']);
-        update_option('gm2_bulk_ai_post_type', 'page');
-        $admin = new Gm2_SEO_Admin();
         $user = self::factory()->user->create(['role' => 'administrator']);
+        update_user_meta($user, 'gm2_bulk_ai_post_type', 'page');
+        $admin = new Gm2_SEO_Admin();
         wp_set_current_user($user);
         ob_start();
         $admin->display_bulk_ai_page();
@@ -78,10 +78,10 @@ class BulkAiFilterTest extends WP_UnitTestCase {
         $cat2 = self::factory()->term->create(['taxonomy' => 'category', 'name' => 'Beta']);
         $in = self::factory()->post->create(['post_title' => 'In', 'post_category' => [$cat1]]);
         $out_post = self::factory()->post->create(['post_title' => 'Out', 'post_category' => [$cat2]]);
-        update_option('gm2_bulk_ai_post_type', 'post');
-        update_option('gm2_bulk_ai_term', 'category:' . $cat1);
-        $admin = new Gm2_SEO_Admin();
         $user = self::factory()->user->create(['role' => 'administrator']);
+        update_user_meta($user, 'gm2_bulk_ai_post_type', 'post');
+        update_user_meta($user, 'gm2_bulk_ai_term', 'category:' . $cat1);
+        $admin = new Gm2_SEO_Admin();
         wp_set_current_user($user);
         ob_start();
         $admin->display_bulk_ai_page();
@@ -123,10 +123,10 @@ class BulkAiFilterTest extends WP_UnitTestCase {
 
 class BulkAiPaginationTest extends WP_UnitTestCase {
     public function test_second_page_shows_expected_posts() {
-        update_option('gm2_bulk_ai_page_size', 2);
+        $user = self::factory()->user->create(['role' => 'administrator']);
+        update_user_meta($user, 'gm2_bulk_ai_page_size', 2);
         $posts = self::factory()->post->create_many(3);
         $admin = new Gm2_SEO_Admin();
-        $user = self::factory()->user->create(['role' => 'administrator']);
         wp_set_current_user($user);
         $_GET['paged'] = 2;
         ob_start();

--- a/uninstall.php
+++ b/uninstall.php
@@ -117,6 +117,20 @@ foreach ( $option_names as $option ) {
     delete_option( $option );
 }
 
+// Remove per-user Bulk AI settings stored as user meta.
+$user_meta_keys = array(
+    'gm2_bulk_ai_page_size',
+    'gm2_bulk_ai_status',
+    'gm2_bulk_ai_post_type',
+    'gm2_bulk_ai_term',
+);
+$user_ids = get_users( array( 'fields' => 'ID' ) );
+foreach ( $user_ids as $uid ) {
+    foreach ( $user_meta_keys as $key ) {
+        delete_user_meta( $uid, $key );
+    }
+}
+
 // Remove dynamic SEO guideline options for supported post types and taxonomies.
 
 // Example table cleanup.


### PR DESCRIPTION
## Summary
- store bulk AI page settings as user meta
- remove those user meta entries during uninstall
- update PHPUnit tests for the new storage mechanism

## Testing
- `npm test`
- `phpunit` *(fails: /tmp/wordpress-tests-lib missing)*

------
https://chatgpt.com/codex/tasks/task_e_688952b06eac8327b34ad06dd94a9d38