### PR TITLE
Add Select Analyzed bulk action

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1344,6 +1344,7 @@ class Gm2_SEO_Admin {
 
         $buttons = '<button type="button" class="button gm2-bulk-analyze" aria-label="' . esc_attr__( 'Analyze Selected', 'gm2-wordpress-suite' ) . '">' . esc_html__( 'Analyze Selected', 'gm2-wordpress-suite' ) . '</button> '
             . '<button type="button" class="button gm2-bulk-cancel">' . esc_html__( 'Cancel', 'gm2-wordpress-suite' ) . '</button> '
+            . '<button type="button" class="button gm2-bulk-select-analyzed">' . esc_html__( 'Select Analyzed', 'gm2-wordpress-suite' ) . '</button> '
             . '<button type="button" class="button gm2-bulk-apply-all">' . esc_html__( 'Apply All', 'gm2-wordpress-suite' ) . '</button> '
             . '<button type="button" class="button gm2-bulk-reset-all">' . esc_html__( 'Reset All', 'gm2-wordpress-suite' ) . '</button> '
             . '<button type="button" class="button gm2-bulk-reset-selected">' . esc_html__( 'Reset Selected', 'gm2-wordpress-suite' ) . '</button> '
@@ -1485,6 +1486,7 @@ class Gm2_SEO_Admin {
         $buttons = '<button type="button" class="button" id="gm2-bulk-term-analyze">' . esc_html__( 'Analyze Selected', 'gm2-wordpress-suite' ) . '</button> '
             . '<button type="button" class="button" id="gm2-bulk-term-desc">' . esc_html__( 'Generate Descriptions', 'gm2-wordpress-suite' ) . '</button> '
             . '<button type="button" class="button" id="gm2-bulk-term-cancel">' . esc_html__( 'Cancel', 'gm2-wordpress-suite' ) . '</button> '
+            . '<button type="button" class="button" id="gm2-bulk-term-select-analyzed">' . esc_html__( 'Select Analyzed', 'gm2-wordpress-suite' ) . '</button> '
             . '<button type="button" class="button" id="gm2-bulk-term-apply-all">' . esc_html__( 'Apply All', 'gm2-wordpress-suite' ) . '</button> '
             . '<button type="button" class="button" id="gm2-bulk-term-reset-all">' . esc_html__( 'Reset All', 'gm2-wordpress-suite' ) . '</button> '
             . '<button type="button" class="button" id="gm2-bulk-term-reset-selected">' . esc_html__( 'Reset Selected', 'gm2-wordpress-suite' ) . '</button> '

--- a/admin/js/gm2-bulk-ai-tax.js
+++ b/admin/js/gm2-bulk-ai-tax.js
@@ -105,6 +105,12 @@ jQuery(function($){
             cell.text(gm2BulkAiTax.i18n.error);
         });
     });
+    $('#gm2-bulk-ai-tax').on('click','#gm2-bulk-term-select-analyzed',function(e){
+        e.preventDefault();
+        $('#gm2-bulk-term-list .gm2-row-select-all').each(function(){
+            $(this).prop('checked',true).trigger('change');
+        });
+    });
     $('#gm2-bulk-ai-tax').on('click','#gm2-bulk-term-apply-all',function(e){
         e.preventDefault();
         var items={};

--- a/admin/js/gm2-bulk-ai.js
+++ b/admin/js/gm2-bulk-ai.js
@@ -274,6 +274,14 @@ jQuery(function($){
             });
     });
 
+    $('#gm2-bulk-ai').on('click','.gm2-bulk-select-analyzed',function(e){
+        e.preventDefault();
+        $('#gm2-bulk-list tr.gm2-status-analyzed').each(function(){
+            var $cb = $(this).find('.gm2-row-select-all');
+            $cb.prop('checked',true).trigger('change');
+        });
+    });
+
     $('#gm2-bulk-ai').on('click','.gm2-bulk-apply-all',function(e){
         e.preventDefault();
         var posts={};

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,7 @@ add_filter('gm2_gmc_realtime_fields', function ($fields) {
 
 - Batching or rate-limiting of AI requests.
 - The new "Apply All" button for applying suggestions in bulk.
+- A "Select Analyzed" button to quickly mark analyzed suggestions before applying them in bulk.
 - The global progress indicator tracking analysis and apply actions.
 - Reuse of cached AI results with options to refresh or clear them.
 - Progress messages now use translation functions for localization.


### PR DESCRIPTION
## Summary
- add Select Analyzed button on Bulk AI Review and Bulk AI Taxonomies pages
- support selecting analyzed rows via new JS handlers
- document Select Analyzed feature in docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893e84eb200832786fec606363fc82c