### PR TITLE
Improve refresh feedback and update row status

### DIFF
--- a/admin/js/gm2-bulk-ai.js
+++ b/admin/js/gm2-bulk-ai.js
@@ -230,25 +230,39 @@ jQuery(function($){
         var id=$(this).data('id');
         var row=$('#gm2-row-'+id);
         var $res=row.find('.gm2-result').empty();
+        var $btn=$(this);
+        var $btnSpinner=$('<span>',{class:'spinner is-active gm2-btn-spinner'});
+        $btn.prop('disabled',true).after($btnSpinner);
         showSpinner($res);
-        $.ajax({
+        var request=$.ajax({
             url: gm2BulkAi.ajax_url,
             method:'POST',
             data:{action:'gm2_ai_research',post_id:id,refresh:1,_ajax_nonce:gm2BulkAi.nonce},
             dataType:'json'
-        }).done(function(resp){
-            hideSpinner($res);
+        });
+        request.done(function(resp){
             if(resp&&resp.success&&resp.data){
                 $res.html(buildHtml(resp.data,id,resp.data.undo));
-                row.removeClass('gm2-status-new gm2-status-applied').addClass('gm2-status-analyzed');
+                row.removeClass('gm2-status-new gm2-status-applied gm2-applied').addClass('gm2-status-analyzed');
+                $res.find('.gm2-result-icon').remove();
+                $res.append(' <span class="gm2-result-icon">✅</span>');
             }else{
-                var msg=(resp&&resp.data)?(resp.data.message||resp.data):'Error';
+                var msg=(resp&&resp.data)?(resp.data.message||resp.data):(window.gm2BulkAi && gm2BulkAi.i18n ? gm2BulkAi.i18n.error : 'Error');
                 $res.text(msg);
+                $res.find('.gm2-result-icon').remove();
+                $res.append(' <span class="gm2-result-icon">❌</span>');
             }
-        }).fail(function(jqXHR,textStatus){
-            hideSpinner($res);
+        });
+        request.fail(function(jqXHR,textStatus){
             var msg=(jqXHR&&jqXHR.responseJSON&&jqXHR.responseJSON.data)?jqXHR.responseJSON.data:(jqXHR&&jqXHR.responseText?jqXHR.responseText:textStatus);
-            $res.text(msg||'Error');
+            $res.text(msg || (window.gm2BulkAi && gm2BulkAi.i18n ? gm2BulkAi.i18n.error : 'Error'));
+            $res.find('.gm2-result-icon').remove();
+            $res.append(' <span class="gm2-result-icon">❌</span>');
+        });
+        request.always(function(){
+            hideSpinner($res);
+            $btnSpinner.remove();
+            $btn.prop('disabled',false);
         });
     });
 


### PR DESCRIPTION
## Summary
- Disable refresh button and show a spinner during AJAX requests
- Display success or error icons after refresh and restore button state
- Ensure refreshed rows switch to `gm2-status-analyzed`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68950aa2ddac83278ceca12a15f338c3