### PR TITLE
Add placeholder tokens for JSON-LD templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,25 @@ add_filter( 'gm2_gmc_realtime_fields', function( $fields ) {
 } );
 ```
 
+## JSON-LD Template Placeholders
+
+JSON-LD templates support the following placeholder tokens. These are replaced
+with dynamic values when schemas are generated:
+
+- `{{title}}` – Post or term title
+- `{{permalink}}` – Permalink URL
+- `{{description}}` – SEO description or excerpt
+- `{{image}}` – Featured image URL
+- `{{price}}` – Product price
+- `{{price_currency}}` – Currency code
+- `{{availability}}` – Stock availability URL
+- `{{sku}}` – Product SKU
+- `{{brand}}` – Brand name
+- `{{rating}}` – Review rating value
+
+Use these placeholders within the JSON-LD template editor on the SEO settings
+page to insert dynamic content.
+
 ## Bulk AI for Taxonomies
 
 The **Bulk AI Taxonomies** page under **Gm2 → Bulk AI Taxonomies** lists terms

--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -721,6 +721,14 @@ class Gm2_SEO_Admin {
             $rt = get_option('gm2_schema_template_review', wp_json_encode(Gm2_SEO_Public::default_review_template(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
 
             echo '<h2>' . esc_html__( 'JSON-LD Templates', 'gm2-wordpress-suite' ) . '</h2>';
+            $ph = Gm2_SEO_Public::get_placeholders();
+            if ($ph) {
+                echo '<p>' . esc_html__( 'Available placeholders:', 'gm2-wordpress-suite' ) . '</p><ul>';
+                foreach ($ph as $token => $desc) {
+                    echo '<li><code>' . esc_html($token) . '</code> ' . esc_html($desc) . '</li>';
+                }
+                echo '</ul>';
+            }
             echo '<table class="form-table"><tbody>';
             echo '<tr><th scope="row">' . esc_html__( 'Product Template', 'gm2-wordpress-suite' ) . '</th><td><textarea name="gm2_schema_template_product" rows="6" class="large-text code">' . esc_textarea($pt) . '</textarea></td></tr>';
             echo '<tr><th scope="row">' . esc_html__( 'Brand Template', 'gm2-wordpress-suite' ) . '</th><td><textarea name="gm2_schema_template_brand" rows="6" class="large-text code">' . esc_textarea($bt) . '</textarea></td></tr>';

--- a/tests/test-schema-placeholders.php
+++ b/tests/test-schema-placeholders.php
@@ -1,0 +1,77 @@
+<?php
+use Gm2\Gm2_SEO_Public;
+
+class SchemaPlaceholderTest extends WP_UnitTestCase {
+    public function setUp(): void {
+        parent::setUp();
+        if (!class_exists('WooCommerce')) {
+            eval('class WooCommerce {}');
+        }
+        if (!function_exists('is_product')) {
+            function is_product() { return true; }
+        }
+        if (!class_exists('WC_Product_Stub')) {
+            eval('class WC_Product_Stub {
+                public function get_image_id() { return 0; }
+                public function get_description() { return "Sample description"; }
+                public function get_sku() { return "SKU"; }
+                public function get_price() { return "10"; }
+                public function is_in_stock() { return true; }
+            }');
+        }
+        if (!function_exists('wc_get_product')) {
+            function wc_get_product($id) { return new WC_Product_Stub(); }
+        }
+        if (!function_exists('get_woocommerce_currency')) {
+            function get_woocommerce_currency() { return 'USD'; }
+        }
+    }
+
+    public function test_default_product_template_placeholders() {
+        register_post_type('product');
+        $post_id = self::factory()->post->create(['post_type' => 'product', 'post_title' => 'Placeholder Product']);
+        $seo = new Gm2_SEO_Public();
+        $this->go_to(get_permalink($post_id));
+        setup_postdata(get_post($post_id));
+        update_option('gm2_schema_product', '1');
+        ob_start();
+        $seo->output_product_schema();
+        $output = ob_get_clean();
+        $this->assertNotEmpty($output);
+        preg_match('/<script type="application\/ld\+json">(.*?)<\/script>/', $output, $m);
+        $data = json_decode($m[1], true);
+        $this->assertSame('Placeholder Product', $data['name']);
+        $this->assertSame(get_permalink($post_id), $data['offers']['url']);
+    }
+
+    public function test_custom_product_template_placeholders() {
+        register_post_type('product');
+        $post_id = self::factory()->post->create(['post_type' => 'product', 'post_title' => 'Custom Product']);
+        $tpl = [
+            '@context' => 'https://schema.org/',
+            '@type' => 'Product',
+            'name' => '{{title}}',
+            'sku' => 'SKU-{{sku}}',
+            'offers' => [
+                '@type' => 'Offer',
+                'priceCurrency' => '{{price_currency}}',
+                'price' => '{{price}}',
+                'url' => '{{permalink}}',
+            ],
+        ];
+        update_option('gm2_schema_template_product', wp_json_encode($tpl));
+        $seo = new Gm2_SEO_Public();
+        $this->go_to(get_permalink($post_id));
+        setup_postdata(get_post($post_id));
+        update_option('gm2_schema_product', '1');
+        ob_start();
+        $seo->output_product_schema();
+        $output = ob_get_clean();
+        preg_match('/<script type="application\/ld\+json">(.*?)<\/script>/', $output, $m);
+        $data = json_decode($m[1], true);
+        $this->assertSame('Custom Product', $data['name']);
+        $this->assertSame('SKU-SKU', $data['sku']);
+        $this->assertSame('10', $data['offers']['price']);
+        $this->assertSame(get_permalink($post_id), $data['offers']['url']);
+    }
+}


### PR DESCRIPTION
## Summary
- add default JSON-LD templates with `{{title}}`, `{{permalink}}`, price and other tokens
- list available placeholders in admin template editor
- document placeholder usage and add unit tests covering default and custom templates

## Testing
- `npm test`
- `phpunit` *(fails: Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6894fa69a3448327bc9e700f335a7b9f