### PR TITLE
Improve AJAX error reporting

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -2853,7 +2853,8 @@ class Gm2_SEO_Admin {
         }
 
         if (is_wp_error($ideas)) {
-            wp_send_json_error( $ideas->get_error_message() );
+            error_log('Keyword ideas error: ' . $ideas->get_error_message());
+            wp_send_json_error( __( 'Keyword ideas request failed', 'gm2-wordpress-suite' ) );
         }
 
         wp_send_json_success([
@@ -2928,7 +2929,8 @@ class Gm2_SEO_Admin {
         }
 
         if (is_wp_error($resp)) {
-            wp_send_json_error($resp->get_error_message());
+            error_log('Content rules request failed: ' . $resp->get_error_message());
+            wp_send_json_error( __( 'AI request failed', 'gm2-wordpress-suite' ) );
         }
 
         $clean = $this->sanitize_ai_json($resp);
@@ -3069,7 +3071,8 @@ class Gm2_SEO_Admin {
         }
 
         if (is_wp_error($resp)) {
-            wp_send_json_error($resp->get_error_message());
+            error_log('Guideline rules request failed: ' . $resp->get_error_message());
+            wp_send_json_error( __( 'AI request failed', 'gm2-wordpress-suite' ) );
         }
 
         $clean = $this->sanitize_ai_json($resp);
@@ -3632,7 +3635,8 @@ class Gm2_SEO_Admin {
         $resp = $chat->query($prompt);
 
         if (is_wp_error($resp)) {
-            wp_send_json_error($resp->get_error_message());
+            error_log('Tax description request failed: ' . $resp->get_error_message());
+            wp_send_json_error( __( 'AI request failed', 'gm2-wordpress-suite' ) );
         }
 
         if ($term_id) {

--- a/admin/js/gm2-bulk-ai.js
+++ b/admin/js/gm2-bulk-ai.js
@@ -179,8 +179,12 @@ jQuery(function($){
                 applied++;
                 updateBar(applied);
             })
-            .fail(function(){
+            .fail(function(jqXHR, textStatus){
                 hideSpinner($res);
+                var msg = (jqXHR && jqXHR.responseJSON && jqXHR.responseJSON.data)
+                    ? jqXHR.responseJSON.data
+                    : (jqXHR && jqXHR.responseText ? jqXHR.responseText : textStatus);
+                $res.text(msg || (window.gm2BulkAi && gm2BulkAi.i18n ? gm2BulkAi.i18n.error : 'Error'));
             });
     });
 
@@ -282,10 +286,14 @@ jQuery(function($){
                 $msg.text((resp&&resp.data)?resp.data:(window.gm2BulkAi && gm2BulkAi.i18n ? gm2BulkAi.i18n.error : 'Error'));
             }
         }).fail(function(jqXHR,textStatus){
+            var msg=(jqXHR && jqXHR.responseJSON && jqXHR.responseJSON.data)
+                ? jqXHR.responseJSON.data
+                : (jqXHR && jqXHR.responseText ? jqXHR.responseText : textStatus);
             $.each(posts,function(id){
-                hideSpinner($('#gm2-row-'+id).find('.gm2-result'));
+                var cell = $('#gm2-row-'+id).find('.gm2-result');
+                hideSpinner(cell);
+                cell.text(msg || (window.gm2BulkAi && gm2BulkAi.i18n ? gm2BulkAi.i18n.error : 'Error'));
             });
-            var msg=(jqXHR&&jqXHR.responseJSON&&jqXHR.responseJSON.data)?jqXHR.responseJSON.data:(jqXHR&&jqXHR.responseText?jqXHR.responseText:textStatus);
             $msg.text(msg || (window.gm2BulkAi && gm2BulkAi.i18n ? gm2BulkAi.i18n.error : 'Error'));
         });
     });


### PR DESCRIPTION
## Summary
- return translated messages for AJAX errors in admin handlers
- surface those messages in gm2-bulk-ai.js failure cases

## Testing
- `npm test`
- `make test` *(fails: Database credentials must be supplied)*

------
https://chatgpt.com/codex/tasks/task_e_6889546b99e08327bad4c48783c34d3e