### PR TITLE
Add live updates for abandoned carts table

### DIFF
--- a/admin/js/gm2-ac-live-updates.js
+++ b/admin/js/gm2-ac-live-updates.js
@@ -1,0 +1,15 @@
+jQuery(function($){
+    function fetchCarts(){
+        $.post(gm2AcLive.ajax_url, {
+            action: 'gm2_ac_get_carts',
+            nonce: gm2AcLive.nonce,
+            paged: gm2AcLive.paged,
+            s: gm2AcLive.s
+        }).done(function(response){
+            if(response && response.success && response.data && response.data.rows){
+                $('#the-list').html(response.data.rows);
+            }
+        });
+    }
+    setInterval(fetchCarts, 30000);
+});


### PR DESCRIPTION
## Summary
- Enqueue polling script and expose AJAX data for abandoned carts
- Add `gm2_ac_get_carts` AJAX handler returning updated rows
- Update admin to live refresh cart list every 30s

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a769e1908832799fb86fe8ffd509e