### PR TITLE
Fix wizard redirect check

### DIFF
--- a/admin/Gm2_SEO_Wizard.php
+++ b/admin/Gm2_SEO_Wizard.php
@@ -23,6 +23,15 @@ class Gm2_SEO_Wizard {
     }
 
     public function handle_redirect() {
+        // Bail out when handling wizard form submissions.
+        if (
+            (isset($_GET['action']) && $_GET['action'] === 'gm2_save_wizard') ||
+            (isset($_POST['action']) && $_POST['action'] === 'gm2_save_wizard') ||
+            (isset($_SERVER['SCRIPT_NAME']) && basename($_SERVER['SCRIPT_NAME']) === 'admin-post.php')
+        ) {
+            return;
+        }
+
         if (get_option('gm2_setup_complete') !== '1') {
             if (!isset($_GET['page'])) {
                 wp_safe_redirect(admin_url('index.php?page=gm2-setup-wizard'));

--- a/tests/test-wizard.php
+++ b/tests/test-wizard.php
@@ -1,0 +1,26 @@
+<?php
+use Gm2\Gm2_SEO_Wizard;
+
+class WizardTest extends WP_UnitTestCase {
+    public function setUp(): void {
+        parent::setUp();
+        update_option('gm2_setup_complete', '0');
+        $this->wizard = new Gm2_SEO_Wizard();
+        wp_set_current_user(self::factory()->user->create(['role' => 'administrator']));
+    }
+
+    public function test_handle_post_executes_when_action_set() {
+        $_POST['action'] = 'gm2_save_wizard';
+        $_POST['gm2_wizard_step'] = 'chatgpt';
+        $_POST['gm2_chatgpt_api_key'] = 'test-key';
+        $_POST['gm2_next_step'] = 'oauth';
+        $_POST['_wpnonce'] = wp_create_nonce('gm2_save_wizard');
+        $_SERVER['SCRIPT_NAME'] = 'admin-post.php';
+
+        $this->wizard->handle_redirect();
+        $this->wizard->handle_post();
+
+        $this->assertSame('test-key', get_option('gm2_chatgpt_api_key'));
+        $this->assertSame('0', get_option('gm2_setup_complete'));
+    }
+}


### PR DESCRIPTION
## Summary
- prevent SEO wizard redirect when saving form
- add unit test for wizard post handling

## Testing
- `phpunit` *(fails: WordPress test suite missing)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d20411b5c8327b3482df8701877d9