### PR TITLE
Add bulk slug cleaning action

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -295,8 +295,8 @@ the last 100 missing URLs to help you create new redirects.
   **SEO → SEO Guidelines**.
 * **Duplicate checks** – upcoming report in **SEO → Tools** that flags posts
   with duplicate titles or descriptions.
-* **Slug cleanup** – bulk action in **SEO → General** to remove stopwords from
-  existing slugs.
+* **Slug cleanup** – bulk action in **SEO → General** or from the posts list to
+  remove stopwords from existing slugs.
 * **Canonical for variations** – meta box option to set a canonical URL on
   individual product variations.
 * **Image alt keyword checks** – SEO meta box warning when alt text is missing

--- a/tests/test-bulk-clean-slugs.php
+++ b/tests/test-bulk-clean-slugs.php
@@ -1,0 +1,23 @@
+<?php
+use Gm2\Gm2_SEO_Admin;
+
+class BulkCleanSlugsTest extends WP_UnitTestCase {
+    public function test_bulk_action_redirects_for_confirmation() {
+        $post = self::factory()->post->create();
+        $admin = new Gm2_SEO_Admin();
+        $url = $admin->redirect_clean_slug_bulk_action('edit.php', 'gm2_bulk_clean_slugs', [$post]);
+        $this->assertStringContainsString('gm2_clean_slugs_ids=' . $post, $url);
+    }
+
+    public function test_handle_bulk_clean_slugs_updates_posts() {
+        update_option('gm2_slug_stopwords', 'the');
+        $post = self::factory()->post->create(['post_name' => 'the-slug']);
+        $admin = new Gm2_SEO_Admin();
+        $_POST['ids'] = (string)$post;
+        $_POST['_wpnonce'] = wp_create_nonce('gm2_bulk_clean_slugs');
+        wp_set_current_user(self::factory()->user->create(['role' => 'administrator']));
+        $admin->handle_bulk_clean_slugs();
+        $post_obj = get_post($post);
+        $this->assertSame('slug', $post_obj->post_name);
+    }
+}


### PR DESCRIPTION
## Summary
- add `gm2_bulk_clean_slugs` bulk action for posts
- implement confirmation step and success notice
- update documentation about slug cleanup
- add tests for the new bulk action

## Testing
- `npm test`
- `phpunit` *(fails: mysqladmin command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a370caacc832789d594b644b45766