### PR TITLE
Add bulk delete support for abandoned carts table

### DIFF
--- a/admin/Gm2_Abandoned_Carts_Admin.php
+++ b/admin/Gm2_Abandoned_Carts_Admin.php
@@ -50,11 +50,21 @@ class Gm2_Abandoned_Carts_Admin {
         echo '</form>';
 
         $table = new GM2_AC_Table();
+        $table->process_bulk_action();
         $table->prepare_items();
         echo '<hr />';
         echo '<form method="get">';
         echo '<input type="hidden" name="page" value="' . esc_attr($_GET['page']) . '" />';
         $table->search_box(__('Search', 'gm2-wordpress-suite'), 'gm2-ac');
+        echo '</form>';
+        echo '<form method="post">';
+        echo '<input type="hidden" name="page" value="' . esc_attr($_GET['page']) . '" />';
+        if (!empty($_REQUEST['s'])) {
+            echo '<input type="hidden" name="s" value="' . esc_attr($_REQUEST['s']) . '" />';
+        }
+        if (!empty($_REQUEST['paged'])) {
+            echo '<input type="hidden" name="paged" value="' . absint($_REQUEST['paged']) . '" />';
+        }
         $table->display();
         echo '</form></div>';
     }

--- a/admin/class-gm2-ac-table.php
+++ b/admin/class-gm2-ac-table.php
@@ -22,6 +22,7 @@ class GM2_AC_Table extends \WP_List_Table {
 
     public function get_columns() {
         return [
+            'cb'           => '<input type="checkbox" />',
             'status'      => __('Status', 'gm2-wordpress-suite'),
             'ip_address'  => __('IP Address', 'gm2-wordpress-suite'),
             'email'       => __('Email', 'gm2-wordpress-suite'),
@@ -36,6 +37,33 @@ class GM2_AC_Table extends \WP_List_Table {
             'revisit_count' => __('Revisits', 'gm2-wordpress-suite'),
             'abandoned_at'=> __('Abandoned At', 'gm2-wordpress-suite'),
         ];
+    }
+
+    public function column_cb($item) {
+        $id = isset($item['id']) ? (int) $item['id'] : 0;
+        return '<input type="checkbox" name="id[]" value="' . esc_attr($id) . '" />';
+    }
+
+    public function get_bulk_actions() {
+        return [
+            'delete' => __('Delete', 'gm2-wordpress-suite'),
+        ];
+    }
+
+    public function process_bulk_action() {
+        if ($this->current_action() !== 'delete') {
+            return;
+        }
+        $ids = isset($_REQUEST['id']) ? (array) $_REQUEST['id'] : [];
+        $ids = array_map('absint', $ids);
+        $ids = array_filter($ids);
+        if (!$ids) {
+            return;
+        }
+        global $wpdb;
+        $table = $wpdb->prefix . 'wc_ac_carts';
+        $placeholders = implode(',', array_fill(0, count($ids), '%d'));
+        $wpdb->query($wpdb->prepare("DELETE FROM $table WHERE id IN ($placeholders)", $ids));
     }
 
     private function ensure_value($value) {
@@ -147,6 +175,7 @@ class GM2_AC_Table extends \WP_List_Table {
             }
 
             $items[] = [
+                'id'          => (int) $row->id,
                 'status'      => esc_html($this->ensure_value($status)),
                 'ip_address'  => esc_html($this->ensure_value($row->ip_address)),
                 'email'       => esc_html($this->ensure_value($row->email)),


### PR DESCRIPTION
## Summary
- add checkbox column and bulk actions to abandoned carts table
- allow deleting selected carts and include ID tracking
- process bulk actions before rendering and post table form to current page

## Testing
- `npm test`
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): Failed to open stream)*

------
https://chatgpt.com/codex/tasks/task_e_68928df938e0832780f444a7259a83b8