### PR TITLE
Add analytics admin module and feature toggle

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -13,6 +13,7 @@ class Gm2_Admin {
     private $cart_settings;
     private $oauth_enabled;
     private $chatgpt_enabled;
+    private $analytics;
 
     public function run() {
         $this->diagnostics = new Gm2_Diagnostics();
@@ -28,6 +29,10 @@ class Gm2_Admin {
         }
         $this->cart_settings = new Gm2_Cart_Settings_Admin();
         $this->cart_settings->register_hooks();
+        if (get_option('gm2_enable_analytics', '1') === '1') {
+            $this->analytics = new Gm2_Analytics_Admin();
+            $this->analytics->run();
+        }
         add_action('admin_enqueue_scripts', [$this, 'enqueue_admin_scripts']);
         add_action('wp_ajax_gm2_add_tariff', [$this, 'ajax_add_tariff']);
         add_action('wp_ajax_nopriv_gm2_add_tariff', [$this, 'ajax_add_tariff']);
@@ -443,6 +448,7 @@ class Gm2_Admin {
             update_option('gm2_enable_google_oauth', empty($_POST['gm2_enable_google_oauth']) ? '0' : '1');
             update_option('gm2_enable_chatgpt', empty($_POST['gm2_enable_chatgpt']) ? '0' : '1');
             update_option('gm2_enable_abandoned_carts', empty($_POST['gm2_enable_abandoned_carts']) ? '0' : '1');
+            update_option('gm2_enable_analytics', empty($_POST['gm2_enable_analytics']) ? '0' : '1');
 
             $enabled = !empty($_POST['gm2_enable_abandoned_carts']);
             if ($enabled) {
@@ -466,6 +472,7 @@ class Gm2_Admin {
         $oauth  = get_option('gm2_enable_google_oauth', '1') === '1';
         $chatgpt = get_option('gm2_enable_chatgpt', '1') === '1';
         $abandoned = get_option('gm2_enable_abandoned_carts', '0') === '1';
+        $analytics = get_option('gm2_enable_analytics', '1') === '1';
 
         echo '<div class="wrap">';
         echo '<h1>' . esc_html__( 'Gm2 Suite', 'gm2-wordpress-suite' ) . '</h1>';
@@ -477,6 +484,7 @@ class Gm2_Admin {
         echo '<tr><th scope="row">' . esc_html__( 'Quantity Discounts', 'gm2-wordpress-suite' ) . '</th><td><label><input type="checkbox" name="gm2_enable_quantity_discounts"' . checked($qd, true, false) . '> ' . esc_html__( 'Enabled', 'gm2-wordpress-suite' ) . '</label></td></tr>';
         echo '<tr><th scope="row">' . esc_html__( 'Google OAuth Setup', 'gm2-wordpress-suite' ) . '</th><td><label><input type="checkbox" name="gm2_enable_google_oauth"' . checked($oauth, true, false) . '> ' . esc_html__( 'Enabled', 'gm2-wordpress-suite' ) . '</label></td></tr>';
         echo '<tr><th scope="row">' . esc_html__( 'ChatGPT', 'gm2-wordpress-suite' ) . '</th><td><label><input type="checkbox" name="gm2_enable_chatgpt"' . checked($chatgpt, true, false) . '> ' . esc_html__( 'Enabled', 'gm2-wordpress-suite' ) . '</label></td></tr>';
+        echo '<tr><th scope="row">' . esc_html__( 'Analytics', 'gm2-wordpress-suite' ) . '</th><td><label><input type="checkbox" name="gm2_enable_analytics"' . checked($analytics, true, false) . '> ' . esc_html__( 'Enabled', 'gm2-wordpress-suite' ) . '</label></td></tr>';
         echo '<tr><th scope="row">' . esc_html__( 'Abandoned Carts', 'gm2-wordpress-suite' ) . '</th><td><label><input type="checkbox" name="gm2_enable_abandoned_carts"' . checked($abandoned, true, false) . '> ' . esc_html__( 'Enabled', 'gm2-wordpress-suite' ) . '</label></td></tr>';
         echo '</tbody></table>';
         submit_button();

--- a/admin/Gm2_Analytics_Admin.php
+++ b/admin/Gm2_Analytics_Admin.php
@@ -1,0 +1,44 @@
+<?php
+namespace Gm2;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Gm2_Analytics_Admin {
+    public function run() {
+        add_action('admin_menu', [ $this, 'add_menu' ]);
+        add_action('admin_enqueue_scripts', [ $this, 'enqueue_scripts' ]);
+    }
+
+    public function add_menu() {
+        add_menu_page(
+            esc_html__( 'Analytics', 'gm2-wordpress-suite' ),
+            esc_html__( 'Analytics', 'gm2-wordpress-suite' ),
+            'manage_options',
+            'gm2-analytics',
+            [ $this, 'display_page' ],
+            'dashicons-chart-area'
+        );
+    }
+
+    public function enqueue_scripts( $hook ) {
+        if ( $hook !== 'toplevel_page_gm2-analytics' ) {
+            return;
+        }
+        wp_enqueue_script(
+            'gm2-analytics',
+            GM2_PLUGIN_URL . 'admin/js/gm2-analytics.js',
+            [ 'jquery' ],
+            file_exists( GM2_PLUGIN_DIR . 'admin/js/gm2-analytics.js' ) ? filemtime( GM2_PLUGIN_DIR . 'admin/js/gm2-analytics.js' ) : GM2_VERSION,
+            true
+        );
+    }
+
+    public function display_page() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'Permission denied', 'gm2-wordpress-suite' ) );
+        }
+        echo '<div class="wrap"><h1>' . esc_html__( 'Analytics', 'gm2-wordpress-suite' ) . '</h1></div>';
+    }
+}

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -120,6 +120,7 @@ function gm2_activate_plugin() {
     add_option('gm2_enable_quantity_discounts', '1');
     add_option('gm2_enable_google_oauth', '1');
     add_option('gm2_enable_chatgpt', '1');
+    add_option('gm2_enable_analytics', '1');
     add_option('gm2_enable_chatgpt_logging', '0');
     add_option('gm2_sitemap_path', ABSPATH . 'sitemap.xml');
     add_option('gm2_sitemap_max_urls', 1000);


### PR DESCRIPTION
## Summary
- enable Analytics by default during plugin activation
- add Analytics feature toggle in dashboard and boot Analytics admin when enabled
- introduce Gm2_Analytics_Admin with top-level menu and script loading

## Testing
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b8f2638f48327affdf3bb550d5923