### PR TITLE
Add taxonomy ItemList schema support

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -665,12 +665,13 @@ class Gm2_SEO_Admin {
             echo '<input type="submit" name="gm2_regenerate" class="button" value="' . esc_attr__( 'Regenerate Sitemap', 'gm2-wordpress-suite' ) . '" />';
             echo '</form>';
         } elseif ($active === 'schema') {
-            $product     = get_option('gm2_schema_product', '1');
-            $brand       = get_option('gm2_schema_brand', '1');
-            $breadcrumbs = get_option('gm2_schema_breadcrumbs', '1');
-            $article     = get_option('gm2_schema_article', '1');
-            $review      = get_option('gm2_schema_review', '1');
-            $footer_bc   = get_option('gm2_show_footer_breadcrumbs', '1');
+            $product       = get_option('gm2_schema_product', '1');
+            $brand         = get_option('gm2_schema_brand', '1');
+            $breadcrumbs   = get_option('gm2_schema_breadcrumbs', '1');
+            $taxonomy_list = get_option('gm2_schema_taxonomy', '1');
+            $article       = get_option('gm2_schema_article', '1');
+            $review        = get_option('gm2_schema_review', '1');
+            $footer_bc     = get_option('gm2_show_footer_breadcrumbs', '1');
             if (!empty($_GET['updated'])) {
                 echo '<div class="updated notice"><p>' . esc_html__('Settings saved.', 'gm2-wordpress-suite') . '</p></div>';
             }
@@ -681,6 +682,7 @@ class Gm2_SEO_Admin {
             echo '<tr><th scope="row">' . esc_html__( 'Product Schema', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="gm2_schema_product" value="1" ' . checked($product, '1', false) . '></td></tr>';
             echo '<tr><th scope="row">' . esc_html__( 'Brand Schema', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="gm2_schema_brand" value="1" ' . checked($brand, '1', false) . '></td></tr>';
             echo '<tr><th scope="row">' . esc_html__( 'Breadcrumb Schema', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="gm2_schema_breadcrumbs" value="1" ' . checked($breadcrumbs, '1', false) . '></td></tr>';
+            echo '<tr><th scope="row">' . esc_html__( 'Taxonomy ItemList Schema', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="gm2_schema_taxonomy" value="1" ' . checked($taxonomy_list, '1', false) . '></td></tr>';
             echo '<tr><th scope="row">' . esc_html__( 'Article Schema', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="gm2_schema_article" value="1" ' . checked($article, '1', false) . '></td></tr>';
             echo '<tr><th scope="row">' . esc_html__( 'Show Breadcrumbs in Footer', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="gm2_show_footer_breadcrumbs" value="1" ' . checked($footer_bc, '1', false) . '></td></tr>';
             echo '<tr><th scope="row">' . esc_html__( 'Review Schema', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="gm2_schema_review" value="1" ' . checked($review, '1', false) . '></td></tr>';
@@ -2019,8 +2021,11 @@ class Gm2_SEO_Admin {
         $brand      = isset($_POST['gm2_schema_brand']) ? '1' : '0';
         update_option('gm2_schema_brand', $brand);
 
-        $breadcrumbs = isset($_POST['gm2_schema_breadcrumbs']) ? '1' : '0';
+        $breadcrumbs   = isset($_POST['gm2_schema_breadcrumbs']) ? '1' : '0';
         update_option('gm2_schema_breadcrumbs', $breadcrumbs);
+
+        $taxonomy_list = isset($_POST['gm2_schema_taxonomy']) ? '1' : '0';
+        update_option('gm2_schema_taxonomy', $taxonomy_list);
 
         $article = isset($_POST['gm2_schema_article']) ? '1' : '0';
         update_option('gm2_schema_article', $article);

--- a/public/Gm2_SEO_Public.php
+++ b/public/Gm2_SEO_Public.php
@@ -30,6 +30,7 @@ class Gm2_SEO_Public {
         add_action('wp_head', [$this, 'output_breadcrumb_schema'], 20);
         add_action('wp_head', [$this, 'output_review_schema'], 20);
         add_action('wp_head', [$this, 'output_article_schema'], 20);
+        add_action('wp_head', [$this, 'output_taxonomy_schema'], 20);
         add_filter('the_content', [$this, 'apply_link_rel']);
         if (get_option('gm2_show_footer_breadcrumbs', '1') === '1') {
             add_action('wp_footer', [$this, 'output_breadcrumbs']);
@@ -489,6 +490,42 @@ class Gm2_SEO_Public {
                 'ratingValue' => $rating,
                 'bestRating'  => '5',
             ],
+        ];
+
+        echo '<script type="application/ld+json">' . wp_json_encode($data) . "</script>\n";
+    }
+
+    public function output_taxonomy_schema() {
+        if (get_option('gm2_schema_taxonomy', '1') !== '1') {
+            return;
+        }
+
+        if (!is_category() && !is_tag() && !is_tax()) {
+            return;
+        }
+
+        global $wp_query;
+        if (empty($wp_query->posts)) {
+            return;
+        }
+
+        $items    = [];
+        $position = 1;
+        foreach ($wp_query->posts as $post) {
+            $items[] = [
+                '@type'    => 'ListItem',
+                'position' => $position++,
+                'url'      => get_permalink($post),
+                'name'     => wp_strip_all_tags(get_the_title($post)),
+            ];
+        }
+
+        $data = [
+            '@context'        => 'https://schema.org/',
+            '@type'           => 'ItemList',
+            'name'            => single_term_title('', false),
+            'numberOfItems'   => count($items),
+            'itemListElement' => $items,
         ];
 
         echo '<script type="application/ld+json">' . wp_json_encode($data) . "</script>\n";


### PR DESCRIPTION
## Summary
- generate Schema.org ItemList schema for taxonomy archive pages
- make taxonomy schema output toggleable in settings

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689130f9b83c83278b82f7fcbe88a5f3