### PR TITLE
Verify analytics nonce on tracking requests

### DIFF
--- a/includes/Gm2_Analytics.php
+++ b/includes/Gm2_Analytics.php
@@ -29,6 +29,7 @@ class Gm2_Analytics {
             'gm2Analytics',
             [
                 'ajax_url' => admin_url('admin-ajax.php'),
+                'nonce'    => wp_create_nonce('gm2_analytics'),
             ]
         );
     }
@@ -77,6 +78,7 @@ class Gm2_Analytics {
     }
 
     public function ajax_track() {
+        check_ajax_referer('gm2_analytics', 'nonce');
         $url      = isset($_POST['url']) ? esc_url_raw(wp_unslash($_POST['url'])) : '';
         $referrer = isset($_POST['referrer']) ? esc_url_raw(wp_unslash($_POST['referrer'])) : '';
         $this->log_event($url, $referrer);

--- a/public/js/gm2-analytics-tracker.js
+++ b/public/js/gm2-analytics-tracker.js
@@ -8,6 +8,9 @@
             url: window.location.href,
             referrer: document.referrer
         });
+        if (gm2Analytics.nonce) {
+            params.append('nonce', gm2Analytics.nonce);
+        }
         if (navigator.sendBeacon) {
             navigator.sendBeacon(gm2Analytics.ajax_url, params);
         } else {

--- a/tests/AnalyticsNonceTest.php
+++ b/tests/AnalyticsNonceTest.php
@@ -1,0 +1,32 @@
+<?php
+namespace Gm2 {
+    function check_ajax_referer($action, $query_arg = false) {
+        if (!isset($_POST[$query_arg]) || $_POST[$query_arg] !== 'good') {
+            throw new \Exception('bad_nonce');
+        }
+    }
+    function wp_send_json_success($data = null) { return ['success'=>true,'data'=>$data]; }
+}
+namespace {
+    if (!defined('ABSPATH')) {
+        define('ABSPATH', __DIR__ . '/../');
+    }
+    if (!defined('GM2_PLUGIN_DIR')) {
+        define('GM2_PLUGIN_DIR', dirname(__DIR__) . '/');
+    }
+    if (!defined('GM2_PLUGIN_URL')) {
+        define('GM2_PLUGIN_URL', '');
+    }
+    if (!defined('GM2_VERSION')) {
+        define('GM2_VERSION', '1.0');
+    }
+    require_once dirname(__DIR__) . '/includes/Gm2_Analytics.php';
+    class AnalyticsNonceTest extends \PHPUnit\Framework\TestCase {
+        public function test_rejects_invalid_nonce() {
+            $_POST = ['url' => 'https://example.com'];
+            $analytics = new \Gm2\Gm2_Analytics();
+            $this->expectException(\Exception::class);
+            $analytics->ajax_track();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Secure analytics tracking by verifying a `gm2_analytics` nonce in `ajax_track`
- Localize a generated nonce when enqueuing the tracker script
- Send nonce with `gm2-analytics-tracker.js` and add tests for missing nonce

## Testing
- `phpunit tests/AnalyticsNonceTest.php --no-configuration`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ca75d66208327a8fa9d9e68af8191