### PR TITLE
Document gm2_bulk_ai_tax_capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ from supported taxonomies like categories and WooCommerce product categories.
 Select multiple terms to generate AI SEO titles and descriptions in bulk then
 apply the suggestions with one click.
 
+By default this page requires the `edit_terms` capability. Developers can
+override the required capability using the following filter:
+
+```php
+add_filter( 'gm2_bulk_ai_tax_capability', function() { return 'edit_posts'; } );
+```
+
 ## Abandoned Carts Module
 
 Enable this feature from **Gm2 → Dashboard** to create two database tables used

--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -345,11 +345,12 @@ class Gm2_SEO_Admin {
             [$this, 'display_bulk_ai_page']
         );
 
+        $cap = apply_filters('gm2_bulk_ai_tax_capability', 'edit_terms');
         add_submenu_page(
             'gm2',
             esc_html__( 'Bulk AI Taxonomies', 'gm2-wordpress-suite' ),
             esc_html__( 'Bulk AI Taxonomies', 'gm2-wordpress-suite' ),
-            'edit_terms',
+            $cap,
             'gm2-bulk-ai-taxonomies',
             [$this, 'display_bulk_ai_tax_page']
         );

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ Existing prompt logic automatically includes these options via `gm2_get_seo_cont
 - New **Wrap Options** control lets you enable flex wrapping so quantity buttons can stack on tablets and mobile.
 - Bulk AI research requests now use JSON-formatted AJAX calls for more robust error handling.
 - Bulk AI now supports categories and product categories on the **Bulk AI Taxonomies** page.
+- The **Bulk AI Taxonomies** screen defaults to the `edit_terms` capability which can be adjusted via the `gm2_bulk_ai_tax_capability` filter.
 
 ## Bulk AI
 


### PR DESCRIPTION
## Summary
- allow customizing Bulk AI taxonomy capability via `gm2_bulk_ai_tax_capability`
- document the filter in README
- mention the capability in docs

## Testing
- `npm test`
- `phpunit -c phpunit.xml` *(fails: missing WordPress test suite)*

------
https://chatgpt.com/codex/tasks/task_e_688d2c5fcc48832789709e723f57853a