### PR TITLE
Add custom schema template selection and placeholder rendering

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -2087,6 +2087,13 @@ class Gm2_SEO_Admin {
             'article'  => __( 'Article', 'gm2-wordpress-suite' ),
             'product'  => __( 'Product', 'gm2-wordpress-suite' ),
         ];
+        $custom = get_option('gm2_custom_schema', []);
+        if (is_array($custom)) {
+            foreach ($custom as $id => $tpl) {
+                $label = is_array($tpl) && isset($tpl['label']) ? $tpl['label'] : $id;
+                $opts[$id] = $label;
+            }
+        }
         foreach ($opts as $val => $label) {
             echo '<option value="' . esc_attr($val) . '"' . selected($schema_type, $val, false) . '>' . esc_html($label) . '</option>';
         }
@@ -5407,6 +5414,13 @@ class Gm2_SEO_Admin {
             'article'  => __( 'Article', 'gm2-wordpress-suite' ),
             'product'  => __( 'Product', 'gm2-wordpress-suite' ),
         ];
+        $custom = get_option('gm2_custom_schema', []);
+        if (is_array($custom)) {
+            foreach ($custom as $id => $tpl) {
+                $label = is_array($tpl) && isset($tpl['label']) ? $tpl['label'] : $id;
+                $opts[$id] = $label;
+            }
+        }
         foreach ($opts as $val => $label) {
             echo '<option value="' . esc_attr($val) . '"' . selected($schema_type, $val, false) . '>' . esc_html($label) . '</option>';
         }


### PR DESCRIPTION
## Summary
- add stored custom templates to schema type selectors
- expose selected templates via schema generation with placeholder substitution
- render schema templates with context-aware placeholder replacement

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*
- `curl -L -o phpunit https://phar.phpunit.de/phpunit-9.phar` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6894f7487ba88327aba0cbfa749406b1