### PR TITLE
Add Site Health diagnostics

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -8,6 +8,7 @@ if (!defined('ABSPATH')) {
 
 class Gm2_Admin {
     private $diagnostics;
+    private $site_health;
     private $quantity_discounts;
     private $oauth_enabled;
     private $chatgpt_enabled;
@@ -15,6 +16,8 @@ class Gm2_Admin {
     public function run() {
         $this->diagnostics = new Gm2_Diagnostics();
         $this->diagnostics->run();
+        $this->site_health = new Gm2_Site_Health();
+        $this->site_health->run();
         $this->oauth_enabled   = get_option('gm2_enable_google_oauth', '1') === '1';
         $this->chatgpt_enabled = get_option('gm2_enable_chatgpt', '1') === '1';
         add_action('admin_menu', [$this, 'add_admin_menu'], 9);

--- a/admin/Gm2_Diagnostics.php
+++ b/admin/Gm2_Diagnostics.php
@@ -86,4 +86,16 @@ class Gm2_Diagnostics {
         echo esc_html__('Please resolve these issues to ensure all SEO features work as expected.', 'gm2-wordpress-suite');
         echo '</p></div>';
     }
+
+    public function get_conflicts() {
+        return $this->conflicts;
+    }
+
+    public function get_integrity_errors() {
+        return $this->integrity_errors;
+    }
+
+    public function get_hook_issues() {
+        return $this->hook_issues;
+    }
 }

--- a/admin/Gm2_Site_Health.php
+++ b/admin/Gm2_Site_Health.php
@@ -1,0 +1,71 @@
+<?php
+namespace Gm2;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Gm2_Site_Health {
+    public function run() {
+        add_filter('site_status_tests', [ $this, 'register_tests' ]);
+    }
+
+    public function register_tests($tests) {
+        $tests['direct']['gm2_suite_diagnostics'] = [
+            'label' => __('Gm2 Suite Diagnostics', 'gm2-wordpress-suite'),
+            'test'  => [ $this, 'perform_test' ],
+        ];
+        return $tests;
+    }
+
+    public function perform_test() {
+        $diag = new Gm2_Diagnostics();
+        $diag->diagnose();
+        $conflicts = $diag->get_conflicts();
+        $files     = $diag->get_integrity_errors();
+        $hooks     = $diag->get_hook_issues();
+
+        $issues = [];
+        if (!empty($conflicts)) {
+            $issues[] = sprintf(
+                esc_html__('Conflicting SEO plugins: %s.', 'gm2-wordpress-suite'),
+                esc_html(implode(', ', $conflicts))
+            );
+        }
+        if (!empty($files)) {
+            $issues[] = sprintf(
+                esc_html__('Missing plugin files: %s.', 'gm2-wordpress-suite'),
+                esc_html(implode(', ', $files))
+            );
+        }
+        if (!empty($hooks)) {
+            $issues[] = sprintf(
+                esc_html__('Theme hooks removed: %s.', 'gm2-wordpress-suite'),
+                esc_html(implode(', ', $hooks))
+            );
+        }
+
+        if (empty($issues)) {
+            return [
+                'label'       => __('Gm2 Suite Diagnostics', 'gm2-wordpress-suite'),
+                'status'      => 'good',
+                'badge'       => [ 'label' => __('Performance', 'gm2-wordpress-suite'), 'color' => 'blue' ],
+                'description' => '<p>' . esc_html__('No issues detected with Gm2 SEO output.', 'gm2-wordpress-suite') . '</p>',
+                'actions'     => '',
+                'test'        => 'gm2_suite_diagnostics',
+            ];
+        }
+
+        $description = '<p>' . implode('<br />', $issues) . '</p>';
+        $actions     = '<p>' . esc_html__('Please resolve these issues to ensure all SEO features work as expected.', 'gm2-wordpress-suite') . '</p>';
+
+        return [
+            'label'       => __('Gm2 Suite Diagnostics', 'gm2-wordpress-suite'),
+            'status'      => 'recommended',
+            'badge'       => [ 'label' => __('Performance', 'gm2-wordpress-suite'), 'color' => 'orange' ],
+            'description' => $description,
+            'actions'     => $actions,
+            'test'        => 'gm2_suite_diagnostics',
+        ];
+    }
+}

--- a/readme.txt
+++ b/readme.txt
@@ -100,6 +100,9 @@ The AI features depend on the DOM/LibXML extension. Verify it is installed by ru
 == Diagnostics ==
 As a first step, open **Gm2 → Diagnostics** to detect plugin conflicts, missing files or theme customizations that may disable SEO output. Any detected issues are listed as an admin notice with steps to resolve them. Diagnostics run only when the SEO module is enabled on the **Gm2 Suite** page.
 
+== Site Health ==
+Open **Tools → Site Health** to run these diagnostics automatically. The Gm2 Suite section lists any conflicts, missing plugin files or removed theme hooks with recommended steps to resolve them.
+
 == Breadcrumbs ==
 Display a breadcrumb trail anywhere using the `[gm2_breadcrumbs]` shortcode. The output
 is an ordered list wrapped in a `<nav>` element with accompanying JSON-LD for search engines.


### PR DESCRIPTION
## Summary
- register Site Health tests to surface SEO issues under Tools → Site Health
- expose diagnostic results from `Gm2_Diagnostics`
- document the new Site Health integration

## Testing
- `npm test`
- `phpunit` *(fails: WordPress test suite missing)*

------
https://chatgpt.com/codex/tasks/task_e_688ce4cc09a0832793056a7580b65b2a