### PR TITLE
Fix constructor parameters for PHP 7

### DIFF
--- a/includes/MobileDetect.php
+++ b/includes/MobileDetect.php
@@ -1049,7 +1049,7 @@ class MobileDetect
      */
     public function __construct(
         ?CacheInterface $cache = null,
-        array $config = [],
+        array $config = []
     ) {
         // If no custom cache provided then use our own.
         $this->cache = $cache ?? new Cache();


### PR DESCRIPTION
## Summary
- remove trailing comma from `MobileDetect` constructor

## Testing
- `phpunit` *(fails: wordpress tests missing)*

------
https://chatgpt.com/codex/tasks/task_e_688d332661988327979869a016100805