### PR TITLE
feat: reorganize bulk AI filters and actions

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1288,15 +1288,24 @@ class Gm2_SEO_Admin {
         echo '<p class="description">' . esc_html__( 'Select posts, click', 'gm2-wordpress-suite' ) . ' <strong>' . esc_html__( 'Analyze Selected', 'gm2-wordpress-suite' ) . '</strong> ' . esc_html__( 'to generate suggestions. Review the suggestions and choose what to apply.', 'gm2-wordpress-suite' ) . '</p>';
         echo '<form method="post" action="' . esc_url( admin_url( 'admin.php?page=gm2-bulk-ai-review' ) ) . '">';
         wp_nonce_field('gm2_bulk_ai_settings');
+
+        // Row 1: page size, post status, SEO status.
         echo '<p><label>' . esc_html__( 'Posts per page', 'gm2-wordpress-suite' ) . ' <input type="number" name="page_size" value="' . esc_attr($page_size) . '" min="1"></label> ';
         echo '<label>' . esc_html__( 'Status', 'gm2-wordpress-suite' ) . ' <select name="status">';
         echo '<option value="publish"' . selected($status, 'publish', false) . '>' . esc_html__( 'Published', 'gm2-wordpress-suite' ) . '</option>';
         echo '<option value="draft"' . selected($status, 'draft', false) . '>' . esc_html__( 'Draft', 'gm2-wordpress-suite' ) . '</option>';
         echo '</select></label> ';
-        echo '<label>' . esc_html__( 'Post Type', 'gm2-wordpress-suite' ) . ' <select name="gm2_post_type">';
+        echo '<label>' . esc_html__( 'SEO Status', 'gm2-wordpress-suite' ) . ' <select name="seo_status">';
+        echo '<option value="all"' . selected($seo_status, 'all', false) . '>' . esc_html__( 'All', 'gm2-wordpress-suite' ) . '</option>';
+        echo '<option value="complete"' . selected($seo_status, 'complete', false) . '>' . esc_html__( 'Complete', 'gm2-wordpress-suite' ) . '</option>';
+        echo '<option value="incomplete"' . selected($seo_status, 'incomplete', false) . '>' . esc_html__( 'Incomplete', 'gm2-wordpress-suite' ) . '</option>';
+        echo '</select></label></p>';
+
+        // Row 2: post type and taxonomy filters.
+        echo '<p><label>' . esc_html__( 'Post Type', 'gm2-wordpress-suite' ) . ' <select name="gm2_post_type">';
         echo '<option value="all"' . selected($post_type, 'all', false) . '>' . esc_html__( 'All', 'gm2-wordpress-suite' ) . '</option>';
         foreach ($this->get_supported_post_types() as $pt) {
-            $obj = get_post_type_object($pt);
+            $obj  = get_post_type_object($pt);
             $name = $obj ? $obj->labels->singular_name : $pt;
             echo '<option value="' . esc_attr($pt) . '"' . selected($post_type, $pt, false) . '>' . esc_html($name) . '</option>';
         }
@@ -1324,31 +1333,34 @@ class Gm2_SEO_Admin {
             }
             echo '</select></label> ';
         }
-        echo '<label>' . esc_html__( 'SEO Status', 'gm2-wordpress-suite' ) . ' <select name="seo_status">';
-        echo '<option value="all"' . selected($seo_status, 'all', false) . '>' . esc_html__( 'All', 'gm2-wordpress-suite' ) . '</option>';
-        echo '<option value="complete"' . selected($seo_status, 'complete', false) . '>' . esc_html__( 'Complete', 'gm2-wordpress-suite' ) . '</option>';
-        echo '<option value="incomplete"' . selected($seo_status, 'incomplete', false) . '>' . esc_html__( 'Incomplete', 'gm2-wordpress-suite' ) . '</option>';
-        echo '</select></label> ';
-        echo '<label><input type="checkbox" name="gm2_missing_title" value="1" ' . checked($missing_title, '1', false) . '> ' . esc_html__( 'Only posts missing SEO Title', 'gm2-wordpress-suite' ) . '</label> ';
+        echo '</p>';
+
+        // Row 3: missing metadata filters and save button.
+        echo '<p><label><input type="checkbox" name="gm2_missing_title" value="1" ' . checked($missing_title, '1', false) . '> ' . esc_html__( 'Only posts missing SEO Title', 'gm2-wordpress-suite' ) . '</label> ';
         echo '<label><input type="checkbox" name="gm2_missing_description" value="1" ' . checked($missing_desc, '1', false) . '> ' . esc_html__( 'Only posts missing Description', 'gm2-wordpress-suite' ) . '</label> ';
+        echo '&nbsp;&nbsp;';
         submit_button( esc_html__( 'Save', 'gm2-wordpress-suite' ), 'secondary', 'gm2_bulk_ai_save', false );
         echo '</p></form>';
