### PR TITLE
Add bulk select filtered feature

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -244,6 +244,7 @@ class Gm2_Admin {
                         'batch_nonce' => wp_create_nonce('gm2_ai_batch'),
                         'reset_nonce' => wp_create_nonce('gm2_bulk_ai_reset'),
                         'clear_nonce' => wp_create_nonce('gm2_bulk_ai_clear'),
+                        'fetch_nonce' => wp_create_nonce('gm2_bulk_ai_fetch_ids'),
                         'ajax_url'    => admin_url('admin-ajax.php'),
                         'i18n'        => [
                             'processing'   => __( 'Processing %1$s / %2$s', 'gm2-wordpress-suite' ),
@@ -264,6 +265,8 @@ class Gm2_Admin {
                             'resetting'    => __( 'Resetting...', 'gm2-wordpress-suite' ),
                             'resetDone'    => __( 'Reset %s posts', 'gm2-wordpress-suite' ),
                             'clearDone'    => __( 'Cleared AI suggestions for %s posts', 'gm2-wordpress-suite' ),
+                            'selectAllPosts' => __( 'Select All', 'gm2-wordpress-suite' ),
+                            'unselectAllPosts' => __( 'Un-Select All', 'gm2-wordpress-suite' ),
                         ],
                     ]
                 );

--- a/admin/css/gm2-seo.css
+++ b/admin/css/gm2-seo.css
@@ -77,6 +77,10 @@
     margin-left:4px;
 }
 
+.gm2-bulk-select-filtered {
+    margin-left:4px;
+}
+
 .gm2-schema-card {
     border:1px solid #ddd;
     background:#fff;


### PR DESCRIPTION
## Summary
- add "Select All" button for filtered results on bulk AI review
- register gm2_bulk_ai_fetch_ids AJAX endpoint and integrate with bulk actions
- track selected IDs client-side with localization and minor styling

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895424534948327878895b38b2889a1