### PR TITLE
Strip HTML tags from taxonomy descriptions in Bulk AI table

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1404,7 +1404,7 @@ class Gm2_SEO_Admin {
         foreach ($terms as $term) {
             $seo_title   = get_term_meta($term->term_id, '_gm2_title', true);
             $description = get_term_meta($term->term_id, '_gm2_description', true);
-            $tax_desc    = term_description($term->term_id, $term->taxonomy);
+            $tax_desc    = wp_strip_all_tags(term_description($term->term_id, $term->taxonomy));
             $stored      = get_term_meta($term->term_id, '_gm2_ai_research', true);
             $result_html = '';
             if ($stored) {


### PR DESCRIPTION
## Summary
- remove markup from taxonomy descriptions shown on the Bulk AI Taxonomies admin page

## Testing
- `npm test`
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689262a8d25c8327a60084fe085c44e5