### PR TITLE
Add bulk taxonomy select-all support

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -290,6 +290,7 @@ class Gm2_Admin {
                         'desc_nonce'  => wp_create_nonce('gm2_ai_generate_tax_description'),
                         'reset_nonce' => wp_create_nonce('gm2_bulk_ai_tax_reset'),
                         'clear_nonce' => wp_create_nonce('gm2_bulk_ai_tax_clear'),
+                        'fetch_nonce' => wp_create_nonce('gm2_bulk_ai_tax_fetch_ids'),
                         'ajax_url'    => admin_url('admin-ajax.php'),
                         'i18n'        => [
                             'apply'      => __( 'Apply', 'gm2-wordpress-suite' ),
@@ -301,6 +302,8 @@ class Gm2_Admin {
                             'resetDone'  => __( 'Reset %s terms', 'gm2-wordpress-suite' ),
                             'clearDone'  => __( 'Cleared AI suggestions for %s terms', 'gm2-wordpress-suite' ),
                             'selectAll'  => __( 'Select all', 'gm2-wordpress-suite' ),
+                            'selectAllTerms'    => __( 'Select All', 'gm2-wordpress-suite' ),
+                            'unselectAllTerms'  => __( 'Un-Select All', 'gm2-wordpress-suite' ),
                         ],
                     ]
                 );

--- a/admin/css/gm2-seo.css
+++ b/admin/css/gm2-seo.css
@@ -81,6 +81,10 @@
     margin-left:4px;
 }
 
+.gm2-bulk-term-select-filtered {
+    margin-left:4px;
+}
+
 .gm2-schema-card {
     border:1px solid #ddd;
     background:#fff;


### PR DESCRIPTION
## Summary
- add "Select All" button for taxonomy bulk AI tools
- support fetching all filtered term IDs via AJAX
- track selected terms client-side and integrate with bulk actions

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689543d6bfd08327bfc2b989d464433a