### PR TITLE
Add taxonomy bulk selection with full dataset handling

### DIFF
--- a/admin/class-gm2-bulk-taxonomies.php
+++ b/admin/class-gm2-bulk-taxonomies.php
@@ -1,0 +1,60 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Gm2_Bulk_Taxonomies {
+
+    public function run() {
+        add_action( 'restrict_manage_posts', [ $this, 'render_button' ] );
+        add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
+        add_action( 'wp_ajax_gm2_fetch_filtered_term_ids', [ $this, 'ajax_fetch_term_ids' ] );
+    }
+
+    public function render_button( $post_type ) {
+        if ( ! isset( $_GET['taxonomy'] ) ) {
+            return;
+        }
+        echo '<button type="button" id="gm2-tax-select-all" class="button">Select All</button>';
+        echo '<input type="hidden" id="gm2-tax-selected-ids" name="gm2_tax_selected_ids" value="" />';
+    }
+
+    public function enqueue_scripts( $hook ) {
+        if ( 'edit-tags.php' !== $hook ) {
+            return;
+        }
+        wp_enqueue_script(
+            'gm2-bulk-taxonomies',
+            GM2_PLUGIN_URL . 'admin/js/gm2-bulk-taxonomies.js',
+            [],
+            GM2_VERSION,
+            true
+        );
+        wp_localize_script( 'gm2-bulk-taxonomies', 'gm2BulkTaxData', [
+            'ajax_url' => admin_url( 'admin-ajax.php' ),
+            'nonce'    => wp_create_nonce( 'gm2_bulk_tax' ),
+        ] );
+    }
+
+    public function ajax_fetch_term_ids() {
+        check_ajax_referer( 'gm2_bulk_tax', 'nonce' );
+        $query_string = isset( $_POST['query'] ) ? wp_unslash( $_POST['query'] ) : '';
+        $params       = [];
+        if ( ! empty( $query_string ) ) {
+            wp_parse_str( $query_string, $params );
+        }
+        $args = [
+            'taxonomy'   => isset( $params['taxonomy'] ) ? sanitize_key( $params['taxonomy'] ) : 'category',
+            'search'     => isset( $params['s'] ) ? sanitize_text_field( $params['s'] ) : '',
+            'hide_empty' => false,
+            'fields'     => 'ids',
+            'number'     => 0,
+        ];
+        $terms = get_terms( $args );
+        if ( is_wp_error( $terms ) ) {
+            wp_send_json_success( [] );
+        } else {
+            wp_send_json_success( $terms );
+        }
+    }
+}

--- a/admin/js/gm2-bulk-taxonomies.js
+++ b/admin/js/gm2-bulk-taxonomies.js
@@ -1,0 +1,65 @@
+(function(global){
+    function init() {
+        var button = document.getElementById('gm2-tax-select-all');
+        if (!button) { return; }
+        var selected = false;
+        var ids = [];
+        var hidden = document.getElementById('gm2-tax-selected-ids');
+
+        button.addEventListener('click', function(){
+            if (!selected) {
+                var query = window.location.search.slice(1);
+                fetch(gm2BulkTaxData.ajax_url, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                    body: 'action=gm2_fetch_filtered_term_ids&nonce=' + encodeURIComponent(gm2BulkTaxData.nonce) + '&query=' + encodeURIComponent(query)
+                }).then(function(resp){
+                    return resp.json();
+                }).then(function(data){
+                    ids = data.data || [];
+                    ids.forEach(function(id){
+                        var cb = document.getElementById('cb-select-' + id);
+                        if (cb) { cb.checked = true; }
+                    });
+                    hidden.value = ids.join(',');
+                    button.textContent = 'Un-Select All';
+                    selected = true;
+                });
+            } else {
+                ids.forEach(function(id){
+                    var cb = document.getElementById('cb-select-' + id);
+                    if (cb) { cb.checked = false; }
+                });
+                ids = [];
+                hidden.value = '';
+                button.textContent = 'Select All';
+                selected = false;
+            }
+        });
+
+        var form = document.getElementById('posts-filter');
+        if (form) {
+            form.addEventListener('submit', function(){
+                if (ids.length) {
+                    ids.forEach(function(id){
+                        if (!document.getElementById('cb-select-' + id)) {
+                            var input = document.createElement('input');
+                            input.type = 'hidden';
+                            input.name = 'delete_tags[]';
+                            input.value = id;
+                            form.appendChild(input);
+                        }
+                    });
+                }
+            });
+        }
+    }
+
+    if (typeof document !== 'undefined') {
+        document.addEventListener('DOMContentLoaded', init);
+    }
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = init;
+    }
+})(this);

--- a/includes/class-gm2-loader.php
+++ b/includes/class-gm2-loader.php
@@ -14,6 +14,7 @@ class Gm2_Loader {
     private function load_dependencies() {
         require_once GM2_PLUGIN_DIR . 'admin/class-gm2-admin.php';
         require_once GM2_PLUGIN_DIR . 'admin/class-gm2-bulk-review.php';
+        require_once GM2_PLUGIN_DIR . 'admin/class-gm2-bulk-taxonomies.php';
         require_once GM2_PLUGIN_DIR . 'public/class-gm2-public.php';
         require_once GM2_PLUGIN_DIR . 'includes/class-gm2-chatgpt.php';
     }
@@ -24,6 +25,9 @@ class Gm2_Loader {
 
         $bulk = new Gm2_Bulk_Review();
         $bulk->run();
+
+        $tax = new Gm2_Bulk_Taxonomies();
+        $tax->run();
 
         $public = new Gm2_Public();
         $public->run();

--- a/package.json
+++ b/package.json
@@ -5,6 +5,6 @@
     "jsdom": "^24.0.0"
   },
   "scripts": {
-    "test:js": "node tests/js/gm2-bulk-review.test.js"
+    "test:js": "node tests/js/gm2-bulk-review.test.js && node tests/js/gm2-bulk-taxonomies.test.js"
   }
 }

