### PR TITLE
Add real-time GMC updates

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,19 @@ Existing prompt logic automatically includes these options via `gm2_get_seo_cont
 - Bulk AI now supports categories and product categories on the **Bulk AI Taxonomies** page.
 - The **Bulk AI Taxonomies** screen defaults to the `manage_categories` capability which can be adjusted via the `gm2_bulk_ai_tax_capability` filter.
 
+## Real-time Google Merchant Centre Data
+
+Price, availability and inventory fields now update in real time. When a WooCommerce product's metadata changes, the values are stored and made available through a REST endpoint at `/gm2/v1/gmc/realtime`. The front-end script `public/js/gm2-gmc-realtime.js` polls this endpoint and dispatches a `gm2GmcRealtimeUpdate` event with the latest data.
+
+Use the `gm2_gmc_realtime_fields` filter to add or remove fields from the real-time list:
+
+```php
+add_filter('gm2_gmc_realtime_fields', function ($fields) {
+    $fields[] = 'sale_price';
+    return $fields;
+});
+```
+
 ## Bulk AI
 
 - Batching or rate-limiting of AI requests.

--- a/includes/Gm2_GMC_Realtime.php
+++ b/includes/Gm2_GMC_Realtime.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Gm2;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Handles real-time Google Merchant Centre data updates.
+ */
+class Gm2_GMC_Realtime {
+    /**
+     * Fields that should be updated in real time.
+     *
+     * @var array
+     */
+    public const REALTIME_FIELDS = ['price', 'availability', 'inventory'];
+
+    /**
+     * Bootstraps hooks.
+     */
+    public function run() {
+        add_action('rest_api_init', [$this, 'register_routes']);
+        add_action('updated_postmeta', [$this, 'maybe_record_update'], 10, 4);
+    }
+
+    /**
+     * Returns the list of real-time fields.
+     *
+     * @return array
+     */
+    public static function get_fields() {
+        return apply_filters('gm2_gmc_realtime_fields', self::REALTIME_FIELDS);
+    }
+
+    /**
+     * Registers REST API routes used for updates.
+     */
+    public function register_routes() {
+        register_rest_route(
+            'gm2/v1',
+            '/gmc/realtime',
+            [
+                'methods'             => 'GET',
+                'callback'            => [$this, 'get_updates'],
+                'permission_callback' => '__return_true',
+            ]
+        );
+    }
+
+    /**
+     * Returns the latest data for the defined fields.
+     *
+     * @return \WP_REST_Response
+     */
+    public function get_updates() {
+        $data = get_option('gm2_gmc_realtime', []);
+        return rest_ensure_response($data);
+    }
+
+    /**
+     * Stores new values when relevant product meta changes.
+     *
+     * @param int    $meta_id    Meta ID.
+     * @param int    $object_id  Object ID.
+     * @param string $meta_key   Meta key.
+     * @param mixed  $meta_value Meta value.
+     */
+    public function maybe_record_update($meta_id, $object_id, $meta_key, $meta_value) {
+        if (get_post_type($object_id) !== 'product') {
+            return;
+        }
+        $fields = self::get_fields();
+        if (!in_array($meta_key, $fields, true)) {
+            return;
+        }
+        $data = get_option('gm2_gmc_realtime', []);
+        if (!isset($data[$object_id])) {
+            $data[$object_id] = [];
+        }
+        $data[$object_id][$meta_key] = $meta_value;
+        update_option('gm2_gmc_realtime', $data);
+    }
+}

--- a/includes/Gm2_Loader.php
+++ b/includes/Gm2_Loader.php
@@ -78,6 +78,14 @@ class Gm2_Loader {
             $seo_public->run();
         }
 
+        $gmc_rt = new Gm2_GMC_Realtime();
+        $gmc_rt->run();
+
+        if (!is_admin()) {
+            $gmc_rt_public = new Gm2_GMC_Realtime_Public();
+            $gmc_rt_public->run();
+        }
+
         $load_elementor = function () use ($enable_seo, $enable_qd) {
             if ($enable_seo) {
                 new Gm2_Elementor_SEO();

--- a/public/Gm2_GMC_Realtime_Public.php
+++ b/public/Gm2_GMC_Realtime_Public.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Gm2;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Front-end integration for real-time Google Merchant Centre data.
+ */
+class Gm2_GMC_Realtime_Public {
+    /**
+     * Bootstraps front-end scripts.
+     */
+    public function run() {
+        add_action('wp_enqueue_scripts', [$this, 'enqueue_script']);
+    }
+
+    /**
+     * Enqueues the polling script and passes config.
+     */
+    public function enqueue_script() {
+        wp_enqueue_script(
+            'gm2-gmc-realtime',
+            GM2_PLUGIN_URL . 'public/js/gm2-gmc-realtime.js',
+            [],
+            GM2_VERSION,
+            true
+        );
+        wp_localize_script(
+            'gm2-gmc-realtime',
+            'gm2GmcRealtime',
+            [
+                'url'    => rest_url('gm2/v1/gmc/realtime'),
+                'nonce'  => wp_create_nonce('wp_rest'),
+                'fields' => Gm2_GMC_Realtime::get_fields(),
+            ]
+        );
+    }
+}

--- a/public/js/gm2-gmc-realtime.js
+++ b/public/js/gm2-gmc-realtime.js
@@ -1,0 +1,22 @@
+(function () {
+    const cfg = window.gm2GmcRealtime || {};
+    if (!cfg.url) {
+        return;
+    }
+    async function poll() {
+        try {
+            const resp = await fetch(cfg.url, {
+                headers: { 'X-WP-Nonce': cfg.nonce }
+            });
+            const data = await resp.json();
+            document.dispatchEvent(
+                new CustomEvent('gm2GmcRealtimeUpdate', { detail: data })
+            );
+        } catch (err) {
+            // eslint-disable-next-line no-console
+            console.error('GMC realtime fetch failed', err);
+        }
+    }
+    poll();
+    setInterval(poll, 5000);
+})();

--- a/readme.txt
+++ b/readme.txt
@@ -21,6 +21,7 @@ Key features include:
 * Bulk AI progress messages support localization
 * Row-level "Select all" checkboxes apply suggestions per post
 * Updated rows are briefly highlighted after applying suggestions
+* Real-time Google Merchant Centre data via REST endpoint
 
 == Installation ==
 1. Upload the plugin files to the `/wp-content/plugins/gm2-wordpress-suite` directory.
@@ -131,6 +132,14 @@ The Google Ads request also requires a language constant and a geo target consta
 
 == Analytics ==
 After connecting a Google account, open the **Analytics** tab under SEO (`admin.php?page=gm2-seo&tab=analytics`). Line and bar charts powered by Chart.js display sessions, bounce rate and top search queries. Select an Analytics property and Search Console site on the **Connect Google Account** screen before viewing the charts.
+
+== Google Merchant Centre ==
+The plugin tracks real-time product updates for Google Merchant Centre. Price, availability and inventory changes are cached and exposed through the REST endpoint `/gm2/v1/gmc/realtime`. A front-end script polls this endpoint and dispatches a `gm2GmcRealtimeUpdate` event with the latest values.
+
+Configuration:
+1. Ensure the WordPress REST API is accessible on your site.
+2. Listen for the `gm2GmcRealtimeUpdate` event in custom scripts to react to updates.
+3. Use the `gm2_gmc_realtime_fields` filter to adjust which fields trigger updates.
 
 == Image Optimization ==
 Enter your compression API key and enable the service from the SEO &gt; Performance screen.


### PR DESCRIPTION
## Summary
- track product price, availability and inventory changes for Google Merchant Centre
- expose `/gm2/v1/gmc/realtime` endpoint and enqueue polling script
- document new real-time update feature and configuration

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68925218f3848327b2637f16044b196b