### PR TITLE
Fix select-all handling in bulk AI list tables

### DIFF
--- a/admin/class-gm2-bulk-ai-list-table.php
+++ b/admin/class-gm2-bulk-ai-list-table.php
@@ -237,8 +237,19 @@ class Gm2_Bulk_Ai_List_Table extends \WP_List_Table {
         $this->display_tablenav('top');
         $classes = implode(' ', $this->get_table_classes());
         echo '<table id="gm2-bulk-list" class="wp-list-table ' . esc_attr($classes) . '">';
+
+        echo '<thead>';
         $this->print_column_headers();
+        echo '</thead>';
+
+        echo '<tbody id="the-list">';
         $this->display_rows_or_placeholder();
+        echo '</tbody>';
+
+        echo '<tfoot>';
+        $this->print_column_headers(false);
+        echo '</tfoot>';
+
         echo '</table>';
         $this->display_tablenav('bottom');
     }

--- a/admin/class-gm2-bulk-ai-tax-list-table.php
+++ b/admin/class-gm2-bulk-ai-tax-list-table.php
@@ -192,8 +192,19 @@ class Gm2_Bulk_Ai_Tax_List_Table extends \WP_List_Table {
         $this->display_tablenav('top');
         $classes = implode(' ', $this->get_table_classes());
         echo '<table id="gm2-bulk-term-list" class="wp-list-table ' . esc_attr($classes) . '">';
+
+        echo '<thead>';
         $this->print_column_headers();
+        echo '</thead>';
+
+        echo '<tbody id="the-list">';
         $this->display_rows_or_placeholder();
+        echo '</tbody>';
+
+        echo '<tfoot>';
+        $this->print_column_headers(false);
+        echo '</tfoot>';
+
         echo '</table>';
         $this->display_tablenav('bottom');
     }


### PR DESCRIPTION
## Summary
- ensure bulk post table display uses thead/tfoot and wraps rows with tbody so WP's select-all checkbox works
- mirror core WP_List_Table markup in bulk term table for consistent select-all behavior

## Testing
- `npm test`
- `phpunit` *(fails: Tests: 211, Assertions: 280, Errors: 72, Failures: 60)*

------
https://chatgpt.com/codex/tasks/task_e_6893cb6e8c688327a290f4a95b452dbb