### PR TITLE
Remove abandoned cart timeout setting and document new metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,18 +129,18 @@ to process the items via WP-Cron or **Cancel Batch** to clear any pending jobs.
 Enable this feature from **Gm2 → Dashboard** to create two database tables used
 for tracking carts and queuing recovery emails. The cart table stores the cart
 contents along with the shopper's email address, IP, detected location and
-device type, the first and last URLs visited, and the cart total. A small
-JavaScript file captures the email as soon as it is entered on the checkout
-page so the address is available even if the customer never completes the
-order.
+device type, the first and last URLs visited, cart total, total browsing time,
+and how many times the shopper returned to the cart. A small JavaScript file
+captures the email as soon as it is entered on the checkout page so the address
+is available even if the customer never completes the order. It also records
+when a cart becomes active or abandoned as the visitor browses the site.
 
-The admin screen under **Gm2 → Abandoned Carts** displays a table of abandoned
-carts showing the IP address, email, location, device, products, cart value,
-entry and exit URLs, and the abandonment time. Recovery emails are added to a
-queue which is processed hourly by WP&nbsp;Cron via the `gm2_ac_process_queue`
-action. Developers can hook `gm2_ac_send_message` to send the actual email
-content. The cart timeout in minutes can be configured on the same settings
-page.
+The admin screen under **Gm2 → Abandoned Carts** displays a table of carts and
+their status—active or abandoned—showing the IP address, email, location, device,
+products, cart value, entry and exit URLs, browsing time, and revisit count.
+Recovery emails are added to a queue which is processed hourly by WP&nbsp;Cron via
+the `gm2_ac_process_queue` action. Developers can hook `gm2_ac_send_message` to
+send the actual email content.
 
 
 

--- a/admin/Gm2_Abandoned_Carts_Admin.php
+++ b/admin/Gm2_Abandoned_Carts_Admin.php
@@ -8,7 +8,6 @@ if (!defined('ABSPATH')) {
 class Gm2_Abandoned_Carts_Admin {
     public function run() {
         add_action('admin_menu', [ $this, 'add_menu' ]);
-        add_action('admin_post_gm2_ac_settings', [ $this, 'save_settings' ]);
     }
 
     public function add_menu() {
@@ -22,28 +21,8 @@ class Gm2_Abandoned_Carts_Admin {
         );
     }
 
-    public function save_settings() {
-        check_admin_referer('gm2_ac_settings');
-        update_option('gm2_ac_timeout', absint($_POST['gm2_ac_timeout']));
-        wp_redirect(admin_url('admin.php?page=gm2-abandoned-carts&updated=1'));
-        exit;
-    }
-
     public function display_page() {
-        $timeout = get_option('gm2_ac_timeout', 60);
         echo '<div class="wrap"><h1>' . esc_html__('Abandoned Carts', 'gm2-wordpress-suite') . '</h1>';
-        if (isset($_GET['updated'])) {
-            echo '<div class="updated notice"><p>' . esc_html__('Settings saved.', 'gm2-wordpress-suite') . '</p></div>';
-        }
-        echo '<form method="post" action="' . esc_url(admin_url('admin-post.php')) . '">';
-        wp_nonce_field('gm2_ac_settings');
-        echo '<input type="hidden" name="action" value="gm2_ac_settings">';
-        echo '<table class="form-table"><tbody>';
-        echo '<tr><th scope="row"><label for="gm2_ac_timeout">' . esc_html__('Abandonment timeout (minutes)', 'gm2-wordpress-suite') . '</label></th>';
-        echo '<td><input name="gm2_ac_timeout" id="gm2_ac_timeout" type="number" value="' . esc_attr($timeout) . '" class="small-text"></td></tr>';
-        echo '</tbody></table>';
-        submit_button();
-        echo '</form>';
 
         $table = new GM2_AC_Table();
         $table->prepare_items();

--- a/readme.txt
+++ b/readme.txt
@@ -14,7 +14,7 @@ Key features include:
 * SEO tools with breadcrumbs, caching and structured data
 * ChatGPT-powered content generation and keyword research
 * WooCommerce quantity discounts with a dedicated Elementor widget (requires WooCommerce)
-* Abandoned cart tracking with email capture and recovery emails
+* Abandoned cart tracking with email capture, browsing-time and revisit metrics, and recovery emails
 * Tariff management and redirects
 * Expanded SEO Context feeds AI prompts with business details
 * Focus keywords are tracked to prevent duplicates in AI suggestions
@@ -308,9 +308,9 @@ This feature requires WooCommerce to be active.
 After activating WooCommerce, open **Gm2 → Quantity Discounts** and click **Add Discount Group** to define bulk pricing rules. Choose the products or categories to apply, enter the minimum quantity and specify either a percentage or fixed discount. When customers meet the threshold the discount is applied automatically in the cart. Install Elementor to add the **Gm2 Qnty Discounts** widget on product pages, giving shoppers buttons for preset quantities that match your rules. If Elementor Pro is active the widget lives in the **WooCommerce** section; otherwise it appears in **General**. The selected rule and discounted price are saved in order item meta and appear in emails and on the admin order screen.
 
 == Abandoned Carts ==
-Enable this module from **Gm2 → Dashboard** to create tables that record the cart contents, email address, IP, location, device type, entry and exit URLs and cart value. A small JavaScript snippet captures the email field on the checkout page so you can reach customers who abandon their cart before placing an order.
+Enable this module from **Gm2 → Dashboard** to create tables that record the cart contents, email address, IP, location, device type, entry and exit URLs, cart value, total browsing time and how many times a shopper revisits their cart. A small JavaScript snippet captures the email field on the checkout page so you can reach customers who abandon their cart before placing an order. It also marks carts as active while the shopper browses and flags them as abandoned when they leave.
 
-Open **Gm2 → Abandoned Carts** to configure the abandonment timeout and view a table listing each cart's IP address, email, location, device, products, value, entry and exit URLs and the time it was abandoned. Recovery messages are queued using WP&nbsp;Cron via the `gm2_ac_process_queue` action. Developers can hook `gm2_ac_send_message` to send the actual emails.
+Open **Gm2 → Abandoned Carts** to view a table listing each cart's status, IP address, email, location, device, products, value, entry and exit URLs, browsing time and revisits. Recovery messages are queued using WP&nbsp;Cron via the `gm2_ac_process_queue` action. Developers can hook `gm2_ac_send_message` to send the actual emails.
 
 == Redirects ==
 Create 301 or 302 redirects from the **SEO → Redirects** tab. The plugin logs


### PR DESCRIPTION
## Summary
- drop manual timeout setting and related saving logic from abandoned carts admin screen
- document active/abandoned tracking with browsing time and revisit metrics in README files

## Testing
- `npm test`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*


------
https://chatgpt.com/codex/tasks/task_e_68928505aca083278075e705569c49a5