### PR TITLE
Add phone field to cart tables and capture

### DIFF
--- a/includes/Gm2_Abandoned_Carts.php
+++ b/includes/Gm2_Abandoned_Carts.php
@@ -668,6 +668,16 @@ class Gm2_Abandoned_Carts {
         if (!$has_revisit_count) {
             $wpdb->query("ALTER TABLE $carts_table ADD revisit_count int DEFAULT 0 AFTER browsing_time");
         }
+
+        $has_phone = $wpdb->get_var($wpdb->prepare("SHOW COLUMNS FROM $carts_table LIKE %s", 'phone'));
+        if (!$has_phone) {
+            $wpdb->query("ALTER TABLE $carts_table ADD phone varchar(50) DEFAULT NULL AFTER email");
+        }
+
+        $rec_has_phone = $wpdb->get_var($wpdb->prepare("SHOW COLUMNS FROM $recovered_table LIKE %s", 'phone'));
+        if (!$rec_has_phone) {
+            $wpdb->query("ALTER TABLE $recovered_table ADD phone varchar(50) DEFAULT NULL AFTER email");
+        }
     }
 
     public static function get_ip_and_location() {

--- a/public/Gm2_Abandoned_Carts_Public.php
+++ b/public/Gm2_Abandoned_Carts_Public.php
@@ -64,8 +64,8 @@ class Gm2_Abandoned_Carts_Public {
 
         $email = sanitize_email($_POST['email'] ?? '');
         $phone = sanitize_text_field($_POST['phone'] ?? '');
-        if (empty($email)) {
-            wp_send_json_error('empty_email');
+        if (empty($email) && empty($phone)) {
+            wp_send_json_error('empty_contact');
         }
 
         $token            = '';


### PR DESCRIPTION
## Summary
- ensure install script defines `phone` column for carts and recovered cart tables
- upgrade path adds `phone` column to existing tables
- allow contact capture to record phone or email and include phone in DB operations

## Testing
- `npm test`
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): No such file or directory)*
- `make test DB_NAME=wp_test DB_USER=root DB_PASS=pass` *(fails: mysqladmin command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a6695c8648327b4e97d0b711ca1bb