### PR TITLE
Conditionally show WP-Cron notice for abandoned carts

### DIFF
--- a/admin/Gm2_Abandoned_Carts_Admin.php
+++ b/admin/Gm2_Abandoned_Carts_Admin.php
@@ -86,7 +86,12 @@ class Gm2_Abandoned_Carts_Admin {
         if ($minutes < 1) {
             $minutes = 1;
         }
-        echo '<p>' . esc_html(sprintf(__('Carts inactive for more than %d minutes appear as "Pending Abandonment" until WP Cron finalizes their status.', 'gm2-wordpress-suite'), $minutes)) . '</p>';
+
+        if (wp_next_scheduled('gm2_ac_mark_abandoned_cron')) {
+            echo '<p>' . esc_html(sprintf(__('Carts inactive for more than %d minutes appear as "Pending Abandonment" until WP Cron finalizes their status.', 'gm2-wordpress-suite'), $minutes)) . '</p>';
+        } else {
+            echo '<p>' . esc_html__('Carts are marked as abandoned in real time.', 'gm2-wordpress-suite') . '</p>';
+        }
 
         if (!empty($_GET['logs_reset'])) {
             echo '<div class="updated notice"><p>' . esc_html__('Logs reset.', 'gm2-wordpress-suite') . '</p></div>';


### PR DESCRIPTION
## Summary
- Only display the WP-Cron pending-abandonment warning when the `gm2_ac_mark_abandoned_cron` event is scheduled
- Show a real-time update message if no cron event is scheduled

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*
- `make test` *(fails: Database credentials must be supplied)*

------
https://chatgpt.com/codex/tasks/task_e_689a80c051848327baaab9a5700cffa9