### PR TITLE
Ensure tab counter decremented once

### DIFF
--- a/public/js/gm2-ac-activity.js
+++ b/public/js/gm2-ac-activity.js
@@ -28,15 +28,12 @@
     }
 
     function incrementTabs() {
-        const count = parseInt(localStorage.getItem(KEY) || '0', 10) + 1;
+        const count = Math.max(parseInt(localStorage.getItem(KEY) || '0', 10), 0) + 1;
         localStorage.setItem(KEY, String(count));
     }
 
     function decrementTabs() {
-        let count = parseInt(localStorage.getItem(KEY) || '0', 10) - 1;
-        if (count < 0) {
-            count = 0;
-        }
+        const count = Math.max(parseInt(localStorage.getItem(KEY) || '0', 10) - 1, 0);
         localStorage.setItem(KEY, String(count));
         if (count === 0) {
             send('gm2_ac_mark_abandoned');
@@ -46,12 +43,5 @@
     incrementTabs();
     send('gm2_ac_mark_active');
 
-    window.addEventListener('beforeunload', decrementTabs);
-    window.addEventListener('pagehide', decrementTabs);
-    window.addEventListener('unload', decrementTabs);
-    document.addEventListener('visibilitychange', function () {
-        if (document.visibilityState === 'hidden') {
-            decrementTabs();
-        }
-    });
+    window.addEventListener('pagehide', decrementTabs, { once: true });
 })();


### PR DESCRIPTION
## Summary
- ensure tab counter never goes negative when updating local storage
- decrement tab counter on a single `pagehide` event with `{ once: true }`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892a4248b548327bcd0cc6e9b3de4d8