### PR TITLE
feat: add configurable inactivity timer

### DIFF
--- a/public/Gm2_Abandoned_Carts_Public.php
+++ b/public/Gm2_Abandoned_Carts_Public.php
@@ -66,12 +66,14 @@ class Gm2_Abandoned_Carts_Public {
             GM2_VERSION,
             true
         );
+        $inactivity_ms = absint(apply_filters('gm2_ac_inactivity_ms', 5 * MINUTE_IN_SECONDS * 1000));
         wp_localize_script(
             'gm2-ac-activity',
             'gm2AcActivity',
             [
-                'ajax_url' => admin_url('admin-ajax.php'),
-                'nonce'    => wp_create_nonce('gm2_ac_activity'),
+                'ajax_url'      => admin_url('admin-ajax.php'),
+                'nonce'         => wp_create_nonce('gm2_ac_activity'),
+                'inactivity_ms' => $inactivity_ms,
             ]
         );
     }


### PR DESCRIPTION
## Summary
- add configurable inactivity timer to gm2-ac-activity.js that sends `gm2_ac_mark_abandoned`
- expose inactivity timeout through `gm2AcActivity` localization with 5min default
- test inactivity timer and reset logic

## Testing
- `npm test`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_689a74be4b048327a0b489a96c034321