### PR TITLE
Document Cart Settings popup capture

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -84,7 +84,11 @@ If you need to clear the log and start over, click the **Reset Logs** button bel
 
 Enable the module from **Gm2 → Dashboard** to begin tracking cart sessions. Activation creates four tables—`wp_wc_ac_carts`, `wp_wc_ac_email_queue`, `wp_wc_ac_recovered` and `wp_wc_ac_cart_activity`—that store carts, queued messages, recovered orders and item‑level activity.
 
+Select an Elementor popup under **Gm2 → Cart Settings** to ask shoppers for an email address or phone number before they leave. The plugin records contact details from that popup and from the checkout billing fields so each cart is linked to an email and/or phone when available.
+
 The **Gm2 → Abandoned Carts** screen groups records by IP address so multiple visits from the same shopper appear as a single row with combined browsing time and revisit counts. Click a row’s **Cart Activity Log** link to view the add/remove/quantity events pulled from the activity table.
+
+Captured email and phone values appear in their own columns on this page, making it easy to follow up with shoppers who abandon their carts.
 
 Developers can adjust the inactivity window using the `gm2_ac_mark_abandoned_interval` filter and send custom recovery emails by hooking into `gm2_ac_send_message` when the hourly `gm2_ac_process_queue` task runs.
 

--- a/readme.txt
+++ b/readme.txt
@@ -14,7 +14,7 @@ Key features include:
 * SEO tools with breadcrumbs, caching and structured data
 * ChatGPT-powered content generation and keyword research
 * WooCommerce quantity discounts with a dedicated Elementor widget (requires WooCommerce)
-* Abandoned cart tracking grouped by IP with email capture, browsing-time and revisit metrics, an activity log, and recovery emails
+* Abandoned cart tracking grouped by IP with email/phone capture, a Cart Settings page for selecting an Elementor popup, browsing-time and revisit metrics, an activity log, and recovery emails
 * Tariff management and redirects
 * Expanded SEO Context feeds AI prompts with business details
 * Focus keywords are tracked to prevent duplicates in AI suggestions
@@ -46,6 +46,7 @@ Key features include:
 9. Install and activate Elementor to use the Gm2 Qnty Discounts widget on product pages. With Elementor Pro the widget appears in the **WooCommerce** section when editing Single Product templates. Otherwise look under **General**.
 10. Open **Gm2 → Quantity Discounts** and create discount groups to define pricing rules.
 11. Configure cart recovery options under **Gm2 → Abandoned Carts**.
+12. Choose an Elementor popup on **Gm2 → Cart Settings** to collect a shopper's email or phone before leaving. Captured contact details appear on the **Gm2 → Abandoned Carts** page.
 
 **Note:** WooCommerce and Elementor Pro must be active. Elementor 3.5+ is recommended and older versions are supported with a fallback.
 


### PR DESCRIPTION
## Summary
- Describe new Cart Settings page for choosing an Elementor popup to collect email or phone
- Explain how contact details are recorded and viewed on the Abandoned Carts page

## Testing
- `npm test`
- `make test` *(fails: Database credentials must be supplied via DB_NAME, DB_USER and DB_PASS)*

------
https://chatgpt.com/codex/tasks/task_e_689a6b6027f88327a6c63f6f66bcde37