### PR TITLE
Refactor brand name inference to shared helper

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -28,6 +28,10 @@ class Gm2_SEO_Admin {
             error_log($message);
         }
     }
+
+    private function infer_brand_name(int $post_id): string {
+        return gm2_infer_brand_name($post_id);
+    }
     public function run() {
         add_action('admin_menu', [$this, 'add_settings_pages']);
         add_action('add_meta_boxes', [$this, 'register_meta_boxes']);
@@ -2205,10 +2209,7 @@ class Gm2_SEO_Admin {
         $schema_type      = isset($_POST['gm2_schema_type']) ? sanitize_text_field($_POST['gm2_schema_type']) : '';
         $schema_brand     = isset($_POST['gm2_schema_brand']) ? sanitize_text_field($_POST['gm2_schema_brand']) : '';
         if ($schema_brand === '') {
-            $terms = wp_get_post_terms($post_id, ['brand', 'product_brand'], ['fields' => 'names']);
-            if (!is_wp_error($terms) && !empty($terms)) {
-                $schema_brand = sanitize_text_field($terms[0]);
-            }
+            $schema_brand = $this->infer_brand_name($post_id);
         }
         $schema_rating    = isset($_POST['gm2_schema_rating']) ? sanitize_text_field($_POST['gm2_schema_rating']) : '';
         $link_rel_data    = isset($_POST['gm2_link_rel']) ? wp_unslash($_POST['gm2_link_rel']) : '';
@@ -5697,10 +5698,7 @@ class Gm2_SEO_Admin {
         $schema_type         = get_post_meta($post->ID, '_gm2_schema_type', true);
         $schema_brand        = get_post_meta($post->ID, '_gm2_schema_brand', true);
         if ($schema_brand === '') {
-            $terms = wp_get_post_terms($post->ID, ['brand', 'product_brand'], ['fields' => 'names']);
-            if (!is_wp_error($terms) && !empty($terms)) {
-                $schema_brand = $terms[0];
-            }
+            $schema_brand = $this->infer_brand_name($post->ID);
         }
         $schema_rating       = get_post_meta($post->ID, '_gm2_schema_rating', true);
 

--- a/includes/Gm2_SEO_Utils.php
+++ b/includes/Gm2_SEO_Utils.php
@@ -199,6 +199,14 @@ namespace {
         return array_values(array_unique($list));
     }
 
+    function gm2_infer_brand_name(int $post_id): string {
+        $terms = wp_get_post_terms($post_id, ['brand', 'product_brand'], ['fields' => 'names']);
+        if (!is_wp_error($terms) && !empty($terms)) {
+            return sanitize_text_field($terms[0]);
+        }
+        return '';
+    }
+
     function gm2_ai_clear() {
         $post_ids = get_posts([
             'post_type'      => get_post_types(['public' => true], 'names'),

--- a/public/Gm2_SEO_Public.php
+++ b/public/Gm2_SEO_Public.php
@@ -149,14 +149,6 @@ class Gm2_SEO_Public {
         return $data;
     }
 
-    private function infer_brand_name($post_id) {
-        $terms = wp_get_post_terms($post_id, ['brand', 'product_brand'], ['fields' => 'names']);
-        if (!is_wp_error($terms) && !empty($terms)) {
-            return $terms[0];
-        }
-        return '';
-    }
-
     private function get_post_context($post_id) {
         $context = [
             '{{title}}'       => get_the_title($post_id),
@@ -170,7 +162,7 @@ class Gm2_SEO_Public {
         }
         $brand = get_post_meta($post_id, '_gm2_schema_brand', true);
         if (!$brand) {
-            $brand = $this->infer_brand_name($post_id);
+            $brand = gm2_infer_brand_name($post_id);
         }
         if ($brand) {
             $context['{{brand}}'] = $brand;
@@ -568,7 +560,7 @@ class Gm2_SEO_Public {
         $schema_type = $overrides['schema_type'] ?? get_post_meta($post_id, '_gm2_schema_type', true);
         $brand       = $overrides['schema_brand'] ?? get_post_meta($post_id, '_gm2_schema_brand', true);
         if (!$brand) {
-            $brand = $this->infer_brand_name($post_id);
+            $brand = gm2_infer_brand_name($post_id);
         }
         $rating      = $overrides['schema_rating'] ?? get_post_meta($post_id, '_gm2_schema_rating', true);
         $context     = $this->get_post_context($post_id);
@@ -881,7 +873,7 @@ class Gm2_SEO_Public {
 
         $brand = is_singular() ? get_post_meta(get_the_ID(), '_gm2_schema_brand', true) : '';
         if (is_singular() && !$brand) {
-            $brand = $this->infer_brand_name(get_the_ID());
+            $brand = gm2_infer_brand_name(get_the_ID());
         }
         if ($brand) {
             $data['name'] = $brand;


### PR DESCRIPTION
## Summary
- centralize taxonomy-based brand lookup in `gm2_infer_brand_name`
- add admin helper `infer_brand_name` and use it in meta box rendering and saving
- reuse shared brand inference in public SEO logic to remove duplication

## Testing
- `npm test`
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689a82cd8a6c83279e8a8689dd85b4fc