### PR TITLE
Add success notice after sitemap generation

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -2044,6 +2044,8 @@ class Gm2_SEO_Admin {
             $result = gm2_generate_sitemap();
             if (is_wp_error($result)) {
                 self::add_notice($result->get_error_message());
+            } else {
+                self::add_notice( __( 'Sitemap generated', 'gm2-wordpress-suite' ), 'success' );
             }
         }
 


### PR DESCRIPTION
## Summary
- show success message when sitemap generation succeeds

## Testing
- `npm test`
- `phpunit` *(fails: WordPress test suite missing)*
- `make test DB_NAME=wp_test DB_USER=root DB_PASS=pass` *(fails: mysqladmin not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d08d1fa808327a1c74d9cc8ed58fe