### PR TITLE
Support taxonomy-specific bulk AI filters

### DIFF
--- a/admin/class-gm2-bulk-ai-list-table.php
+++ b/admin/class-gm2-bulk-ai-list-table.php
@@ -158,21 +158,24 @@ class Gm2_Bulk_Ai_List_Table extends \WP_List_Table {
 
         if ($this->terms) {
             $taxonomies = $this->admin->get_supported_taxonomies();
-            $tax_query  = [ 'relation' => 'OR' ];
-            foreach ($this->terms as $t) {
-                if (strpos($t, ':') === false) {
+            $tax_query  = [];
+            foreach ($this->terms as $tax => $ids) {
+                if (!in_array($tax, $taxonomies, true)) {
                     continue;
                 }
-                list($tax, $id) = explode(':', $t);
-                if (in_array($tax, $taxonomies, true)) {
+                $ids = array_filter(array_map('absint', (array) $ids));
+                if ($ids) {
                     $tax_query[] = [
                         'taxonomy' => $tax,
                         'field'    => 'term_id',
-                        'terms'    => absint($id),
+                        'terms'    => $ids,
                     ];
                 }
             }
-            if (count($tax_query) > 1) {
+            if ($tax_query) {
+                if (count($tax_query) > 1) {
+                    $tax_query = array_merge(['relation' => 'AND'], $tax_query);
+                }
                 $args['tax_query'] = $tax_query;
             }
         }

--- a/tests/test-bulk-ai.php
+++ b/tests/test-bulk-ai.php
@@ -80,7 +80,7 @@ class BulkAiFilterTest extends WP_UnitTestCase {
         $out_post = self::factory()->post->create(['post_title' => 'Out', 'post_category' => [$cat2]]);
         $user = self::factory()->user->create(['role' => 'administrator']);
         update_user_meta($user, 'gm2_bulk_ai_post_type', 'post');
-        update_user_meta($user, 'gm2_bulk_ai_term', 'category:' . $cat1);
+        update_user_meta($user, 'gm2_bulk_ai_term', ['category' => [$cat1]]);
         $admin = new Gm2_SEO_Admin();
         wp_set_current_user($user);
         ob_start();
@@ -98,7 +98,7 @@ class BulkAiFilterTest extends WP_UnitTestCase {
 
         $user = self::factory()->user->create(['role' => 'administrator']);
         update_user_meta($user, 'gm2_bulk_ai_post_type', 'post');
-        update_user_meta($user, 'gm2_bulk_ai_term', 'category:' . $cat1 . ',category:' . $cat2);
+        update_user_meta($user, 'gm2_bulk_ai_term', ['category' => [$cat1, $cat2]]);
         $admin = new Gm2_SEO_Admin();
         wp_set_current_user($user);
         ob_start();
@@ -119,7 +119,7 @@ class BulkAiFilterTest extends WP_UnitTestCase {
 
         $user = self::factory()->user->create(['role' => 'administrator']);
         update_user_meta($user, 'gm2_bulk_ai_post_type', 'product');
-        update_user_meta($user, 'gm2_bulk_ai_term', 'product_cat:' . $cat);
+        update_user_meta($user, 'gm2_bulk_ai_term', ['product_cat' => [$cat]]);
         $admin = new Gm2_SEO_Admin();
         wp_set_current_user($user);
         ob_start();


### PR DESCRIPTION
## Summary
- Render separate taxonomy multi-selects on Bulk AI Review page and persist selections per taxonomy.
- Build WP_Query tax_query arrays for each selected taxonomy to filter posts accordingly.
- Adjust tests for new per-taxonomy term storage.

## Testing
- `npm test`
- `phpunit` *(fails: Failed to open stream: No such file or directory)*
- `make test` *(fails: Database credentials must be supplied)*

------
https://chatgpt.com/codex/tasks/task_e_6893cf1eaa5483278a46f179d867eee6