### PR TITLE
Fix version() signature for PHP 7

### DIFF
--- a/includes/MobileDetect.php
+++ b/includes/MobileDetect.php
@@ -1666,7 +1666,7 @@ class MobileDetect
      *
      * @return string|float|false The version of the property we are trying to extract.
      */
-    public function version(string $propertyName, string $type = self::VERSION_TYPE_STRING): float|bool|string
+    public function version(string $propertyName, string $type = self::VERSION_TYPE_STRING)
     {
         if (empty($propertyName) || !$this->hasUserAgent()) {
             return false;


### PR DESCRIPTION
## Summary
- remove union return type from MobileDetect version() method

## Testing
- `php -l includes/MobileDetect.php`
- `php -l gm2-wordpress-suite.php`
- `~/.local/share/mise/installs/php/8.4.11/.composer/vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_688d369956948327bfa7538962c04b54