### PR TITLE
Track last seen URL and send exit beacons

### DIFF
--- a/public/js/gm2-ac-activity.js
+++ b/public/js/gm2-ac-activity.js
@@ -138,5 +138,12 @@
         }
     });
 
+    document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'hidden') {
+            decrementTabs();
+        }
+    });
+
+    window.addEventListener('beforeunload', decrementTabs);
     window.addEventListener('pagehide', decrementTabs, { once: true });
 })();

--- a/tests/test-abandoned-carts.php
+++ b/tests/test-abandoned-carts.php
@@ -161,6 +161,20 @@ class AbandonedCartsTest extends WP_UnitTestCase {
         $this->assertSame('https://external.com/off', $row['exit_url']);
     }
 
+    public function test_shutdown_updates_exit_url() {
+        $table = $GLOBALS['wpdb']->prefix . 'wc_ac_carts';
+        $ac    = new \Gm2\Gm2_Abandoned_Carts();
+        WC()->session->set('gm2_ac_last_seen_url', 'https://example.com/final');
+        $ac->update_exit_url_from_session();
+        $row = $GLOBALS['wpdb']->data[$table][0];
+        $this->assertSame('https://example.com/final', $row['exit_url']);
+
+        $before = $row;
+        WC()->session->set('gm2_ac_last_seen_url', 'https://example.com/final');
+        $ac->update_exit_url_from_session();
+        $this->assertSame($before, $GLOBALS['wpdb']->data[$table][0]);
+    }
+
     public function test_mark_cart_recovered_moves_row() {
         $ac = new \Gm2\Gm2_Abandoned_Carts();
         $ac->mark_cart_recovered(123);


### PR DESCRIPTION
## Summary
- persist each page's URL in the WooCommerce session and update the cart's exit URL on shutdown only when it changes
- send `gm2_ac_mark_abandoned` via `navigator.sendBeacon` when tabs hide, unload, or follow external links
- cover exit-tracking logic with Jest and PHP tests

## Testing
- `npm test`
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689a2b86f5f08327a78cc4d24dae78cd