### PR TITLE
Mark preloaded AI suggestions as analyzed

### DIFF
--- a/admin/js/gm2-bulk-ai.js
+++ b/admin/js/gm2-bulk-ai.js
@@ -4,7 +4,16 @@ jQuery(function($){
     var stopProcessing = false;
 
     // Mark all rows as new on initial load
-    $('#gm2-bulk-list tr[id^="gm2-row-"]').addClass('gm2-status-new');
+    var $rows = $('#gm2-bulk-list tr[id^="gm2-row-"]').addClass('gm2-status-new');
+
+    // If AI suggestions already exist, mark the row as analyzed
+    $rows.each(function(){
+        var $row = $(this);
+        var $res = $row.find('.gm2-result');
+        if($res.find('.gm2-apply').length || $.trim($res.text()).length){
+            $row.removeClass('gm2-status-new').addClass('gm2-status-analyzed');
+        }
+    });
 
     function initBar(max){
         var $bars = $('.gm2-bulk-progress-bar');

--- a/tests/js/gm2-bulk-ai.test.js
+++ b/tests/js/gm2-bulk-ai.test.js
@@ -30,3 +30,32 @@ test('row select all toggles suggestion checkboxes', () => {
   selectAll.prop('checked', false).trigger('change');
   expect(boxes.filter(':checked').length).toBe(0);
 });
+
+test('rows with suggestions get analyzed status on load', () => {
+  const dom = new JSDOM(`
+    <table id="gm2-bulk-list">
+      <tr id="gm2-row-1">
+        <td class="gm2-result">
+          <p><label><input type="checkbox" class="gm2-apply"> Suggestion</label></p>
+        </td>
+      </tr>
+      <tr id="gm2-row-2">
+        <td class="gm2-result"></td>
+      </tr>
+    </table>
+  `, { url: 'http://localhost' });
+  const $ = jquery(dom.window);
+  Object.assign(global, { window: dom.window, document: dom.window.document, jQuery: $, $ });
+
+  var $rows = $('#gm2-bulk-list tr[id^="gm2-row-"]').addClass('gm2-status-new');
+  $rows.each(function(){
+    var $row = $(this);
+    var $res = $row.find('.gm2-result');
+    if($res.find('.gm2-apply').length || $.trim($res.text()).length){
+      $row.removeClass('gm2-status-new').addClass('gm2-status-analyzed');
+    }
+  });
+
+  expect($('#gm2-row-1').hasClass('gm2-status-analyzed')).toBe(true);
+  expect($('#gm2-row-2').hasClass('gm2-status-new')).toBe(true);
+});


### PR DESCRIPTION
## Summary
- Detect existing AI suggestions in bulk list and set rows to analyzed on load
- Add Jest test covering analyzed status initialization

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894fb9ec3a4832787c63436ebe31986