### PR TITLE
Make setup wizard optional

### DIFF
--- a/admin/Gm2_SEO_Wizard.php
+++ b/admin/Gm2_SEO_Wizard.php
@@ -32,7 +32,9 @@ class Gm2_SEO_Wizard {
             return;
         }
 
-        if (get_option('gm2_setup_complete') !== '1') {
+        $flag = get_option('gm2_do_activation_redirect');
+        if ($flag === '1') {
+            delete_option('gm2_do_activation_redirect');
             if (!isset($_GET['page'])) {
                 wp_safe_redirect(admin_url('index.php?page=gm2-setup-wizard'));
                 exit;

--- a/readme.txt
+++ b/readme.txt
@@ -53,7 +53,7 @@ archive with `bash bin/build-plugin.sh`. This command packages the plugin with
 all dependencies into `gm2-wordpress-suite.zip` for installation via the
 **Plugins → Add New** screen.
 == Setup Wizard ==
-Activating the plugin redirects administrators to the **Gm2 Setup Wizard** (`index.php?page=gm2-setup-wizard`). The wizard walks through entering your ChatGPT API key, Google OAuth credentials, sitemap settings and which modules to enable. You can revisit it from the Gm2 Suite menu until **Finish Setup** is clicked. Have your OpenAI key and Google developer token ready.
+After activation the **Gm2 Setup Wizard** (`index.php?page=gm2-setup-wizard`) opens once to walk through entering your ChatGPT API key, Google OAuth credentials, sitemap settings and which modules to enable. The wizard is optional and can be launched again from the **Gm2 Suite** dashboard at any time.
 
 
 == Feature Toggles ==


### PR DESCRIPTION
## Summary
- check activation flag instead of setup_complete in `handle_redirect`
- document that the wizard is optional and can be relaunched later

## Testing
- `phpunit` *(fails: PHPUnit Polyfills not installed)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d24ea0c1c8327a862cf67bbe7fc10