### PR TITLE
Add CSV filename sanitization and stream error handling

### DIFF
--- a/includes/Gm2_CSV_Helper.php
+++ b/includes/Gm2_CSV_Helper.php
@@ -4,14 +4,34 @@ if (!defined('ABSPATH')) {
     exit;
 }
 class Gm2_CSV_Helper {
+    /**
+     * Output an array of rows as a CSV file.
+     *
+     * @param array  $rows     Array of rows to output.
+     * @param string $filename Optional. Name of the file to download. Default 'export.csv'.
+     */
     public static function output(array $rows, $filename = 'export.csv') {
+        $filename = sanitize_file_name($filename);
+
         nocache_headers();
         header('Content-Type: text/csv; charset=utf-8');
         header('Content-Disposition: attachment; filename="' . $filename . '"');
         $out = fopen('php://output', 'w');
+
+        if (false === $out) {
+            // Bail out if the output stream cannot be opened. wp_die() will display an error
+            // message in a WordPress context; otherwise we return quietly.
+            if (function_exists('wp_die')) {
+                wp_die(esc_html__('Unable to open output stream', 'gm2-wordpress-suite'));
+            }
+
+            return;
+        }
+
         foreach ($rows as $row) {
             fputcsv($out, $row);
         }
+
         fclose($out);
     }
 }


### PR DESCRIPTION
## Summary
- sanitize CSV output filename before sending headers
- add fopen failure check with wp_die or graceful return
- document CSV helper and error handling

## Testing
- `npm test`
- `~/.local/share/mise/installs/php/8.4.11/.composer/vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_6893aa9125788327badcefe7d7139ded