### PR TITLE
Raise min PHP requirement to 8.0

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['7.3', '8.1']
+        php-version: ['8.0', '8.1']
     services:
       mysql:
         image: mysql:5.7

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The PHPUnit tests rely on the official WordPress test suite. Before running the 
 
 ### Prerequisites
 
-- **PHP** 7.3 or higher
+ - **PHP** 8.0 or higher
 - **Composer** for installing PHPUnit
 - **Node.js** and **npm** for running JavaScript tests
 

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -9,7 +9,7 @@
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       gm2-wordpress-suite
  * Domain Path:       /languages
- * Requires PHP:      7.3
+ * Requires PHP:      8.0
  */
 
 defined('ABSPATH') or die('No script kiddies please!');


### PR DESCRIPTION
## Summary
- require PHP 8.0 in plugin header
- update prerequisites in `README.md`
- update GitHub Actions matrix to test PHP 8.0 and 8.1

## Testing
- `npm test`
- `phpunit` *(fails: WordPress test suite missing)*

------
https://chatgpt.com/codex/tasks/task_e_688d3d1328cc8327b19f9286c85c90d4