### PR TITLE
Replace abandoned cart timeout with activity tracking

### DIFF
--- a/public/Gm2_Abandoned_Carts_Public.php
+++ b/public/Gm2_Abandoned_Carts_Public.php
@@ -10,6 +10,10 @@ class Gm2_Abandoned_Carts_Public {
         add_action('wp_enqueue_scripts', [ $this, 'enqueue_scripts' ]);
         add_action('wp_ajax_gm2_ac_email_capture', [ $this, 'handle_email_capture' ]);
         add_action('wp_ajax_nopriv_gm2_ac_email_capture', [ $this, 'handle_email_capture' ]);
+        add_action('wp_ajax_gm2_ac_mark_active', [ Gm2_Abandoned_Carts::class, 'gm2_ac_mark_active' ]);
+        add_action('wp_ajax_nopriv_gm2_ac_mark_active', [ Gm2_Abandoned_Carts::class, 'gm2_ac_mark_active' ]);
+        add_action('wp_ajax_gm2_ac_mark_abandoned', [ Gm2_Abandoned_Carts::class, 'gm2_ac_mark_abandoned' ]);
+        add_action('wp_ajax_nopriv_gm2_ac_mark_abandoned', [ Gm2_Abandoned_Carts::class, 'gm2_ac_mark_abandoned' ]);
     }
 
     public function enqueue_scripts() {
@@ -26,6 +30,22 @@ class Gm2_Abandoned_Carts_Public {
             [
                 'ajax_url' => admin_url('admin-ajax.php'),
                 'nonce'    => wp_create_nonce('gm2_ac_email_capture'),
+            ]
+        );
+
+        wp_enqueue_script(
+            'gm2-ac-activity',
+            GM2_PLUGIN_URL . 'public/js/gm2-ac-activity.js',
+            [],
+            GM2_VERSION,
+            true
+        );
+        wp_localize_script(
+            'gm2-ac-activity',
+            'gm2AcActivity',
+            [
+                'ajax_url' => admin_url('admin-ajax.php'),
+                'nonce'    => wp_create_nonce('gm2_ac_activity'),
             ]
         );
     }

--- a/public/js/gm2-ac-activity.js
+++ b/public/js/gm2-ac-activity.js
@@ -1,0 +1,45 @@
+(function () {
+    const KEY = 'gm2AcTabCount';
+    const ajaxUrl = gm2AcActivity.ajax_url;
+    const nonce = gm2AcActivity.nonce;
+    const url = window.location.href;
+
+    function send(action) {
+        const data = new URLSearchParams({ action, nonce, url });
+        if (action === 'gm2_ac_mark_abandoned' && navigator.sendBeacon) {
+            navigator.sendBeacon(ajaxUrl, data);
+        } else {
+            fetch(ajaxUrl, {
+                method: 'POST',
+                credentials: 'same-origin',
+                body: data,
+            });
+        }
+    }
+
+    function incrementTabs() {
+        const count = parseInt(localStorage.getItem(KEY) || '0', 10) + 1;
+        localStorage.setItem(KEY, String(count));
+    }
+
+    function decrementTabs() {
+        let count = parseInt(localStorage.getItem(KEY) || '0', 10) - 1;
+        if (count < 0) {
+            count = 0;
+        }
+        localStorage.setItem(KEY, String(count));
+        if (count === 0) {
+            send('gm2_ac_mark_abandoned');
+        }
+    }
+
+    incrementTabs();
+    send('gm2_ac_mark_active');
+
+    window.addEventListener('beforeunload', decrementTabs);
+    document.addEventListener('visibilitychange', function () {
+        if (document.visibilityState === 'hidden') {
+            decrementTabs();
+        }
+    });
+})();


### PR DESCRIPTION
## Summary
- replace cron-based abandoned cart detection with AJAX endpoints
- track cart activity via localStorage and navigator.sendBeacon
- load new activity script and register AJAX hooks

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689279fc7b6883279320e5e7f3f2e78a