### PR TITLE
Toggle analyzed rows in bulk AI selection

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -267,6 +267,8 @@ class Gm2_Admin {
                             'clearDone'    => __( 'Cleared AI suggestions for %s posts', 'gm2-wordpress-suite' ),
                             'selectAllPosts' => __( 'Select All', 'gm2-wordpress-suite' ),
                             'unselectAllPosts' => __( 'Un-Select All', 'gm2-wordpress-suite' ),
+                            'selectAnalyzed'   => __( 'Select Analyzed', 'gm2-wordpress-suite' ),
+                            'unselectAnalyzed' => __( 'Unselect Analyzed', 'gm2-wordpress-suite' ),
                         ],
                     ]
                 );

--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -1381,7 +1381,7 @@ class Gm2_SEO_Admin {
         $buttons = '<button type="button" class="button gm2-bulk-analyze" aria-label="' . esc_attr__( 'Analyze Selected', 'gm2-wordpress-suite' ) . '">' . esc_html__( 'Analyze Selected', 'gm2-wordpress-suite' ) . '</button> '
             . '<button type="button" class="button gm2-bulk-cancel">' . esc_html__( 'Cancel', 'gm2-wordpress-suite' ) . '</button> '
             . '<button type="button" class="button gm2-bulk-select-filtered">' . esc_html__( 'Select All', 'gm2-wordpress-suite' ) . '</button> '
-            . '<button type="button" class="button gm2-bulk-select-analyzed">' . esc_html__( 'Select Analyzed', 'gm2-wordpress-suite' ) . '</button> '
+            . '<button type="button" class="button gm2-bulk-select-analyzed" data-select="' . esc_attr__( 'Select Analyzed', 'gm2-wordpress-suite' ) . '" data-unselect="' . esc_attr__( 'Unselect Analyzed', 'gm2-wordpress-suite' ) . '">' . esc_html__( 'Select Analyzed', 'gm2-wordpress-suite' ) . '</button> '
             . '<button type="button" class="button gm2-bulk-apply-all">' . esc_html__( 'Apply All', 'gm2-wordpress-suite' ) . '</button> '
             . '<button type="button" class="button gm2-bulk-reset-all">' . esc_html__( 'Reset All', 'gm2-wordpress-suite' ) . '</button> '
             . '<button type="button" class="button gm2-bulk-reset-selected">' . esc_html__( 'Reset Selected', 'gm2-wordpress-suite' ) . '</button> '

--- a/admin/js/gm2-bulk-ai.js
+++ b/admin/js/gm2-bulk-ai.js
@@ -455,10 +455,22 @@ jQuery(function($){
 
     $('#gm2-bulk-ai').on('click','.gm2-bulk-select-analyzed',function(e){
         e.preventDefault();
-        $('#gm2-bulk-list tr.gm2-status-analyzed').each(function(){
-            $(this).find('.gm2-select').prop('checked',true);
-            $(this).find('.gm2-row-select-all').prop('checked',true).trigger('change');
-        });
+        var $btn=$(this);
+        var selectText=$btn.data('select')||(gm2BulkAi.i18n&&gm2BulkAi.i18n.selectAnalyzed)||'Select Analyzed';
+        var unselectText=$btn.data('unselect')||(gm2BulkAi.i18n&&gm2BulkAi.i18n.unselectAnalyzed)||'Unselect Analyzed';
+        if($btn.data('selected')){
+            $('#gm2-bulk-list tr.gm2-status-analyzed').each(function(){
+                $(this).find('.gm2-select').prop('checked',false);
+                $(this).find('.gm2-row-select-all').prop('checked',false).trigger('change');
+            });
+            $btn.data('selected',false).text(selectText);
+        }else{
+            $('#gm2-bulk-list tr.gm2-status-analyzed').each(function(){
+                $(this).find('.gm2-select').prop('checked',true);
+                $(this).find('.gm2-row-select-all').prop('checked',true).trigger('change');
+            });
+            $btn.data('selected',true).text(unselectText);
+        }
     });
 
     $('#gm2-bulk-ai').on('click','.gm2-bulk-apply-all',function(e){

--- a/tests/js/gm2-bulk-ai.test.js
+++ b/tests/js/gm2-bulk-ai.test.js
@@ -64,10 +64,10 @@ test('rows with suggestions get analyzed status on load', () => {
   expect($('#gm2-row-2').hasClass('gm2-status-new')).toBe(true);
 });
 
-test('select analyzed checks row checkbox and suggestions', () => {
+test('select analyzed toggles analyzed rows and button label', () => {
     const dom = new JSDOM(`
       <div id="gm2-bulk-ai">
-        <button class="gm2-bulk-select-analyzed">Select analyzed</button>
+        <button class="gm2-bulk-select-analyzed" data-select="Select Analyzed" data-unselect="Unselect Analyzed">Select Analyzed</button>
         <table id="gm2-bulk-list">
           <tr id="gm2-row-1" class="gm2-status-analyzed">
             <td>
@@ -100,18 +100,36 @@ test('select analyzed checks row checkbox and suggestions', () => {
 
   $('#gm2-bulk-ai').on('click', '.gm2-bulk-select-analyzed', function(e){
     e.preventDefault();
-    $('#gm2-bulk-list tr.gm2-status-analyzed').each(function(){
-      $(this).find('.gm2-select').prop('checked', true);
-      $(this).find('.gm2-row-select-all').prop('checked', true).trigger('change');
-    });
+    const $btn=$(this);
+    const selectText=$btn.data('select')||'Select Analyzed';
+    const unselectText=$btn.data('unselect')||'Unselect Analyzed';
+    if($btn.data('selected')){
+      $('#gm2-bulk-list tr.gm2-status-analyzed').each(function(){
+        $(this).find('.gm2-select').prop('checked', false);
+        $(this).find('.gm2-row-select-all').prop('checked', false).trigger('change');
+      });
+      $btn.data('selected',false).text(selectText);
+    } else {
+      $('#gm2-bulk-list tr.gm2-status-analyzed').each(function(){
+        $(this).find('.gm2-select').prop('checked', true);
+        $(this).find('.gm2-row-select-all').prop('checked', true).trigger('change');
+      });
+      $btn.data('selected',true).text(unselectText);
+    }
   });
 
-  $('.gm2-bulk-select-analyzed').trigger('click');
-
+  const $btn=$('.gm2-bulk-select-analyzed');
+  $btn.trigger('click');
+  expect($btn.text()).toBe('Unselect Analyzed');
   expect($('#gm2-row-1 .gm2-select').prop('checked')).toBe(true);
   expect($('#gm2-row-1 .gm2-apply').prop('checked')).toBe(true);
   expect($('#gm2-row-2 .gm2-select').prop('checked')).toBe(false);
   expect($('#gm2-row-2 .gm2-apply').prop('checked')).toBe(false);
+
+  $btn.trigger('click');
+  expect($btn.text()).toBe('Select Analyzed');
+  expect($('#gm2-row-1 .gm2-select').prop('checked')).toBe(false);
+  expect($('#gm2-row-1 .gm2-apply').prop('checked')).toBe(false);
 });
 
 test('select filtered toggles between select and unselect all', () => {


### PR DESCRIPTION
## Summary
- add data attributes and localization strings for Select/Unselect Analyzed
- enable toggling analyzed rows via button state in bulk AI UI
- test selecting and unselecting analyzed rows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68966e5ee5648327884ff086100eb142