### PR TITLE
Track product SKUs in abandoned carts

### DIFF
--- a/includes/Gm2_Abandoned_Carts.php
+++ b/includes/Gm2_Abandoned_Carts.php
@@ -79,6 +79,7 @@ class Gm2_Abandoned_Carts {
                 'name'  => $name,
                 'qty'   => $qty,
                 'price' => $price,
+                'sku'   => $product ? $product->get_sku() : '',
             ];
         }
         $contents   = wp_json_encode($cart_items);


### PR DESCRIPTION
## Summary
- Store product SKU when capturing WooCommerce cart items
- Include SKU in legacy cart conversions and show SKUs in admin table
- Update admin column header to reflect SKU-based display

## Testing
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_6892946c87688327802f50ec91b49b3a