### PR TITLE
Improve abandoned cart tracking reliability

### DIFF
--- a/public/js/gm2-ac-activity.js
+++ b/public/js/gm2-ac-activity.js
@@ -6,8 +6,32 @@
 
     function send(action) {
         const data = new URLSearchParams({ action, nonce, url });
-        if (action === 'gm2_ac_mark_abandoned' && navigator.sendBeacon) {
-            navigator.sendBeacon(ajaxUrl, data);
+
+        if (action === 'gm2_ac_mark_abandoned') {
+            let queued = false;
+
+            if (navigator.sendBeacon) {
+                queued = navigator.sendBeacon(ajaxUrl, data);
+            }
+
+            if (!queued) {
+                fetch(ajaxUrl, {
+                    method: 'POST',
+                    credentials: 'same-origin',
+                    body: data,
+                    keepalive: true,
+                });
+            } else {
+                // Fallback in case the beacon is dropped
+                setTimeout(function () {
+                    fetch(ajaxUrl, {
+                        method: 'POST',
+                        credentials: 'same-origin',
+                        body: data,
+                        keepalive: true,
+                    });
+                }, 100);
+            }
         } else {
             fetch(ajaxUrl, {
                 method: 'POST',
@@ -38,6 +62,7 @@
 
     window.addEventListener('beforeunload', decrementTabs);
     window.addEventListener('pagehide', decrementTabs);
+    window.addEventListener('unload', decrementTabs);
     document.addEventListener('visibilitychange', function () {
         if (document.visibilityState === 'hidden') {
             decrementTabs();


### PR DESCRIPTION
## Summary
- ensure sendBeacon fallback and retry for abandoned cart detection
- add unload handler to reliably decrement open tab count

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68929e7bfc588327ac4403e6eb4491a6