### PR TITLE
Temporarily disable recovery email queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,8 @@ notification from reaching WordPress.
 The admin screen under **Gm2 → Abandoned Carts** displays a table of carts and
 their status—active or abandoned—showing the IP address, email, location, device,
 products, cart value, entry and exit URLs, browsing time, and revisit count.
-Recovery emails are added to a queue which is processed hourly by WP&nbsp;Cron via
-the `gm2_ac_process_queue` action. Developers can hook `gm2_ac_send_message` to
-send the actual email content.
+Recovery emails are planned to be queued and processed by WP&nbsp;Cron via the
+`gm2_ac_process_queue` action, but this feature is currently disabled.
 
 
 

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -54,7 +54,8 @@ require_once GM2_PLUGIN_DIR . 'includes/Gm2_PageSpeed.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_SEO_Utils.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_CSV_Helper.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_Abandoned_Carts.php';
-require_once GM2_PLUGIN_DIR . 'includes/Gm2_Abandoned_Carts_Messaging.php';
+// Temporarily disable Recovery Email Queue.
+// require_once GM2_PLUGIN_DIR . 'includes/Gm2_Abandoned_Carts_Messaging.php';
 require_once GM2_PLUGIN_DIR . 'admin/Gm2_Abandoned_Carts_Admin.php';
 require_once GM2_PLUGIN_DIR . 'admin/class-gm2-ac-table.php';
 require_once GM2_PLUGIN_DIR . 'admin/class-gm2-bulk-ai-list-table.php';

--- a/includes/Gm2_Loader.php
+++ b/includes/Gm2_Loader.php
@@ -56,8 +56,9 @@ class Gm2_Loader {
             $ac = new Gm2_Abandoned_Carts();
             $ac->run();
 
-            $ac_msg = new Gm2_Abandoned_Carts_Messaging();
-            $ac_msg->run();
+            // Temporarily disable Recovery Email Queue.
+            // $ac_msg = new Gm2_Abandoned_Carts_Messaging();
+            // $ac_msg->run();
 
             if (is_admin()) {
                 $ac_admin = new Gm2_Abandoned_Carts_Admin();

--- a/readme.txt
+++ b/readme.txt
@@ -315,7 +315,7 @@ The tracking script listens for `beforeunload`, `visibilitychange` and
 older browsers these events or background requests may be suppressed, which can
 prevent the abandonment notice from reaching WordPress.
 
-Open **Gm2 → Abandoned Carts** to view a table listing each cart's status, IP address, email, location, device, products, value, entry and exit URLs, browsing time and revisits. Recovery messages are queued using WP&nbsp;Cron via the `gm2_ac_process_queue` action. Developers can hook `gm2_ac_send_message` to send the actual emails.
+Open **Gm2 → Abandoned Carts** to view a table listing each cart's status, IP address, email, location, device, products, value, entry and exit URLs, browsing time and revisits. Recovery messages were planned to be queued using WP&nbsp;Cron via the `gm2_ac_process_queue` action, but this feature is currently disabled.
 
 == Redirects ==
 Create 301 or 302 redirects from the **SEO → Redirects** tab. The plugin logs


### PR DESCRIPTION
## Summary
- disable recovery email queue in abandoned cart module
- update docs noting recovery email queue is disabled

## Testing
- `npm test`
- `php /usr/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*


------
https://chatgpt.com/codex/tasks/task_e_6893b136ed988327bb07faecec081853