### PR TITLE
Add basic analytics tracking

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -54,6 +54,7 @@ require_once GM2_PLUGIN_DIR . 'includes/Gm2_PageSpeed.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_SEO_Utils.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_CSV_Helper.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_Abandoned_Carts.php';
+require_once GM2_PLUGIN_DIR . 'includes/Gm2_Analytics.php';
 // Temporarily disable Recovery Email Queue.
 // require_once GM2_PLUGIN_DIR . 'includes/Gm2_Abandoned_Carts_Messaging.php';
 require_once GM2_PLUGIN_DIR . 'admin/Gm2_Abandoned_Carts_Admin.php';
@@ -129,6 +130,26 @@ function gm2_activate_plugin() {
     add_option('gm2_ac_mark_abandoned_interval', 5);
     add_option('gm2_setup_complete', '0');
     add_option('gm2_do_activation_redirect', '1');
+
+    global $wpdb;
+    $table_name = $wpdb->prefix . 'gm2_analytics_log';
+    $charset_collate = $wpdb->get_charset_collate();
+    require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+    $sql = "CREATE TABLE $table_name (
+        id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+        session_id varchar(64) NOT NULL,
+        user_id varchar(64) NOT NULL,
+        url text NOT NULL,
+        referrer text DEFAULT NULL,
+        `timestamp` datetime NOT NULL,
+        user_agent text NOT NULL,
+        device varchar(20) NOT NULL,
+        ip varchar(100) NOT NULL,
+        PRIMARY KEY  (id),
+        KEY session_id (session_id),
+        KEY user_id (user_id)
+    ) $charset_collate;";
+    dbDelta($sql);
 
     Gm2_Abandoned_Carts::schedule_event();
 }

--- a/includes/Gm2_Analytics.php
+++ b/includes/Gm2_Analytics.php
@@ -1,0 +1,122 @@
+<?php
+namespace Gm2;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Gm2_Analytics {
+    const COOKIE_NAME = 'gm2_analytics_id';
+    const SESSION_COOKIE = 'gm2_analytics_session';
+
+    public function run() {
+        add_action('init', [ $this, 'maybe_log_request' ]);
+        add_action('wp_enqueue_scripts', [ $this, 'enqueue_tracker' ]);
+        add_action('wp_ajax_nopriv_gm2_analytics_track', [ $this, 'ajax_track' ]);
+        add_action('wp_ajax_gm2_analytics_track', [ $this, 'ajax_track' ]);
+    }
+
+    public function enqueue_tracker() {
+        wp_enqueue_script(
+            'gm2-analytics-tracker',
+            GM2_PLUGIN_URL . 'public/js/gm2-analytics-tracker.js',
+            [],
+            GM2_VERSION,
+            true
+        );
+        wp_localize_script(
+            'gm2-analytics-tracker',
+            'gm2Analytics',
+            [
+                'ajax_url' => admin_url('admin-ajax.php'),
+            ]
+        );
+    }
+
+    public function maybe_log_request() {
+        if (wp_doing_ajax() || (defined('REST_REQUEST') && REST_REQUEST)) {
+            return;
+        }
+
+        $user_id    = $this->get_user_id();
+        $session_id = $this->get_session_id();
+        $url        = esc_url_raw(home_url($_SERVER['REQUEST_URI'] ?? ''));
+        $referrer   = isset($_SERVER['HTTP_REFERER']) ? esc_url_raw($_SERVER['HTTP_REFERER']) : '';
+        $user_agent = isset($_SERVER['HTTP_USER_AGENT']) ? sanitize_text_field(wp_unslash($_SERVER['HTTP_USER_AGENT'])) : '';
+        $device     = wp_is_mobile() ? 'mobile' : 'desktop';
+        $ip         = isset($_SERVER['REMOTE_ADDR']) ? sanitize_text_field($_SERVER['REMOTE_ADDR']) : '';
+
+        $this->insert_log([
+            'session_id' => $session_id,
+            'user_id'    => $user_id,
+            'url'        => $url,
+            'referrer'   => $referrer,
+            'timestamp'  => current_time('mysql'),
+            'user_agent' => $user_agent,
+            'device'     => $device,
+            'ip'         => $ip,
+        ]);
+    }
+
+    private function get_user_id() {
+        if (!isset($_COOKIE[self::COOKIE_NAME])) {
+            $id = wp_generate_uuid4();
+            setcookie(self::COOKIE_NAME, $id, time() + YEAR_IN_SECONDS * 2, COOKIEPATH, COOKIE_DOMAIN);
+            $_COOKIE[self::COOKIE_NAME] = $id;
+        }
+        return sanitize_text_field($_COOKIE[self::COOKIE_NAME]);
+    }
+
+    private function get_session_id() {
+        if (!isset($_COOKIE[self::SESSION_COOKIE])) {
+            $session = wp_generate_uuid4();
+            setcookie(self::SESSION_COOKIE, $session, 0, COOKIEPATH, COOKIE_DOMAIN);
+            $_COOKIE[self::SESSION_COOKIE] = $session;
+        }
+        return sanitize_text_field($_COOKIE[self::SESSION_COOKIE]);
+    }
+
+    public function ajax_track() {
+        $url      = isset($_POST['url']) ? esc_url_raw(wp_unslash($_POST['url'])) : '';
+        $referrer = isset($_POST['referrer']) ? esc_url_raw(wp_unslash($_POST['referrer'])) : '';
+        $this->log_event($url, $referrer);
+        wp_send_json_success();
+    }
+
+    private function log_event($url, $referrer = '') {
+        $user_id    = $this->get_user_id();
+        $session_id = $this->get_session_id();
+        $user_agent = isset($_SERVER['HTTP_USER_AGENT']) ? sanitize_text_field(wp_unslash($_SERVER['HTTP_USER_AGENT'])) : '';
+        $device     = wp_is_mobile() ? 'mobile' : 'desktop';
+        $ip         = isset($_SERVER['REMOTE_ADDR']) ? sanitize_text_field($_SERVER['REMOTE_ADDR']) : '';
+
+        $this->insert_log([
+            'session_id' => $session_id,
+            'user_id'    => $user_id,
+            'url'        => $url,
+            'referrer'   => $referrer,
+            'timestamp'  => current_time('mysql'),
+            'user_agent' => $user_agent,
+            'device'     => $device,
+            'ip'         => $ip,
+        ]);
+    }
+
+    private function insert_log($data) {
+        global $wpdb;
+        $table = $wpdb->prefix . 'gm2_analytics_log';
+        $wpdb->query(
+            $wpdb->prepare(
+                "INSERT INTO $table (`session_id`,`user_id`,`url`,`referrer`,`timestamp`,`user_agent`,`device`,`ip`) VALUES (%s,%s,%s,%s,%s,%s,%s,%s)",
+                $data['session_id'],
+                $data['user_id'],
+                $data['url'],
+                $data['referrer'],
+                $data['timestamp'],
+                $data['user_agent'],
+                $data['device'],
+                $data['ip']
+            )
+        );
+    }
+}

