### PR TITLE
Cache SEO context per request

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@ This release adds several new SEO and AI options:
 - New helper functions `gm2_get_project_description()` and `gm2_ai_send_prompt()` supporting custom language models (`gpt-3.5-turbo` or `gpt-4`) and temperature settings.
 
 Existing prompt logic automatically includes these options via `gm2_get_seo_context()`.
+- Repeated calls to `gm2_get_seo_context()` now reuse a cached array within each request for fewer database queries.
 
 - The **Gm2 Qnty Discounts** widget now offers typography, color, shadow, padding and background controls for quantity labels and prices with Normal, Hover and Active tabs. Choose an icon for the currency symbol and style it alongside new box options for each quantity button, plus an **Icon Margin** option to control spacing around the currency icon. A new **Icon Color** style option lets you set colors for the currency icon in Normal, Hover and Active states.
 - The price section now uses flexbox by default and includes responsive **Horizontal** and **Vertical** alignment controls to adjust `justify-content` and `align-items`.

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Gm2 WordPress Suite
  * Description:       A powerful suite of tools and features for WordPress, by Gm2.
- * Version:           1.6.17
+ * Version:           1.6.18
  * Author:            Your Name or Team Gm2
  * Author URI:        https://yourwebsite.com
  * License:           GPL-2.0+
@@ -15,7 +15,7 @@
 defined('ABSPATH') or die('No script kiddies please!');
 
 // Define constants
-define('GM2_VERSION', '1.6.17');
+define('GM2_VERSION', '1.6.18');
 define('GM2_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('GM2_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('GM2_CHATGPT_LOG_FILE', GM2_PLUGIN_DIR . 'chatgpt.log');

--- a/includes/Gm2_SEO_Utils.php
+++ b/includes/Gm2_SEO_Utils.php
@@ -8,6 +8,11 @@ namespace Gm2 {
 
 namespace {
     function gm2_get_seo_context() {
+        static $cached = null;
+        if (is_array($cached)) {
+            return $cached;
+        }
+
         $context = [
             'business_model'        => sanitize_textarea_field(get_option('gm2_context_business_model', '')),
             'industry_category'     => sanitize_text_field(get_option('gm2_context_industry_category', '')),
@@ -46,6 +51,7 @@ namespace {
          * @param array $context Associative array of context strings.
          */
         $context = apply_filters('gm2_seo_context', $context);
+        $cached  = $context;
         return $context;
     }
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: gm2team
 Tags: admin, tools, suite, performance
 Requires at least: 6.0
 Tested up to: 6.5
-Stable tag: 1.6.17
+Stable tag: 1.6.18
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -347,6 +347,8 @@ the last 100 missing URLs to help you create new redirects.
 * **Real-time character counts** – display running totals in the SEO meta box.
 
 == Changelog ==
+= 1.6.18 =
+* SEO context options are cached per request so repeated calls avoid extra database queries.
 = 1.6.17 =
 * Abandoned cart checks now run every 5 minutes by default. The interval can be lowered to one minute using the `gm2_ac_mark_abandoned_interval` filter or corresponding option.
 = 1.6.16 =


### PR DESCRIPTION
## Summary
- cache gm2_get_seo_context results for the request
- document the caching in docs
- bump plugin version to 1.6.18
- note change in changelog

## Testing
- `npm test`
- `make test` *(fails: mysqladmin not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d13eff9fc8327af6a8fd00e61bb6b