### PR TITLE
Update taxonomy capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ from supported taxonomies like categories and WooCommerce product categories.
 Select multiple terms to generate AI SEO titles and descriptions in bulk then
 apply the suggestions with one click.
 
-By default this page requires the `edit_terms` capability. Developers can
+By default this page requires the `manage_categories` capability. Developers can
 override the required capability using the following filter:
 
 ```php

--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -345,7 +345,7 @@ class Gm2_SEO_Admin {
             [$this, 'display_bulk_ai_page']
         );
 
-        $cap = apply_filters('gm2_bulk_ai_tax_capability', 'edit_terms');
+        $cap = apply_filters('gm2_bulk_ai_tax_capability', 'manage_categories');
         add_submenu_page(
             'gm2',
             esc_html__( 'Bulk AI Taxonomies', 'gm2-wordpress-suite' ),
@@ -1395,7 +1395,8 @@ class Gm2_SEO_Admin {
     }
 
     public function display_bulk_ai_tax_page() {
-        if (!current_user_can('edit_terms')) {
+        $cap = apply_filters('gm2_bulk_ai_tax_capability', 'manage_categories');
+        if (!current_user_can($cap)) {
             esc_html_e( 'Permission denied', 'gm2-wordpress-suite' );
             return;
         }
@@ -4067,7 +4068,8 @@ class Gm2_SEO_Admin {
                 wp_send_json_error( __( 'permission denied', 'gm2-wordpress-suite' ), 403 );
             }
         } else {
-            if (!current_user_can('edit_terms')) {
+            $cap = apply_filters('gm2_bulk_ai_tax_capability', 'manage_categories');
+            if (!current_user_can($cap)) {
                 wp_send_json_error( __( 'permission denied', 'gm2-wordpress-suite' ), 403 );
             }
         }

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ Existing prompt logic automatically includes these options via `gm2_get_seo_cont
 - New **Wrap Options** control lets you enable flex wrapping so quantity buttons can stack on tablets and mobile.
 - Bulk AI research requests now use JSON-formatted AJAX calls for more robust error handling.
 - Bulk AI now supports categories and product categories on the **Bulk AI Taxonomies** page.
-- The **Bulk AI Taxonomies** screen defaults to the `edit_terms` capability which can be adjusted via the `gm2_bulk_ai_tax_capability` filter.
+- The **Bulk AI Taxonomies** screen defaults to the `manage_categories` capability which can be adjusted via the `gm2_bulk_ai_tax_capability` filter.
 
 ## Bulk AI
 


### PR DESCRIPTION
## Summary
- allow `manage_categories` capability for Bulk AI Taxonomies screen via filter
- document the new default capability in README and docs

## Testing
- `npm test`
- `make test DB_NAME=wp_test DB_USER=root DB_PASS=pass` *(fails: mysqladmin not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d3e5bdfd08327b19d98092bf2926f