### PR TITLE
Refactor abandon cart tracking to fetch immediately after beacon

### DIFF
--- a/public/js/gm2-ac-activity.js
+++ b/public/js/gm2-ac-activity.js
@@ -8,30 +8,16 @@
         const data = new URLSearchParams({ action, nonce, url });
 
         if (action === 'gm2_ac_mark_abandoned') {
-            let queued = false;
-
             if (navigator.sendBeacon) {
-                queued = navigator.sendBeacon(ajaxUrl, data);
+                navigator.sendBeacon(ajaxUrl, data);
             }
 
-            if (!queued) {
-                fetch(ajaxUrl, {
-                    method: 'POST',
-                    credentials: 'same-origin',
-                    body: data,
-                    keepalive: true,
-                });
-            } else {
-                // Fallback in case the beacon is dropped
-                setTimeout(function () {
-                    fetch(ajaxUrl, {
-                        method: 'POST',
-                        credentials: 'same-origin',
-                        body: data,
-                        keepalive: true,
-                    });
-                }, 100);
-            }
+            fetch(ajaxUrl, {
+                method: 'POST',
+                credentials: 'same-origin',
+                body: data,
+                keepalive: true,
+            });
         } else {
             fetch(ajaxUrl, {
                 method: 'POST',


### PR DESCRIPTION
## Summary
- ensure `fetch` executes immediately after `navigator.sendBeacon` without delay
- keep `keepalive: true` so request completes during page unload

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892a2b78784832787b9133153c3bbe9