### PR TITLE
Document taxonomy batch scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ override the required capability using the following filter:
 add_filter( 'gm2_bulk_ai_tax_capability', function() { return 'edit_posts'; } );
 ```
 
+### Scheduling and Cancelling Batches
+
 Selected terms can also be queued for background processing. Use **Schedule Batch**
 to process the items via WP-Cron or **Cancel Batch** to clear any pending jobs.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,10 @@ add_filter('gm2_gmc_realtime_fields', function ($fields) {
 - Each row in the table includes a "Select All" checkbox to quickly apply that post's suggestions.
 - Rows highlight after applying suggestions so you can see what changed.
 
+### Bulk AI for Taxonomies
+
+Use the **Bulk AI Taxonomies** page under **Gm2 → Bulk AI Taxonomies** to generate AI SEO titles and descriptions for taxonomy terms. Use the **Only terms missing SEO Title** and **Only terms missing Description** filters to show only terms lacking metadata. After selecting terms, click **Schedule Batch** to queue them for background processing via WP‑Cron or **Cancel Batch** to remove pending jobs.
+
 ### Bulk AI Task Summary
 
 - **Edit Post links** – titles link to each edit screen from `display_bulk_ai_page()` in `admin/Gm2_SEO_Admin.php`.


### PR DESCRIPTION
## Summary
- Document Bulk AI taxonomy tools in README and docs with filters and batch scheduling guidance

## Testing
- `npm test`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*


------
https://chatgpt.com/codex/tasks/task_e_6892578d1a088327b75857e4338ec6d0