### PR TITLE
Make column_default public

### DIFF
--- a/admin/class-gm2-ac-table.php
+++ b/admin/class-gm2-ac-table.php
@@ -27,7 +27,7 @@ class GM2_AC_Table extends \WP_List_Table {
         ];
     }
 
-    protected function column_default($item, $column_name) {
+    public function column_default($item, $column_name) {
         return $item[$column_name] ?? '';
     }
 


### PR DESCRIPTION
## Summary
- expose `column_default` in `GM2_AC_Table` as public to match `WP_List_Table`

## Testing
- `npm test`
- `phpunit` *(fails: Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6892498e18788327ad39481c2356a9ba