--- a/tests/BulkTaxonomiesTest.php
+++ b/tests/BulkTaxonomiesTest.php
@@ -28,32 +28,30 @@ if ( ! function_exists( 'sanitize_text_field' ) ) {
 if ( ! function_exists( 'admin_url' ) ) {
     function admin_url( $path = '' ) { return $path; }
 }
-if ( ! class_exists( 'WP_Query' ) ) {
-    class WP_Query {
-        public $posts;
-        public function __construct( $args ) {
-            $this->posts = [1,2,3];
-        }
-    }
+if ( ! function_exists( 'get_terms' ) ) {
+    function get_terms( $args ) { return [4,5,6]; }
+}
+if ( ! function_exists( 'is_wp_error' ) ) {
+    function is_wp_error( $thing ) { return false; }
 }
 
 define( 'ABSPATH', __DIR__ );
-require_once __DIR__ . '/../admin/class-gm2-bulk-review.php';
+require_once __DIR__ . '/../admin/class-gm2-bulk-taxonomies.php';
 
-class BulkReviewTest extends TestCase {
-    public function test_fetch_filtered_ids_returns_all_posts() {
+class BulkTaxonomiesTest extends TestCase {
+    public function test_fetch_filtered_ids_returns_all_terms() {
         $_POST['nonce'] = 'dummy';
-        $_POST['query'] = '';
-        $handler = new Gm2_Bulk_Review();
+        $_POST['query'] = 'taxonomy=category';
+        $handler = new Gm2_Bulk_Taxonomies();
         ob_start();
         try {
-            $handler->ajax_fetch_post_ids();
+            $handler->ajax_fetch_term_ids();
         } catch ( Exception $e ) {
             // Expected due to wp_die stub
         }
         $output = ob_get_clean();
         $response = json_decode( $output, true );
         $this->assertTrue( $response['success'] );
-        $this->assertEquals( [1,2,3], $response['data'] );
+        $this->assertEquals( [4,5,6], $response['data'] );
     }
 }

--- a/tests/js/gm2-bulk-taxonomies.test.js
+++ b/tests/js/gm2-bulk-taxonomies.test.js
@@ -1,0 +1,45 @@
+const assert = require('assert');
+const {JSDOM} = require('jsdom');
+const init = require('../../admin/js/gm2-bulk-taxonomies.js');
+
+(async () => {
+    const dom = new JSDOM(`<!DOCTYPE html><form id="posts-filter">
+        <button id="gm2-tax-select-all">Select All</button>
+        <input type="hidden" id="gm2-tax-selected-ids" />
+        <input type="checkbox" id="cb-select-1" />
+        <input type="checkbox" id="cb-select-2" />
+    </form>`, {url: 'http://example.com/wp-admin/edit-tags.php?taxonomy=category'});
+
+    global.window = dom.window;
+    global.document = dom.window.document;
+    global.gm2BulkTaxData = {ajax_url: '/ajax', nonce: 'nonce'};
+    global.fetch = () => Promise.resolve({json: () => Promise.resolve({success: true, data: [1,2,3]})});
+
+    init();
+    const button = document.getElementById('gm2-tax-select-all');
+    const form = document.getElementById('posts-filter');
+
+    // First select all
+    button.dispatchEvent(new window.Event('click'));
+    await new Promise(resolve => setTimeout(resolve, 0));
+    const cb1 = document.getElementById('cb-select-1');
+    const cb2 = document.getElementById('cb-select-2');
+    const hidden = document.getElementById('gm2-tax-selected-ids');
+    assert.strictEqual(cb1.checked && cb2.checked, true, 'checkboxes checked');
+    assert.strictEqual(hidden.value, '1,2,3', 'hidden has ids');
+    assert.strictEqual(button.textContent, 'Un-Select All', 'button toggled');
+
+    // Toggle unselect
+    button.dispatchEvent(new window.Event('click'));
+    assert.strictEqual(cb1.checked || cb2.checked, false, 'checkboxes cleared');
+    assert.strictEqual(hidden.value, '', 'hidden cleared');
+    assert.strictEqual(button.textContent, 'Select All', 'button reset');
+
+    // Select again and submit to verify hidden inputs
+    button.dispatchEvent(new window.Event('click'));
+    await new Promise(resolve => setTimeout(resolve, 0));
+    form.dispatchEvent(new window.Event('submit'));
+    const extra = [...form.querySelectorAll('input[name="delete_tags[]"]')].find(el => el.value === '3');
+    assert.ok(extra, 'hidden input for missing id added');
+    console.log('Taxonomy JS test passed');
+})();


### PR DESCRIPTION
## Summary
- add taxonomy bulk management controller and script
- support Select All/Un-Select All for filtered term lists via AJAX
- ensure bulk actions include all selected term IDs
- add PHP and JS tests for taxonomy selection

## Testing
- `npm run test:js`
- `vendor/bin/phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_68953f758ec88327b6137e1dc58f2512