### PR TITLE
Invoke live cart fetch immediately on page load

### DIFF
--- a/admin/js/gm2-ac-live-updates.js
+++ b/admin/js/gm2-ac-live-updates.js
@@ -11,5 +11,6 @@ jQuery(function($){
             }
         });
     }
+    fetchCarts();
     setInterval(fetchCarts, 30000);
 });


### PR DESCRIPTION
## Summary
- start live cart updates immediately and continue polling every 30 seconds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689aa11dd2548327bdd63d06fee7f2e4