### PR TITLE
Add Elementor popup capture for abandoned carts

### DIFF
--- a/public/Gm2_Abandoned_Carts_Public.php
+++ b/public/Gm2_Abandoned_Carts_Public.php
@@ -39,6 +39,26 @@ class Gm2_Abandoned_Carts_Public {
             ]
         );
 
+        $popup_id = (int) get_option('gm2_cart_popup_id', 0);
+        if ($popup_id > 0) {
+            wp_enqueue_script(
+                'gm2-ac-popup',
+                GM2_PLUGIN_URL . 'public/js/gm2-ac-popup.js',
+                [ 'jquery' ],
+                GM2_VERSION,
+                true
+            );
+            wp_localize_script(
+                'gm2-ac-popup',
+                'gm2AcPopup',
+                [
+                    'ajax_url' => admin_url('admin-ajax.php'),
+                    'nonce'    => wp_create_nonce('gm2_ac_contact_capture'),
+                    'popup_id' => $popup_id,
+                ]
+            );
+        }
+
         wp_enqueue_script(
             'gm2-ac-activity',
             GM2_PLUGIN_URL . 'public/js/gm2-ac-activity.js',

--- a/public/js/gm2-ac-popup.js
+++ b/public/js/gm2-ac-popup.js
@@ -1,0 +1,36 @@
+jQuery(function($){
+    if (typeof gm2AcPopup === 'undefined' || !gm2AcPopup.popup_id) {
+        return;
+    }
+
+    function openPopup() {
+        if (window.elementorProFrontend && elementorProFrontend.modules && elementorProFrontend.modules.popup) {
+            try {
+                elementorProFrontend.modules.popup.showPopup({ id: gm2AcPopup.popup_id });
+            } catch (e) {
+                console.error('GM2 AC Popup: failed to open popup', e);
+            }
+        }
+    }
+
+    if (window.elementorProFrontend && elementorProFrontend.modules && elementorProFrontend.modules.popup) {
+        openPopup();
+    } else {
+        $(window).on('elementor/frontend/init', openPopup);
+    }
+
+    $(document).on('submit', '.elementor-form', function(){
+        var $form = $(this);
+        var email = $form.find('input[type="email"]').val();
+        var phone = $form.find('input[type="tel"]').val();
+        if (!email && !phone) {
+            return;
+        }
+        $.post(gm2AcPopup.ajax_url, {
+            action: 'gm2_ac_contact_capture',
+            nonce: gm2AcPopup.nonce,
+            email: email,
+            phone: phone
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Add gm2-ac-popup.js to trigger Elementor popup and capture contact via AJAX
- Enqueue popup script when gm2_cart_popup_id option is set

## Testing
- `npm test`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_689a6a484b7083279291fe4300ad5a3d