### PR TITLE
Allow custom brand taxonomies in SEO tools

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -145,12 +145,14 @@ class Gm2_SEO_Admin {
         if (taxonomy_exists('product_cat')) {
             $taxonomies[] = 'product_cat';
         }
-        if (taxonomy_exists('brand')) {
-            $taxonomies[] = 'brand';
+
+        $brand_taxonomies = apply_filters('gm2_brand_taxonomies', ['brand', 'product_brand']);
+        foreach ($brand_taxonomies as $tax) {
+            if (taxonomy_exists($tax)) {
+                $taxonomies[] = $tax;
+            }
         }
-        if (taxonomy_exists('product_brand')) {
-            $taxonomies[] = 'product_brand';
-        }
+
         return $taxonomies;
     }
 

--- a/includes/Gm2_SEO_Utils.php
+++ b/includes/Gm2_SEO_Utils.php
@@ -200,7 +200,8 @@ namespace {
     }
 
     function gm2_infer_brand_name(int $post_id): string {
-        $terms = wp_get_post_terms($post_id, ['brand', 'product_brand'], ['fields' => 'names']);
+        $taxonomies = apply_filters('gm2_brand_taxonomies', ['brand', 'product_brand']);
+        $terms      = wp_get_post_terms($post_id, $taxonomies, ['fields' => 'names']);
         if (!is_wp_error($terms) && !empty($terms)) {
             return sanitize_text_field($terms[0]);
         }


### PR DESCRIPTION
## Summary
- use `gm2_brand_taxonomies` filter for brand inference
- update admin taxonomy list to use the brand filter

## Testing
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a8b7b22948327a403026ecb17f10e