### PR TITLE
Add filter to override admin exclusion in abandoned cart tracking

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -87,6 +87,8 @@ The **Gm2 → Abandoned Carts** screen groups records by IP address so multiple 
 
 Developers can adjust the inactivity window using the `gm2_ac_mark_abandoned_interval` filter and send custom recovery emails by hooking into `gm2_ac_send_message` when the hourly `gm2_ac_process_queue` task runs.
 
+Use the `gm2_ac_skip_admin` filter to include administrator sessions while testing abandoned cart features. It defaults to `true` so admin carts are ignored unless the filter returns `false`.
+
 ## Exporting SEO Settings
 
 Use the **Export Settings** button on the SEO dashboard to download a `gm2-seo-settings.json` file containing all options that start with `gm2_`. The matching **Import Settings** form accepts the same JSON format and updates each option. The file is a simple key/value object:

--- a/includes/Gm2_Abandoned_Carts.php
+++ b/includes/Gm2_Abandoned_Carts.php
@@ -104,7 +104,13 @@ class Gm2_Abandoned_Carts {
     }
 
     public function capture_cart() {
-        if (function_exists('current_user_can') && current_user_can('manage_options')) {
+        // Developers can return false to include admin sessions for testing.
+        $skip_admin = apply_filters('gm2_ac_skip_admin', true);
+        if (
+            $skip_admin &&
+            function_exists('current_user_can') &&
+            current_user_can('manage_options')
+        ) {
             return;
         }
         if (!class_exists('WC_Cart')) {
@@ -334,7 +340,13 @@ class Gm2_Abandoned_Carts {
     }
 
     public static function gm2_ac_mark_active() {
-        if (function_exists('current_user_can') && current_user_can('manage_options')) {
+        // Developers can return false to include admin sessions for testing.
+        $skip_admin = apply_filters('gm2_ac_skip_admin', true);
+        if (
+            $skip_admin &&
+            function_exists('current_user_can') &&
+            current_user_can('manage_options')
+        ) {
             wp_send_json_success();
         }
         check_ajax_referer('gm2_ac_activity', 'nonce');
@@ -409,7 +421,13 @@ class Gm2_Abandoned_Carts {
     }
 
     public static function gm2_ac_mark_abandoned() {
-        if (function_exists('current_user_can') && current_user_can('manage_options')) {
+        // Developers can return false to include admin sessions for testing.
+        $skip_admin = apply_filters('gm2_ac_skip_admin', true);
+        if (
+            $skip_admin &&
+            function_exists('current_user_can') &&
+            current_user_can('manage_options')
+        ) {
             wp_send_json_success();
         }
         check_ajax_referer('gm2_ac_activity', 'nonce');


### PR DESCRIPTION
## Summary
- add `gm2_ac_skip_admin` filter around admin capability checks in abandoned cart handlers
- document how to include administrator sessions for testing

## Testing
- `npm test`
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689a2101f578832780f5cbe7fc37dd8f