### PR TITLE
Infer brand name from taxonomy terms

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -2204,6 +2204,12 @@ class Gm2_SEO_Admin {
         $og_image         = isset($_POST['gm2_og_image']) ? absint($_POST['gm2_og_image']) : 0;
         $schema_type      = isset($_POST['gm2_schema_type']) ? sanitize_text_field($_POST['gm2_schema_type']) : '';
         $schema_brand     = isset($_POST['gm2_schema_brand']) ? sanitize_text_field($_POST['gm2_schema_brand']) : '';
+        if ($schema_brand === '') {
+            $terms = wp_get_post_terms($post_id, ['brand', 'product_brand'], ['fields' => 'names']);
+            if (!is_wp_error($terms) && !empty($terms)) {
+                $schema_brand = $terms[0];
+            }
+        }
         $schema_rating    = isset($_POST['gm2_schema_rating']) ? sanitize_text_field($_POST['gm2_schema_rating']) : '';
         $link_rel_data    = isset($_POST['gm2_link_rel']) ? wp_unslash($_POST['gm2_link_rel']) : '';
         if (!is_array(json_decode($link_rel_data, true)) && $link_rel_data !== '') {
@@ -2262,17 +2268,26 @@ class Gm2_SEO_Admin {
         $max_image_preview = isset($_POST['gm2_max_image_preview']) ? sanitize_text_field($_POST['gm2_max_image_preview']) : '';
         $max_video_preview = isset($_POST['gm2_max_video_preview']) ? sanitize_text_field($_POST['gm2_max_video_preview']) : '';
         $og_image         = isset($_POST['gm2_og_image']) ? absint($_POST['gm2_og_image']) : 0;
-        $schema_type      = isset($_POST['gm2_schema_type']) ? sanitize_text_field($_POST['gm2_schema_type']) : '';
-        $schema_brand     = isset($_POST['gm2_schema_brand']) ? sanitize_text_field($_POST['gm2_schema_brand']) : '';
-        $schema_rating    = isset($_POST['gm2_schema_rating']) ? sanitize_text_field($_POST['gm2_schema_rating']) : '';
-        if ($schema_type === '') {
-            $taxonomy = isset($_POST['taxonomy']) ? sanitize_key($_POST['taxonomy']) : '';
-            if ($taxonomy === '') {
-                $term = get_term($term_id);
-                if ($term && !is_wp_error($term)) {
-                    $taxonomy = $term->taxonomy;
-                }
+        $schema_type   = isset($_POST['gm2_schema_type']) ? sanitize_text_field($_POST['gm2_schema_type']) : '';
+        $schema_brand  = isset($_POST['gm2_schema_brand']) ? sanitize_text_field($_POST['gm2_schema_brand']) : '';
+        $schema_rating = isset($_POST['gm2_schema_rating']) ? sanitize_text_field($_POST['gm2_schema_rating']) : '';
+        $taxonomy      = isset($_POST['taxonomy']) ? sanitize_key($_POST['taxonomy']) : '';
+        $term          = null;
+        if ($taxonomy === '') {
+            $term = get_term($term_id);
+            if ($term && !is_wp_error($term)) {
+                $taxonomy = $term->taxonomy;
             }
+        }
+        if ($schema_brand === '' && in_array($taxonomy, ['brand', 'product_brand'], true)) {
+            if (!$term) {
+                $term = get_term($term_id, $taxonomy);
+            }
+            if ($term && !is_wp_error($term)) {
+                $schema_brand = $term->name;
+            }
+        }
+        if ($schema_type === '') {
             if (in_array($taxonomy, ['brand', 'product_brand'], true)) {
                 $schema_type = 'brand';
             }
@@ -5681,6 +5696,12 @@ class Gm2_SEO_Admin {
         $max_video_preview   = get_post_meta($post->ID, '_gm2_max_video_preview', true);
         $schema_type         = get_post_meta($post->ID, '_gm2_schema_type', true);
         $schema_brand        = get_post_meta($post->ID, '_gm2_schema_brand', true);
+        if ($schema_brand === '') {
+            $terms = wp_get_post_terms($post->ID, ['brand', 'product_brand'], ['fields' => 'names']);
+            if (!is_wp_error($terms) && !empty($terms)) {
+                $schema_brand = $terms[0];
+            }
+        }
         $schema_rating       = get_post_meta($post->ID, '_gm2_schema_rating', true);
 
         if ($schema_type === '') {

--- a/public/Gm2_SEO_Public.php
+++ b/public/Gm2_SEO_Public.php
@@ -149,6 +149,14 @@ class Gm2_SEO_Public {
         return $data;
     }
 
+    private function infer_brand_name($post_id) {
+        $terms = wp_get_post_terms($post_id, ['brand', 'product_brand'], ['fields' => 'names']);
+        if (!is_wp_error($terms) && !empty($terms)) {
+            return $terms[0];
+        }
+        return '';
+    }
+
     private function get_post_context($post_id) {
         $context = [
             '{{title}}'       => get_the_title($post_id),
@@ -161,6 +169,9 @@ class Gm2_SEO_Public {
             $context['{{image}}'] = $image;
         }
         $brand = get_post_meta($post_id, '_gm2_schema_brand', true);
+        if (!$brand) {
+            $brand = $this->infer_brand_name($post_id);
+        }
         if ($brand) {
             $context['{{brand}}'] = $brand;
         }
@@ -556,6 +567,9 @@ class Gm2_SEO_Public {
 
         $schema_type = $overrides['schema_type'] ?? get_post_meta($post_id, '_gm2_schema_type', true);
         $brand       = $overrides['schema_brand'] ?? get_post_meta($post_id, '_gm2_schema_brand', true);
+        if (!$brand) {
+            $brand = $this->infer_brand_name($post_id);
+        }
         $rating      = $overrides['schema_rating'] ?? get_post_meta($post_id, '_gm2_schema_rating', true);
         $context     = $this->get_post_context($post_id);
         $custom_tpls = get_option('gm2_custom_schema', []);
@@ -866,6 +880,9 @@ class Gm2_SEO_Public {
         }
 
         $brand = is_singular() ? get_post_meta(get_the_ID(), '_gm2_schema_brand', true) : '';
+        if (is_singular() && !$brand) {
+            $brand = $this->infer_brand_name(get_the_ID());
+        }
         if ($brand) {
             $data['name'] = $brand;
             unset($data['description']);


### PR DESCRIPTION
## Summary
- Prefill brand schema field from first `brand`/`product_brand` term when post meta is empty
- Store taxonomy term name as brand schema when `gm2_schema_brand` is missing for posts or term edits
- Add `infer_brand_name()` helper and use it to fall back to taxonomy terms on the front end

## Testing
- `npm test`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_689a768fbf7083279e038b9aaacd416d