### PR TITLE
Allow filtering of search console meta

### DIFF
--- a/public/Gm2_SEO_Public.php
+++ b/public/Gm2_SEO_Public.php
@@ -569,7 +569,8 @@ class Gm2_SEO_Public {
     public function output_search_console_meta() {
         $code = get_option('gm2_search_console_verification', '');
         if ($code) {
-            echo '<meta name="google-site-verification" content="' . esc_attr($code) . '" />' . "\n";
+            $html = '<meta name="google-site-verification" content="' . esc_attr($code) . '" />' . "\n";
+            echo apply_filters('gm2_search_console_meta', $html, $code);
         }
     }
 


### PR DESCRIPTION
## Summary
- expose a `gm2_search_console_meta` filter in `output_search_console_meta()` so developers can adjust the markup

## Testing
- `npm test`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_688d12fc6cec8327a32393e38cc1ca29