### PR TITLE
Add WP-Cron AI research batch processing

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -214,6 +214,7 @@ class Gm2_Admin {
                     [
                         'nonce'       => wp_create_nonce('gm2_ai_research'),
                         'apply_nonce' => wp_create_nonce('gm2_bulk_ai_apply'),
+                        'batch_nonce' => wp_create_nonce('gm2_ai_batch'),
                         'ajax_url'    => admin_url('admin-ajax.php'),
                         'i18n'        => [
                             'processing'   => __( 'Processing %1$s / %2$s', 'gm2-wordpress-suite' ),

--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -9,6 +9,8 @@ if (!defined('ABSPATH')) {
 class Gm2_SEO_Admin {
     private $elementor_initialized = false;
     private static $notices = [];
+    const AI_CRON_HOOK = 'gm2_ai_batch_process';
+    const AI_QUEUE_OPTION = 'gm2_ai_batch_queue';
 
     private function debug_log($message) {
         if (defined('WP_DEBUG') && WP_DEBUG) {
@@ -51,6 +53,9 @@ class Gm2_SEO_Admin {
         add_action('wp_ajax_gm2_bulk_ai_undo', [$this, 'ajax_bulk_ai_undo']);
         add_action('wp_ajax_gm2_bulk_ai_tax_apply', [$this, 'ajax_bulk_ai_tax_apply']);
         add_action('wp_ajax_gm2_bulk_ai_tax_apply_batch', [$this, 'ajax_bulk_ai_tax_apply_batch']);
+        add_action('wp_ajax_gm2_ai_batch_schedule', [$this, 'ajax_ai_batch_schedule']);
+        add_action('wp_ajax_gm2_ai_batch_cancel', [$this, 'ajax_ai_batch_cancel']);
+        add_action(self::AI_CRON_HOOK, [$this, 'cron_process_ai_queue']);
 
         add_action('add_attachment', [$this, 'auto_fill_alt_on_upload']);
         add_action('admin_notices', [$this, 'admin_notices']);
@@ -1349,6 +1354,8 @@ class Gm2_SEO_Admin {
             '<button type="button" class="button" id="gm2-bulk-apply-all">' . esc_html__( 'Apply All', 'gm2-wordpress-suite' ) . '</button> ' .
             '<span id="gm2-bulk-apply-msg"></span></p>';
         echo '<p><progress id="gm2-bulk-progress-bar" value="0" max="100" style="width:100%;display:none" role="progressbar" aria-live="polite"></progress></p>';
+        echo '<p><button type="button" class="button" id="gm2-bulk-schedule">' . esc_html__( 'Schedule Batch', 'gm2-wordpress-suite' ) . '</button> ' .
+            '<button type="button" class="button" id="gm2-bulk-cancel-batch">' . esc_html__( 'Cancel Batch', 'gm2-wordpress-suite' ) . '</button></p>';
         echo '</div>';
     }
 
@@ -4741,6 +4748,89 @@ class Gm2_SEO_Admin {
             $this->render_seo_tabs_meta_box($post);
             echo '</div>';
         }
+    }
+
+    public static function cron_die_handler($message = '', $title = '', $args = []) {
+        echo $message;
+    }
+
+    public function run_ai_research_cron($post_id) {
+        if (!defined('DOING_AJAX')) {
+            define('DOING_AJAX', true);
+        }
+        add_filter('wp_die_ajax_handler', [__CLASS__, 'cron_die_handler']);
+        add_filter('wp_die_handler', [__CLASS__, 'cron_die_handler']);
+        $_POST = [
+            'post_id' => $post_id,
+            '_ajax_nonce' => wp_create_nonce('gm2_ai_research'),
+        ];
+        $_REQUEST = $_POST;
+        ob_start();
+        $this->ajax_ai_research();
+        $json = ob_get_clean();
+        remove_filter('wp_die_ajax_handler', [__CLASS__, 'cron_die_handler']);
+        remove_filter('wp_die_handler', [__CLASS__, 'cron_die_handler']);
+        $data = json_decode($json, true);
+        if ($data && isset($data['success']) && $data['success']) {
+            return $data['data'];
+        }
+        return new \WP_Error('gm2_ai_error', is_array($data) && isset($data['data']) ? $data['data'] : 'error');
+    }
+
+    private function queue_ai_posts(array $ids) {
+        $queue = get_option(self::AI_QUEUE_OPTION, []);
+        $queue = array_unique(array_merge($queue, array_map('absint', $ids)));
+        update_option(self::AI_QUEUE_OPTION, $queue);
+        if (!wp_next_scheduled(self::AI_CRON_HOOK)) {
+            wp_schedule_event(time(), 'hourly', self::AI_CRON_HOOK);
+        }
+    }
+
+    private function clear_ai_queue() {
+        delete_option(self::AI_QUEUE_OPTION);
+        $ts = wp_next_scheduled(self::AI_CRON_HOOK);
+        if ($ts) {
+            wp_unschedule_event($ts, self::AI_CRON_HOOK);
+        }
+    }
+
+    public function cron_process_ai_queue() {
+        $queue = get_option(self::AI_QUEUE_OPTION, []);
+        if (empty($queue)) {
+            $this->clear_ai_queue();
+            return;
+        }
+        $limit = apply_filters('gm2_ai_batch_limit', 5);
+        $processed = 0;
+        $remaining = [];
+        foreach ($queue as $id) {
+            if ($processed >= $limit) {
+                $remaining[] = $id;
+                continue;
+            }
+            $this->run_ai_research_cron($id);
+            $processed++;
+        }
+        update_option(self::AI_QUEUE_OPTION, $remaining);
+        if (empty($remaining)) {
+            $this->clear_ai_queue();
+        }
+    }
+
+    public function ajax_ai_batch_schedule() {
+        check_ajax_referer('gm2_ai_batch');
+        $ids = isset($_POST['ids']) ? json_decode(wp_unslash($_POST['ids']), true) : [];
+        if (!is_array($ids)) {
+            wp_send_json_error(__( 'invalid data', 'gm2-wordpress-suite' ));
+        }
+        $this->queue_ai_posts($ids);
+        wp_send_json_success();
+    }
+
+    public function ajax_ai_batch_cancel() {
+        check_ajax_referer('gm2_ai_batch');
+        $this->clear_ai_queue();
+        wp_send_json_success();
     }
 
     public function add_settings_help() {

--- a/admin/js/gm2-bulk-ai.js
+++ b/admin/js/gm2-bulk-ai.js
@@ -338,4 +338,17 @@ jQuery(function($){
             $msg.text(msg || (window.gm2BulkAi && gm2BulkAi.i18n ? gm2BulkAi.i18n.error : 'Error'));
         });
     });
+
+    $('#gm2-bulk-ai').on('click','#gm2-bulk-schedule',function(e){
+        e.preventDefault();
+        var ids=[];
+        $('#gm2-bulk-list .gm2-select:checked').each(function(){ids.push($(this).val());});
+        if(!ids.length) return;
+        $.post(gm2BulkAi.ajax_url,{action:'gm2_ai_batch_schedule',ids:JSON.stringify(ids),_ajax_nonce:gm2BulkAi.batch_nonce});
+    });
+
+    $('#gm2-bulk-ai').on('click','#gm2-bulk-cancel-batch',function(e){
+        e.preventDefault();
+        $.post(gm2BulkAi.ajax_url,{action:'gm2_ai_batch_cancel',_ajax_nonce:gm2BulkAi.batch_nonce});
+    });
 });


### PR DESCRIPTION
## Summary
- add cron constants and register gm2_ai_batch_process action
- implement queue management helpers and ajax endpoints
- expose 'Schedule Batch' controls and JS handlers
- localize batch nonce for script

## Testing
- `npm test`
- `phpunit` *(fails: PHPUnit Polyfills library requirement)*

------
https://chatgpt.com/codex/tasks/task_e_688cebbf1e108327bad1521ada5786f5