### PR TITLE
Rearrange Bulk AI Taxonomies filters and actions

### DIFF
--- a/admin/class-gm2-bulk-ai-tax-list-table.php
+++ b/admin/class-gm2-bulk-ai-tax-list-table.php
@@ -12,6 +12,7 @@ if (!class_exists('\\WP_List_Table')) {
 class Gm2_Bulk_Ai_Tax_List_Table extends \WP_List_Table {
     private $admin;
     private $page_size;
+    private $status;
     private $taxonomy;
     private $search;
     private $missing_title;
@@ -21,6 +22,7 @@ class Gm2_Bulk_Ai_Tax_List_Table extends \WP_List_Table {
     public function __construct($admin, $args) {
         $this->admin         = $admin;
         $this->page_size     = max(1, (int) ($args['page_size'] ?? 10));
+        $this->status        = $args['status'] ?? 'publish';
         $this->taxonomy      = $args['taxonomy'] ?? 'all';
         $this->search        = $args['search'] ?? '';
         $this->seo_status    = $args['seo_status'] ?? 'all';
@@ -119,6 +121,7 @@ class Gm2_Bulk_Ai_Tax_List_Table extends \WP_List_Table {
         $args = [
             'taxonomy'   => $tax_arg,
             'hide_empty' => false,
+            'status'     => $this->status,
             'number'     => $this->page_size,
             'offset'     => $this->page_size * ($this->get_pagenum() - 1),
         ];

--- a/admin/js/gm2-bulk-ai-tax.js
+++ b/admin/js/gm2-bulk-ai-tax.js
@@ -167,6 +167,7 @@ jQuery(function($){
             action:'gm2_bulk_ai_tax_reset',
             all:1,
             taxonomy:$('select[name="gm2_taxonomy"]').val(),
+            status:$('select[name="gm2_tax_status"]').val(),
             search:$('input[name="gm2_tax_search"]').val()||'',
             seo_status:$('select[name="gm2_tax_seo_status"]').val(),
             missing_title:$('input[name="gm2_bulk_ai_tax_missing_title"]').is(':checked')?1:0,


### PR DESCRIPTION
## Summary
- Split Bulk AI Taxonomies controls into two rows and added a new Status filter
- Show action buttons above the table and reorder both button groups
- Pass Status filter through list table and reset logic

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893dd14805083279b720ea315677249