### PR TITLE
Infer brand name after term assignment

### DIFF
--- a/tests/test-ai-seo.php
+++ b/tests/test-ai-seo.php
@@ -687,7 +687,7 @@ class LongTailKeywordsTest extends WP_UnitTestCase {
         $admin = new Gm2\Gm2_SEO_Admin();
         $_POST['gm2_seo_nonce'] = wp_create_nonce('gm2_save_seo_meta');
         $_POST['gm2_long_tail_keywords'] = 'alpha, beta ';
-        $admin->save_post_meta($post_id);
+        $admin->save_post_meta($post_id, get_post($post_id));
         $this->assertSame('alpha, beta', get_post_meta($post_id, '_gm2_long_tail_keywords', true));
     }
 }

--- a/tests/test-generated-fields.php
+++ b/tests/test-generated-fields.php
@@ -23,7 +23,7 @@ class GeneratedFieldsTest extends WP_UnitTestCase {
         $admin = new Gm2_SEO_Admin();
         $_POST['gm2_seo_nonce'] = wp_create_nonce('gm2_save_seo_meta');
         $_POST['gm2_seo_description'] = '';
-        $admin->save_post_meta($post_id);
+        $admin->save_post_meta($post_id, get_post($post_id));
 
         remove_filter('pre_http_request', $filter, 10);
 

--- a/tests/test-save-post-brand.php
+++ b/tests/test-save-post-brand.php
@@ -11,30 +11,31 @@ class BrandMetaTest extends WP_UnitTestCase {
             'taxonomy' => 'brand',
             'name'     => 'Acme',
         ]);
-        add_action('save_post', [$this, 'assign_brand_term'], 20, 1);
     }
 
     public function tearDown(): void {
-        remove_action('save_post', [$this, 'assign_brand_term'], 20);
         $_POST = [];
         parent::tearDown();
-    }
-
-    public function assign_brand_term($post_id) {
-        wp_set_post_terms($post_id, [$this->term_id], 'brand');
     }
 
     public function test_schema_brand_populated_after_save_post() {
         $user_id = self::factory()->user->create(['role' => 'administrator']);
         wp_set_current_user($user_id);
 
-        $_POST['gm2_seo_nonce'] = wp_create_nonce('gm2_save_seo_meta');
-
         $admin = new Gm2_SEO_Admin();
         $admin->run();
-
+        
+        // Create a post without a brand assigned.
         $post_id = wp_insert_post([
             'post_title'  => 'Brand Post',
+            'post_status' => 'draft',
+        ]);
+
+        // Assign brand term then save the post for the first time.
+        wp_set_post_terms($post_id, [$this->term_id], 'brand');
+        $_POST['gm2_seo_nonce'] = wp_create_nonce('gm2_save_seo_meta');
+        wp_update_post([
+            'ID'          => $post_id,
             'post_status' => 'publish',
         ]);
 


### PR DESCRIPTION
## Summary
- hook meta saving into `wp_after_insert_post` to run after terms are assigned
- accept post object in `save_post_meta` and infer brand name when field left empty
- add test ensuring brand meta is set on first save after assigning a brand

## Testing
- `npm test`
- `make test DB_NAME=wp_test DB_USER=root DB_PASS=pass` *(fails: mysqladmin command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a9cb4266883279fd3314d336e70fd