### PR TITLE
Prompt activation for Abandoned Carts module

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -120,7 +120,7 @@ function gm2_activate_plugin() {
     add_option('gm2_enable_chatgpt_logging', '0');
     add_option('gm2_sitemap_path', ABSPATH . 'sitemap.xml');
     add_option('gm2_sitemap_max_urls', 1000);
-    add_option('gm2_enable_abandoned_carts', '0');
+    add_option('gm2_enable_abandoned_carts', '1');
     add_option('gm2_ac_mark_abandoned_interval', 5);
     add_option('gm2_setup_complete', '0');
     add_option('gm2_do_activation_redirect', '1');
@@ -474,6 +474,13 @@ function gm2_guideline_rules_migration_notice() {
     }
 }
 add_action('admin_notices', 'gm2_guideline_rules_migration_notice');
+
+function gm2_plugin_action_links($links) {
+    $url = admin_url('admin.php?page=gm2');
+    $links[] = '<a href="' . esc_url($url) . '">' . esc_html__( 'Settings', 'gm2-wordpress-suite' ) . '</a>';
+    return $links;
+}
+add_filter('plugin_action_links_' . plugin_basename(__FILE__), 'gm2_plugin_action_links');
 
 if (defined('WP_CLI') && WP_CLI) {
     require_once GM2_PLUGIN_DIR . 'includes/cli/class-gm2-cli.php';

--- a/includes/Gm2_Loader.php
+++ b/includes/Gm2_Loader.php
@@ -31,7 +31,18 @@ class Gm2_Loader {
 
         $enable_seo = get_option('gm2_enable_seo', '1') === '1';
         $enable_qd  = get_option('gm2_enable_quantity_discounts', '1') === '1';
-        $enable_ac  = get_option('gm2_enable_abandoned_carts', '0') === '1';
+        $enable_ac  = get_option('gm2_enable_abandoned_carts', '1') === '1';
+
+        if (!$enable_ac && is_admin()) {
+            add_action('admin_notices', function () {
+                $url = admin_url('admin.php?page=gm2');
+                $msg = sprintf(
+                    __('The Abandoned Carts module is currently disabled. <a href="%s">Enable it in the Gm2 settings.</a>', 'gm2-wordpress-suite'),
+                    esc_url($url)
+                );
+                echo '<div class="notice notice-warning"><p>' . wp_kses_post($msg) . '</p></div>';
+            });
+        }
 
         if ($enable_seo) {
             $seo_admin = new Gm2_SEO_Admin();


### PR DESCRIPTION
## Summary
- Default Abandoned Carts module to enabled and warn admins when disabled
- Expose plugin settings via action link for easier module toggling

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689250bd65748327a7699e90d6109974