### PR TITLE
Return updated fields and show apply status

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -4539,7 +4539,14 @@ class Gm2_SEO_Admin {
             update_post_meta($post_id, '_gm2_description', sanitize_textarea_field(wp_unslash($_POST['seo_description'])));
         }
 
-        wp_send_json_success();
+        $response = [
+            'title'       => get_post_field('post_title', $post_id),
+            'seo_title'   => get_post_meta($post_id, '_gm2_title', true),
+            'description' => get_post_meta($post_id, '_gm2_description', true),
+            'slug'        => get_post_field('post_name', $post_id),
+        ];
+
+        wp_send_json_success($response);
     }
 
     public function ajax_bulk_ai_apply_batch() {

--- a/admin/js/gm2-bulk-ai.js
+++ b/admin/js/gm2-bulk-ai.js
@@ -182,13 +182,20 @@ jQuery(function($){
         });
         var row = $('#gm2-row-'+id);
         var $res=row.find('.gm2-result');
+        var $btn=$(this);
+        var $btnSpinner=$('<span>',{class:'spinner is-active gm2-btn-spinner'});
+        $btn.prop('disabled',true).after($btnSpinner);
         showSpinner($res);
-        $.post(gm2BulkAi.ajax_url,data)
-            .done(function(resp){
-                hideSpinner($res);
+        var request=$.post(gm2BulkAi.ajax_url,data);
+        request.done(function(resp){
                 if(resp && resp.success){
+                    row.find('td').eq(0).text(resp.data.title);
+                    row.find('td').eq(1).text(resp.data.seo_title);
+                    row.find('td').eq(2).text(resp.data.description);
+                    row.find('td').eq(3).text(resp.data.slug);
                     row.find('.gm2-result .gm2-undo-btn').remove();
-                    row.find('.gm2-result').append(' <button class="button gm2-undo-btn" data-id="'+id+'">'+(gm2BulkAi.i18n?gm2BulkAi.i18n.undo:'Undo')+'</button> <span> ✓</span>');
+                    $res.find('.gm2-result-icon').remove();
+                    row.find('.gm2-result').append(' <button class="button gm2-undo-btn" data-id="'+id+'">'+(gm2BulkAi.i18n?gm2BulkAi.i18n.undo:'Undo')+'</button> <span class="gm2-result-icon">✅</span>');
                     row.removeClass('gm2-status-new gm2-status-analyzed')
                         .addClass('gm2-status-applied gm2-applied');
                     setTimeout(function(){
@@ -199,14 +206,22 @@ jQuery(function($){
                 }else{
                     var msg=(resp && resp.data)?(resp.data.message||resp.data):(window.gm2BulkAi && gm2BulkAi.i18n ? gm2BulkAi.i18n.error : 'Error');
                     $res.text(msg);
+                    $res.find('.gm2-result-icon').remove();
+                    $res.append(' <span class="gm2-result-icon">❌</span>');
                 }
-            })
-            .fail(function(jqXHR, textStatus){
-                hideSpinner($res);
+            });
+        request.fail(function(jqXHR, textStatus){
                 var msg = (jqXHR && jqXHR.responseJSON && jqXHR.responseJSON.data)
                     ? jqXHR.responseJSON.data
                     : (jqXHR && jqXHR.responseText ? jqXHR.responseText : textStatus);
                 $res.text(msg || (window.gm2BulkAi && gm2BulkAi.i18n ? gm2BulkAi.i18n.error : 'Error'));
+                $res.find('.gm2-result-icon').remove();
+                $res.append(' <span class="gm2-result-icon">❌</span>');
+            });
+        request.always(function(){
+                hideSpinner($res);
+                $btnSpinner.remove();
+                $btn.prop('disabled',false);
             });
     });
 


### PR DESCRIPTION
## Summary
- return updated post fields from `ajax_bulk_ai_apply`
- add button spinner/disabled state and update row values on success
- display success/failure icons and messages for bulk AI apply

## Testing
- `npm test`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_68950860311c8327a9f4c042127a0677