### PR TITLE
Add SEO status filter for taxonomy bulk AI

### DIFF
--- a/admin/class-gm2-bulk-ai-tax-list-table.php
+++ b/admin/class-gm2-bulk-ai-tax-list-table.php
@@ -16,12 +16,14 @@ class Gm2_Bulk_Ai_Tax_List_Table extends \WP_List_Table {
     private $search;
     private $missing_title;
     private $missing_desc;
+    private $seo_status;
 
     public function __construct($admin, $args) {
         $this->admin         = $admin;
         $this->page_size     = max(1, (int) ($args['page_size'] ?? 10));
         $this->taxonomy      = $args['taxonomy'] ?? 'all';
         $this->search        = $args['search'] ?? '';
+        $this->seo_status    = $args['seo_status'] ?? 'all';
         $this->missing_title = $args['missing_title'] ?? '0';
         $this->missing_desc  = $args['missing_description'] ?? '0';
 
@@ -126,6 +128,18 @@ class Gm2_Bulk_Ai_Tax_List_Table extends \WP_List_Table {
         }
 
         $meta_query = [];
+        if ($this->seo_status === 'complete') {
+            $meta_query[] = [ 'key' => '_gm2_title', 'value' => '', 'compare' => '!=' ];
+            $meta_query[] = [ 'key' => '_gm2_description', 'value' => '', 'compare' => '!=' ];
+        } elseif ($this->seo_status === 'incomplete') {
+            $meta_query[] = [
+                'relation' => 'OR',
+                [ 'key' => '_gm2_title', 'compare' => 'NOT EXISTS' ],
+                [ 'key' => '_gm2_title', 'value' => '', 'compare' => '=' ],
+                [ 'key' => '_gm2_description', 'compare' => 'NOT EXISTS' ],
+                [ 'key' => '_gm2_description', 'value' => '', 'compare' => '=' ],
+            ];
+        }
         if ($this->missing_title === '1') {
             $meta_query[] = [
                 'relation' => 'OR',

--- a/admin/js/gm2-bulk-ai-tax.js
+++ b/admin/js/gm2-bulk-ai-tax.js
@@ -168,6 +168,7 @@ jQuery(function($){
             all:1,
             taxonomy:$('select[name="gm2_taxonomy"]').val(),
             search:$('input[name="gm2_tax_search"]').val()||'',
+            seo_status:$('select[name="gm2_tax_seo_status"]').val(),
             missing_title:$('input[name="gm2_bulk_ai_tax_missing_title"]').is(':checked')?1:0,
             missing_desc:$('input[name="gm2_bulk_ai_tax_missing_description"]').is(':checked')?1:0,
             _ajax_nonce:gm2BulkAiTax.reset_nonce


### PR DESCRIPTION
## Summary
- add SEO Status dropdown and persistence for taxonomy bulk AI
- include status in list table filtering and reset-all requests
- update reset handler to honor SEO Status filter

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893bc27b3388327bdb515b4b6e741f5