### PR TITLE
Serialize abandoned cart beacon payload

### DIFF
--- a/public/js/gm2-ac-activity.js
+++ b/public/js/gm2-ac-activity.js
@@ -9,7 +9,8 @@
 
         if (action === 'gm2_ac_mark_abandoned') {
             if (navigator.sendBeacon) {
-                navigator.sendBeacon(ajaxUrl, data);
+                const payload = new Blob([data.toString()], { type: 'application/x-www-form-urlencoded' });
+                navigator.sendBeacon(ajaxUrl, payload);
             }
 
             fetch(ajaxUrl, {


### PR DESCRIPTION
## Summary
- ensure `navigator.sendBeacon` sends a serialized payload for abandoned cart tracking
- retain `fetch` fallback with `keepalive` for older browsers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892b3e96ca08327865ca4c40db9e8d1