### PR TITLE
Add success notice when clearing 404 logs

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -2230,6 +2230,8 @@ class Gm2_SEO_Admin {
 
         delete_option('gm2_404_logs');
 
+        self::add_notice( __( '404 logs cleared.', 'gm2-wordpress-suite' ), 'success' );
+
         wp_redirect(admin_url('admin.php?page=gm2-seo&tab=redirects&logs_cleared=1'));
         exit;
     }


### PR DESCRIPTION
## Summary
- add a success notice in `handle_clear_404_logs`
- preserve the existing query string redirect so the Redirects tab will display the cleared message

## Testing
- `npm test`
- `make test DB_NAME=wp_test DB_USER=root DB_PASS=root` *(fails: Can't connect to MySQL server)*

------
https://chatgpt.com/codex/tasks/task_e_688d09d3a7c08327b5f107025600d601