### PR TITLE
Handle URLSearchParams in sendBeacon

### DIFF
--- a/public/js/gm2-ac-activity.js
+++ b/public/js/gm2-ac-activity.js
@@ -9,8 +9,23 @@
 
         if (action === 'gm2_ac_mark_abandoned') {
             if (navigator.sendBeacon) {
-                const payload = new Blob([data.toString()], { type: 'application/x-www-form-urlencoded' });
-                navigator.sendBeacon(ajaxUrl, payload);
+                try {
+                    const sent = navigator.sendBeacon(ajaxUrl, data);
+
+                    if (!sent) {
+                        const payload = new Blob([data.toString()], { type: 'application/x-www-form-urlencoded' });
+                        navigator.sendBeacon(ajaxUrl, payload);
+                    }
+                } catch (err) {
+                    console.debug('sendBeacon URLSearchParams failed', err);
+
+                    try {
+                        const payload = new Blob([data.toString()], { type: 'application/x-www-form-urlencoded' });
+                        navigator.sendBeacon(ajaxUrl, payload);
+                    } catch (error) {
+                        console.error('sendBeacon failed', error);
+                    }
+                }
             }
 
             fetch(ajaxUrl, {


### PR DESCRIPTION
## Summary
- fall back to Blob when sendBeacon rejects URLSearchParams
- add debugging around sendBeacon failures

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892bcf05ec08327b8aabe2c7bda5f10