### PR TITLE
Add test for abandoned cart revisit flow

### DIFF
--- a/tests/test-abandoned-carts.php
+++ b/tests/test-abandoned-carts.php
@@ -1,0 +1,121 @@
+<?php
+namespace Gm2 {
+    function check_ajax_referer($action, $query_arg = false) { return true; }
+    function wp_send_json_success($data = null) { return ['success'=>true,'data'=>$data]; }
+    function wp_send_json_error($data = null) { return ['success'=>false,'data'=>$data]; }
+    function current_time($type) { return gmdate('Y-m-d H:i:s'); }
+}
+
+namespace {
+if (!class_exists('WC_Session')) {
+    class WC_Session {
+        private $cid;
+        public function __construct($id) { $this->cid = $id; }
+        public function get_customer_id() { return $this->cid; }
+    }
+}
+if (!function_exists('WC')) {
+    function WC() {
+        global $wc_session_obj;
+        if (!$wc_session_obj) {
+            $wc_session_obj = (object) ['session' => new WC_Session('default')];
+        }
+        return $wc_session_obj;
+    }
+}
+
+class AbandonedCartsTest extends WP_UnitTestCase {
+    private $orig_wpdb;
+    private $token = 'tok123';
+
+    public function setUp(): void {
+        parent::setUp();
+        $this->orig_wpdb = $GLOBALS['wpdb'];
+        $GLOBALS['wpdb'] = new AbandonedCartFakeDB($this->token);
+        global $wc_session_obj;
+        $wc_session_obj = (object) ['session' => new WC_Session($this->token)];
+    }
+
+    public function tearDown(): void {
+        $GLOBALS['wpdb'] = $this->orig_wpdb;
+        parent::tearDown();
+    }
+
+    public function test_active_abandoned_revisit_flow() {
+        $_POST = [ 'nonce' => 'n', 'url' => 'https://example.com' ];
+        $_REQUEST = $_POST;
+        \Gm2\Gm2_Abandoned_Carts::gm2_ac_mark_active();
+
+        $table = $GLOBALS['wpdb']->prefix . 'wc_ac_carts';
+        $row = $GLOBALS['wpdb']->data[$table][0];
+        $this->assertNotEmpty($row['session_start']);
+        $this->assertNull($row['abandoned_at']);
+        $this->assertSame(0, $row['revisit_count']);
+
+        $_POST = [ 'nonce' => 'n', 'url' => 'https://example.com' ];
+        $_REQUEST = $_POST;
+        \Gm2\Gm2_Abandoned_Carts::gm2_ac_mark_abandoned();
+
+        $row = $GLOBALS['wpdb']->data[$table][0];
+        $this->assertNotNull($row['abandoned_at']);
+        $this->assertNull($row['session_start']);
+
+        $_POST = [ 'nonce' => 'n', 'url' => 'https://example.com' ];
+        $_REQUEST = $_POST;
+        \Gm2\Gm2_Abandoned_Carts::gm2_ac_mark_active();
+
+        $row = $GLOBALS['wpdb']->data[$table][0];
+        $this->assertNull($row['abandoned_at']);
+        $this->assertNotEmpty($row['session_start']);
+        $this->assertSame(1, $row['revisit_count']);
+    }
+}
+
+class AbandonedCartFakeDB {
+    public $prefix = 'wp_';
+    public $data;
+    private $last_token;
+    private $last_table;
+
+    public function __construct($token) {
+        $table = $this->prefix . 'wc_ac_carts';
+        $this->data[$table] = [
+            [
+                'id' => 1,
+                'cart_token' => $token,
+                'abandoned_at' => null,
+                'session_start' => null,
+                'revisit_count' => 0,
+                'browsing_time' => 0,
+            ],
+        ];
+    }
+
+    public function prepare($query, $token) {
+        $this->last_token = $token;
+        if (preg_match('/FROM\s+(\w+)/', $query, $m)) {
+            $this->last_table = $m[1];
+        }
+        return $query;
+    }
+
+    public function get_row($query) {
+        foreach ($this->data[$this->last_table] as $row) {
+            if ($row['cart_token'] === $this->last_token) {
+                return (object) $row;
+            }
+        }
+        return null;
+    }
+
+    public function update($table, $data, $where) {
+        foreach ($this->data[$table] as &$row) {
+            if ($row['id'] === $where['id']) {
+                foreach ($data as $k => $v) {
+                    $row[$k] = $v;
+                }
+            }
+        }
+    }
+}
+}


### PR DESCRIPTION
## Summary
- add unit test simulating cart activation, abandonment, and reactivation
- mock WooCommerce session and database layer to verify `abandoned_at`, `session_start`, and `revisit_count`

## Testing
- `phpunit --filter AbandonedCartsTest`
- `phpunit` *(fails: many tests error due to missing external dependencies and WordPress configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6892bdca10888327b6542600113dc4da