### PR TITLE
Add taxonomy refresh/clear/undo controls

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -290,6 +290,9 @@ class Gm2_Admin {
                         'ajax_url'    => admin_url('admin-ajax.php'),
                         'i18n'        => [
                             'apply'      => __( 'Apply', 'gm2-wordpress-suite' ),
+                            'refresh'    => __( 'Refresh', 'gm2-wordpress-suite' ),
+                            'clear'      => __( 'Clear', 'gm2-wordpress-suite' ),
+                            'undo'       => __( 'Undo', 'gm2-wordpress-suite' ),
                             'error'      => __( 'Error', 'gm2-wordpress-suite' ),
                             'resetting'  => __( 'Resetting...', 'gm2-wordpress-suite' ),
                             'resetDone'  => __( 'Reset %s terms', 'gm2-wordpress-suite' ),


### PR DESCRIPTION
## Summary
- Add Refresh, Clear, and Undo controls to taxonomy AI suggestion rows
- Handle taxonomy refresh, clear, and undo actions in JS with spinners and status icons
- Store previous term SEO fields and restore them via new undo endpoint

## Testing
- `npm test`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6895361d05ec83278effef9fdb765d1c