### PR TITLE
Anonymize analytics IP storage

### DIFF
--- a/includes/Gm2_Analytics.php
+++ b/includes/Gm2_Analytics.php
@@ -46,6 +46,7 @@ class Gm2_Analytics {
         $user_agent = isset($_SERVER['HTTP_USER_AGENT']) ? sanitize_text_field(wp_unslash($_SERVER['HTTP_USER_AGENT'])) : '';
         $device     = wp_is_mobile() ? 'mobile' : 'desktop';
         $ip         = isset($_SERVER['REMOTE_ADDR']) ? sanitize_text_field($_SERVER['REMOTE_ADDR']) : '';
+        $ip         = $ip ? wp_privacy_anonymize_ip($ip) : '';
 
         $this->insert_log([
             'session_id' => $session_id,
@@ -91,6 +92,7 @@ class Gm2_Analytics {
         $user_agent = isset($_SERVER['HTTP_USER_AGENT']) ? sanitize_text_field(wp_unslash($_SERVER['HTTP_USER_AGENT'])) : '';
         $device     = wp_is_mobile() ? 'mobile' : 'desktop';
         $ip         = isset($_SERVER['REMOTE_ADDR']) ? sanitize_text_field($_SERVER['REMOTE_ADDR']) : '';
+        $ip         = $ip ? wp_privacy_anonymize_ip($ip) : '';
 
         $this->insert_log([
             'session_id' => $session_id,

--- a/readme.txt
+++ b/readme.txt
@@ -444,3 +444,7 @@ and run them with:
 npm install
 npm test
 ```
+
+== Privacy ==
+
+This plugin logs page visits and events to a custom table. IP addresses are anonymized before storage by truncating the final octet of IPv4 addresses (and the equivalent segment for IPv6) using WordPress's `wp_privacy_anonymize_ip()` function. No full IP addresses are retained.

--- a/tests/AnalyticsIpAnonymizationTest.php
+++ b/tests/AnalyticsIpAnonymizationTest.php
@@ -1,0 +1,96 @@
+<?php
+namespace Gm2 {
+    function wp_doing_ajax() { return false; }
+    function home_url($path = '') { return 'https://example.com' . $path; }
+    function esc_url_raw($url) { return $url; }
+    function sanitize_text_field($str) { return $str; }
+    function wp_unslash($str) { return $str; }
+    function wp_is_mobile() { return false; }
+    function current_time($type) { return '2024-01-01 00:00:00'; }
+    function wp_privacy_anonymize_ip($ip) {
+        $parts = explode('.', $ip);
+        if (4 === count($parts)) {
+            $parts[3] = '0';
+            return implode('.', $parts);
+        }
+        return $ip;
+    }
+    function check_ajax_referer($action, $query_arg = false) {}
+    function wp_send_json_success($data = null) {}
+}
+namespace {
+    if (!defined('ABSPATH')) {
+        define('ABSPATH', __DIR__ . '/../');
+    }
+    if (!defined('GM2_PLUGIN_DIR')) {
+        define('GM2_PLUGIN_DIR', dirname(__DIR__) . '/');
+    }
+    if (!defined('GM2_PLUGIN_URL')) {
+        define('GM2_PLUGIN_URL', '');
+    }
+    if (!defined('GM2_VERSION')) {
+        define('GM2_VERSION', '1.0');
+    }
+    if (!defined('DAY_IN_SECONDS')) {
+        define('DAY_IN_SECONDS', 24 * 60 * 60);
+    }
+    if (!defined('YEAR_IN_SECONDS')) {
+        define('YEAR_IN_SECONDS', 365 * DAY_IN_SECONDS);
+    }
+    if (!defined('COOKIEPATH')) {
+        define('COOKIEPATH', '');
+    }
+    if (!defined('COOKIE_DOMAIN')) {
+        define('COOKIE_DOMAIN', '');
+    }
+
+    require_once dirname(__DIR__) . '/includes/Gm2_Analytics.php';
+}
+namespace {
+    class WPDBStub {
+        public string $prefix = '';
+        public array $prepared_args = [];
+        public function prepare($query, ...$args) {
+            $this->prepared_args = $args;
+            return '';
+        }
+        public function query($query) {}
+    }
+
+    class AnalyticsIpAnonymizationTest extends \PHPUnit\Framework\TestCase {
+        private WPDBStub $wpdbStub;
+
+        protected function setUp(): void {
+            global $wpdb;
+            $this->wpdbStub = new WPDBStub();
+            $wpdb = $this->wpdbStub;
+            $_COOKIE = [];
+        }
+
+        public function test_maybe_log_request_anonymizes_ip() {
+            $_COOKIE[\Gm2\Gm2_Analytics::COOKIE_NAME] = 'uid';
+            $_COOKIE[\Gm2\Gm2_Analytics::SESSION_COOKIE] = 'sid';
+            $_SERVER['REQUEST_URI'] = '/test';
+            $_SERVER['REMOTE_ADDR'] = '123.123.123.123';
+            $_SERVER['HTTP_USER_AGENT'] = 'UA';
+
+            $analytics = new \Gm2\Gm2_Analytics();
+            $analytics->maybe_log_request();
+
+            $this->assertSame('123.123.123.0', $this->wpdbStub->prepared_args[7]);
+        }
+
+        public function test_log_event_anonymizes_ip() {
+            $_COOKIE[\Gm2\Gm2_Analytics::COOKIE_NAME] = 'uid';
+            $_COOKIE[\Gm2\Gm2_Analytics::SESSION_COOKIE] = 'sid';
+            $_SERVER['REMOTE_ADDR'] = '123.123.123.123';
+            $_SERVER['HTTP_USER_AGENT'] = 'UA';
+
+            $analytics = new \Gm2\Gm2_Analytics();
+            $_POST = ['url' => 'https://example.com', 'referrer' => '', 'nonce' => 'ok'];
+            $analytics->ajax_track();
+
+            $this->assertSame('123.123.123.0', $this->wpdbStub->prepared_args[7]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Anonymize IP addresses using `wp_privacy_anonymize_ip()` before logging analytics events
- Document IP truncation in privacy notes
- Add PHPUnit tests confirming logged IPs are anonymized

## Testing
- `~/.local/share/mise/installs/php/8.4.11/.composer/vendor/bin/phpunit --no-configuration tests/AnalyticsNonceTest.php`
- `~/.local/share/mise/installs/php/8.4.11/.composer/vendor/bin/phpunit --no-configuration tests/AnalyticsIpAnonymizationTest.php`


------
https://chatgpt.com/codex/tasks/task_e_689ca992b09883279ca50e2c3a4b48be