+
+        $buttons = '<button type="button" class="button gm2-bulk-analyze" aria-label="' . esc_attr__( 'Analyze Selected', 'gm2-wordpress-suite' ) . '">' . esc_html__( 'Analyze Selected', 'gm2-wordpress-suite' ) . '</button> '
+            . '<button type="button" class="button gm2-bulk-cancel">' . esc_html__( 'Cancel', 'gm2-wordpress-suite' ) . '</button> '
+            . '<button type="button" class="button gm2-bulk-apply-all">' . esc_html__( 'Apply All', 'gm2-wordpress-suite' ) . '</button> '
+            . '<button type="button" class="button gm2-bulk-reset-all">' . esc_html__( 'Reset All', 'gm2-wordpress-suite' ) . '</button> '
+            . '<button type="button" class="button gm2-bulk-reset-selected">' . esc_html__( 'Reset Selected', 'gm2-wordpress-suite' ) . '</button> '
+            . '<button type="button" class="button gm2-bulk-schedule">' . esc_html__( 'Schedule Batch', 'gm2-wordpress-suite' ) . '</button> '
+            . '<button type="button" class="button gm2-bulk-cancel-batch">' . esc_html__( 'Cancel Batch', 'gm2-wordpress-suite' ) . '</button>';
+
+        // Row 4 (top action buttons).
+        echo '<p class="gm2-bulk-actions">' . $buttons . '</p>';
 
         echo '<form method="get">';
         echo '<input type="hidden" name="page" value="gm2-bulk-ai-review" />';
         $table->search_box( esc_html__( 'Search Title', 'gm2-wordpress-suite' ), 'gm2-bulk-search' );
         $table->display();
         echo '</form>';
-        echo '<p><button type="button" class="button" id="gm2-bulk-analyze" aria-label="' . esc_attr__( 'Analyze Selected', 'gm2-wordpress-suite' ) . '">' . esc_html__( 'Analyze Selected', 'gm2-wordpress-suite' ) . '</button> ' .
-            '<button type="button" class="button" id="gm2-select-none">' . esc_html__( 'Select None', 'gm2-wordpress-suite' ) . '</button> ' .
-            '<button type="button" class="button" id="gm2-bulk-cancel">' . esc_html__( 'Cancel', 'gm2-wordpress-suite' ) . '</button> ' .
-            '<button type="button" class="button" id="gm2-bulk-apply-all">' . esc_html__( 'Apply All', 'gm2-wordpress-suite' ) . '</button> ' .
-            '<button type="button" class="button" id="gm2-bulk-reset-selected">' . esc_html__( 'Reset Selected', 'gm2-wordpress-suite' ) . '</button> ' .
-            '<button type="button" class="button" id="gm2-bulk-reset-all">' . esc_html__( 'Reset All', 'gm2-wordpress-suite' ) . '</button> ' .
-            '<span id="gm2-bulk-apply-msg"></span></p>';
+        // Bottom action buttons.
+        echo '<p class="gm2-bulk-actions">' . $buttons . ' <span id="gm2-bulk-apply-msg"></span></p>';
         echo '<p><progress id="gm2-bulk-progress-bar" value="0" max="100" style="width:100%;display:none" role="progressbar" aria-live="polite"></progress></p>';
-        echo '<p><button type="button" class="button" id="gm2-bulk-schedule">' . esc_html__( 'Schedule Batch', 'gm2-wordpress-suite' ) . '</button> ' .
-            '<button type="button" class="button" id="gm2-bulk-cancel-batch">' . esc_html__( 'Cancel Batch', 'gm2-wordpress-suite' ) . '</button></p>';
         echo '</div>';
     }
 

