### PR TITLE
Add analytics tab with search console metrics

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -462,6 +462,7 @@ class Gm2_SEO_Admin {
             'schema'      => esc_html__( 'Structured Data', 'gm2-wordpress-suite' ),
             'performance' => esc_html__( 'Performance', 'gm2-wordpress-suite' ),
             'keywords'    => esc_html__( 'Keyword Research', 'gm2-wordpress-suite' ),
+            'analytics'   => esc_html__( 'Analytics', 'gm2-wordpress-suite' ),
             'rules'       => esc_html__( 'Content Rules', 'gm2-wordpress-suite' ),
             'guidelines'  => esc_html__( 'SEO Guidelines', 'gm2-wordpress-suite' ),
             'context'     => esc_html__( 'Context', 'gm2-wordpress-suite' ),
@@ -711,6 +712,38 @@ class Gm2_SEO_Admin {
                 }
             } else {
                 echo '<p>' . esc_html__('Connect your Google account to fetch query and analytics data.', 'gm2-wordpress-suite') . '</p>';
+            }
+        } elseif ($active === 'analytics') {
+            $limit  = get_option('gm2_sc_query_limit', 10);
+            $days   = get_option('gm2_analytics_days', 30);
+            $oauth  = apply_filters('gm2_google_oauth_instance', new Gm2_Google_OAuth());
+
+            if ($oauth->is_connected()) {
+                $site    = home_url('/');
+                $prop    = get_option('gm2_ga_measurement_id', '');
+                $queries = $oauth->get_search_console_metrics($site, $limit);
+                $metrics = $oauth->get_analytics_metrics($prop, $days);
+
+                echo '<h3>' . esc_html__( 'Analytics Overview', 'gm2-wordpress-suite' ) . '</h3>';
+                if (!empty($metrics)) {
+                    echo '<p>Sessions: ' . esc_html($metrics['sessions']) . '</p>';
+                    echo '<p>Bounce Rate: ' . esc_html($metrics['bounce_rate']) . '</p>';
+                } else {
+                    echo '<p>' . esc_html__('No analytics data found.', 'gm2-wordpress-suite') . '</p>';
+                }
+
+                echo '<h3>' . esc_html__( 'Top Queries', 'gm2-wordpress-suite' ) . '</h3>';
+                if ($queries) {
+                    echo '<table class="widefat"><thead><tr><th>' . esc_html__( 'Query', 'gm2-wordpress-suite' ) . '</th><th>' . esc_html__( 'Clicks', 'gm2-wordpress-suite' ) . '</th><th>' . esc_html__( 'Impressions', 'gm2-wordpress-suite' ) . '</th></tr></thead><tbody>';
+                    foreach ($queries as $row) {
+                        echo '<tr><td>' . esc_html($row['query']) . '</td><td>' . esc_html($row['clicks']) . '</td><td>' . esc_html($row['impressions']) . '</td></tr>';
+                    }
+                    echo '</tbody></table>';
+                } else {
+                    echo '<p>' . esc_html__('No search console data found.', 'gm2-wordpress-suite') . '</p>';
+                }
+            } else {
+                echo '<p>' . esc_html__('Connect your Google account to view analytics.', 'gm2-wordpress-suite') . '</p>';
             }
         } elseif ($active === 'rules') {
             $all_rules = get_option('gm2_content_rules', []);

--- a/readme.txt
+++ b/readme.txt
@@ -289,7 +289,7 @@ Create 301 or 302 redirects from the **SEO → Redirects** tab. The plugin logs
 the last 100 missing URLs to help you create new redirects.
 
 == Planned Features ==
-* **Search Console metrics** – new **SEO → Analytics** tab will show clicks and
+* **Search Console metrics** – the **SEO → Analytics** tab shows clicks and
   impressions from connected sites.
 * **Expanded rules** – guideline rules for each content type editable under
   **SEO → SEO Guidelines**.

--- a/tests/test-analytics-tab.php
+++ b/tests/test-analytics-tab.php
@@ -1,0 +1,45 @@
+<?php
+use Gm2\Gm2_SEO_Admin;
+
+class AnalyticsTabTest extends WP_UnitTestCase {
+    public function tearDown(): void {
+        remove_all_filters('gm2_google_oauth_instance');
+        delete_option('gm2_sc_query_limit');
+        delete_option('gm2_analytics_days');
+        delete_option('gm2_ga_measurement_id');
+        parent::tearDown();
+    }
+
+    public function test_metrics_table_rendered() {
+        $_GET['tab'] = 'analytics';
+        update_option('gm2_google_refresh_token', 'tok');
+        update_option('gm2_ga_measurement_id', 'G-123');
+        update_option('gm2_sc_query_limit', 2);
+        update_option('gm2_analytics_days', 7);
+
+        add_filter('gm2_google_oauth_instance', function() {
+            return new class {
+                public function is_connected() { return true; }
+                public function get_search_console_metrics($site, $limit) {
+                    return [
+                        ['query' => 'alpha', 'clicks' => 5, 'impressions' => 10],
+                        ['query' => 'beta', 'clicks' => 3, 'impressions' => 8],
+                    ];
+                }
+                public function get_search_console_queries($site, $limit) { return ['alpha', 'beta']; }
+                public function get_analytics_metrics($prop, $days) { return ['sessions' => 10, 'bounce_rate' => 20]; }
+            };
+        });
+
+        $admin = new Gm2_SEO_Admin();
+        ob_start();
+        $admin->display_dashboard();
+        $out = ob_get_clean();
+
+        $this->assertStringContainsString('alpha', $out);
+        $this->assertStringContainsString('5', $out);
+        $this->assertStringContainsString('Sessions', $out);
+        $this->assertStringContainsString('10', $out);
+    }
+}
+?>


### PR DESCRIPTION
## Summary
- show an `Analytics` tab in SEO settings
- pull top queries with clicks and impressions
- display GA sessions and bounce rate
- document analytics tab in readme
- add unit test for analytics output

## Testing
- `make test DB_NAME=wp_test DB_USER=root DB_PASS=pass` *(fails: The PHPUnit Polyfills library is missing)*

------
https://chatgpt.com/codex/tasks/task_e_688a332fa7bc8327a773cc451ec7d8f9