### PR TITLE
Add shared progress bars for bulk taxonomy operations

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1535,6 +1535,9 @@ class Gm2_SEO_Admin {
         // Top action buttons.
         echo '<p class="gm2-bulk-actions">' . $buttons . '</p>';
 
+        // Progress bar above the table.
+        echo '<p><progress class="gm2-bulk-term-progress-bar" value="0" max="100" style="width:100%;display:none" role="progressbar" aria-live="polite"></progress></p>';
+
         echo '<form method="get">';
         echo '<input type="hidden" name="page" value="gm2-bulk-ai-taxonomies" />';
         $table->display();
@@ -1543,7 +1546,7 @@ class Gm2_SEO_Admin {
         // Bottom action buttons.
         echo '<p class="gm2-bulk-actions">' . $buttons . '</p>';
         echo '<p id="gm2-bulk-term-msg"></p>';
-        echo '<p><progress id="gm2-bulk-term-progress-bar" value="0" max="100" style="width:100%;display:none" role="progressbar" aria-live="polite"></progress></p>';
+        echo '<p><progress class="gm2-bulk-term-progress-bar" value="0" max="100" style="width:100%;display:none" role="progressbar" aria-live="polite"></progress></p>';
         echo '</div>';
     }
 

--- a/admin/js/gm2-bulk-ai-tax.js
+++ b/admin/js/gm2-bulk-ai-tax.js
@@ -22,9 +22,9 @@ jQuery(function($){
         var ids=[];
         $('#gm2-bulk-term-list .gm2-select:checked').each(function(){ids.push($(this).val());});
         if(!ids.length) return;
-        $('#gm2-bulk-term-progress-bar').attr('max',ids.length).val(0).show();
+        $('.gm2-bulk-term-progress-bar').attr('max',ids.length).val(0).show();
         function next(){
-            if(stop||!ids.length){$('#gm2-bulk-term-progress-bar').hide();return;}
+            if(stop||!ids.length){$('.gm2-bulk-term-progress-bar').hide();return;}
             var key=ids.shift();
             var parts=key.split(':');
             var tax=parts[0], id=parts[1];
@@ -49,15 +49,15 @@ jQuery(function($){
                 cell.find('.gm2-ai-spinner').remove();
                 cell.text(gm2BulkAiTax.i18n.error);
             }).always(function(){
-                var done = parseInt($('#gm2-bulk-term-progress-bar').val(),10)+1;
-                $('#gm2-bulk-term-progress-bar').val(done);
+                var done = parseInt($('.gm2-bulk-term-progress-bar').first().val(),10)+1;
+                $('.gm2-bulk-term-progress-bar').val(done);
                 next();
             });
         }
         next();
     });
     $('#gm2-bulk-ai-tax').on('click','#gm2-bulk-term-cancel',function(e){
-        e.preventDefault();stop=true;$('#gm2-bulk-term-progress-bar').hide();
+        e.preventDefault();stop=true;$('.gm2-bulk-term-progress-bar').hide();
     });
     $('#gm2-bulk-ai-tax').on('click','#gm2-bulk-term-desc',function(e){
         e.preventDefault();
@@ -65,9 +65,9 @@ jQuery(function($){
         var ids=[];
         $('#gm2-bulk-term-list .gm2-select:checked').each(function(){ids.push($(this).val());});
         if(!ids.length) return;
-        $('#gm2-bulk-term-progress-bar').attr('max',ids.length).val(0).show();
+        $('.gm2-bulk-term-progress-bar').attr('max',ids.length).val(0).show();
         function next(){
-            if(stop||!ids.length){$('#gm2-bulk-term-progress-bar').hide();return;}
+            if(stop||!ids.length){$('.gm2-bulk-term-progress-bar').hide();return;}
             var key=ids.shift();
             var parts=key.split(':');
             var tax=parts[0], id=parts[1];
@@ -89,8 +89,8 @@ jQuery(function($){
                 cell.find('.gm2-ai-spinner').remove();
                 cell.text(gm2BulkAiTax.i18n.error);
             }).always(function(){
-                var done=parseInt($('#gm2-bulk-term-progress-bar').val(),10)+1;
-                $('#gm2-bulk-term-progress-bar').val(done);
+                var done=parseInt($('.gm2-bulk-term-progress-bar').first().val(),10)+1;
+                $('.gm2-bulk-term-progress-bar').val(done);
                 next();
             });
         }


### PR DESCRIPTION
## Summary
- Render top and bottom progress bars for bulk taxonomy AI actions using a shared class
- Update bulk taxonomy JavaScript to target and update all progress bars

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68951554840483278704466490d0652a