### PR TITLE
Add WebPage schema fallback for singular pages

### DIFF
--- a/tests/test-schema.php
+++ b/tests/test-schema.php
@@ -86,4 +86,22 @@ class SchemaOutputTest extends WP_UnitTestCase {
         $this->assertIsArray($data);
         $this->assertSame('Article', $data['@type']);
     }
+
+    public function test_webpage_schema_json_ld_output() {
+        register_post_type('book');
+        $post_id = self::factory()->post->create(['post_type' => 'book', 'post_title' => 'Book Title']);
+        $seo = new Gm2_SEO_Public();
+        $this->go_to(get_permalink($post_id));
+        setup_postdata(get_post($post_id));
+        ob_start();
+        $seo->output_webpage_schema();
+        $output = ob_get_clean();
+        $this->assertNotEmpty($output);
+        preg_match('/<script type="application\/ld\+json">(.*?)<\/script>/s', $output, $m);
+        $json = $m[1] ?? '';
+        $data = json_decode($json, true);
+        $this->assertIsArray($data);
+        $this->assertSame('WebPage', $data['@type']);
+        $this->assertSame(get_permalink($post_id), $data['url']);
+    }
 }


### PR DESCRIPTION
## Summary
- track whether Product or Article schema already ran
- emit Schema.org WebPage schema for singular pages without other schema
- cover WebPage schema with new PHPUnit test

## Testing
- `npm test`
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): Failed to open stream)*

------
https://chatgpt.com/codex/tasks/task_e_6891334586288327bc454d0138e5f531