### PR TITLE
feat: server-side entry URL tracking

### DIFF
--- a/public/Gm2_Abandoned_Carts_Public.php
+++ b/public/Gm2_Abandoned_Carts_Public.php
@@ -79,11 +79,11 @@ class Gm2_Abandoned_Carts_Public {
         }
 
         $stored_entry = '';
-        if (isset($_COOKIE['gm2_entry_url'])) {
-            $stored_entry = esc_url_raw(wp_unslash($_COOKIE['gm2_entry_url']));
-        } elseif (!empty($session_entry_url)) {
+        if (!empty($session_entry_url)) {
             $stored_entry = esc_url_raw($session_entry_url);
             WC()->session->set('gm2_entry_url', null);
+        } elseif (isset($_COOKIE['gm2_entry_url'])) {
+            $stored_entry = esc_url_raw(wp_unslash($_COOKIE['gm2_entry_url']));
         }
 
         $request_uri = isset($_SERVER['REQUEST_URI']) ? esc_url_raw(wp_unslash($_SERVER['REQUEST_URI'])) : '/';


### PR DESCRIPTION
## Summary
- capture entry URL on server via template_redirect and store in session/db
- prefer session-stored entry URL over client cookie as fallback

## Testing
- `npm test`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*


------
https://chatgpt.com/codex/tasks/task_e_689a293dcc5c83279969022647b9c60f