--- a/includes/Gm2_Loader.php
+++ b/includes/Gm2_Loader.php
@@ -29,10 +29,11 @@ class Gm2_Loader {
             $links->run();
         }
 
-        $enable_seo = get_option('gm2_enable_seo', '1') === '1';
-        $enable_qd  = get_option('gm2_enable_quantity_discounts', '1') === '1';
-        $enable_ac  = get_option('gm2_enable_abandoned_carts', '1') === '1';
+        $enable_seo       = get_option('gm2_enable_seo', '1') === '1';
+        $enable_qd        = get_option('gm2_enable_quantity_discounts', '1') === '1';
+        $enable_ac        = get_option('gm2_enable_abandoned_carts', '1') === '1';
         $enable_phone_login = get_option('gm2_enable_phone_login', '0') === '1';
+        $enable_analytics = get_option('gm2_enable_analytics', '1') === '1';
 
         if (!$enable_ac && is_admin()) {
             add_action('admin_notices', function () {
@@ -52,6 +53,11 @@ class Gm2_Loader {
 
         $public = new Gm2_Public();
         $public->run();
+
+        if ($enable_analytics) {
+            $analytics = new Gm2_Analytics();
+            $analytics->run();
+        }
 
         if ($enable_phone_login) {
             $phone_auth = new Gm2_Phone_Auth();

--- a/public/js/gm2-analytics-tracker.js
+++ b/public/js/gm2-analytics-tracker.js
@@ -1,0 +1,22 @@
+(function(){
+    document.addEventListener('DOMContentLoaded', function(){
+        if (typeof gm2Analytics === 'undefined' || !gm2Analytics.ajax_url) {
+            return;
+        }
+        var params = new URLSearchParams({
+            action: 'gm2_analytics_track',
+            url: window.location.href,
+            referrer: document.referrer
+        });
+        if (navigator.sendBeacon) {
+            navigator.sendBeacon(gm2Analytics.ajax_url, params);
+        } else {
+            fetch(gm2Analytics.ajax_url, {
+                method: 'POST',
+                credentials: 'same-origin',
+                headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+                body: params.toString()
+            });
+        }
+    });
+})();


### PR DESCRIPTION
## Summary
- add analytics tracker class that logs requests and enqueues a JS tracker
- create `wp_gm2_analytics_log` table on plugin activation
- track page views via AJAX using new frontend script

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b91a8199c8327a3fd37ce81820717