### PR TITLE
Enable phone-based authentication via WooCommerce

### DIFF
--- a/includes/Gm2_Loader.php
+++ b/includes/Gm2_Loader.php
@@ -32,6 +32,7 @@ class Gm2_Loader {
         $enable_seo = get_option('gm2_enable_seo', '1') === '1';
         $enable_qd  = get_option('gm2_enable_quantity_discounts', '1') === '1';
         $enable_ac  = get_option('gm2_enable_abandoned_carts', '1') === '1';
+        $enable_phone_login = get_option('gm2_enable_phone_login', '0') === '1';
 
         if (!$enable_ac && is_admin()) {
             add_action('admin_notices', function () {
@@ -51,6 +52,11 @@ class Gm2_Loader {
 
         $public = new Gm2_Public();
         $public->run();
+
+        if ($enable_phone_login) {
+            $phone_auth = new Gm2_Phone_Auth();
+            $phone_auth->run();
+        }
 
         if ($enable_ac) {
             $ac = new Gm2_Abandoned_Carts();

--- a/includes/Gm2_Phone_Auth.php
+++ b/includes/Gm2_Phone_Auth.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Gm2;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Gm2_Phone_Auth {
+    public function run() {
+        add_action('woocommerce_register_form', [$this, 'render_registration_phone_field']);
+        add_filter('woocommerce_register_post', [$this, 'require_phone_or_email'], 10, 3);
+        add_action('woocommerce_created_customer', [$this, 'save_phone_on_register']);
+        add_filter('authenticate', [$this, 'authenticate'], 10, 3);
+        add_action('woocommerce_edit_account_form', [$this, 'render_account_phone_field']);
+        add_action('woocommerce_save_account_details', [$this, 'save_account_phone']);
+    }
+
+    public function render_registration_phone_field() {
+        $phone = isset($_POST['billing_phone']) ? wc_clean(wp_unslash($_POST['billing_phone'])) : '';
+        woocommerce_form_field('billing_phone', [
+            'type'     => 'tel',
+            'label'    => __('Phone', 'gm2-wordpress-suite'),
+            'required' => false,
+        ], $phone);
+    }
+
+    public function require_phone_or_email($username, $email, $errors) {
+        $phone = isset($_POST['billing_phone']) ? trim(wp_unslash($_POST['billing_phone'])) : '';
+        if (empty($email) && empty($phone)) {
+            $errors->add('registration-error-phone-email', __('Please enter an email address or phone number.', 'gm2-wordpress-suite'));
+        }
+        return $errors;
+    }
+
+    public function save_phone_on_register($customer_id) {
+        if (isset($_POST['billing_phone'])) {
+            update_user_meta($customer_id, 'billing_phone', wc_clean(wp_unslash($_POST['billing_phone'])));
+        }
+    }
+
+    public function authenticate($user, $username, $password) {
+        if (!empty($user) || empty($username) || empty($password) || false !== strpos($username, '@')) {
+            return $user;
+        }
+
+        $users = get_users([
+            'meta_key'   => 'billing_phone',
+            'meta_value' => $username,
+            'number'     => 1,
+            'fields'     => 'all',
+        ]);
+
+        if (!empty($users)) {
+            $login = $users[0]->user_login;
+            $user  = wp_authenticate_username_password(null, $login, $password);
+        }
+
+        return $user;
+    }
+
+    public function render_account_phone_field() {
+        $user  = wp_get_current_user();
+        $phone = get_user_meta($user->ID, 'billing_phone', true);
+        woocommerce_form_field('billing_phone', [
+            'type'     => 'tel',
+            'label'    => __('Phone', 'gm2-wordpress-suite'),
+            'required' => false,
+        ], $phone);
+    }
+
+    public function save_account_phone($user_id) {
+        if (isset($_POST['billing_phone'])) {
+            update_user_meta($user_id, 'billing_phone', wc_clean(wp_unslash($_POST['billing_phone'])));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `Gm2_Phone_Auth` to support phone field registration, profile editing and login
- load phone auth when `gm2_enable_phone_login` option is enabled

## Testing
- `npm test`
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689b81f44f7483278ba9d9781e2342d3