### PR TITLE
Add WP-CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,22 @@ sitemap file. When a file reaches this number the plugin creates additional
 files like `sitemap-1.xml` and `sitemap-2.xml` and updates the index at
 `sitemap.xml`.
 
+## WP-CLI Commands
+
+The suite exposes a `gm2` command group when run under WP-CLI.
+
+Generate the sitemap:
+
+```bash
+wp gm2 sitemap generate
+```
+
+Clear cached AI data and ChatGPT logs:
+
+```bash
+wp gm2 ai clear
+```
+
 ## Bulk AI for Taxonomies
 
 The **Bulk AI Taxonomies** page under **Gm2 → Bulk AI Taxonomies** lists terms

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -461,3 +461,7 @@ function gm2_guideline_rules_migration_notice() {
 }
 add_action('admin_notices', 'gm2_guideline_rules_migration_notice');
 
+if (defined('WP_CLI') && WP_CLI) {
+    require_once GM2_PLUGIN_DIR . 'includes/cli/class-gm2-cli.php';
+}
+

--- a/includes/Gm2_SEO_Utils.php
+++ b/includes/Gm2_SEO_Utils.php
@@ -192,4 +192,35 @@ namespace {
         }
         return array_values(array_unique($list));
     }
+
+    function gm2_ai_clear() {
+        $post_ids = get_posts([
+            'post_type'      => get_post_types(['public' => true], 'names'),
+            'post_status'    => 'any',
+            'meta_key'       => '_gm2_ai_research',
+            'posts_per_page' => -1,
+            'fields'         => 'ids',
+        ]);
+        foreach ($post_ids as $pid) {
+            delete_post_meta($pid, '_gm2_ai_research');
+        }
+
+        $terms = get_terms([
+            'taxonomy'   => get_taxonomies([], 'names'),
+            'hide_empty' => false,
+            'meta_query' => [ [ 'key' => '_gm2_ai_research' ] ],
+            'fields'     => 'ids',
+        ]);
+        if (!is_wp_error($terms)) {
+            foreach ($terms as $tid) {
+                delete_term_meta($tid, '_gm2_ai_research');
+            }
+        }
+
+        if (defined('GM2_CHATGPT_LOG_FILE') && file_exists(GM2_CHATGPT_LOG_FILE)) {
+            file_put_contents(GM2_CHATGPT_LOG_FILE, '');
+        }
+
+        return true;
+    }
 }

--- a/includes/cli/class-gm2-cli.php
+++ b/includes/cli/class-gm2-cli.php
@@ -1,0 +1,53 @@
+<?php
+namespace Gm2;
+
+if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+    return;
+}
+
+class Gm2_CLI extends \WP_CLI_Command {
+    /**
+     * Manage the plugin sitemap.
+     *
+     * ## SUBCOMMANDS
+     *
+     * generate  Generate the XML sitemap
+     */
+    public function sitemap( $args, $assoc_args ) {
+        $sub = $args[0] ?? '';
+        if ( $sub !== 'generate' ) {
+            \WP_CLI::error( 'Usage: wp gm2 sitemap generate' );
+        }
+
+        $result = \gm2_generate_sitemap();
+        if ( is_wp_error( $result ) ) {
+            \WP_CLI::error( $result->get_error_message() );
+        }
+        \WP_CLI::success( 'Sitemap generated.' );
+    }
+
+    /**
+     * Clear stored AI data and logs.
+     *
+     * ## SUBCOMMANDS
+     *
+     * clear  Remove cached AI research and logs
+     */
+    public function ai( $args, $assoc_args ) {
+        $sub = $args[0] ?? '';
+        if ( $sub !== 'clear' ) {
+            \WP_CLI::error( 'Usage: wp gm2 ai clear' );
+        }
+
+        if ( ! function_exists( '\gm2_ai_clear' ) ) {
+            \WP_CLI::error( 'gm2_ai_clear() function not found.' );
+        }
+        $result = \gm2_ai_clear();
+        if ( is_wp_error( $result ) ) {
+            \WP_CLI::error( $result->get_error_message() );
+        }
+        \WP_CLI::success( 'AI data cleared.' );
+    }
+}
+
+\WP_CLI::add_command( 'gm2', __NAMESPACE__ . '\\Gm2_CLI' );


### PR DESCRIPTION
## Summary
- add WP-CLI command class
- register command loader in plugin main file
- support clearing AI data via `gm2_ai_clear`
- document new commands in README

## Testing
- `npm test`
- `phpunit` *(fails: WordPress test suite missing)*

------
https://chatgpt.com/codex/tasks/task_e_688ce73e7f3c83278a17fa49bf49d8f3