### PR TITLE
Gracefully handle localStorage failures in tab tracking

### DIFF
--- a/public/js/gm2-ac-activity.js
+++ b/public/js/gm2-ac-activity.js
@@ -77,15 +77,41 @@
         }
     }
 
+    let memoryTabCount = 0;
+
     function incrementTabs() {
-        const count = Math.max(parseInt(localStorage.getItem(KEY) || '0', 10), 0) + 1;
-        localStorage.setItem(KEY, String(count));
+        let count;
+        try {
+            count = Math.max(parseInt(localStorage.getItem(KEY) || '0', 10), 0) + 1;
+            localStorage.setItem(KEY, String(count));
+        } catch (e) {
+            try {
+                const match = document.cookie.match(new RegExp('(?:^|; )' + KEY + '=([^;]*)'));
+                count = Math.max(parseInt(match ? decodeURIComponent(match[1]) : '0', 10), 0) + 1;
+                document.cookie = `${KEY}=${count}; path=/`;
+            } catch (err) {
+                count = ++memoryTabCount;
+            }
+        }
     }
 
     function decrementTabs() {
-        const count = Math.max(parseInt(localStorage.getItem(KEY) || '0', 10) - 1, 0);
-        localStorage.setItem(KEY, String(count));
-        if (count === 0) {
+        let count;
+        try {
+            count = Math.max(parseInt(localStorage.getItem(KEY) || '0', 10) - 1, 0);
+            localStorage.setItem(KEY, String(count));
+        } catch (e) {
+            try {
+                const match = document.cookie.match(new RegExp('(?:^|; )' + KEY + '=([^;]*)'));
+                count = Math.max(parseInt(match ? decodeURIComponent(match[1]) : '0', 10) - 1, 0);
+                document.cookie = `${KEY}=${count}; path=/`;
+            } catch (err) {
+                count = Math.max(memoryTabCount - 1, 0);
+                memoryTabCount = count;
+            }
+        }
+
+        if (typeof count === 'undefined' || count === 0) {
             send('gm2_ac_mark_abandoned');
         }
     }

--- a/tests/js/gm2-ac-activity.test.js
+++ b/tests/js/gm2-ac-activity.test.js
@@ -1,0 +1,35 @@
+const { JSDOM } = require('jsdom');
+
+test('records exit URL when localStorage is disabled', () => {
+  const dom = new JSDOM(`<!DOCTYPE html><body></body>`, { url: 'https://example.com/page' });
+  const { window } = dom;
+
+  const fetchMock = jest.fn().mockResolvedValue({ ok: true });
+  window.fetch = fetchMock;
+  global.fetch = fetchMock;
+  window.navigator.sendBeacon = jest.fn().mockReturnValue(true);
+
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    get() {
+      throw new Error('access denied');
+    },
+  });
+
+  Object.assign(global, { window, document: window.document, navigator: window.navigator });
+  global.gm2AcActivity = { ajax_url: '/ajax', nonce: 'nonce' };
+
+  jest.resetModules();
+  require('../../public/js/gm2-ac-activity.js');
+
+  window.dispatchEvent(new window.Event('pagehide'));
+
+  const abandonCalls = fetchMock.mock.calls.filter((c) => {
+    const params = new URLSearchParams(c[1].body);
+    return params.get('action') === 'gm2_ac_mark_abandoned';
+  });
+
+  expect(abandonCalls.length).toBe(1);
+  const params = new URLSearchParams(abandonCalls[0][1].body);
+  expect(params.get('url')).toBe('https://example.com/page');
+});


### PR DESCRIPTION
## Summary
- Safeguard tab counter updates with try/catch and cookies or in-memory fallback
- Send abandonment signal even when storage access fails
- Add Jest test covering storage-disabled scenario

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68954d20e5f88327b95e5000a2fc859d