### PR TITLE
Reset taxonomy AI data via bulk reset endpoint

### DIFF
--- a/admin/js/gm2-bulk-ai-tax.js
+++ b/admin/js/gm2-bulk-ai-tax.js
@@ -282,30 +282,36 @@ jQuery(function($){
         var ids=[];
         $('#gm2-bulk-term-list .gm2-select:checked').each(function(){ids.push($(this).val());});
         if(!ids.length) return;
+        var $btn=$(this);
         var $msg=$('#gm2-bulk-term-msg');
-        var total=ids.length, cleared=0;
+        var total=ids.length, reset=0;
         $('.gm2-bulk-term-progress-bar').attr('max',total).val(0).show();
         $msg.text(gm2BulkAiTax.i18n.resetting);
+        var $spinner=$('<span>',{class:'spinner is-active gm2-ai-spinner'}).insertAfter($btn);
+        $btn.prop('disabled',true);
         function updateProgress(){
-            $('.gm2-bulk-term-progress-bar').val(cleared);
+            $('.gm2-bulk-term-progress-bar').val(reset);
         }
         updateProgress();
         $.ajax({
             url: gm2BulkAiTax.ajax_url,
             method:'POST',
-            data:{action:'gm2_bulk_ai_tax_clear',ids:JSON.stringify(ids),_ajax_nonce:gm2BulkAiTax.clear_nonce},
+            data:{action:'gm2_bulk_ai_tax_reset',ids:JSON.stringify(ids),_ajax_nonce:gm2BulkAiTax.reset_nonce},
             dataType:'json'
         }).done(function(resp){
             if(resp&&resp.success){
                 $.each(ids,function(i,key){
                     var parts=key.split(':');
                     var row=$('#gm2-term-'+parts[0]+'-'+parts[1]);
+                    row.find('.column-seo_title').text('');
+                    row.find('.column-description').text('');
                     row.find('.gm2-result').empty();
-                    row.removeClass('gm2-status-analyzed').addClass('gm2-status-new');
-                    cleared++;
+                    row.find('.gm2-select').prop('checked',false);
+                    row.removeClass('gm2-status-analyzed gm2-status-applied').addClass('gm2-status-new');
+                    reset++;
                     updateProgress();
                 });
-                $msg.text(gm2BulkAiTax.i18n.clearDone.replace('%s',resp.data.cleared));
+                $msg.text(gm2BulkAiTax.i18n.resetDone.replace('%s',resp.data.reset));
             }else{
                 $msg.text((resp&&resp.data)?resp.data:gm2BulkAiTax.i18n.error);
             }
@@ -314,6 +320,8 @@ jQuery(function($){
             $msg.text(msg||gm2BulkAiTax.i18n.error);
         }).always(function(){
             $('.gm2-bulk-term-progress-bar').hide();
+            $spinner.remove();
+            $btn.prop('disabled',false);
         });
     });
 


### PR DESCRIPTION
## Summary
- Use `gm2_bulk_ai_tax_reset` for taxonomy reset so AI research meta is removed
- After reset, clear AI results, reset SEO columns, update row status, and show spinner

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68952acce534832784fba0df8e1d80be