### PR TITLE
Ensure brand meta saves after terms set

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -35,7 +35,7 @@ class Gm2_SEO_Admin {
     public function run() {
         add_action('admin_menu', [$this, 'add_settings_pages']);
         add_action('add_meta_boxes', [$this, 'register_meta_boxes']);
-        add_action('save_post', [$this, 'save_post_meta']);
+        add_action('save_post', [$this, 'save_post_meta'], 100);
         add_action('admin_enqueue_scripts', [$this, 'enqueue_editor_scripts']);
         add_action('enqueue_block_editor_assets', [$this, 'enqueue_editor_scripts']);
         add_action('admin_enqueue_scripts', [$this, 'enqueue_taxonomy_scripts']);

--- a/tests/test-save-post-brand.php
+++ b/tests/test-save-post-brand.php
@@ -1,0 +1,44 @@
+<?php
+use Gm2\Gm2_SEO_Admin;
+
+class BrandMetaTest extends WP_UnitTestCase {
+    private $term_id;
+
+    public function setUp(): void {
+        parent::setUp();
+        register_taxonomy('brand', 'post');
+        $this->term_id = self::factory()->term->create([
+            'taxonomy' => 'brand',
+            'name'     => 'Acme',
+        ]);
+        add_action('save_post', [$this, 'assign_brand_term'], 20, 1);
+    }
+
+    public function tearDown(): void {
+        remove_action('save_post', [$this, 'assign_brand_term'], 20);
+        $_POST = [];
+        parent::tearDown();
+    }
+
+    public function assign_brand_term($post_id) {
+        wp_set_post_terms($post_id, [$this->term_id], 'brand');
+    }
+
+    public function test_schema_brand_populated_after_save_post() {
+        $user_id = self::factory()->user->create(['role' => 'administrator']);
+        wp_set_current_user($user_id);
+
+        $_POST['gm2_seo_nonce'] = wp_create_nonce('gm2_save_seo_meta');
+
+        $admin = new Gm2_SEO_Admin();
+        $admin->run();
+
+        $post_id = wp_insert_post([
+            'post_title'  => 'Brand Post',
+            'post_status' => 'publish',
+        ]);
+
+        $this->assertSame('Acme', get_post_meta($post_id, '_gm2_schema_brand', true));
+    }
+}
+


### PR DESCRIPTION
## Summary
- delay `save_post` hook so taxonomy terms exist before inferring brand
- test that saving a post with a brand term stores `_gm2_schema_brand`

## Testing
- `npm test`
- `phpunit` *(fails: Cannot redeclare function Gm2\add_action)*

------
https://chatgpt.com/codex/tasks/task_e_689a86a38034832790aa084879956e8b