### PR TITLE
Wrap bulk AI results and refine selection logic

### DIFF
--- a/admin/class-gm2-bulk-ai-list-table.php
+++ b/admin/class-gm2-bulk-ai-list-table.php
@@ -96,7 +96,7 @@ class Gm2_Bulk_Ai_List_Table extends \WP_List_Table {
         } elseif ($has_prev) {
             $result_html = $this->render_result([], $item->ID, true);
         }
-        return $result_html;
+        return '<div class="gm2-result">' . $result_html . '</div>';
     }
 
     private function render_result($data, $post_id, $has_prev = false) {

--- a/admin/class-gm2-bulk-ai-tax-list-table.php
+++ b/admin/class-gm2-bulk-ai-tax-list-table.php
@@ -86,7 +86,7 @@ class Gm2_Bulk_Ai_Tax_List_Table extends \WP_List_Table {
                 $result_html = $this->render_result($data, $item);
             }
         }
-        return $result_html;
+        return '<div class="gm2-result">' . $result_html . '</div>';
     }
 
     private function render_result($data, $item) {

--- a/admin/js/gm2-bulk-ai-tax.js
+++ b/admin/js/gm2-bulk-ai-tax.js
@@ -1,5 +1,13 @@
 jQuery(function($){
     var stop=false;
+    var $rows=$('#gm2-bulk-term-list tr').addClass('gm2-status-new');
+    $rows.each(function(){
+        var $row=$(this);
+        var $res=$row.find('.gm2-result');
+        if($res.find('.gm2-apply').length||$.trim($res.text()).length){
+            $row.removeClass('gm2-status-new').addClass('gm2-status-analyzed');
+        }
+    });
     $('#gm2-bulk-term-select-all').on('click',function(){
         var c=$(this).prop('checked');
         $('#gm2-bulk-term-list .gm2-select').prop('checked',c);
@@ -113,8 +121,9 @@ jQuery(function($){
     });
     $('#gm2-bulk-ai-tax').on('click','#gm2-bulk-term-select-analyzed',function(e){
         e.preventDefault();
-        $('#gm2-bulk-term-list .gm2-row-select-all').each(function(){
-            $(this).prop('checked',true).trigger('change');
+        $('#gm2-bulk-term-list tr.gm2-status-analyzed').each(function(){
+            $(this).find('.gm2-select').prop('checked',true);
+            $(this).find('.gm2-row-select-all').prop('checked',true).trigger('change');
         });
     });
     $('#gm2-bulk-ai-tax').on('click','#gm2-bulk-term-apply-all',function(e){

--- a/tests/js/gm2-bulk-ai-tax.test.js
+++ b/tests/js/gm2-bulk-ai-tax.test.js
@@ -1,0 +1,83 @@
+const jquery = require('jquery');
+const { JSDOM } = require('jsdom');
+
+test('taxonomy rows with suggestions get analyzed status on load', () => {
+  const dom = new JSDOM(`
+    <table id="gm2-bulk-term-list">
+      <tr id="gm2-term-1">
+        <td>
+          <div class="gm2-result">
+            <p><label><input type="checkbox" class="gm2-apply"> Suggestion</label></p>
+          </div>
+        </td>
+      </tr>
+      <tr id="gm2-term-2">
+        <td><div class="gm2-result"></div></td>
+      </tr>
+    </table>
+  `, { url: 'http://localhost' });
+  const $ = jquery(dom.window);
+  Object.assign(global, { window: dom.window, document: dom.window.document, jQuery: $, $ });
+
+  var $rows = $('#gm2-bulk-term-list tr').addClass('gm2-status-new');
+  $rows.each(function(){
+    var $row = $(this);
+    var $res = $row.find('.gm2-result');
+    if($res.find('.gm2-apply').length || $.trim($res.text()).length){
+      $row.removeClass('gm2-status-new').addClass('gm2-status-analyzed');
+    }
+  });
+
+  expect($('#gm2-term-1').hasClass('gm2-status-analyzed')).toBe(true);
+  expect($('#gm2-term-2').hasClass('gm2-status-new')).toBe(true);
+});
+
+test('taxonomy select analyzed checks row checkbox and suggestions', () => {
+  const dom = new JSDOM(`
+    <div id="gm2-bulk-ai-tax">
+      <button id="gm2-bulk-term-select-analyzed">Select analyzed</button>
+      <table id="gm2-bulk-term-list">
+        <tr id="gm2-term-cat-1" class="gm2-status-analyzed">
+          <td>
+            <input type="checkbox" class="gm2-select">
+            <div class="gm2-result">
+              <p><label><input type="checkbox" class="gm2-row-select-all"> Select all</label></p>
+              <p><label><input type="checkbox" class="gm2-apply"> Suggestion</label></p>
+            </div>
+          </td>
+        </tr>
+        <tr id="gm2-term-cat-2" class="gm2-status-new">
+          <td>
+            <input type="checkbox" class="gm2-select">
+            <div class="gm2-result">
+              <p><label><input type="checkbox" class="gm2-row-select-all"> Select all</label></p>
+              <p><label><input type="checkbox" class="gm2-apply"> Suggestion</label></p>
+            </div>
+          </td>
+        </tr>
+      </table>
+    </div>
+  `, { url: 'http://localhost' });
+  const $ = jquery(dom.window);
+  Object.assign(global, { window: dom.window, document: dom.window.document, jQuery: $, $ });
+
+  $('#gm2-bulk-term-list').on('change', '.gm2-row-select-all', function(){
+    const checked = $(this).prop('checked');
+    $(this).closest('td').find('.gm2-apply').prop('checked', checked);
+  });
+
+  $('#gm2-bulk-ai-tax').on('click', '#gm2-bulk-term-select-analyzed', function(e){
+    e.preventDefault();
+    $('#gm2-bulk-term-list tr.gm2-status-analyzed').each(function(){
+      $(this).find('.gm2-select').prop('checked', true);
+      $(this).find('.gm2-row-select-all').prop('checked', true).trigger('change');
+    });
+  });
+
+  $('#gm2-bulk-term-select-analyzed').trigger('click');
+
+  expect($('#gm2-term-cat-1 .gm2-select').prop('checked')).toBe(true);
+  expect($('#gm2-term-cat-1 .gm2-apply').prop('checked')).toBe(true);
+  expect($('#gm2-term-cat-2 .gm2-select').prop('checked')).toBe(false);
+  expect($('#gm2-term-cat-2 .gm2-apply').prop('checked')).toBe(false);
+});

--- a/tests/js/gm2-bulk-ai.test.js
+++ b/tests/js/gm2-bulk-ai.test.js
@@ -2,17 +2,19 @@ const jquery = require('jquery');
 const { JSDOM } = require('jsdom');
 
 test('row select all toggles suggestion checkboxes', () => {
-  const dom = new JSDOM(`
-    <table id="gm2-bulk-list">
-      <tr id="gm2-row-1">
-        <td>
-          <p><label><input type="checkbox" class="gm2-row-select-all"> Select all</label></p>
-          <p><label><input type="checkbox" class="gm2-apply"> First</label></p>
-          <p><label><input type="checkbox" class="gm2-apply"> Second</label></p>
-        </td>
-      </tr>
-    </table>
-  `, { url: 'http://localhost' });
+    const dom = new JSDOM(`
+      <table id="gm2-bulk-list">
+        <tr id="gm2-row-1">
+          <td>
+            <div class="gm2-result">
+              <p><label><input type="checkbox" class="gm2-row-select-all"> Select all</label></p>
+              <p><label><input type="checkbox" class="gm2-apply"> First</label></p>
+              <p><label><input type="checkbox" class="gm2-apply"> Second</label></p>
+            </div>
+          </td>
+        </tr>
+      </table>
+    `, { url: 'http://localhost' });
   const $ = jquery(dom.window);
   Object.assign(global, { window: dom.window, document: dom.window.document, jQuery: $, $ });
 
@@ -32,18 +34,20 @@ test('row select all toggles suggestion checkboxes', () => {
 });
 
 test('rows with suggestions get analyzed status on load', () => {
-  const dom = new JSDOM(`
-    <table id="gm2-bulk-list">
-      <tr id="gm2-row-1">
-        <td class="gm2-result">
-          <p><label><input type="checkbox" class="gm2-apply"> Suggestion</label></p>
-        </td>
-      </tr>
-      <tr id="gm2-row-2">
-        <td class="gm2-result"></td>
-      </tr>
-    </table>
-  `, { url: 'http://localhost' });
+    const dom = new JSDOM(`
+      <table id="gm2-bulk-list">
+        <tr id="gm2-row-1">
+          <td>
+            <div class="gm2-result">
+              <p><label><input type="checkbox" class="gm2-apply"> Suggestion</label></p>
+            </div>
+          </td>
+        </tr>
+        <tr id="gm2-row-2">
+          <td><div class="gm2-result"></div></td>
+        </tr>
+      </table>
+    `, { url: 'http://localhost' });
   const $ = jquery(dom.window);
   Object.assign(global, { window: dom.window, document: dom.window.document, jQuery: $, $ });
 
@@ -61,27 +65,31 @@ test('rows with suggestions get analyzed status on load', () => {
 });
 
 test('select analyzed checks row checkbox and suggestions', () => {
-  const dom = new JSDOM(`
-    <div id="gm2-bulk-ai">
-      <button class="gm2-bulk-select-analyzed">Select analyzed</button>
-      <table id="gm2-bulk-list">
-        <tr id="gm2-row-1" class="gm2-status-analyzed">
-          <td>
-            <input type="checkbox" class="gm2-select">
-            <p><label><input type="checkbox" class="gm2-row-select-all"> Select all</label></p>
-            <p><label><input type="checkbox" class="gm2-apply"> Suggestion</label></p>
-          </td>
-        </tr>
-        <tr id="gm2-row-2" class="gm2-status-new">
-          <td>
-            <input type="checkbox" class="gm2-select">
-            <p><label><input type="checkbox" class="gm2-row-select-all"> Select all</label></p>
-            <p><label><input type="checkbox" class="gm2-apply"> Suggestion</label></p>
-          </td>
-        </tr>
-      </table>
-    </div>
-  `, { url: 'http://localhost' });
+    const dom = new JSDOM(`
+      <div id="gm2-bulk-ai">
+        <button class="gm2-bulk-select-analyzed">Select analyzed</button>
+        <table id="gm2-bulk-list">
+          <tr id="gm2-row-1" class="gm2-status-analyzed">
+            <td>
+              <input type="checkbox" class="gm2-select">
+              <div class="gm2-result">
+                <p><label><input type="checkbox" class="gm2-row-select-all"> Select all</label></p>
+                <p><label><input type="checkbox" class="gm2-apply"> Suggestion</label></p>
+              </div>
+            </td>
+          </tr>
+          <tr id="gm2-row-2" class="gm2-status-new">
+            <td>
+              <input type="checkbox" class="gm2-select">
+              <div class="gm2-result">
+                <p><label><input type="checkbox" class="gm2-row-select-all"> Select all</label></p>
+                <p><label><input type="checkbox" class="gm2-apply"> Suggestion</label></p>
+              </div>
+            </td>
+          </tr>
+        </table>
+      </div>
+    `, { url: 'http://localhost' });
   const $ = jquery(dom.window);
   Object.assign(global, { window: dom.window, document: dom.window.document, jQuery: $, $ });
 

--- a/tests/test-bulk-ai.php
+++ b/tests/test-bulk-ai.php
@@ -1,5 +1,7 @@
 <?php
 use Gm2\Gm2_SEO_Admin;
+use Gm2\Gm2_Bulk_Ai_List_Table;
+use Gm2\Gm2_Bulk_Ai_Tax_List_Table;
 
 class BulkAiPageTest extends WP_UnitTestCase {
     public function test_page_requires_edit_posts_cap() {
@@ -383,5 +385,39 @@ class BulkAiTaxSelectAllTest extends WP_UnitTestCase {
 
         $this->assertStringContainsString('gm2-row-select-all', $html);
         $this->assertStringContainsString('Select all', $html);
+    }
+}
+
+class BulkAiColumnAiTest extends WP_UnitTestCase {
+    public function test_column_ai_wraps_output() {
+        $post_id = self::factory()->post->create();
+        update_post_meta($post_id, '_gm2_ai_research', wp_json_encode([
+            'seo_title' => 'Title',
+        ]));
+        $admin = new Gm2_SEO_Admin();
+        $table = new Gm2_Bulk_Ai_List_Table($admin, []);
+        $method = new ReflectionMethod($table, 'column_ai');
+        $method->setAccessible(true);
+        $html = $method->invoke($table, get_post($post_id));
+        $this->assertStringContainsString('<div class="gm2-result">', $html);
+        $this->assertStringContainsString('Title', $html);
+        $this->assertStringContainsString('</div>', $html);
+    }
+}
+
+class BulkAiTaxColumnAiTest extends WP_UnitTestCase {
+    public function test_tax_column_ai_wraps_output() {
+        $term = self::factory()->term->create_and_get(['taxonomy' => 'category', 'name' => 'Term']);
+        update_term_meta($term->term_id, '_gm2_ai_research', wp_json_encode([
+            'seo_title' => 'Term Title',
+        ]));
+        $admin = new Gm2_SEO_Admin();
+        $table = new Gm2_Bulk_Ai_Tax_List_Table($admin, []);
+        $method = new ReflectionMethod($table, 'column_ai');
+        $method->setAccessible(true);
+        $html = $method->invoke($table, $term);
+        $this->assertStringContainsString('<div class="gm2-result">', $html);
+        $this->assertStringContainsString('Term Title', $html);
+        $this->assertStringContainsString('</div>', $html);
     }
 }


### PR DESCRIPTION
## Summary
- Wrap AI suggestion output in `<div class="gm2-result">` for both posts and terms
- Ensure bulk AI scripts mark analyzed rows and select their suggestions via new wrapper
- Add PHP and JS tests for wrapped output and analyzed-row selection

## Testing
- `phpunit` *(fails: missing WordPress test library)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895115df5048327803578182087f4e2