### PR TITLE
Add taxonomy description length option

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -370,6 +370,9 @@ class Gm2_SEO_Admin {
         register_setting('gm2_seo_options', 'gm2_tax_desc_prompt', [
             'sanitize_callback' => 'sanitize_textarea_field',
         ]);
+        register_setting('gm2_seo_options', 'gm2_tax_min_length', [
+            'sanitize_callback' => 'absint',
+        ]);
         register_setting('gm2_seo_options', 'gm2_bulk_ai_page_size', [
             'sanitize_callback' => 'absint',
         ]);
@@ -554,6 +557,7 @@ class Gm2_SEO_Admin {
             'analytics'   => esc_html__( 'Analytics', 'gm2-wordpress-suite' ),
             'rules'       => esc_html__( 'Content Rules', 'gm2-wordpress-suite' ),
             'guidelines'  => esc_html__( 'SEO Guidelines', 'gm2-wordpress-suite' ),
+            'taxonomies'  => esc_html__( 'Taxonomies', 'gm2-wordpress-suite' ),
             'context'     => esc_html__( 'Context', 'gm2-wordpress-suite' ),
         ];
 
@@ -891,6 +895,15 @@ class Gm2_SEO_Admin {
             echo '<tr><th scope="row">' . esc_html__( 'Minimum External Links', 'gm2-wordpress-suite' ) . '</th><td><input type="number" name="gm2_min_external_links" value="' . esc_attr($min_ext) . '" class="small-text" /></td></tr>';
             echo '</tbody></table>';
             submit_button( esc_html__( 'Save Rules', 'gm2-wordpress-suite' ) );
+            echo '</form>';
+        } elseif ($active === 'taxonomies') {
+            echo '<form method="post" action="options.php">';
+            settings_fields('gm2_seo_options');
+            $min = (int) get_option('gm2_tax_min_length', 150);
+            echo '<table class="form-table"><tbody>';
+            echo '<tr><th scope="row"><label for="gm2_tax_min_length">' . esc_html__( 'Minimum Description Length', 'gm2-wordpress-suite' ) . '</label></th><td><input type="number" id="gm2_tax_min_length" name="gm2_tax_min_length" value="' . esc_attr($min) . '" class="small-text" /></td></tr>';
+            echo '</tbody></table>';
+            submit_button( esc_html__( 'Save Settings', 'gm2-wordpress-suite' ) );
             echo '</form>';
         } elseif ($active === 'context') {
             echo '<form method="post" action="options.php">';
@@ -1794,6 +1807,14 @@ class Gm2_SEO_Admin {
         $max_image_preview = isset($_POST['gm2_max_image_preview']) ? sanitize_text_field($_POST['gm2_max_image_preview']) : '';
         $max_video_preview = isset($_POST['gm2_max_video_preview']) ? sanitize_text_field($_POST['gm2_max_video_preview']) : '';
         $og_image         = isset($_POST['gm2_og_image']) ? absint($_POST['gm2_og_image']) : 0;
+
+        $min_len = (int) get_option('gm2_tax_min_length', 0);
+        if ($min_len > 0 && isset($_POST['description'])) {
+            $word_count = str_word_count( wp_strip_all_tags( wp_unslash( $_POST['description'] ) ) );
+            if ($word_count < $min_len) {
+                self::add_notice( sprintf( __( 'Description has %d words; minimum is %d.', 'gm2-wordpress-suite' ), $word_count, $min_len ) );
+            }
+        }
         update_term_meta($term_id, '_gm2_title', $title);
         update_term_meta($term_id, '_gm2_description', $description);
         update_term_meta($term_id, '_gm2_noindex', $noindex);

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -227,6 +227,7 @@ function gm2_initialize_content_rules() {
     add_option('gm2_content_rules', $rules);
     add_option('gm2_min_internal_links', 1);
     add_option('gm2_min_external_links', 1);
+    add_option('gm2_tax_min_length', 150);
 }
 
 function gm2_initialize_guideline_rules() {

--- a/tests/test-tax-min-length.php
+++ b/tests/test-tax-min-length.php
@@ -1,0 +1,26 @@
+<?php
+use Gm2\Gm2_SEO_Admin;
+
+class TaxonomyMinLengthTest extends WP_UnitTestCase {
+    public function test_notice_when_description_short() {
+        update_option('gm2_tax_min_length', 5);
+        $term_id = self::factory()->term->create(['taxonomy' => 'category']);
+        wp_set_current_user(self::factory()->user->create(['role' => 'administrator']));
+        $admin = new Gm2_SEO_Admin();
+        $_POST['gm2_seo_nonce'] = wp_create_nonce('gm2_save_seo_meta');
+        $_POST['description'] = 'one two';
+        $admin->save_taxonomy_meta($term_id);
+        $prop = new ReflectionProperty(Gm2_SEO_Admin::class, 'notices');
+        $prop->setAccessible(true);
+        $notices = $prop->getValue();
+        $found = false;
+        foreach ($notices as $n) {
+            if (strpos($n['message'], '5') !== false) {
+                $found = true;
+                break;
+            }
+        }
+        $this->assertTrue($found);
+    }
+}
+

--- a/uninstall.php
+++ b/uninstall.php
@@ -84,6 +84,7 @@ $option_names = array(
     'gm2_bulk_ai_term',
     'gm2_bulk_ai_missing_title',
     'gm2_bulk_ai_missing_description',
+    'gm2_tax_min_length',
     'gm2_clean_slugs',
     'gm2_slug_stopwords',
     'gm2_tax_desc_prompt',


### PR DESCRIPTION
## Summary
- add `gm2_tax_min_length` default setting
- clean up on uninstall
- register and display new option on the Taxonomies tab
- warn when taxonomy description is shorter than required
- test taxonomy description minimum length

## Testing
- `make test DB_NAME=wp_test DB_USER=root DB_PASS=pass` *(fails: mysqladmin not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a3db291688327b0c1d255e5f02c42