### PR TITLE
Make single_row method public

### DIFF
--- a/admin/class-gm2-bulk-ai-list-table.php
+++ b/admin/class-gm2-bulk-ai-list-table.php
@@ -213,7 +213,7 @@ class Gm2_Bulk_Ai_List_Table extends \WP_List_Table {
         ]);
     }
 
-    protected function single_row($item) {
+    public function single_row($item) {
         echo '<tr id="gm2-row-' . intval($item->ID) . '">';
         $this->single_row_columns($item);
         echo '</tr>';


### PR DESCRIPTION
## Summary
- make single_row method public in bulk AI list table

## Testing
- `php -l admin/class-gm2-bulk-ai-list-table.php`
- `php /tmp/test_load_plugin.php`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68924837c0248327b4695c9381db6b3d