### PR TITLE
Sanitize redirect targets and enforce safe redirects

### DIFF
--- a/public/Gm2_SEO_Public.php
+++ b/public/Gm2_SEO_Public.php
@@ -81,8 +81,14 @@ class Gm2_SEO_Public {
         foreach ($redirects as $r) {
             $source = untrailingslashit(parse_url($r['source'], PHP_URL_PATH));
             if ($source === $current) {
-                wp_redirect($r['target'], intval($r['type']));
-                exit;
+                $target = esc_url_raw($r['target']);
+                $is_internal = !parse_url($target, PHP_URL_HOST) || strpos($target, home_url('/')) === 0;
+                if ($is_internal) {
+                    $type = (int) $r['type'];
+                    $type = in_array($type, [301, 302], true) ? $type : 302;
+                    wp_safe_redirect($target, $type);
+                    exit;
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- sanitize redirect targets before redirecting
- ensure redirects stay internal and restrict status codes to 301/302

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893af8902108327b171bb0a228f3633