### PR TITLE
Add undo feature for bulk AI changes

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -212,6 +212,7 @@ class Gm2_Admin {
                             'clear'        => __( 'Clear', 'gm2-wordpress-suite' ),
                             'selectAll'    => __( 'Select all', 'gm2-wordpress-suite' ),
                             'cancel'       => __( 'Cancel', 'gm2-wordpress-suite' ),
+                            'undo'         => __( 'Undo', 'gm2-wordpress-suite' ),
                         ],
                     ]
                 );


### PR DESCRIPTION
## Summary
- keep previous SEO values when applying bulk AI updates
- display Undo button in bulk AI results when prior data exists
- restore prior values via new AJAX endpoint
- expose new `undo` translation for JS
- support Undo interactions in bulk AI JS

## Testing
- `npm test`
- `phpunit` *(fails: Missing WordPress test suite)*

------
https://chatgpt.com/codex/tasks/task_e_688963ac1b0c83278c4b0edb9fdef231