### PR TITLE
Add taxonomy reset controls for bulk AI

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -254,10 +254,13 @@ class Gm2_Admin {
                         'apply_nonce' => wp_create_nonce('gm2_bulk_ai_apply'),
                         'batch_nonce' => wp_create_nonce('gm2_ai_batch'),
                         'desc_nonce'  => wp_create_nonce('gm2_ai_generate_tax_description'),
+                        'reset_nonce' => wp_create_nonce('gm2_bulk_ai_tax_reset'),
                         'ajax_url'    => admin_url('admin-ajax.php'),
                         'i18n'        => [
-                            'apply'   => __( 'Apply', 'gm2-wordpress-suite' ),
-                            'error'   => __( 'Error', 'gm2-wordpress-suite' ),
+                            'apply'      => __( 'Apply', 'gm2-wordpress-suite' ),
+                            'error'      => __( 'Error', 'gm2-wordpress-suite' ),
+                            'resetting'  => __( 'Resetting...', 'gm2-wordpress-suite' ),
+                            'resetDone'  => __( 'Reset %s terms', 'gm2-wordpress-suite' ),
                         ],
                     ]
                 );

--- a/admin/js/gm2-bulk-ai-tax.js
+++ b/admin/js/gm2-bulk-ai-tax.js
@@ -129,4 +129,60 @@ jQuery(function($){
         e.preventDefault();
         $.post(gm2BulkAiTax.ajax_url,{action:'gm2_ai_tax_batch_cancel',_ajax_nonce:gm2BulkAiTax.batch_nonce});
     });
+
+    $('#gm2-bulk-ai-tax').on('click','#gm2-bulk-term-reset-selected',function(e){
+        e.preventDefault();
+        var ids=[];
+        $('#gm2-bulk-term-list .gm2-select:checked').each(function(){ids.push($(this).val());});
+        if(!ids.length) return;
+        var $msg=$('#gm2-bulk-term-msg');
+        $msg.text(gm2BulkAiTax.i18n.resetting);
+        $.ajax({
+            url: gm2BulkAiTax.ajax_url,
+            method:'POST',
+            data:{action:'gm2_bulk_ai_tax_reset',ids:JSON.stringify(ids),_ajax_nonce:gm2BulkAiTax.reset_nonce},
+            dataType:'json'
+        }).done(function(resp){
+            if(resp&&resp.success){
+                $.each(ids,function(i,key){
+                    var parts=key.split(':');
+                    var row=$('#gm2-term-'+parts[0]+'-'+parts[1]);
+                    row.find('.column-seo_title').text('');
+                    row.find('.column-description').text('');
+                    row.find('.gm2-result').empty();
+                });
+                $msg.text(gm2BulkAiTax.i18n.resetDone.replace('%s',resp.data.reset));
+            }else{
+                $msg.text((resp&&resp.data)?resp.data:gm2BulkAiTax.i18n.error);
+            }
+        }).fail(function(jqXHR,textStatus){
+            var msg=(jqXHR&&jqXHR.responseJSON&&jqXHR.responseJSON.data)?jqXHR.responseJSON.data:(jqXHR&&jqXHR.responseText?jqXHR.responseText:textStatus);
+            $msg.text(msg||gm2BulkAiTax.i18n.error);
+        });
+    });
+
+    $('#gm2-bulk-ai-tax').on('click','#gm2-bulk-term-reset-all',function(e){
+        e.preventDefault();
+        var data={
+            action:'gm2_bulk_ai_tax_reset',
+            all:1,
+            taxonomy:$('select[name="gm2_taxonomy"]').val(),
+            search:$('input[name="gm2_tax_search"]').val()||'',
+            missing_title:$('input[name="gm2_bulk_ai_tax_missing_title"]').is(':checked')?1:0,
+            missing_desc:$('input[name="gm2_bulk_ai_tax_missing_description"]').is(':checked')?1:0,
+            _ajax_nonce:gm2BulkAiTax.reset_nonce
+        };
+        var $msg=$('#gm2-bulk-term-msg');
+        $msg.text(gm2BulkAiTax.i18n.resetting);
+        $.post(gm2BulkAiTax.ajax_url,data).done(function(resp){
+            if(resp&&resp.success){
+                location.reload();
+            }else{
+                $msg.text((resp&&resp.data)?resp.data:gm2BulkAiTax.i18n.error);
+            }
+        }).fail(function(jqXHR,textStatus){
+            var msg=(jqXHR&&jqXHR.responseJSON&&jqXHR.responseJSON.data)?jqXHR.responseJSON.data:(jqXHR&&jqXHR.responseText?jqXHR.responseText:textStatus);
+            $msg.text(msg||gm2BulkAiTax.i18n.error);
+        });
+    });
 });


### PR DESCRIPTION
## Summary
- add Reset Selected and Reset All buttons to bulk taxonomy AI page
- implement AJAX handler to clear term SEO meta
- wire up client-side logic and localization for reset actions

## Testing
- `npm test`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*


------
https://chatgpt.com/codex/tasks/task_e_6893764203f48327a5c61243fa391764