### PR TITLE
Allow configurable items per page in abandoned carts admin

### DIFF
--- a/admin/Gm2_Abandoned_Carts_Admin.php
+++ b/admin/Gm2_Abandoned_Carts_Admin.php
@@ -24,6 +24,11 @@ class Gm2_Abandoned_Carts_Admin {
     }
 
     public function display_page() {
+        add_screen_option('per_page', [
+            'label'   => __('Items per page', 'gm2-wordpress-suite'),
+            'default' => 20,
+            'option'  => 'gm2_ac_per_page',
+        ]);
         echo '<div class="wrap"><h1>' . esc_html__('Abandoned Carts', 'gm2-wordpress-suite') . '</h1>';
 
         if (!empty($_GET['logs_reset'])) {

--- a/admin/class-gm2-ac-table.php
+++ b/admin/class-gm2-ac-table.php
@@ -10,7 +10,6 @@ if (!class_exists('\\WP_List_Table')) {
 }
 
 class GM2_AC_Table extends \WP_List_Table {
-    private $items_per_page = 20;
 
     public function __construct() {
         parent::__construct([
@@ -110,7 +109,7 @@ class GM2_AC_Table extends \WP_List_Table {
 
         global $wpdb;
         $table   = $wpdb->prefix . 'wc_ac_carts';
-        $per_page = $this->items_per_page;
+        $per_page = $this->get_items_per_page("gm2_ac_per_page", 20);
         $paged    = $this->get_pagenum();
         $search   = isset($_REQUEST['s']) ? trim($_REQUEST['s']) : '';
 


### PR DESCRIPTION
## Summary
- pull items-per-page value using `get_items_per_page()` to persist preference
- expose screen option to allow admins to adjust abandoned cart list pagination

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*
- `curl -L https://phar.phpunit.de/phpunit-9.phar -o phpunit.phar` *(fails: response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689290e4ad888327a64c762dd4678247