### PR TITLE
Document JavaScript test process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,14 @@ WP_TESTS_DIR=/path/to/wordpress-tests-lib phpunit
 
 This command executes the PHPUnit tests located in the `tests/` directory.
 
+JavaScript unit tests live in `tests/js` and use Jest. Install the Node
+dependencies once and execute the suite with:
+
+```bash
+npm install
+npm test
+```
+
 ### Database credentials
 
 Before running the test suite via `make test`, export your database connection

--- a/readme.txt
+++ b/readme.txt
@@ -437,3 +437,11 @@ The PHPUnit tests rely on the WordPress test suite and the `phpunit` executable.
 3. **Run the tests.** Execute `phpunit` or `make test` from the project root. The Makefile will install the test suite automatically if it is missing. Set `WP_TESTS_DIR` if you installed the suite elsewhere.
 
 The tests cover the AJAX endpoints used for content analysis and AI research (`gm2_check_rules`, `gm2_keyword_ideas`, `gm2_research_guidelines` and `gm2_ai_research`).
+
+JavaScript tests reside in `tests/js` and use Jest. Install Node dependencies
+and run them with:
+
+```
+npm install
+npm test
+```


### PR DESCRIPTION
## Summary
- Explain how to run the Jest-based JavaScript tests in CONTRIBUTING
- Mention the Jest suite in readme.txt alongside PHP test instructions

## Testing
- `npm test`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_68938ba2e3ac8327990aae9799a1902d