### PR TITLE
Handle missing WooCommerce session

### DIFF
--- a/includes/Gm2_Abandoned_Carts.php
+++ b/includes/Gm2_Abandoned_Carts.php
@@ -83,7 +83,12 @@ class Gm2_Abandoned_Carts {
             ];
         }
         $contents   = wp_json_encode($cart_items);
-        $token      = WC()->session->get_customer_id();
+
+        $wc = WC();
+        if (!is_object($wc->session)) {
+            return;
+        }
+        $token      = $wc->session->get_customer_id();
         $ip         = isset($_SERVER['REMOTE_ADDR']) ? sanitize_text_field(wp_unslash($_SERVER['REMOTE_ADDR'])) : '';
         $agent      = isset($_SERVER['HTTP_USER_AGENT']) ? sanitize_text_field(wp_unslash($_SERVER['HTTP_USER_AGENT'])) : '';
         $browser    = self::get_browser($agent);

--- a/tests/AbandonedCartSessionTest.php
+++ b/tests/AbandonedCartSessionTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Gm2 {
+    function add_action($hook, $callback) {}
+}
+
+namespace {
+use PHPUnit\Framework\TestCase;
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/../');
+}
+if (!defined('GM2_PLUGIN_DIR')) {
+    define('GM2_PLUGIN_DIR', __DIR__ . '/../');
+}
+
+if (!function_exists('wp_json_encode')) {
+    function wp_json_encode($data) {
+        return json_encode($data);
+    }
+}
+
+if (!class_exists('WC_Cart')) {
+    class WC_Cart {
+        private $items;
+        public function __construct($items = []) {
+            $this->items = $items;
+        }
+        public function is_empty() {
+            return empty($this->items);
+        }
+        public function get_cart() {
+            return $this->items;
+        }
+    }
+}
+
+if (!function_exists('WC')) {
+    function WC() {
+        global $wc_obj;
+        return $wc_obj;
+    }
+}
+
+require_once __DIR__ . '/../includes/Gm2_Abandoned_Carts.php';
+
+final class AbandonedCartSessionTest extends TestCase {
+    public function test_capture_cart_handles_missing_session() {
+        global $wc_obj;
+        $product = new class {
+            public function get_name() { return 'Test'; }
+            public function get_price() { return 1.0; }
+            public function get_sku() { return 'TST'; }
+        };
+        $wc_obj = (object) [
+            'cart' => new WC_Cart([
+                [
+                    'product_id' => 1,
+                    'quantity' => 1,
+                    'data' => $product,
+                ],
+            ]),
+            'session' => null,
+        ];
+        $ac = new \Gm2\Gm2_Abandoned_Carts();
+        $ac->capture_cart();
+        $this->assertTrue(true);
+    }
+}
+}


### PR DESCRIPTION
## Summary
- Safely handle missing WooCommerce session when capturing abandoned carts
- Add unit test ensuring capture_cart exits gracefully when session is null

## Testing
- `phpunit --no-configuration tests/AbandonedCartSessionTest.php`


------
https://chatgpt.com/codex/tasks/task_e_6893ace0daec83278895eabe3a1512b2