### PR TITLE
Add SEO snippet field char counters

### DIFF
--- a/admin/css/gm2-seo.css
+++ b/admin/css/gm2-seo.css
@@ -69,3 +69,10 @@
     color:#545454;
     font-size:13px;
 }
+
+.gm2-char-count {
+    display:inline-block;
+    font-size:12px;
+    color:#666;
+    margin-left:4px;
+}

--- a/admin/js/gm2-snippet-preview.js
+++ b/admin/js/gm2-snippet-preview.js
@@ -10,12 +10,24 @@ jQuery(function($){
         $('#gm2-snippet-preview .gm2-snippet-title').text(title);
         $('#gm2-snippet-preview .gm2-snippet-url').text(url);
         $('#gm2-snippet-preview .gm2-snippet-description').text(desc);
+
+        $('.gm2-title-count').text(title.length + '/60');
+        $('.gm2-desc-count').text(desc.length + '/160');
     }
     function init(){
-        var $desc = $('#gm2_seo_description');
+        var $title = $('#gm2_seo_title');
+        var $desc  = $('#gm2_seo_description');
         if(!$desc.length || $('#gm2-snippet-preview').length){
             return;
         }
+
+        if(!$title.next('.gm2-char-count').length){
+            $('<span class="gm2-char-count gm2-title-count"></span>').insertAfter($title);
+        }
+        if(!$desc.next('.gm2-char-count').length){
+            $('<span class="gm2-char-count gm2-desc-count"></span>').insertAfter($desc);
+        }
+
         var box = $('<div id="gm2-snippet-preview" class="gm2-snippet-preview">'+
             '<div class="gm2-snippet-title"></div>'+
             '<div class="gm2-snippet-url"></div>'+


### PR DESCRIPTION
## Summary
- show character counts for the SEO title and description
- style new counters in gm2-seo.css

## Testing
- `npm test`
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688cd517e7c88327abffaaa941fd4d22