### PR TITLE
Specify meta_query compare for focus keywords

### DIFF
--- a/includes/Gm2_SEO_Utils.php
+++ b/includes/Gm2_SEO_Utils.php
@@ -175,7 +175,7 @@ namespace {
         $term_ids = get_terms([
             'taxonomy'   => get_taxonomies([], 'names'),
             'hide_empty' => false,
-            'meta_query' => [ [ 'key' => '_gm2_focus_keywords' ] ],
+            'meta_query' => [ [ 'key' => '_gm2_focus_keywords', 'compare' => 'EXISTS' ] ],
             'fields'     => 'ids',
         ]);
         if (!is_wp_error($term_ids)) {


### PR DESCRIPTION
## Summary
- ensure term query checks for focus keyword meta key existence

## Testing
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893a715af988327a26b3947a3a759d2