--- a/admin/js/gm2-bulk-ai.js
+++ b/admin/js/gm2-bulk-ai.js
@@ -10,7 +10,7 @@ jQuery(function($){
         var $bar = $('#gm2-bulk-progress-bar');
         if(!$bar.length){
             $bar = $('<progress>',{id:'gm2-bulk-progress-bar',value:0,max:max,style:'width:100%;',role:'progressbar','aria-live':'polite'});
-            $('#gm2-bulk-analyze').parent().after($bar);
+            $('.gm2-bulk-analyze').last().parent().after($bar);
         }
         $bar.attr({max:max,role:'progressbar','aria-live':'polite'}).val(0).show();
     }
@@ -54,16 +54,11 @@ jQuery(function($){
         var c=$(this).prop('checked');
         $('#gm2-bulk-list .gm2-select').prop('checked',c);
     });
-    $('#gm2-bulk-ai').on('click','#gm2-select-none',function(e){
-        e.preventDefault();
-        $('#gm2-bulk-select-all').prop('checked',false);
-        $('#gm2-bulk-list .gm2-select').prop('checked',false);
-    });
     $('#gm2-bulk-list').on('click','.gm2-row-select-all',function(){
         var checked=$(this).prop('checked');
         $(this).closest('.gm2-result').find('.gm2-apply').prop('checked',checked);
     });
-    $('#gm2-bulk-ai').on('click','#gm2-bulk-analyze',function(e){
+    $('#gm2-bulk-ai').on('click','.gm2-bulk-analyze',function(e){
         e.preventDefault();
         stopProcessing = false;
         var ids=[];
@@ -157,7 +152,7 @@ jQuery(function($){
         updateProgress();
         processNext();
     });
-    $('#gm2-bulk-ai').on('click','#gm2-bulk-cancel',function(e){
+    $('#gm2-bulk-ai').on('click','.gm2-bulk-cancel',function(e){
         e.preventDefault();
         stopProcessing = true;
         $('#gm2-bulk-progress-bar').hide();
@@ -279,7 +274,7 @@ jQuery(function($){
             });
     });
 
-    $('#gm2-bulk-ai').on('click','#gm2-bulk-apply-all',function(e){
+    $('#gm2-bulk-ai').on('click','.gm2-bulk-apply-all',function(e){
         e.preventDefault();
         var posts={};
         $('#gm2-bulk-list tr').each(function(){
@@ -346,7 +341,7 @@ jQuery(function($){
         });
     });
 
-    $('#gm2-bulk-ai').on('click','#gm2-bulk-reset-selected',function(e){
+    $('#gm2-bulk-ai').on('click','.gm2-bulk-reset-selected',function(e){
         e.preventDefault();
         var ids=[];
         $('#gm2-bulk-list .gm2-select:checked').each(function(){ids.push($(this).val());});
@@ -379,7 +374,7 @@ jQuery(function($){
         });
     });
 
-    $('#gm2-bulk-ai').on('click','#gm2-bulk-reset-all',function(e){
+    $('#gm2-bulk-ai').on('click','.gm2-bulk-reset-all',function(e){
         e.preventDefault();
         var data={
             action:'gm2_bulk_ai_reset',
@@ -408,7 +403,7 @@ jQuery(function($){
         });
     });
 
-    $('#gm2-bulk-ai').on('click','#gm2-bulk-schedule',function(e){
+    $('#gm2-bulk-ai').on('click','.gm2-bulk-schedule',function(e){
         e.preventDefault();
         var ids=[];
         $('#gm2-bulk-list .gm2-select:checked').each(function(){ids.push($(this).val());});
@@ -416,7 +411,7 @@ jQuery(function($){
         $.post(gm2BulkAi.ajax_url,{action:'gm2_ai_batch_schedule',ids:JSON.stringify(ids),_ajax_nonce:gm2BulkAi.batch_nonce});
     });
 
-    $('#gm2-bulk-ai').on('click','#gm2-bulk-cancel-batch',function(e){
+    $('#gm2-bulk-ai').on('click','.gm2-bulk-cancel-batch',function(e){
         e.preventDefault();
         $.post(gm2BulkAi.ajax_url,{action:'gm2_ai_batch_cancel',_ajax_nonce:gm2BulkAi.batch_nonce});
     });

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,10 +55,9 @@ Use the **Bulk AI Taxonomies** page under **Gm2 → Bulk AI Taxonomies** to gene
 - **Usage instructions** – short description printed in the same function before the settings form.
 - **Spinner during analysis** – handled by `showSpinner()` and `hideSpinner()` in `admin/js/gm2-bulk-ai.js`.
 - **Fade-out rows** – `gm2-applied` class removed after a delay in `gm2-bulk-ai.js` with styles in `admin/css/gm2-seo.css`.
-- **Cancel analysis** – `#gm2-bulk-cancel` listener in `gm2-bulk-ai.js` stops the queue.
+- **Cancel analysis** – `.gm2-bulk-cancel` listener in `gm2-bulk-ai.js` stops the queue.
 - **Missing metadata filters** – checkboxes `gm2_missing_title` and `gm2_missing_description` saved in `display_bulk_ai_page()`.
 - **ARIA progress bar** – `<progress>` element with `role="progressbar"` and button `aria-label` attributes in `display_bulk_ai_page()`.
-- **Select None control** – `#gm2-select-none` button in `gm2-bulk-ai.js` clears all selections.
 - **Search field** – `gm2_search_title` input filters posts by title.
 - **CSV export** – `handle_bulk_ai_export()` outputs a `gm2-bulk-ai.csv` file.
 - **Taxonomy CSV export** – `handle_bulk_ai_tax_export()` outputs a `gm2-bulk-ai-tax.csv` file.


### PR DESCRIPTION
## Summary
- split Bulk AI Review filters into distinct rows and add top action buttons
- reorder Analyze/Reset/Schedule controls and drop Select None
- update JS bindings and docs to reflect new button layout

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893d79cbad4832797cdea358b9e356a