### PR TITLE
Add reset AI suggestion controls to bulk AI pages

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -234,6 +234,7 @@ class Gm2_Admin {
                         'apply_nonce' => wp_create_nonce('gm2_bulk_ai_apply'),
                         'batch_nonce' => wp_create_nonce('gm2_ai_batch'),
                         'reset_nonce' => wp_create_nonce('gm2_bulk_ai_reset'),
+                        'clear_nonce' => wp_create_nonce('gm2_bulk_ai_clear'),
                         'ajax_url'    => admin_url('admin-ajax.php'),
                         'i18n'        => [
                             'processing'   => __( 'Processing %1$s / %2$s', 'gm2-wordpress-suite' ),
@@ -253,6 +254,7 @@ class Gm2_Admin {
                             'undo'         => __( 'Undo', 'gm2-wordpress-suite' ),
                             'resetting'    => __( 'Resetting...', 'gm2-wordpress-suite' ),
                             'resetDone'    => __( 'Reset %s posts', 'gm2-wordpress-suite' ),
+                            'clearDone'    => __( 'Cleared AI suggestions for %s posts', 'gm2-wordpress-suite' ),
                         ],
                     ]
                 );
@@ -275,12 +277,14 @@ class Gm2_Admin {
                         'batch_nonce' => wp_create_nonce('gm2_ai_batch'),
                         'desc_nonce'  => wp_create_nonce('gm2_ai_generate_tax_description'),
                         'reset_nonce' => wp_create_nonce('gm2_bulk_ai_tax_reset'),
+                        'clear_nonce' => wp_create_nonce('gm2_bulk_ai_tax_clear'),
                         'ajax_url'    => admin_url('admin-ajax.php'),
                         'i18n'        => [
                             'apply'      => __( 'Apply', 'gm2-wordpress-suite' ),
                             'error'      => __( 'Error', 'gm2-wordpress-suite' ),
                             'resetting'  => __( 'Resetting...', 'gm2-wordpress-suite' ),
                             'resetDone'  => __( 'Reset %s terms', 'gm2-wordpress-suite' ),
+                            'clearDone'  => __( 'Cleared AI suggestions for %s terms', 'gm2-wordpress-suite' ),
                             'selectAll'  => __( 'Select all', 'gm2-wordpress-suite' ),
                         ],
                     ]

--- a/admin/js/gm2-bulk-ai-tax.js
+++ b/admin/js/gm2-bulk-ai-tax.js
@@ -171,6 +171,35 @@ jQuery(function($){
         });
     });
 
+    $('#gm2-bulk-ai-tax').on('click','#gm2-bulk-term-reset-ai',function(e){
+        e.preventDefault();
+        var ids=[];
+        $('#gm2-bulk-term-list .gm2-select:checked').each(function(){ids.push($(this).val());});
+        if(!ids.length) return;
+        var $msg=$('#gm2-bulk-term-msg');
+        $msg.text(gm2BulkAiTax.i18n.resetting);
+        $.ajax({
+            url: gm2BulkAiTax.ajax_url,
+            method:'POST',
+            data:{action:'gm2_bulk_ai_tax_clear',ids:JSON.stringify(ids),_ajax_nonce:gm2BulkAiTax.clear_nonce},
+            dataType:'json'
+        }).done(function(resp){
+            if(resp&&resp.success){
+                $.each(ids,function(i,key){
+                    var parts=key.split(':');
+                    var row=$('#gm2-term-'+parts[0]+'-'+parts[1]);
+                    row.find('.gm2-result').empty();
+                });
+                $msg.text(gm2BulkAiTax.i18n.clearDone.replace('%s',resp.data.cleared));
+            }else{
+                $msg.text((resp&&resp.data)?resp.data:gm2BulkAiTax.i18n.error);
+            }
+        }).fail(function(jqXHR,textStatus){
+            var msg=(jqXHR&&jqXHR.responseJSON&&jqXHR.responseJSON.data)?jqXHR.responseJSON.data:(jqXHR&&jqXHR.responseText?jqXHR.responseText:textStatus);
+            $msg.text(msg||gm2BulkAiTax.i18n.error);
+        });
+    });
+
     $('#gm2-bulk-ai-tax').on('click','#gm2-bulk-term-reset-all',function(e){
         e.preventDefault();
         var data={

--- a/admin/js/gm2-bulk-ai.js
+++ b/admin/js/gm2-bulk-ai.js
@@ -382,6 +382,37 @@ jQuery(function($){
         });
     });
 
+    $('#gm2-bulk-ai').on('click','.gm2-bulk-reset-ai',function(e){
+        e.preventDefault();
+        var ids=[];
+        $('#gm2-bulk-list .gm2-select:checked').each(function(){ids.push($(this).val());});
+        if(!ids.length) return;
+        var $msg=$('#gm2-bulk-apply-msg');
+        var resettingText = window.gm2BulkAi && gm2BulkAi.i18n ? gm2BulkAi.i18n.resetting : 'Resetting...';
+        $msg.text(resettingText);
+        $.ajax({
+            url: gm2BulkAi.ajax_url,
+            method:'POST',
+            data:{action:'gm2_bulk_ai_clear',ids:JSON.stringify(ids),_ajax_nonce:gm2BulkAi.clear_nonce},
+            dataType:'json'
+        }).done(function(resp){
+            if(resp&&resp.success){
+                $.each(ids,function(i,id){
+                    var row=$('#gm2-row-'+id);
+                    row.find('.gm2-result').empty();
+                    row.removeClass('gm2-status-applied gm2-status-analyzed').addClass('gm2-status-new');
+                });
+                var doneText = window.gm2BulkAi && gm2BulkAi.i18n ? gm2BulkAi.i18n.clearDone : 'Cleared AI suggestions for %s posts';
+                $msg.text(doneText.replace('%s', resp.data.cleared));
+            }else{
+                $msg.text((resp&&resp.data)?resp.data:(window.gm2BulkAi && gm2BulkAi.i18n ? gm2BulkAi.i18n.error : 'Error'));
+            }
+        }).fail(function(jqXHR,textStatus){
+            var msg=(jqXHR && jqXHR.responseJSON && jqXHR.responseJSON.data)?jqXHR.responseJSON.data:(jqXHR && jqXHR.responseText?jqXHR.responseText:textStatus);
+            $msg.text(msg || (window.gm2BulkAi && gm2BulkAi.i18n ? gm2BulkAi.i18n.error : 'Error'));
+        });
+    });
+
     $('#gm2-bulk-ai').on('click','.gm2-bulk-reset-all',function(e){
         e.preventDefault();
         var data={


### PR DESCRIPTION
## Summary
- add **Reset AI Suggestion** button to Bulk AI Review
- add **Reset AI Suggestion** button to Bulk AI Taxonomies
- support new reset actions and JS handlers for removing stored AI suggestions

## Testing
- `npm test`
- `phpunit` *(fails: Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6894e6157c9483278ec539e4ef1aa3d0