### PR TITLE
Add top progress indicator and sync bulk AI status

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1379,6 +1379,8 @@ class Gm2_SEO_Admin {
 
         // Row 4 (top action buttons).
         echo '<p class="gm2-bulk-actions">' . $buttons . '</p>';
+        echo '<p><progress id="gm2-bulk-progress-bar-top" class="gm2-bulk-progress-bar" value="0" max="100" style="width:100%;display:none" role="progressbar" aria-live="polite"></progress></p>';
+        echo '<p id="gm2-bulk-progress-top" class="gm2-bulk-progress"></p>';
 
         echo '<form method="get">';
         echo '<input type="hidden" name="page" value="gm2-bulk-ai-review" />';
@@ -1387,7 +1389,8 @@ class Gm2_SEO_Admin {
         echo '</form>';
         // Bottom action buttons.
         echo '<p class="gm2-bulk-actions">' . $buttons . ' <span id="gm2-bulk-apply-msg"></span></p>';
-        echo '<p><progress id="gm2-bulk-progress-bar" value="0" max="100" style="width:100%;display:none" role="progressbar" aria-live="polite"></progress></p>';
+        echo '<p><progress id="gm2-bulk-progress-bar" class="gm2-bulk-progress-bar" value="0" max="100" style="width:100%;display:none" role="progressbar" aria-live="polite"></progress></p>';
+        echo '<p id="gm2-bulk-progress" class="gm2-bulk-progress"></p>';
         echo '</div>';
     }
 

--- a/admin/js/gm2-bulk-ai.js
+++ b/admin/js/gm2-bulk-ai.js
@@ -7,16 +7,19 @@ jQuery(function($){
     $('#gm2-bulk-list tr[id^="gm2-row-"]').addClass('gm2-status-new');
 
     function initBar(max){
-        var $bar = $('#gm2-bulk-progress-bar');
-        if(!$bar.length){
-            $bar = $('<progress>',{id:'gm2-bulk-progress-bar',value:0,max:max,style:'width:100%;',role:'progressbar','aria-live':'polite'});
-            $('.gm2-bulk-analyze').last().parent().after($bar);
+        var $bars = $('.gm2-bulk-progress-bar');
+        if(!$bars.length){
+            $bars = $('<progress>',{id:'gm2-bulk-progress-bar',class:'gm2-bulk-progress-bar',value:0,max:max,style:'width:100%;',role:'progressbar','aria-live':'polite'});
+            $('.gm2-bulk-analyze').last().parent().after($bars);
         }
-        $bar.attr({max:max,role:'progressbar','aria-live':'polite'}).val(0).show();
+        $bars.each(function(){
+            $(this).attr({max:max,role:'progressbar','aria-live':'polite'}).val(0).show();
+        });
+        $('.gm2-bulk-progress').text('');
     }
 
     function updateBar(val){
-        $('#gm2-bulk-progress-bar').val(val);
+        $('.gm2-bulk-progress-bar').val(val);
     }
 
     function showSpinner($cell){
@@ -69,28 +72,31 @@ jQuery(function($){
         applied = 0;
         initBar(totalPosts);
 
-        var $progress = $('#gm2-bulk-progress');
-        if(!$progress.length){
-            $progress = $('<p>',{id:'gm2-bulk-progress'});
-            $('#gm2-bulk-progress-bar').after($progress);
+        var $progresses = $('.gm2-bulk-progress');
+        if(!$progresses.length){
+            $('.gm2-bulk-progress-bar').each(function(){
+                var $p = $('<p>',{class:'gm2-bulk-progress'});
+                $(this).after($p);
+            });
+            $progresses = $('.gm2-bulk-progress');
         }
-        $progress.text('');
+        $progresses.text('');
         var total = ids.length, processed = 0, fatal = false;
 
         function updateProgress(msg){
             if(msg){
-                $progress.text(msg);
+                $progresses.text(msg);
             }else{
                 var procText = window.gm2BulkAi && gm2BulkAi.i18n ? gm2BulkAi.i18n.processing : 'Processing %1$s / %2$s';
-                $progress.text(procText.replace('%1$s', processed).replace('%2$s', total));
+                $progresses.text(procText.replace('%1$s', processed).replace('%2$s', total));
             }
             updateBar(processed);
         }
 
         function processNext(){
             if(fatal || stopProcessing){
-                $('#gm2-bulk-progress-bar').hide();
-                $progress.text('');
+                $('.gm2-bulk-progress-bar').hide();
+                $progresses.text('');
                 return;
             }
             if(!ids.length){
@@ -155,8 +161,8 @@ jQuery(function($){
     $('#gm2-bulk-ai').on('click','.gm2-bulk-cancel',function(e){
         e.preventDefault();
         stopProcessing = true;
-        $('#gm2-bulk-progress-bar').hide();
-        $('#gm2-bulk-progress').text('');
+        $('.gm2-bulk-progress-bar').hide();
+        $('.gm2-bulk-progress').text('');
     });
     $('#gm2-bulk-list').on('click','.gm2-apply-btn',function(e){
         e.preventDefault();


### PR DESCRIPTION
## Summary
- show a progress bar and status text beneath both bulk action button groups
- track and update all progress displays through class-based selectors
- ensure canceling a bulk run clears both progress indicators

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894f8e9dbcc8327945da8cfd144a2e1