### PR TITLE
Add MobileDetect cache classes & autoload support

### DIFF
--- a/includes/Detection/Cache/Cache.php
+++ b/includes/Detection/Cache/Cache.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Detection\Cache;
+
+use Psr\SimpleCache\CacheInterface;
+use DateInterval;
+use DateTime;
+
+use function is_int;
+use function time;
+
+/**
+ * In-memory cache implementation of PSR-16
+ * @see https://www.php-fig.org/psr/psr-16/
+ */
+class Cache implements CacheInterface
+{
+    protected array $cache = [];
+
+    /**
+     * @inheritdoc
+     * @throws CacheInvalidArgumentException
+     */
+    public function get(string $key, mixed $default = null): mixed
+    {
+        $this->checkKey($key);
+
+        if (isset($this->cache[$key])) {
+            if ($this->cache[$key]['ttl'] === null || $this->cache[$key]['ttl'] > time()) {
+                return $this->cache[$key]['content'];
+            }
+
+            // @Note: this is an interpretation of "Definitions" -> "Expiration"
+            // Implementing Libraries MAY expire an item before its requested Expiration Time,
+            // but MUST treat an item as expired once its Expiration Time is reached.
+            $this->deleteSingle($key);
+        }
+
+        return $default;
+    }
+
+    /**
+     * @inheritdoc
+     * @throws CacheInvalidArgumentException
+     */
+    public function set(string $key, mixed $value, int|DateInterval|null $ttl = null): bool
+    {
+        $this->checkKey($key);
+
+        // From https://www.php-fig.org/psr/psr-16/ "Definitions" -> "Expiration"
+        // If a negative or zero TTL is provided, the item MUST be deleted from the cache if it exists, as it is expired already.
+        if (is_int($ttl) && $ttl <= 0) {
+            $this->deleteSingle($key);
+            return false;
+        }
+
+        $ttl = $this->getTTL($ttl);
+
+        if ($ttl !== null) {
+            $ttl = (time() + $ttl);
+        }
+
+        $this->cache[$key] = ['ttl' => $ttl, 'content' => $value];
+
+        return true;
+    }
+
+    /** @inheritdoc */
+    public function delete(string $key): bool
+    {
+        $this->checkKey($key);
+        $this->deleteSingle($key);
+
+        return true;
+    }
+
+    /**
+     * Deletes the cache item from memory.
+     *
+     * @param string $key Cache key
+     * @return void
+     */
+    private function deleteSingle(string $key): void
+    {
+        unset($this->cache[$key]);
+    }
+
+    /** @inheritdoc */
+    public function clear(): bool
+    {
+        $this->cache = [];
+
+        return true;
+    }
+
+    /** @inheritdoc */
+    public function has(string $key): bool
+    {
+        $key = $this->checkKey($key);
+
+        return isset($this->cache[$key]);
+    }
+
+    /** @inheritdoc */
+    public function getMultiple(iterable $keys, mixed $default = null): iterable
+    {
+        $data = [];
+
+        foreach ($keys as $key) {
+            $data[$key] = $this->get($key, $default);
+        }
+
+        return $data;
+    }
+
+    /** @inheritdoc */
+    public function setMultiple(iterable $values, int|DateInterval|null $ttl = null): bool
+    {
+        $return = [];
+
+        foreach ($values as $key => $value) {
+            $return[] = $this->set($key, $value, $ttl);
+        }
+
+        return $this->checkReturn($return);
+    }
+
+    /** @inheritdoc */
+    public function deleteMultiple(iterable $keys): bool
+    {
+        foreach ($keys as $key) {
+            $this->delete($key);
+        }
+
+        return true;
+    }
+
+    /**
+     * @throws CacheInvalidArgumentException
+     */
+    protected function checkKey(string $key): string
+    {
+        if ($key === '' || !preg_match('/^[A-Za-z0-9_.]{1,64}$/', $key)) {
+            throw new CacheInvalidArgumentException("Invalid key: '$key'. Must be alphanumeric, can contain _ and . and can be maximum of 64 chars.");
+        }
+
+        return $key;
+    }
+
+    /**  */
+    protected function getTTL(DateInterval|int|null $ttl): ?int
+    {
+        if ($ttl instanceof DateInterval) {
+            return (new DateTime())->add($ttl)->getTimeStamp() - time();
+        }
+
+        // We treat 0 as a valid value.
+        if (is_int($ttl)) {
+            return $ttl;
+        }
+
+        return null;
+    }
+
+    /**
+     * Checks if at least one of the values is FALSE, then returns FALSE.
+     *
+     * @param bool[] $booleans
+     */
+    protected function checkReturn(array $booleans): bool
+    {
+        return !in_array(false, $booleans, true);
+    }
+
+    /**
+     * Get all cache keys.
+     *
+     * @internal Needed for testing purposes.
+     * @return string[]
+     */
+    public function getKeys(): array
+    {
+        return array_keys($this->cache);
+    }
+}

