### PR TITLE
Persist entry URL across sessions for abandoned carts

### DIFF
--- a/includes/Gm2_Abandoned_Carts.php
+++ b/includes/Gm2_Abandoned_Carts.php
@@ -152,8 +152,6 @@ class Gm2_Abandoned_Carts {
         $stored_entry = '';
         if (isset($_COOKIE['gm2_entry_url'])) {
             $stored_entry = esc_url_raw(wp_unslash($_COOKIE['gm2_entry_url']));
-            setcookie('gm2_entry_url', '', time() - HOUR_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN);
-            unset($_COOKIE['gm2_entry_url']);
         } else {
             $session_entry = $wc->session->get('gm2_entry_url');
             if (!empty($session_entry)) {
@@ -243,9 +241,17 @@ class Gm2_Abandoned_Carts {
         $token = '';
         if (class_exists('WC_Session') && WC()->session) {
             $token = WC()->session->get_customer_id();
-            // store the most recent URL in the session instead of updating the database
             if (method_exists(WC()->session, 'set')) {
+                // store the most recent URL in the session instead of updating the database
                 WC()->session->set('gm2_ac_last_url', $url);
+                $session_entry = method_exists(WC()->session, 'get') ? WC()->session->get('gm2_entry_url') : '';
+                if (empty($session_entry) && !empty($url)) {
+                    WC()->session->set('gm2_entry_url', $url);
+                    if (isset($_COOKIE['gm2_entry_url'])) {
+                        setcookie('gm2_entry_url', '', time() - HOUR_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN);
+                        unset($_COOKIE['gm2_entry_url']);
+                    }
+                }
             }
         }
         if (empty($token)) {

--- a/public/Gm2_Abandoned_Carts_Public.php
+++ b/public/Gm2_Abandoned_Carts_Public.php
@@ -81,8 +81,6 @@ class Gm2_Abandoned_Carts_Public {
         $stored_entry = '';
         if (isset($_COOKIE['gm2_entry_url'])) {
             $stored_entry = esc_url_raw(wp_unslash($_COOKIE['gm2_entry_url']));
-            setcookie('gm2_entry_url', '', time() - HOUR_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN);
-            unset($_COOKIE['gm2_entry_url']);
         } elseif (!empty($session_entry_url)) {
             $stored_entry = esc_url_raw($session_entry_url);
             WC()->session->set('gm2_entry_url', null);

--- a/public/js/gm2-ac-activity.js
+++ b/public/js/gm2-ac-activity.js
@@ -73,8 +73,9 @@
         try {
             localStorage.setItem(ENTRY_KEY, value);
         } catch (e) {
-            document.cookie = `${ENTRY_KEY}=${encodeURIComponent(value)}; path=/`;
+            // localStorage might be unavailable; ignore errors.
         }
+        document.cookie = `${ENTRY_KEY}=${encodeURIComponent(value)}; path=/`;
     }
 
     let memoryTabCount = 0;


### PR DESCRIPTION
## Summary
- Write the initial entry URL to both `localStorage` and a `gm2_entry_url` cookie
- Save the entry URL in the WooCommerce session and clear the cookie once stored
- Keep the cookie intact until the session is populated so server-side hooks can read it

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896835ebbf483279a0009f2d11df62f