### PR TITLE
Add per-post schema preview and overrides

### DIFF
--- a/admin/js/gm2-schema-preview.js
+++ b/admin/js/gm2-schema-preview.js
@@ -1,0 +1,19 @@
+jQuery(function($){
+    function fetchSchema(){
+        var data = {
+            action: 'gm2_schema_preview',
+            nonce: gm2SchemaPreview.nonce,
+            post_id: gm2SchemaPreview.post_id,
+            schema_type: $('#gm2_schema_type').val(),
+            schema_brand: $('#gm2_schema_brand').val(),
+            schema_rating: $('#gm2_schema_rating').val()
+        };
+        $.post(gm2SchemaPreview.ajax_url, data, function(resp){
+            if(resp && resp.success){
+                $('#gm2-schema-preview').text(JSON.stringify(resp.data, null, 2));
+            }
+        });
+    }
+    $('#gm2_schema_type, #gm2_schema_brand, #gm2_schema_rating').on('change input', fetchSchema);
+    fetchSchema();
+});


### PR DESCRIPTION
## Summary
- add Schema tab with per-post schema fields and live JSON preview
- hook up AJAX handler and script for on-the-fly schema generation
- respect per-post schema overrides when rendering frontend schema

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893820dd3fc832787f3e45e2ec76150