### PR TITLE
Add pagehide listener for abandoned cart tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,11 @@ captures the email as soon as it is entered on the checkout page so the address
 is available even if the customer never completes the order. It also records
 when a cart becomes active or abandoned as the visitor browses the site.
 
+The script listens for `beforeunload`, `visibilitychange` and `pagehide` events
+to mark a cart abandoned when the last browser tab closes. Some older browsers
+may ignore these events or block background requests, which can prevent the
+notification from reaching WordPress.
+
 The admin screen under **Gm2 → Abandoned Carts** displays a table of carts and
 their status—active or abandoned—showing the IP address, email, location, device,
 products, cart value, entry and exit URLs, browsing time, and revisit count.

--- a/public/js/gm2-ac-activity.js
+++ b/public/js/gm2-ac-activity.js
@@ -37,6 +37,7 @@
     send('gm2_ac_mark_active');
 
     window.addEventListener('beforeunload', decrementTabs);
+    window.addEventListener('pagehide', decrementTabs);
     document.addEventListener('visibilitychange', function () {
         if (document.visibilityState === 'hidden') {
             decrementTabs();

--- a/readme.txt
+++ b/readme.txt
@@ -310,6 +310,11 @@ After activating WooCommerce, open **Gm2 → Quantity Discounts** and click **Ad
 == Abandoned Carts ==
 Enable this module from **Gm2 → Dashboard** to create tables that record the cart contents, email address, IP, location, device type, entry and exit URLs, cart value, total browsing time and how many times a shopper revisits their cart. A small JavaScript snippet captures the email field on the checkout page so you can reach customers who abandon their cart before placing an order. It also marks carts as active while the shopper browses and flags them as abandoned when they leave.
 
+The tracking script listens for `beforeunload`, `visibilitychange` and
+`pagehide` events to mark a cart abandoned when the last browser tab closes. On
+older browsers these events or background requests may be suppressed, which can
+prevent the abandonment notice from reaching WordPress.
+
 Open **Gm2 → Abandoned Carts** to view a table listing each cart's status, IP address, email, location, device, products, value, entry and exit URLs, browsing time and revisits. Recovery messages are queued using WP&nbsp;Cron via the `gm2_ac_process_queue` action. Developers can hook `gm2_ac_send_message` to send the actual emails.
 
 == Redirects ==


### PR DESCRIPTION
## Summary
- mark abandoned carts on `pagehide` to handle tabs closed without `beforeunload`
- document browser limitations for cart tracking scripts

## Testing
- `npm test`
- jsdom script dispatching `pagehide`
- attempted Playwright cross-browser run (missing system dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68929a0da3188327a797130f7762b6f5