### PR TITLE
Add SEO status filter to bulk AI tools

### DIFF
--- a/admin/class-gm2-bulk-ai-list-table.php
+++ b/admin/class-gm2-bulk-ai-list-table.php
@@ -17,6 +17,7 @@ class Gm2_Bulk_Ai_List_Table extends \WP_List_Table {
     private $terms;
     private $missing_title;
     private $missing_desc;
+    private $seo_status;
 
     public function __construct($admin, $args) {
         $this->admin         = $admin;
@@ -24,6 +25,7 @@ class Gm2_Bulk_Ai_List_Table extends \WP_List_Table {
         $this->status        = $args['status'] ?? 'publish';
         $this->post_type     = $args['post_type'] ?? 'all';
         $this->terms         = $args['terms'] ?? [];
+        $this->seo_status    = $args['seo_status'] ?? 'all';
         $this->missing_title = $args['missing_title'] ?? '0';
         $this->missing_desc  = $args['missing_desc'] ?? '0';
 
@@ -186,6 +188,18 @@ class Gm2_Bulk_Ai_List_Table extends \WP_List_Table {
         if ($this->missing_desc === '1') {
             $meta_query[] = [
                 'relation' => 'OR',
+                [ 'key' => '_gm2_description', 'compare' => 'NOT EXISTS' ],
+                [ 'key' => '_gm2_description', 'value' => '', 'compare' => '=' ],
+            ];
+        }
+        if ($this->seo_status === 'complete') {
+            $meta_query[] = [ 'key' => '_gm2_title', 'value' => '', 'compare' => '!=' ];
+            $meta_query[] = [ 'key' => '_gm2_description', 'value' => '', 'compare' => '!=' ];
+        } elseif ($this->seo_status === 'incomplete') {
+            $meta_query[] = [
+                'relation' => 'OR',
+                [ 'key' => '_gm2_title', 'compare' => 'NOT EXISTS' ],
+                [ 'key' => '_gm2_title', 'value' => '', 'compare' => '=' ],
                 [ 'key' => '_gm2_description', 'compare' => 'NOT EXISTS' ],
                 [ 'key' => '_gm2_description', 'value' => '', 'compare' => '=' ],
             ];

--- a/admin/js/gm2-bulk-ai.js
+++ b/admin/js/gm2-bulk-ai.js
@@ -386,6 +386,7 @@ jQuery(function($){
             all:1,
             status:$('select[name="status"]').val(),
             post_type:$('select[name="gm2_post_type"]').val(),
+            seo_status:$('select[name="seo_status"]').val(),
             terms:$('select[name="term[]"]').val()||[],
             missing_title:$('input[name="gm2_missing_title"]').is(':checked')?1:0,
             missing_desc:$('input[name="gm2_missing_description"]').is(':checked')?1:0,


### PR DESCRIPTION
## Summary
- add SEO Status dropdown for Bulk AI Review and persist selection
- filter list table by complete/incomplete SEO metadata
- respect SEO Status in reset-all operations

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893ba0c570c832787a3ea6d258327e8