### PR TITLE
Add bulk AI for taxonomy terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ The plugin stores the generated XML sitemap at `sitemap.xml` in the WordPress
 root directory. You can change this location by setting the `gm2_sitemap_path`
 option on the **SEO → Sitemap** settings page.
 
+## Bulk AI for Taxonomies
+
+The **Bulk AI Taxonomies** page under **Gm2 → Bulk AI Taxonomies** lists terms
+from supported taxonomies like categories and WooCommerce product categories.
+Select multiple terms to generate AI SEO titles and descriptions in bulk then
+apply the suggestions with one click.
+
 ## Abandoned Carts Module
 
 Enable this feature from **Gm2 → Dashboard** to create two database tables used

--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -56,6 +56,7 @@ class Gm2_Admin {
         $seo_pages = [
             'gm2_page_gm2-seo',
             'gm2_page_gm2-bulk-ai-review',
+            'gm2_page_gm2-bulk-ai-taxonomies',
         ];
 
         if ($hook === 'gm2_page_gm2-chatgpt') {
@@ -213,6 +214,27 @@ class Gm2_Admin {
                             'selectAll'    => __( 'Select all', 'gm2-wordpress-suite' ),
                             'cancel'       => __( 'Cancel', 'gm2-wordpress-suite' ),
                             'undo'         => __( 'Undo', 'gm2-wordpress-suite' ),
+                        ],
+                    ]
+                );
+            } elseif ($hook === 'gm2_page_gm2-bulk-ai-taxonomies') {
+                wp_enqueue_script(
+                    'gm2-bulk-ai-tax',
+                    GM2_PLUGIN_URL . 'admin/js/gm2-bulk-ai-tax.js',
+                    ['jquery'],
+                    filemtime(GM2_PLUGIN_DIR . 'admin/js/gm2-bulk-ai-tax.js'),
+                    true
+                );
+                wp_localize_script(
+                    'gm2-bulk-ai-tax',
+                    'gm2BulkAiTax',
+                    [
+                        'nonce'       => wp_create_nonce('gm2_ai_research'),
+                        'apply_nonce' => wp_create_nonce('gm2_bulk_ai_apply'),
+                        'ajax_url'    => admin_url('admin-ajax.php'),
+                        'i18n'        => [
+                            'apply'   => __( 'Apply', 'gm2-wordpress-suite' ),
+                            'error'   => __( 'Error', 'gm2-wordpress-suite' ),
                         ],
                     ]
                 );
@@ -720,6 +742,7 @@ class Gm2_Admin {
         $seo_pages = [
             'gm2_page_gm2-seo',
             'gm2_page_gm2-bulk-ai-review',
+            'gm2_page_gm2-bulk-ai-taxonomies',
         ];
         if ($screen && in_array($screen->id, $seo_pages, true)) {
             $url = admin_url('admin.php?page=gm2-chatgpt');

--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -44,6 +44,8 @@ class Gm2_SEO_Admin {
         add_action('wp_ajax_gm2_bulk_ai_apply', [$this, 'ajax_bulk_ai_apply']);
         add_action('wp_ajax_gm2_bulk_ai_apply_batch', [$this, 'ajax_bulk_ai_apply_batch']);
         add_action('wp_ajax_gm2_bulk_ai_undo', [$this, 'ajax_bulk_ai_undo']);
+        add_action('wp_ajax_gm2_bulk_ai_tax_apply', [$this, 'ajax_bulk_ai_tax_apply']);
+        add_action('wp_ajax_gm2_bulk_ai_tax_apply_batch', [$this, 'ajax_bulk_ai_tax_apply_batch']);
 
         add_action('add_attachment', [$this, 'auto_fill_alt_on_upload']);
         add_action('admin_notices', [$this, 'admin_notices']);
@@ -321,6 +323,15 @@ class Gm2_SEO_Admin {
             'edit_posts',
             'gm2-bulk-ai-review',
             [$this, 'display_bulk_ai_page']
+        );
+
+        add_submenu_page(
+            'gm2',
+            esc_html__( 'Bulk AI Taxonomies', 'gm2-wordpress-suite' ),
+            esc_html__( 'Bulk AI Taxonomies', 'gm2-wordpress-suite' ),
+            'edit_terms',
+            'gm2-bulk-ai-taxonomies',
+            [$this, 'display_bulk_ai_tax_page']
         );
     }
 
@@ -1310,6 +1321,79 @@ class Gm2_SEO_Admin {
         }
 
         return $html;
+    }
+
+    public function display_bulk_ai_tax_page() {
+        if (!current_user_can('edit_terms')) {
+            esc_html_e( 'Permission denied', 'gm2-wordpress-suite' );
+            return;
+        }
+
+        $user_id  = get_current_user_id();
+        $taxonomy = get_user_meta($user_id, 'gm2_bulk_ai_tax_taxonomy', true) ?: 'all';
+        $search   = get_option('gm2_bulk_ai_tax_search', '');
+
+        if (isset($_POST['gm2_bulk_ai_tax_save']) && check_admin_referer('gm2_bulk_ai_tax_settings')) {
+            $taxonomy = sanitize_key($_POST['gm2_taxonomy'] ?? 'all');
+            $search   = sanitize_text_field($_POST['gm2_tax_search'] ?? '');
+            update_user_meta($user_id, 'gm2_bulk_ai_tax_taxonomy', $taxonomy);
+            update_option('gm2_bulk_ai_tax_search', $search);
+        }
+
+        $tax_list = $this->get_supported_taxonomies();
+        $args = [
+            'taxonomy'   => ($taxonomy === 'all') ? $tax_list : $taxonomy,
+            'hide_empty' => false,
+            'search'     => $search,
+            'number'     => 50,
+        ];
+        $terms = get_terms($args);
+
+        echo '<div class="wrap" id="gm2-bulk-ai-tax">';
+        echo '<h1>' . esc_html__( 'Bulk AI Taxonomies', 'gm2-wordpress-suite' ) . '</h1>';
+        echo '<form method="post" action="' . esc_url( admin_url('admin.php?page=gm2-bulk-ai-taxonomies') ) . '">';
+        wp_nonce_field('gm2_bulk_ai_tax_settings');
+        echo '<p><label>' . esc_html__( 'Taxonomy', 'gm2-wordpress-suite' ) . ' <select name="gm2_taxonomy">';
+        echo '<option value="all"' . selected($taxonomy, 'all', false) . '>' . esc_html__( 'All', 'gm2-wordpress-suite' ) . '</option>';
+        foreach ($tax_list as $tax) {
+            $obj = get_taxonomy($tax);
+            $name = $obj ? $obj->labels->singular_name : $tax;
+            echo '<option value="' . esc_attr($tax) . '"' . selected($taxonomy, $tax, false) . '>' . esc_html($name) . '</option>';
+        }
+        echo '</select></label> ';
+        echo '<label>' . esc_html__( 'Search', 'gm2-wordpress-suite' ) . ' <input type="text" name="gm2_tax_search" value="' . esc_attr($search) . '"></label> ';
+        submit_button( esc_html__( 'Save', 'gm2-wordpress-suite' ), 'secondary', 'gm2_bulk_ai_tax_save', false );
+        echo '</p></form>';
+
+        echo '<table class="widefat" id="gm2-bulk-term-list"><thead><tr><th class="check-column"><input type="checkbox" id="gm2-bulk-term-select-all"></th><th>' . esc_html__( 'Name', 'gm2-wordpress-suite' ) . '</th><th>' . esc_html__( 'SEO Title', 'gm2-wordpress-suite' ) . '</th><th>' . esc_html__( 'Description', 'gm2-wordpress-suite' ) . '</th><th>' . esc_html__( 'AI Suggestions', 'gm2-wordpress-suite' ) . '</th></tr></thead><tbody>';
+        foreach ($terms as $term) {
+            $seo_title   = get_term_meta($term->term_id, '_gm2_title', true);
+            $description = get_term_meta($term->term_id, '_gm2_description', true);
+            $stored      = get_term_meta($term->term_id, '_gm2_ai_research', true);
+            $result_html = '';
+            if ($stored) {
+                $data = json_decode($stored, true);
+                if (json_last_error() === JSON_ERROR_NONE && is_array($data)) {
+                    $result_html = $this->render_bulk_ai_result($data, $term->term_id);
+                }
+            }
+            $key = $term->taxonomy . ':' . $term->term_id;
+            echo '<tr id="gm2-term-' . esc_attr($term->taxonomy) . '-' . intval($term->term_id) . '" data-key="' . esc_attr($key) . '">';
+            $edit_link = get_edit_term_link($term->term_id, $term->taxonomy);
+            $name      = $edit_link ? '<a href="' . esc_url($edit_link) . '" target="_blank">' . esc_html($term->name) . '</a>' : esc_html($term->name);
+            echo '<th scope="row" class="check-column"><input type="checkbox" class="gm2-select" value="' . esc_attr($key) . '"></th>';
+            echo '<td>' . $name . '</td>';
+            echo '<td>' . esc_html($seo_title) . '</td>';
+            echo '<td>' . esc_html($description) . '</td>';
+            echo '<td class="gm2-result">' . $result_html . '</td>';
+            echo '</tr>';
+        }
+        echo '</tbody></table>';
+        echo '<p><button type="button" class="button" id="gm2-bulk-term-analyze">' . esc_html__( 'Analyze Selected', 'gm2-wordpress-suite' ) . '</button> ';
+        echo '<button type="button" class="button" id="gm2-bulk-term-cancel">' . esc_html__( 'Cancel', 'gm2-wordpress-suite' ) . '</button> ';
+        echo '<button type="button" class="button" id="gm2-bulk-term-apply-all">' . esc_html__( 'Apply All', 'gm2-wordpress-suite' ) . '</button></p>';
+        echo '<p><progress id="gm2-bulk-term-progress-bar" value="0" max="100" style="width:100%;display:none" role="progressbar" aria-live="polite"></progress></p>';
+        echo '</div>';
     }
 
     public function handle_bulk_ai_export() {
@@ -3977,6 +4061,53 @@ class Gm2_SEO_Admin {
         }
 
         wp_send_json_error( __( 'invalid parameters', 'gm2-wordpress-suite' ) );
+    }
+
+    public function ajax_bulk_ai_tax_apply() {
+        check_ajax_referer('gm2_bulk_ai_apply');
+
+        $term_id  = isset($_POST['term_id']) ? absint($_POST['term_id']) : 0;
+        $taxonomy = isset($_POST['taxonomy']) ? sanitize_key($_POST['taxonomy']) : '';
+        if (!$term_id || !$taxonomy || !current_user_can('edit_term', $term_id)) {
+            wp_send_json_error( __( 'permission denied', 'gm2-wordpress-suite' ), 403 );
+        }
+
+        if (isset($_POST['seo_title'])) {
+            update_term_meta($term_id, '_gm2_title', sanitize_text_field(wp_unslash($_POST['seo_title'])));
+        }
+        if (isset($_POST['seo_description'])) {
+            update_term_meta($term_id, '_gm2_description', sanitize_textarea_field(wp_unslash($_POST['seo_description'])));
+        }
+
+        wp_send_json_success();
+    }
+
+    public function ajax_bulk_ai_tax_apply_batch() {
+        check_ajax_referer('gm2_bulk_ai_apply');
+
+        $terms = isset($_POST['terms']) ? json_decode(wp_unslash($_POST['terms']), true) : null;
+        if (!is_array($terms)) {
+            wp_send_json_error( __( 'invalid data', 'gm2-wordpress-suite' ) );
+        }
+
+        foreach ($terms as $key => $fields) {
+            if (strpos($key, ':') === false) {
+                continue;
+            }
+            list($taxonomy, $id) = explode(':', $key);
+            $term_id = absint($id);
+            if (!$term_id || !taxonomy_exists($taxonomy) || !current_user_can('edit_term', $term_id)) {
+                continue;
+            }
+            if (isset($fields['seo_title'])) {
+                update_term_meta($term_id, '_gm2_title', sanitize_text_field($fields['seo_title']));
+            }
+            if (isset($fields['seo_description'])) {
+                update_term_meta($term_id, '_gm2_description', sanitize_textarea_field($fields['seo_description']));
+            }
+        }
+
+        wp_send_json_success();
     }
 
     public function enqueue_editor_scripts($hook = null) {

--- a/admin/js/gm2-bulk-ai-tax.js
+++ b/admin/js/gm2-bulk-ai-tax.js
@@ -1,0 +1,84 @@
+jQuery(function($){
+    var stop=false;
+    $('#gm2-bulk-term-select-all').on('click',function(){
+        var c=$(this).prop('checked');
+        $('#gm2-bulk-term-list .gm2-select').prop('checked',c);
+    });
+    $('#gm2-bulk-ai-tax').on('click','#gm2-bulk-term-analyze',function(e){
+        e.preventDefault();
+        stop=false;
+        var ids=[];
+        $('#gm2-bulk-term-list .gm2-select:checked').each(function(){ids.push($(this).val());});
+        if(!ids.length) return;
+        $('#gm2-bulk-term-progress-bar').attr('max',ids.length).val(0).show();
+        function next(){
+            if(stop||!ids.length){$('#gm2-bulk-term-progress-bar').hide();return;}
+            var key=ids.shift();
+            var parts=key.split(':');
+            var tax=parts[0], id=parts[1];
+            var row=$('#gm2-term-'+tax+'-'+id);
+            var cell=row.find('.gm2-result').empty();
+            $('<span>',{class:'spinner is-active gm2-ai-spinner'}).appendTo(cell);
+            $.ajax({
+                url: gm2BulkAiTax.ajax_url,
+                method:'POST',
+                data:{action:'gm2_ai_research',term_id:id,taxonomy:tax,_ajax_nonce:gm2BulkAiTax.nonce},
+                dataType:'json'
+            }).done(function(resp){
+                cell.find('.gm2-ai-spinner').remove();
+                if(resp&&resp.success&&resp.data){
+                    var html='';
+                    if(resp.data.seo_title){html+='<p><label><input type="checkbox" class="gm2-apply" data-field="seo_title" data-value="'+resp.data.seo_title.replace(/"/g,'&quot;')+'"> '+resp.data.seo_title+'</label></p>';}
+                    if(resp.data.description){html+='<p><label><input type="checkbox" class="gm2-apply" data-field="seo_description" data-value="'+resp.data.description.replace(/"/g,'&quot;')+'"> '+resp.data.description+'</label></p>';}
+                    html+='<p><button class="button gm2-apply-btn" data-key="'+key+'">'+gm2BulkAiTax.i18n.apply+'</button></p>';
+                    cell.html(html);
+                }else{cell.text(gm2BulkAiTax.i18n.error);}
+            }).fail(function(){
+                cell.find('.gm2-ai-spinner').remove();
+                cell.text(gm2BulkAiTax.i18n.error);
+            }).always(function(){
+                var done = parseInt($('#gm2-bulk-term-progress-bar').val(),10)+1;
+                $('#gm2-bulk-term-progress-bar').val(done);
+                next();
+            });
+        }
+        next();
+    });
+    $('#gm2-bulk-ai-tax').on('click','#gm2-bulk-term-cancel',function(e){
+        e.preventDefault();stop=true;$('#gm2-bulk-term-progress-bar').hide();
+    });
+    $('#gm2-bulk-term-list').on('click','.gm2-apply-btn',function(e){
+        e.preventDefault();
+        var key=$(this).data('key');
+        var parts=key.split(':');
+        var data={action:'gm2_bulk_ai_tax_apply',term_id:parts[1],taxonomy:parts[0],_ajax_nonce:gm2BulkAiTax.apply_nonce};
+        $(this).closest('.gm2-result').find('.gm2-apply:checked').each(function(){
+            data[$(this).data('field')]=$(this).data('value');
+        });
+        var cell=$(this).closest('.gm2-result');
+        $('<span>',{class:'spinner is-active gm2-ai-spinner'}).appendTo(cell);
+        $.post(gm2BulkAiTax.ajax_url,data).done(function(){
+            cell.find('.gm2-ai-spinner').remove();
+        }).fail(function(){
+            cell.find('.gm2-ai-spinner').remove();
+            cell.text(gm2BulkAiTax.i18n.error);
+        });
+    });
+    $('#gm2-bulk-ai-tax').on('click','#gm2-bulk-term-apply-all',function(e){
+        e.preventDefault();
+        var items={};
+        $('#gm2-bulk-term-list tr').each(function(){
+            var k=$(this).data('key');if(!k) return;
+            var fields={};
+            $(this).find('.gm2-apply:checked').each(function(){fields[$(this).data('field')]=$(this).data('value');});
+            if(Object.keys(fields).length){items[k]=fields;}
+        });
+        if($.isEmptyObject(items)) return;
+        $.ajax({
+            url: gm2BulkAiTax.ajax_url,
+            method:'POST',
+            data:{action:'gm2_bulk_ai_tax_apply_batch',terms:JSON.stringify(items),_ajax_nonce:gm2BulkAiTax.apply_nonce},
+            dataType:'json'
+        }).fail(function(){alert(gm2BulkAiTax.i18n.error);});
+    });
+});

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ Existing prompt logic automatically includes these options via `gm2_get_seo_cont
 - The price section now uses flexbox by default and includes responsive **Horizontal** and **Vertical** alignment controls to adjust `justify-content` and `align-items`.
 - New **Wrap Options** control lets you enable flex wrapping so quantity buttons can stack on tablets and mobile.
 - Bulk AI research requests now use JSON-formatted AJAX calls for more robust error handling.
+- Bulk AI now supports categories and product categories on the **Bulk AI Taxonomies** page.
 
 ## Bulk AI
 


### PR DESCRIPTION
## Summary
- add Bulk AI Taxonomies admin page and menu item
- implement AJAX endpoints for applying AI term suggestions
- include new JS handler `gm2-bulk-ai-tax.js`
- document Bulk AI taxonomy support

## Testing
- `npm test`
- `phpunit` *(fails: WordPress test suite missing)*

------
https://chatgpt.com/codex/tasks/task_e_688a48ec0be48327a3a55c2bd890f187