### PR TITLE
Add select-all option to Bulk AI taxonomy results

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -281,6 +281,7 @@ class Gm2_Admin {
                             'error'      => __( 'Error', 'gm2-wordpress-suite' ),
                             'resetting'  => __( 'Resetting...', 'gm2-wordpress-suite' ),
                             'resetDone'  => __( 'Reset %s terms', 'gm2-wordpress-suite' ),
+                            'selectAll'  => __( 'Select all', 'gm2-wordpress-suite' ),
                         ],
                     ]
                 );

--- a/admin/class-gm2-bulk-ai-tax-list-table.php
+++ b/admin/class-gm2-bulk-ai-tax-list-table.php
@@ -102,6 +102,7 @@ class Gm2_Bulk_Ai_Tax_List_Table extends \WP_List_Table {
 
         if ($suggestions !== '') {
             $key  = $item->taxonomy . ':' . $item->term_id;
+            $html .= '<p><label><input type="checkbox" class="gm2-row-select-all"> ' . esc_html__( 'Select all', 'gm2-wordpress-suite' ) . '</label></p>';
             $html .= $suggestions;
             $html .= '<p><button class="button gm2-apply-btn" data-key="' . esc_attr($key) . '" aria-label="' . esc_attr__( 'Apply', 'gm2-wordpress-suite' ) . '">' . esc_html__( 'Apply', 'gm2-wordpress-suite' ) . '</button></p>';
         }

--- a/admin/js/gm2-bulk-ai-tax.js
+++ b/admin/js/gm2-bulk-ai-tax.js
@@ -4,6 +4,10 @@ jQuery(function($){
         var c=$(this).prop('checked');
         $('#gm2-bulk-term-list .gm2-select').prop('checked',c);
     });
+    $('#gm2-bulk-term-list').on('click','.gm2-row-select-all',function(){
+        var checked=$(this).prop('checked');
+        $(this).closest('.gm2-result').find('.gm2-apply').prop('checked',checked);
+    });
     $('#gm2-bulk-ai-tax').on('click','#gm2-bulk-term-analyze',function(e){
         e.preventDefault();
         stop=false;
@@ -27,7 +31,7 @@ jQuery(function($){
             }).done(function(resp){
                 cell.find('.gm2-ai-spinner').remove();
                 if(resp&&resp.success&&resp.data){
-                    var html='';
+                    var html='<p><label><input type="checkbox" class="gm2-row-select-all"> '+gm2BulkAiTax.i18n.selectAll+'</label></p>';
                     if(resp.data.seo_title){html+='<p><label><input type="checkbox" class="gm2-apply" data-field="seo_title" data-value="'+resp.data.seo_title.replace(/"/g,'&quot;')+'"> '+resp.data.seo_title+'</label></p>';}
                     if(resp.data.description){html+='<p><label><input type="checkbox" class="gm2-apply" data-field="seo_description" data-value="'+resp.data.description.replace(/"/g,'&quot;')+'"> '+resp.data.description+'</label></p>';}
                     html+='<p><button class="button gm2-apply-btn" data-key="'+key+'">'+gm2BulkAiTax.i18n.apply+'</button></p>';

--- a/tests/test-bulk-ai.php
+++ b/tests/test-bulk-ai.php
@@ -293,3 +293,24 @@ class BulkAiTaxExportTest extends WP_UnitTestCase {
         $this->assertStringContainsString('category', $csv);
     }
 }
+
+class BulkAiTaxSelectAllTest extends WP_UnitTestCase {
+    public function test_select_all_option_displayed() {
+        $term_id = self::factory()->term->create(['taxonomy' => 'category', 'name' => 'Analyzed']);
+        update_term_meta($term_id, '_gm2_ai_research', wp_json_encode([
+            'seo_title'  => 'Title',
+            'description'=> 'Desc',
+        ]));
+
+        $admin = new Gm2_SEO_Admin();
+        $user  = self::factory()->user->create(['role' => 'administrator']);
+        wp_set_current_user($user);
+
+        ob_start();
+        $admin->display_bulk_ai_tax_page();
+        $html = ob_get_clean();
+
+        $this->assertStringContainsString('gm2-row-select-all', $html);
+        $this->assertStringContainsString('Select all', $html);
+    }
+}


### PR DESCRIPTION
## Summary
- allow selecting all term suggestion checkboxes in taxonomy bulk AI
- localize "Select all" text for taxonomy AI suggestions
- test that analyzed taxonomy terms render a select-all option

## Testing
- `phpunit tests/test-bulk-ai.php` *(fails: Error establishing a database connection)*

------
https://chatgpt.com/codex/tasks/task_e_6893e10480bc8327a8bca5f0aabd819f