### PR TITLE
Add tests for taxonomy bulk selection handling

### DIFF
--- a/tests/js/gm2-bulk-ai-tax.test.js
+++ b/tests/js/gm2-bulk-ai-tax.test.js
@@ -118,3 +118,147 @@ test('clearing taxonomy suggestions removes analyzed status', () => {
   expect($('#gm2-term-cat-1 .gm2-result').text()).toBe('✓');
   expect($('#gm2-bulk-term-msg').text()).toBe('Cleared AI suggestions for 1 terms');
 });
+
+test('taxonomy select filtered toggles between select and unselect all', () => {
+  const dom = new JSDOM(`
+    <div id="gm2-bulk-ai-tax">
+      <button id="gm2-bulk-term-select-filtered">Select All</button>
+      <table id="gm2-bulk-term-list">
+        <tr id="gm2-term-cat-1"><td><input type="checkbox" class="gm2-select" value="cat:1"></td></tr>
+        <tr id="gm2-term-cat-2"><td><input type="checkbox" class="gm2-select" value="cat:2"></td></tr>
+      </table>
+    </div>
+  `, { url: 'http://localhost' });
+  const $ = jquery(dom.window);
+  Object.assign(global, { window: dom.window, document: dom.window.document, jQuery: $, $ });
+  global.gm2BulkAiTax = {
+    ajax_url: '/ajax',
+    fetch_nonce: 'nonce',
+    i18n: { selectAllTerms: 'Select All', unselectAllTerms: 'Un-Select All' }
+  };
+
+  let selectedKeys = [];
+  function getSelectedKeys(){
+    if(selectedKeys.length){ return selectedKeys.slice(); }
+    const ids=[]; $('#gm2-bulk-term-list .gm2-select:checked').each(function(){ ids.push($(this).val()); });
+    return ids;
+  }
+
+  $('#gm2-bulk-term-list').on('change','.gm2-select',function(){
+    if(!selectedKeys.length) return;
+    const key=$(this).val();
+    if($(this).is(':checked')){
+      if($.inArray(key, selectedKeys) === -1){ selectedKeys.push(key); }
+    } else {
+      selectedKeys=$.grep(selectedKeys,function(v){ return v!=key; });
+    }
+  });
+
+  $.post = jest.fn(() => ({
+    done(cb){ cb({ success:true, data:{ ids:['cat:1','cat:2','tag:3'] } }); return this; },
+    fail(){ return this; }
+  }));
+
+  $('#gm2-bulk-ai-tax').on('click','#gm2-bulk-term-select-filtered',function(e){
+    e.preventDefault();
+    const $btn=$(this);
+    if($btn.data('selected')){
+      selectedKeys=[];
+      $('#gm2-bulk-term-list .gm2-select').prop('checked',false);
+      $btn.data('selected',false).text(gm2BulkAiTax.i18n.selectAllTerms);
+      return;
+    }
+    const data={
+      action:'gm2_bulk_ai_tax_fetch_ids',
+      taxonomy:'all',
+      status:'publish',
+      search:'',
+      seo_status:'all',
+      missing_title:0,
+      missing_desc:0,
+      _ajax_nonce:gm2BulkAiTax.fetch_nonce
+    };
+    $btn.prop('disabled',true);
+    $.post(gm2BulkAiTax.ajax_url,data).done(function(resp){
+      $btn.prop('disabled',false);
+      if(resp&&resp.success){
+        selectedKeys=resp.data.ids||[];
+        $('#gm2-bulk-term-list .gm2-select').prop('checked',true);
+        $btn.data('selected',true).text(gm2BulkAiTax.i18n.unselectAllTerms);
+      }
+    }).fail(function(){ $btn.prop('disabled',false); });
+  });
+
+  const $btn=$('#gm2-bulk-term-select-filtered');
+  $btn.trigger('click');
+  expect(selectedKeys).toEqual(['cat:1','cat:2','tag:3']);
+  expect($('#gm2-bulk-term-list .gm2-select:checked').length).toBe(2);
+  expect($btn.text()).toBe('Un-Select All');
+  $('#gm2-term-cat-1 .gm2-select').prop('checked',false).trigger('change');
+  expect(selectedKeys).toEqual(['cat:2','tag:3']);
+  $btn.trigger('click');
+  expect(selectedKeys).toEqual([]);
+  expect($('#gm2-bulk-term-list .gm2-select:checked').length).toBe(0);
+  expect($btn.text()).toBe('Select All');
+});
+
+test('taxonomy reset selected uses stored keys', () => {
+  const dom = new JSDOM(`
+    <div id="gm2-bulk-ai-tax">
+      <button id="gm2-bulk-term-reset-selected">Reset Selected</button>
+      <p id="gm2-bulk-term-msg"></p>
+      <progress class="gm2-bulk-term-progress-bar" value="0" max="100"></progress>
+    </div>
+  `, { url: 'http://localhost' });
+  const $ = jquery(dom.window);
+  Object.assign(global, { window: dom.window, document: dom.window.document, jQuery: $, $ });
+  global.gm2BulkAiTax = {
+    ajax_url: '/ajax',
+    reset_nonce: 'nonce',
+    i18n: { resetting: 'Resetting', resetDone: 'Reset %s', error: 'Error' }
+  };
+
+  let selectedKeys=['cat:1','tag:3'];
+  function getSelectedKeys(){
+    if(selectedKeys.length){ return selectedKeys.slice(); }
+    const ids=[]; $('#gm2-bulk-term-list .gm2-select:checked').each(function(){ ids.push($(this).val()); });
+    return ids;
+  }
+
+  $.ajax = jest.fn(() => ({
+    done(cb){ cb({ success:true, data:{ reset:selectedKeys.length } }); return this; },
+    fail(){ return this; },
+    always(cb){ cb(); return this; }
+  }));
+
+  $('#gm2-bulk-ai-tax').on('click','#gm2-bulk-term-reset-selected',function(e){
+    e.preventDefault();
+    var ids=getSelectedKeys();
+    if(!ids.length) return;
+    var $msg=$('#gm2-bulk-term-msg');
+    var total=ids.length, processed=0;
+    $('.gm2-bulk-term-progress-bar').attr('max',total).val(0).show();
+    $msg.text(gm2BulkAiTax.i18n.resetting);
+    function updateProgress(){
+      $('.gm2-bulk-term-progress-bar').val(processed);
+    }
+    updateProgress();
+    $.ajax({
+      url: gm2BulkAiTax.ajax_url,
+      method:'POST',
+      data:{action:'gm2_bulk_ai_tax_reset',ids:JSON.stringify(ids),_ajax_nonce:gm2BulkAiTax.reset_nonce},
+      dataType:'json'
+    }).done(function(resp){
+      $msg.text(gm2BulkAiTax.i18n.resetDone.replace('%s', resp.data.reset));
+    }).fail(function(){
+      $msg.text(gm2BulkAiTax.i18n.error);
+    }).always(function(){
+      $('.gm2-bulk-term-progress-bar').hide();
+    });
+  });
+
+  $('#gm2-bulk-term-reset-selected').trigger('click');
+  expect($.ajax).toHaveBeenCalledWith(expect.objectContaining({
+    data: expect.objectContaining({ ids: JSON.stringify(['cat:1','tag:3']) })
+  }));
+});


### PR DESCRIPTION
## Summary
- test: add coverage for taxonomy Select All/Un-Select All toggle
- test: ensure bulk reset uses stored selection keys

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896519207ac8327b2fc6ddc15dd3fd8