### PR TITLE
Add rich results preview for taxonomy terms

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1851,9 +1851,13 @@ class Gm2_SEO_Admin {
         echo '<p><label for="gm2_seo_description">' . esc_html__( 'SEO Description', 'gm2-wordpress-suite' ) . '</label>';
         echo '<textarea id="gm2_seo_description" name="gm2_seo_description" class="widefat" rows="3" placeholder="' . esc_attr__( 'One sentence summary shown in search results', 'gm2-wordpress-suite' ) . '">' . esc_textarea($description) . '</textarea> <span class="dashicons dashicons-info" title="' . esc_attr__( 'Keep under 160 characters', 'gm2-wordpress-suite' ) . '"></span></p>';
 
-        $permalink = get_permalink($post);
-        $rich_url  = 'https://search.google.com/test/rich-results?url=' . rawurlencode($permalink);
-        echo '<p><a id="gm2-rich-results-preview" class="button button-secondary" href="' . esc_url($rich_url) . '" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Rich Results Preview', 'gm2-wordpress-suite' ) . '</a></p>';
+        if (is_object($term)) {
+            $link = get_term_link($term);
+            if (!is_wp_error($link)) {
+                $rich_url = 'https://search.google.com/test/rich-results?url=' . rawurlencode($link);
+                echo '<p><a id="gm2-rich-results-preview" class="button button-secondary" href="' . esc_url($rich_url) . '" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Rich Results Preview', 'gm2-wordpress-suite' ) . '</a></p>';
+            }
+        }
         echo '<p><label for="gm2_focus_keywords">' . esc_html__( 'Focus Keywords (comma separated)', 'gm2-wordpress-suite' ) . '</label>';
         echo '<input type="text" id="gm2_focus_keywords" name="gm2_focus_keywords" value="' . esc_attr($focus_keywords) . '" placeholder="' . esc_attr__( 'keyword1, keyword2', 'gm2-wordpress-suite' ) . '" class="widefat" /> <span class="dashicons dashicons-info" title="' . esc_attr__( 'Separate with commas', 'gm2-wordpress-suite' ) . '"></span></p>';
         echo '<p><label for="gm2_long_tail_keywords">' . esc_html__( 'Long Tail Keywords (comma separated)', 'gm2-wordpress-suite' ) . '</label>';
@@ -4619,6 +4623,7 @@ class Gm2_SEO_Admin {
             GM2_VERSION,
             true
         );
+
         wp_localize_script(
             'gm2-ai-seo',
             'gm2AiSeo',
@@ -4756,6 +4761,14 @@ class Gm2_SEO_Admin {
             'gm2-snippet-preview',
             GM2_PLUGIN_URL . 'admin/js/gm2-snippet-preview.js',
             ['jquery'],
+            GM2_VERSION,
+            true
+        );
+
+        wp_enqueue_script(
+            'gm2-rich-preview',
+            GM2_PLUGIN_URL . 'admin/js/gm2-rich-preview.js',
+            ['jquery', 'wp-data'],
             GM2_VERSION,
             true
         );


### PR DESCRIPTION
## Summary
- add Rich Results Preview button to taxonomy SEO meta box using the term URL
- load rich-preview script on taxonomy edit screens

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68937c4b8bec8327842ea5d74fbd420c