### PR TITLE
Delay exit_url assignment until cart abandonment

### DIFF
--- a/includes/Gm2_Abandoned_Carts.php
+++ b/includes/Gm2_Abandoned_Carts.php
@@ -537,7 +537,8 @@ class Gm2_Abandoned_Carts {
                 'location'      => $location,
                 'device'        => $device,
                 'entry_url'     => $url,
-                'exit_url'      => $url,
+                // exit_url will be populated when the cart is actually abandoned.
+                'exit_url'      => '',
                 'cart_total'    => $total,
                 'browsing_time' => 0,
                 'revisit_count' => 0,

--- a/tests/test-abandoned-carts.php
+++ b/tests/test-abandoned-carts.php
@@ -171,6 +171,29 @@ class AbandonedCartsTest extends WP_UnitTestCase {
         $this->assertSame('https://external.com/off', $row['exit_url']);
     }
 
+    public function test_exit_url_populated_only_on_abandonment_for_new_cart() {
+        $table = $GLOBALS['wpdb']->prefix . 'wc_ac_carts';
+        // Start with an empty cart table to simulate a brand new cart.
+        $GLOBALS['wpdb']->data[$table] = [];
+
+        $_POST = [ 'nonce' => 'n', 'url' => 'https://example.com/start' ];
+        $_REQUEST = $_POST;
+        \Gm2\Gm2_Abandoned_Carts::gm2_ac_mark_active();
+
+        $this->assertCount(1, $GLOBALS['wpdb']->data[$table]);
+        $row = $GLOBALS['wpdb']->data[$table][0];
+        // exit_url should be empty until the cart is abandoned
+        $this->assertSame('', $row['exit_url']);
+
+        // Abandon the cart and ensure exit_url is now recorded
+        $_POST = [ 'nonce' => 'n', 'url' => 'https://example.com/start' ];
+        $_REQUEST = $_POST;
+        \Gm2\Gm2_Abandoned_Carts::gm2_ac_mark_abandoned();
+
+        $row = $GLOBALS['wpdb']->data[$table][0];
+        $this->assertSame('https://example.com/start', $row['exit_url']);
+    }
+
     public function test_shutdown_caches_last_url() {
         $table = $GLOBALS['wpdb']->prefix . 'wc_ac_carts';
         $ac    = new \Gm2\Gm2_Abandoned_Carts();


### PR DESCRIPTION
## Summary
- avoid setting `exit_url` when activating a cart; it will now be filled only on abandonment
- add regression test ensuring new carts record `exit_url` only after they are abandoned

## Testing
- `npm test`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*


------
https://chatgpt.com/codex/tasks/task_e_689a9c9445fc83279ab28a382a0c8efa