--- a/includes/Detection/Cache/CacheException.php
+++ b/includes/Detection/Cache/CacheException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Detection\Cache;
+
+class CacheException extends \Exception implements \Psr\SimpleCache\CacheException
+{
+}

--- a/includes/Detection/Cache/CacheInvalidArgumentException.php
+++ b/includes/Detection/Cache/CacheInvalidArgumentException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Detection\Cache;
+
+use Psr\SimpleCache\InvalidArgumentException;
+
+class CacheInvalidArgumentException extends CacheException implements InvalidArgumentException
+{
+}

--- a/includes/Detection/Exception/MobileDetectException.php
+++ b/includes/Detection/Exception/MobileDetectException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Detection\Exception;
+
+class MobileDetectException extends \Exception
+{
+}

--- a/includes/Detection/Exception/MobileDetectExceptionCode.php
+++ b/includes/Detection/Exception/MobileDetectExceptionCode.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Detection\Exception;
+
+class MobileDetectExceptionCode
+{
+    public const INVALID_USER_AGENT_ERR = 0x1;
+    public const IS_MOBILE_ERR = 0x2;
+    public const IS_TABLET_ERR = 0x3;
+    public const IS_MAGIC_ERR = 0x4;
+}

--- a/includes/Psr/SimpleCache/CacheException.php
+++ b/includes/Psr/SimpleCache/CacheException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Psr\SimpleCache;
+
+/**
+ * Interface used for all types of exceptions thrown by the implementing library.
+ */
+interface CacheException extends \Throwable
+{
+}

