### PR TITLE
Differentiate post and product categories in Bulk AI dropdown

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1359,6 +1359,11 @@ class Gm2_SEO_Admin {
         foreach ($tax_list as $tax) {
             $obj = get_taxonomy($tax);
             $name = $obj ? $obj->labels->singular_name : $tax;
+            if ('category' === $tax) {
+                $name = __('Post Category', 'gm2-wordpress-suite');
+            } elseif ('product_cat' === $tax) {
+                $name = __('Product Category', 'gm2-wordpress-suite');
+            }
             echo '<option value="' . esc_attr($tax) . '"' . selected($taxonomy, $tax, false) . '>' . esc_html($name) . '</option>';
         }
         echo '</select></label> ';


### PR DESCRIPTION
## Summary
- Give unique labels to post and product categories in the Bulk AI Taxonomies selector

## Testing
- `npm test`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_68924c1eda2483278695c730a18c8966