### PR TITLE
Add inactivity timeout with sendBeacon fallback

### DIFF
--- a/public/js/gm2-ac-activity.js
+++ b/public/js/gm2-ac-activity.js
@@ -10,40 +10,41 @@
         const data = new URLSearchParams({ action, nonce, url: targetUrl || window.location.href });
 
         if (action === 'gm2_ac_mark_abandoned') {
+            let beaconSent = false;
             if (navigator.sendBeacon) {
                 try {
-                    const sent = navigator.sendBeacon(ajaxUrl, data);
-
-                    if (!sent) {
+                    beaconSent = navigator.sendBeacon(ajaxUrl, data);
+                    if (!beaconSent) {
                         const payload = new Blob([data.toString()], { type: 'application/x-www-form-urlencoded' });
-                        navigator.sendBeacon(ajaxUrl, payload);
+                        beaconSent = navigator.sendBeacon(ajaxUrl, payload);
                     }
                 } catch (err) {
                     console.debug('sendBeacon URLSearchParams failed', err);
-
                     try {
                         const payload = new Blob([data.toString()], { type: 'application/x-www-form-urlencoded' });
-                        navigator.sendBeacon(ajaxUrl, payload);
+                        beaconSent = navigator.sendBeacon(ajaxUrl, payload);
                     } catch (error) {
                         console.error('sendBeacon failed', error);
                     }
                 }
             }
 
-            fetch(ajaxUrl, {
-                method: 'POST',
-                credentials: 'same-origin',
-                body: data,
-                keepalive: true,
-            })
-                .then((response) => {
-                    if (!response.ok) {
-                        console.error('gm2_ac_mark_abandoned request failed', response.status, response.statusText);
-                    }
+            if (!beaconSent) {
+                fetch(ajaxUrl, {
+                    method: 'POST',
+                    credentials: 'same-origin',
+                    body: data,
+                    keepalive: true,
                 })
-                .catch((error) => {
-                    console.error('gm2_ac_mark_abandoned request error', error);
-                });
+                    .then((response) => {
+                        if (!response.ok) {
+                            console.error('gm2_ac_mark_abandoned request failed', response.status, response.statusText);
+                        }
+                    })
+                    .catch((error) => {
+                        console.error('gm2_ac_mark_abandoned request error', error);
+                    });
+            }
         } else {
             fetch(ajaxUrl, {
                 method: 'POST',

--- a/tests/js/gm2-ac-activity.test.js
+++ b/tests/js/gm2-ac-activity.test.js
@@ -25,13 +25,13 @@ test('records exit URL when localStorage is disabled', () => {
 
   window.dispatchEvent(new window.Event('pagehide'));
 
-  const abandonCalls = fetchMock.mock.calls.filter((c) => {
-    const params = new URLSearchParams(c[1].body);
+  const abandonCalls = window.navigator.sendBeacon.mock.calls.filter((c) => {
+    const params = new URLSearchParams(c[1].toString());
     return params.get('action') === 'gm2_ac_mark_abandoned';
   });
 
   expect(abandonCalls.length).toBe(1);
-  const params = new URLSearchParams(abandonCalls[0][1].body);
+  const params = new URLSearchParams(abandonCalls[0][1].toString());
   expect(params.get('url')).toBe('https://example.com/page');
   jest.clearAllTimers();
   jest.useRealTimers();
@@ -57,13 +57,13 @@ test('captures external link destination before navigation', () => {
   link.addEventListener('click', (e) => e.preventDefault());
   link.dispatchEvent(new window.MouseEvent('click', { bubbles: true, cancelable: true }));
 
-  const abandonCalls = fetchMock.mock.calls.filter((c) => {
-    const params = new URLSearchParams(c[1].body);
+  const abandonCalls = window.navigator.sendBeacon.mock.calls.filter((c) => {
+    const params = new URLSearchParams(c[1].toString());
     return params.get('action') === 'gm2_ac_mark_abandoned';
   });
 
   expect(abandonCalls.length).toBe(1);
-  const params = new URLSearchParams(abandonCalls[0][1].body);
+  const params = new URLSearchParams(abandonCalls[0][1].toString());
   expect(params.get('url')).toBe('https://external.com/path');
   jest.clearAllTimers();
   jest.useRealTimers();
@@ -88,13 +88,13 @@ test('marks abandoned on visibilitychange hidden', () => {
   Object.defineProperty(window.document, 'visibilityState', { configurable: true, value: 'hidden' });
   window.document.dispatchEvent(new window.Event('visibilitychange'));
 
-  const abandonCalls = fetchMock.mock.calls.filter((c) => {
-    const params = new URLSearchParams(c[1].body);
+  const abandonCalls = window.navigator.sendBeacon.mock.calls.filter((c) => {
+    const params = new URLSearchParams(c[1].toString());
     return params.get('action') === 'gm2_ac_mark_abandoned';
   });
 
   expect(abandonCalls.length).toBe(1);
-  const params = new URLSearchParams(abandonCalls[0][1].body);
+  const params = new URLSearchParams(abandonCalls[0][1].toString());
   expect(params.get('url')).toBe('https://example.com/page');
   jest.clearAllTimers();
   jest.useRealTimers();
@@ -118,13 +118,13 @@ test('marks abandoned on beforeunload', () => {
 
   window.dispatchEvent(new window.Event('beforeunload'));
 
-  const abandonCalls = fetchMock.mock.calls.filter((c) => {
-    const params = new URLSearchParams(c[1].body);
+  const abandonCalls = window.navigator.sendBeacon.mock.calls.filter((c) => {
+    const params = new URLSearchParams(c[1].toString());
     return params.get('action') === 'gm2_ac_mark_abandoned';
   });
 
   expect(abandonCalls.length).toBe(1);
-  const params = new URLSearchParams(abandonCalls[0][1].body);
+  const params = new URLSearchParams(abandonCalls[0][1].toString());
   expect(params.get('url')).toBe('https://example.com/page');
   jest.clearAllTimers();
   jest.useRealTimers();
@@ -148,8 +148,8 @@ test('marks abandoned after inactivity threshold', () => {
 
   jest.advanceTimersByTime(60);
 
-  const abandonCalls = fetchMock.mock.calls.filter((c) => {
-    const params = new URLSearchParams(c[1].body);
+  const abandonCalls = window.navigator.sendBeacon.mock.calls.filter((c) => {
+    const params = new URLSearchParams(c[1].toString());
     return params.get('action') === 'gm2_ac_mark_abandoned';
   });
 
@@ -176,15 +176,15 @@ test('resets inactivity timer on interaction', () => {
 
   window.document.dispatchEvent(new window.Event('mousemove'));
   jest.advanceTimersByTime(40);
-  let abandonCalls = fetchMock.mock.calls.filter((c) => {
-    const params = new URLSearchParams(c[1].body);
+  let abandonCalls = window.navigator.sendBeacon.mock.calls.filter((c) => {
+    const params = new URLSearchParams(c[1].toString());
     return params.get('action') === 'gm2_ac_mark_abandoned';
   });
   expect(abandonCalls.length).toBe(0);
 
   jest.advanceTimersByTime(20);
-  abandonCalls = fetchMock.mock.calls.filter((c) => {
-    const params = new URLSearchParams(c[1].body);
+  abandonCalls = window.navigator.sendBeacon.mock.calls.filter((c) => {
+    const params = new URLSearchParams(c[1].toString());
     return params.get('action') === 'gm2_ac_mark_abandoned';
   });
   expect(abandonCalls.length).toBe(1);


### PR DESCRIPTION
## Summary
- ensure `gm2_ac_mark_abandoned` uses `navigator.sendBeacon` with fetch fallback
- reset a configurable inactivity timer on user actions and expose its interval via `gm2AcActivity`

## Testing
- `npm test`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_689a76c05b908327ab93d1a97f064b12