### PR TITLE
Improve abandoned cart diagnostics

### DIFF
--- a/includes/Gm2_Abandoned_Carts.php
+++ b/includes/Gm2_Abandoned_Carts.php
@@ -167,6 +167,16 @@ class Gm2_Abandoned_Carts {
         }
     }
 
+    private static function log_no_cart($action) {
+        $message = sprintf('Gm2 Abandoned Carts: %s called without cart token.', $action);
+        error_log($message);
+        if (is_admin()) {
+            add_action('admin_notices', function () use ($message) {
+                echo '<div class="notice notice-error"><p>' . esc_html($message) . '</p></div>';
+            });
+        }
+    }
+
     public static function gm2_ac_mark_active() {
         check_ajax_referer('gm2_ac_activity', 'nonce');
 
@@ -176,6 +186,7 @@ class Gm2_Abandoned_Carts {
             $token = WC()->session->get_customer_id();
         }
         if (empty($token)) {
+            self::log_no_cart(__FUNCTION__);
             wp_send_json_error('no_cart');
         }
 
@@ -206,6 +217,7 @@ class Gm2_Abandoned_Carts {
             $token = WC()->session->get_customer_id();
         }
         if (empty($token)) {
+            self::log_no_cart(__FUNCTION__);
             wp_send_json_error('no_cart');
         }
 

--- a/public/js/gm2-ac-activity.js
+++ b/public/js/gm2-ac-activity.js
@@ -18,13 +18,29 @@
                 credentials: 'same-origin',
                 body: data,
                 keepalive: true,
-            });
+            })
+                .then((response) => {
+                    if (!response.ok) {
+                        console.error('gm2_ac_mark_abandoned request failed', response.status, response.statusText);
+                    }
+                })
+                .catch((error) => {
+                    console.error('gm2_ac_mark_abandoned request error', error);
+                });
         } else {
             fetch(ajaxUrl, {
                 method: 'POST',
                 credentials: 'same-origin',
                 body: data,
-            });
+            })
+                .then((response) => {
+                    if (!response.ok) {
+                        console.error(`${action} request failed`, response.status, response.statusText);
+                    }
+                })
+                .catch((error) => {
+                    console.error(`${action} request error`, error);
+                });
         }
     }
 


### PR DESCRIPTION
## Summary
- log network errors from fetch calls in AC activity script
- report missing cart tokens via error log and admin notices

## Testing
- `npm test`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*


------
https://chatgpt.com/codex/tasks/task_e_6892b4fa0ce48327afb5dfbc0c2f4df7