### PR TITLE
Send active cart ping after AJAX add-to-cart

### DIFF
--- a/public/js/gm2-ac-activity.js
+++ b/public/js/gm2-ac-activity.js
@@ -6,7 +6,7 @@
     const url = window.location.href;
 
     function send(action) {
-        const data = new URLSearchParams({ action, nonce, url });
+        const data = new URLSearchParams({ action, nonce, url: window.location.href });
 
         if (action === 'gm2_ac_mark_abandoned') {
             if (navigator.sendBeacon) {
@@ -95,6 +95,10 @@
         setEntryUrl(url);
     }
     send('gm2_ac_mark_active');
+
+    document.body.addEventListener('added_to_cart', () => {
+        send('gm2_ac_mark_active');
+    });
 
     window.addEventListener('pagehide', decrementTabs, { once: true });
 })();


### PR DESCRIPTION
## Summary
- ensure cart activity requests always include current page URL
- mark carts active when WooCommerce's `added_to_cart` event fires

## Testing
- `npm test`
- `phpunit` *(fails: could not open `/tmp/wordpress-tests-lib/includes/functions.php`)*

------
https://chatgpt.com/codex/tasks/task_e_6893c04529a883278962255787329df8