### PR TITLE
Add SEO snippet preview

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -3873,6 +3873,14 @@ class Gm2_SEO_Admin {
             GM2_VERSION,
             true
         );
+
+        wp_enqueue_script(
+            'gm2-snippet-preview',
+            GM2_PLUGIN_URL . 'admin/js/gm2-snippet-preview.js',
+            ['jquery'],
+            GM2_VERSION,
+            true
+        );
         wp_localize_script(
             'gm2-ai-seo',
             'gm2AiSeo',
@@ -4001,6 +4009,14 @@ class Gm2_SEO_Admin {
         wp_enqueue_script(
             'gm2-ai-seo',
             GM2_PLUGIN_URL . 'admin/js/gm2-ai-seo.js',
+            ['jquery'],
+            GM2_VERSION,
+            true
+        );
+
+        wp_enqueue_script(
+            'gm2-snippet-preview',
+            GM2_PLUGIN_URL . 'admin/js/gm2-snippet-preview.js',
             ['jquery'],
             GM2_VERSION,
             true

--- a/admin/css/gm2-seo.css
+++ b/admin/css/gm2-seo.css
@@ -45,3 +45,27 @@
 .gm2-status-applied {
     background: #f0fff0;
 }
+
+#gm2-snippet-preview {
+    border:1px solid #ddd;
+    background:#fff;
+    padding:10px;
+    margin-top:10px;
+    max-width:600px;
+    font-family:Arial,Helvetica,sans-serif;
+    line-height:1.4;
+}
+#gm2-snippet-preview .gm2-snippet-title {
+    color:#1a0dab;
+    font-size:18px;
+    margin-bottom:2px;
+}
+#gm2-snippet-preview .gm2-snippet-url {
+    color:#006621;
+    font-size:14px;
+    margin-bottom:2px;
+}
+#gm2-snippet-preview .gm2-snippet-description {
+    color:#545454;
+    font-size:13px;
+}

--- a/admin/js/gm2-snippet-preview.js
+++ b/admin/js/gm2-snippet-preview.js
@@ -1,0 +1,30 @@
+jQuery(function($){
+    function getSlug(){
+        return $('#post_name').val() || $('#tag-slug').val() || $('#slug').val() || $('#editable-post-name-full').text() || '';
+    }
+    function updatePreview(){
+        var title = $('#gm2_seo_title').val() || '';
+        var desc  = $('#gm2_seo_description').val() || '';
+        var slug  = getSlug();
+        var url   = window.location.origin.replace(/\/$/,'') + '/' + slug;
+        $('#gm2-snippet-preview .gm2-snippet-title').text(title);
+        $('#gm2-snippet-preview .gm2-snippet-url').text(url);
+        $('#gm2-snippet-preview .gm2-snippet-description').text(desc);
+    }
+    function init(){
+        var $desc = $('#gm2_seo_description');
+        if(!$desc.length || $('#gm2-snippet-preview').length){
+            return;
+        }
+        var box = $('<div id="gm2-snippet-preview" class="gm2-snippet-preview">'+
+            '<div class="gm2-snippet-title"></div>'+
+            '<div class="gm2-snippet-url"></div>'+
+            '<div class="gm2-snippet-description"></div>'+
+        '</div>');
+        $desc.closest('p, .form-field, tr').after(box);
+        updatePreview();
+        $('#gm2_seo_title, #gm2_seo_description, #post_name, #tag-slug, #slug').on('input change', updatePreview);
+        $(document).on('input', '#editable-post-name', updatePreview);
+    }
+    $(init);
+});


### PR DESCRIPTION
## Summary
- add JavaScript to preview SEO snippet
- enqueue snippet preview script on post and taxonomy edit screens
- style preview box like a Google result

## Testing
- `npm test`
- `phpunit` *(fails: WordPress test suite missing)*

------
https://chatgpt.com/codex/tasks/task_e_688a3127eec08327bbb1039427042de0