### PR TITLE
Add PHP and JS tests for abandoned cart activity

### DIFF
--- a/tests/CaptureCartActivityTest.php
+++ b/tests/CaptureCartActivityTest.php
@@ -1,0 +1,178 @@
+<?php
+namespace Gm2 {
+    if (!function_exists(__NAMESPACE__ . '\\current_time')) {
+        function current_time($type) { return '2024-01-01 00:00:00'; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\current_user_can')) {
+        function current_user_can($cap = '') { return false; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\wp_json_encode')) {
+        function wp_json_encode($data) { return json_encode($data); }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\sanitize_text_field')) {
+        function sanitize_text_field($str) { return $str; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\wp_unslash')) {
+        function wp_unslash($v) { return $v; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\esc_url_raw')) {
+        function esc_url_raw($url) { return $url; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\home_url')) {
+        function home_url($path = '') { return 'https://example.com' . $path; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\get_current_user_id')) {
+        function get_current_user_id() { return 1; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\is_admin')) {
+        function is_admin() { return false; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\apply_filters')) {
+        function apply_filters($tag, $value) { return $value; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\get_option')) {
+        function get_option($name, $default = false) { return $default; }
+    }
+}
+
+namespace {
+use PHPUnit\Framework\TestCase;
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/../');
+}
+if (!defined('GM2_PLUGIN_DIR')) {
+    define('GM2_PLUGIN_DIR', __DIR__ . '/../');
+}
+if (!defined('HOUR_IN_SECONDS')) {
+    define('HOUR_IN_SECONDS', 3600);
+}
+if (!defined('COOKIEPATH')) {
+    define('COOKIEPATH', '/');
+}
+if (!defined('COOKIE_DOMAIN')) {
+    define('COOKIE_DOMAIN', '');
+}
+
+if (!function_exists('wc_get_user_ip')) {
+    function wc_get_user_ip() { return '1.2.3.4'; }
+}
+if (!class_exists('WC_Geolocation')) {
+    class WC_Geolocation {
+        public static function geolocate_ip($ip, $arg1 = false, $arg2 = false) { return ['country' => 'US', 'state' => 'CA']; }
+        public static function get_ip_address() { return '1.2.3.4'; }
+    }
+}
+
+if (!class_exists('WC_Session')) {
+    class WC_Session {
+        private $cid; private $data = [];
+        public function __construct($id) { $this->cid = $id; }
+        public function get_customer_id() { return $this->cid; }
+        public function get($key) { return $this->data[$key] ?? null; }
+        public function set($key, $val) { if ($val === null) { unset($this->data[$key]); } else { $this->data[$key] = $val; } }
+    }
+}
+if (!class_exists('WC_Cart')) {
+    class WC_Cart {
+        private $items; public function __construct($items) { $this->items = $items; }
+        public function get_cart() { return $this->items; }
+        public function set_items($items) { $this->items = $items; }
+        public function is_empty() { return empty($this->items); }
+        public function get_cart_contents_total() {
+            $total = 0; foreach ($this->items as $item) { $prod = $item['data']; $total += $prod->get_price() * $item['quantity']; } return $total;
+        }
+    }
+}
+if (!function_exists('WC')) {
+    function WC() { global $wc_obj; return $wc_obj; }
+}
+if (!class_exists('FakeProduct')) {
+    class FakeProduct {
+        private $id; public function __construct($id) { $this->id = $id; }
+        public function get_name() { return 'Product ' . $this->id; }
+        public function get_price() { return 5; }
+        public function get_sku() { return 'SKU' . $this->id; }
+    }
+}
+if (!function_exists('wc_get_product')) {
+    function wc_get_product($id) { return new FakeProduct($id); }
+}
+
+class FakeDB {
+    public $prefix = 'wp_';
+    public $data = [];
+    public $insert_id = 0;
+    private $last_table; private $last_token;
+    public function __construct() {
+        $this->data[$this->prefix.'wc_ac_carts'] = [];
+        $this->data[$this->prefix.'wc_ac_cart_activity'] = [];
+    }
+    public function prepare($query, $token) {
+        $this->last_token = $token;
+        if (preg_match('/FROM\s+(\w+)/', $query, $m)) { $this->last_table = $m[1]; }
+        return $query;
+    }
+    public function get_row($query, $output = OBJECT) {
+        foreach ($this->data[$this->last_table] as $row) {
+            if ($row['cart_token'] === $this->last_token) { return $output === ARRAY_A ? $row : (object)$row; }
+        }
+        return null;
+    }
+    public function insert($table, $data) {
+        $data['id'] = count($this->data[$table]) + 1;
+        $this->data[$table][] = $data;
+        $this->insert_id = $data['id'];
+    }
+    public function update($table, $data, $where) {
+        foreach ($this->data[$table] as &$row) {
+            $match = true; foreach ($where as $k=>$v) { if ($row[$k] !== $v) { $match=false; break; } }
+            if ($match) { foreach ($data as $k=>$v) { $row[$k] = $v; } }
+        }
+    }
+}
+
+require_once __DIR__.'/../includes/Gm2_Abandoned_Carts.php';
+
+final class CaptureCartActivityTest extends TestCase {
+    private $ac; private $db; private $cart;
+    protected function setUp(): void {
+        $this->db = new FakeDB();
+        $GLOBALS['wpdb'] = $this->db;
+        $this->cart = new WC_Cart([
+            [ 'product_id'=>1, 'quantity'=>1, 'data'=>new FakeProduct(1) ],
+        ]);
+        $session = new WC_Session('tok');
+        global $wc_obj; $wc_obj = (object)['cart'=>$this->cart, 'session'=>$session];
+        $_SERVER['HTTP_USER_AGENT'] = 'Mozilla';
+        $this->ac = new \Gm2\Gm2_Abandoned_Carts();
+    }
+    public function test_capture_cart_logs_activity() {
+        $this->ac->capture_cart();
+        $activity = $this->db->data[$this->db->prefix.'wc_ac_cart_activity'];
+        $this->assertCount(1, $activity);
+        $this->assertSame('add', $activity[0]['action']);
+        $this->assertSame(1, $activity[0]['product_id']);
+        $this->assertSame(1, $activity[0]['quantity']);
+
+        // quantity change
+        $this->cart->set_items([[ 'product_id'=>1, 'quantity'=>2, 'data'=>new FakeProduct(1) ]]);
+        $this->ac->capture_cart();
+        $activity = $this->db->data[$this->db->prefix.'wc_ac_cart_activity'];
+        $this->assertCount(2, $activity);
+        $this->assertSame('quantity', $activity[1]['action']);
+        $this->assertSame(2, $activity[1]['quantity']);
+
+        // remove old product and add new
+        $this->cart->set_items([[ 'product_id'=>2, 'quantity'=>1, 'data'=>new FakeProduct(2) ]]);
+        $this->ac->capture_cart();
+        $activity = $this->db->data[$this->db->prefix.'wc_ac_cart_activity'];
+        $this->assertCount(4, $activity);
+        $this->assertSame('remove', $activity[2]['action']);
+        $this->assertSame(1, $activity[2]['product_id']);
+        $this->assertSame(0, $activity[2]['quantity']);
+        $this->assertSame('add', $activity[3]['action']);
+        $this->assertSame(2, $activity[3]['product_id']);
+    }
+}
+}

--- a/tests/GroupedQueryTest.php
+++ b/tests/GroupedQueryTest.php
@@ -1,0 +1,87 @@
+<?php
+namespace {
+use PHPUnit\Framework\TestCase;
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/../');
+}
+if (!class_exists('WP_List_Table')) {
+    class WP_List_Table {
+        public $items = [];
+        public function __construct($args = []) {}
+        protected function get_items_per_page($opt, $default) { return $default; }
+        protected function get_pagenum() { return 1; }
+        protected function set_pagination_args($args) {}
+    }
+}
+if (!function_exists('apply_filters')) {
+    function apply_filters($tag, $value) { return $value; }
+}
+if (!function_exists('get_option')) {
+    function get_option($name, $default = false) { return $default; }
+}
+if (!function_exists('absint')) {
+    function absint($value) { return (int) abs($value); }
+}
+if (!function_exists('maybe_unserialize')) {
+    function maybe_unserialize($data) { return $data; }
+}
+if (!function_exists('wc_get_product')) {
+    function wc_get_product($id) { return null; }
+}
+
+class GroupedDB {
+    public $prefix = 'wp_';
+    public $data = [];
+    public function __construct() {
+        $this->data[$this->prefix.'wc_ac_carts'] = [
+            ['id'=>1,'ip_address'=>'1.1.1.1','cart_contents'=>'[]','created_at'=>'2024-01-01 00:00:00','revisit_count'=>1,'browsing_time'=>30,'email'=>'','location'=>'','device'=>'','browser'=>'','entry_url'=>'','exit_url'=>'','cart_total'=>0,'abandoned_at'=>null],
+            ['id'=>2,'ip_address'=>'1.1.1.1','cart_contents'=>'[]','created_at'=>'2024-01-02 00:00:00','revisit_count'=>2,'browsing_time'=>40,'email'=>'','location'=>'','device'=>'','browser'=>'','entry_url'=>'','exit_url'=>'','cart_total'=>0,'abandoned_at'=>null],
+            ['id'=>3,'ip_address'=>'2.2.2.2','cart_contents'=>'[]','created_at'=>'2024-01-03 00:00:00','revisit_count'=>1,'browsing_time'=>20,'email'=>'','location'=>'','device'=>'','browser'=>'','entry_url'=>'','exit_url'=>'','cart_total'=>0,'abandoned_at'=>null],
+        ];
+    }
+    public function prepare($query, ...$args) { return $query; }
+    public function esc_like($text) { return $text; }
+    public function get_var($query) {
+        return 2; // distinct IPs
+    }
+    public function get_results($query) {
+        $table = $this->data[$this->prefix.'wc_ac_carts'];
+        $grouped = [];
+        foreach ($table as $row) {
+            $ip = $row['ip_address'];
+            if (!isset($grouped[$ip])) {
+                $grouped[$ip] = $row;
+                $grouped[$ip]['total_revisit_count'] = $row['revisit_count'];
+                $grouped[$ip]['total_browsing_time'] = $row['browsing_time'];
+            } else {
+                if ($row['created_at'] > $grouped[$ip]['created_at']) {
+                    $grouped[$ip] = $row + ['total_revisit_count'=>$grouped[$ip]['total_revisit_count'] + $row['revisit_count'], 'total_browsing_time'=>$grouped[$ip]['total_browsing_time'] + $row['browsing_time']];
+                } else {
+                    $grouped[$ip]['total_revisit_count'] += $row['revisit_count'];
+                    $grouped[$ip]['total_browsing_time'] += $row['browsing_time'];
+                }
+            }
+        }
+        // order by created_at DESC
+        usort($grouped, function($a,$b){ return strcmp($b['created_at'],$a['created_at']); });
+        return array_map(fn($r)=>(object)$r, $grouped);
+    }
+}
+
+require_once __DIR__.'/../admin/class-gm2-ac-table.php';
+
+final class GroupedQueryTest extends TestCase {
+    public function test_prepare_items_groups_by_ip() {
+        $db = new GroupedDB();
+        $GLOBALS['wpdb'] = $db;
+        $table = new \Gm2\GM2_AC_Table(['table'=>'wc_ac_carts']);
+        $table->prepare_items();
+        $this->assertCount(2, $table->items);
+        $ips = array_map(fn($i)=>$i['ip_address'], $table->items);
+        $this->assertSame(['2.2.2.2','1.1.1.1'], $ips);
+        $revisits = array_column($table->items, 'revisit_count');
+        $this->assertSame([1,3], $revisits);
+    }
+}
+}

--- a/tests/js/gm2-ac-activity.test.js
+++ b/tests/js/gm2-ac-activity.test.js
@@ -61,3 +61,70 @@ test('captures external link destination before navigation', () => {
   const params = new URLSearchParams(abandonCalls[0][1].body);
   expect(params.get('url')).toBe('https://external.com/path');
 });
+
+function setupJQuery(postImpl) {
+  function createWrapper(elem) {
+    return {
+      elem,
+      on(ev, fn) { elem.addEventListener(ev, fn); return this; },
+      closest(sel) { return createWrapper(elem.closest(sel)); },
+      next() { return createWrapper(elem.nextElementSibling); },
+      hasClass(cls) { return elem && elem.classList.contains(cls); },
+      remove() { if (elem) elem.remove(); },
+      prop(name, val) { if (val === undefined) return elem[name]; elem[name] = val; return this; },
+      data(name) { return elem.getAttribute('data-' + name); },
+      children() { return { length: elem.children.length }; },
+      after(html) { elem.insertAdjacentHTML('afterend', html); return this; },
+      trigger(ev) { elem.dispatchEvent(new window.Event(ev, { bubbles: true })); return this; },
+      length: elem ? 1 : 0,
+    };
+  }
+  function $(arg) {
+    if (typeof arg === 'function') { arg($); return; }
+    const el = typeof arg === 'string' ? document.querySelector(arg) : arg;
+    return createWrapper(el);
+  }
+  $.post = postImpl;
+  return $;
+}
+
+test('renders and toggles activity log rows', () => {
+  jest.resetModules();
+  const dom = new JSDOM(`<!DOCTYPE html><table><tbody><tr id="r"><td><a href="#" class="gm2-ac-activity-log-button" data-ip="1.1.1.1">log</a></td></tr></tbody></table>`);
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.gm2AcActivityLog = { ajax_url: '/ajax', nonce: 'n', empty: 'Empty', error: 'Err' };
+  const res = { success: true, data: [{ changed_at: 'now', action: 'add', sku: 'SKU', quantity: 2 }] };
+  const post = jest.fn(() => ({ done(cb){ cb(res); return this; }, fail(){ return this; }, always(cb){ cb(); return this; } }));
+  const $ = setupJQuery(post);
+  global.jQuery = global.$ = $;
+
+  require('../../admin/js/gm2-ac-activity-log.js');
+
+  const btn = $('.gm2-ac-activity-log-button');
+  btn.trigger('click');
+  expect($.post).toHaveBeenCalledTimes(1);
+  expect($('.gm2-ac-activity-row').length).toBe(1);
+  expect($('.gm2-ac-activity-row li').elem.textContent).toContain('add SKU x2');
+  expect(btn.prop('disabled')).toBe(false);
+
+  btn.trigger('click');
+  expect($('.gm2-ac-activity-row').length).toBe(0);
+  expect($.post).toHaveBeenCalledTimes(1);
+});
+
+test('shows error message on failed activity request', () => {
+  jest.resetModules();
+  const dom = new JSDOM(`<!DOCTYPE html><table><tbody><tr id="r"><td><a href="#" class="gm2-ac-activity-log-button" data-ip="1.1.1.1">log</a></td></tr></tbody></table>`);
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.gm2AcActivityLog = { ajax_url: '/ajax', nonce: 'n', empty: 'Empty', error: 'Err' };
+  const post = jest.fn(() => ({ done(){ return this; }, fail(cb){ cb(); return this; }, always(cb){ cb(); return this; } }));
+  const $ = setupJQuery(post);
+  global.jQuery = global.$ = $;
+
+  require('../../admin/js/gm2-ac-activity-log.js');
+
+  $('.gm2-ac-activity-log-button').trigger('click');
+  expect($('.gm2-ac-activity-row').elem.textContent).toBe('Err');
+});


### PR DESCRIPTION
## Summary
- add PHP unit tests covering cart activity logging and grouped IP queries
- extend JS tests for expandable cart activity log UI and AJAX responses

## Testing
- `npm test`
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68992a8452648327bbb7a7c99005fd07