--- a/includes/Psr/SimpleCache/CacheInterface.php
+++ b/includes/Psr/SimpleCache/CacheInterface.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Psr\SimpleCache;
+
+use DateInterval;
+
+interface CacheInterface
+{
+    /**
+     * Fetches a value from the cache.
+     *
+     * @param string $key     The unique key of this item in the cache.
+     * @param mixed  $default Default value to return if the key does not exist.
+     *
+     * @return mixed The value of the item from the cache, or $default in case of cache miss.
+     *
+     * @throws InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function get(string $key, mixed $default = null): mixed;
+
+    /**
+     * Persists data in the cache, uniquely referenced by a key with an optional expiration TTL time.
+     *
+     * @param string                $key   The key of the item to store.
+     * @param mixed                 $value The value of the item to store, must be serializable.
+     * @param null|int|DateInterval $ttl   Optional. The TTL value of this item.
+     *
+     * @return bool True on success and false on failure.
+     *
+     * @throws InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function set(string $key, mixed $value, null|int|DateInterval $ttl = null): bool;
+
+    /**
+     * Delete an item from the cache by its unique key.
+     *
+     * @param string $key The unique cache key of the item to delete.
+     *
+     * @return bool True if the item was successfully removed. False if there was an error.
+     *
+     * @throws InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function delete(string $key): bool;
+
+    /**
+     * Wipes clean the entire cache's keys.
+     *
+     * @return bool True on success and false on failure.
+     */
+    public function clear(): bool;
+
+    /**
+     * Obtains multiple cache items by their unique keys.
+     *
+     * @param iterable $keys    A list of keys that can be obtained in a single operation.
+     * @param mixed    $default Default value to return for keys that do not exist.
+     *
+     * @return iterable A list of key => value pairs. Cache keys that do not exist or are stale will have $default as value.
+     *
+     * @throws InvalidArgumentException
+     *   MUST be thrown if $keys is neither an array nor a Traversable,
+     *   or if any of the $keys are not a legal value.
+     */
+    public function getMultiple(iterable $keys, mixed $default = null): iterable;
+
+    /**
+     * Persists a set of key => value pairs in the cache, with an optional TTL.
+     *
+     * @param iterable               $values A list of key => value pairs for a multiple-set operation.
+     * @param null|int|DateInterval  $ttl    Optional. The TTL value of this item.
+     *
+     * @return bool True on success and false on failure.
+     *
+     * @throws InvalidArgumentException
+     *   MUST be thrown if $values is neither an array nor a Traversable,
+     *   or if any of the $values are not a legal value.
+     */
+    public function setMultiple(iterable $values, null|int|DateInterval $ttl = null): bool;
+
+    /**
+     * Deletes multiple cache items in a single operation.
+     *
+     * @param iterable $keys A list of string-based keys to be deleted.
+     *
+     * @return bool True if the items were successfully removed. False if there was an error.
+     *
+     * @throws InvalidArgumentException
+     *   MUST be thrown if $keys is neither an array nor a Traversable,
+     *   or if any of the $keys are not a legal value.
+     */
+    public function deleteMultiple(iterable $keys): bool;
+
+    /**
+     * Determines whether an item is present in the cache.
+     *
+     * @param string $key The cache item key.
+     *
+     * @return bool
+     *
+     * @throws InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function has(string $key): bool;
+}

--- a/includes/Psr/SimpleCache/InvalidArgumentException.php
+++ b/includes/Psr/SimpleCache/InvalidArgumentException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Psr\SimpleCache;
+
+/**
+ * Exception interface for invalid cache arguments.
+ *
+ * When an invalid argument is passed it must throw an exception which implements
+ * this interface
+ */
+interface InvalidArgumentException extends CacheException
+{
+}

--- a/includes/autoload.php
+++ b/includes/autoload.php
@@ -1,21 +1,40 @@
 <?php
 spl_autoload_register(function ($class) {
-    if (strpos($class, 'Gm2\\') !== 0) {
+    if (strpos($class, 'Gm2\\') === 0) {
+        if (function_exists('gm2_substr')) {
+            $name = gm2_substr($class, 4); // class name without namespace
+        } elseif (function_exists('mb_substr')) {
+            $name = mb_substr($class, 4, null, 'UTF-8');
+        } else {
+            $name = substr($class, 4);
+        }
+        foreach (['includes', 'admin', 'public'] as $dir) {
+            $file = GM2_PLUGIN_DIR . $dir . '/' . $name . '.php';
+            if (file_exists($file)) {
+                require_once $file;
+                return;
+            }
+        }
         return;
     }
 
-    if (function_exists('gm2_substr')) {
-        $name = gm2_substr($class, 4); // class name without namespace
-    } elseif (function_exists('mb_substr')) {
-        $name = mb_substr($class, 4, null, 'UTF-8');
-    } else {
-        $name = substr($class, 4);
-    }
-    foreach (['includes', 'admin', 'public'] as $dir) {
-        $file = GM2_PLUGIN_DIR . $dir . '/' . $name . '.php';
+    if (strpos($class, 'Detection\\') === 0) {
+        if ($class === 'Detection\\MobileDetect') {
+            $file = GM2_PLUGIN_DIR . 'includes/MobileDetect.php';
+        } else {
+            $file = GM2_PLUGIN_DIR . 'includes/' . str_replace('\\', '/', $class) . '.php';
+        }
         if (file_exists($file)) {
             require_once $file;
-            return;
         }
+        return;
+    }
+
+    if (strpos($class, 'Psr\\SimpleCache\\') === 0) {
+        $file = GM2_PLUGIN_DIR . 'includes/' . str_replace('\\', '/', $class) . '.php';
+        if (file_exists($file)) {
+            require_once $file;
+        }
+        return;
     }
 });


### PR DESCRIPTION
## Summary
- copy Cache classes and exceptions from Mobile Detect
- define MobileDetect exception classes
- stub PSR Simple Cache interfaces
- extend autoloader to handle `Detection` and `Psr\SimpleCache` namespaces

## Testing
- `php -l includes/Detection/Cache/Cache.php`
- `phpunit --configuration phpunit.xml` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_688d3976cf288327b3e1d04b1e30b35a