### PR TITLE
Add timestamp index to analytics log table

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,7 @@
 
 This release adds several new SEO and AI options:
 
+- Added an index on the `timestamp` column of the `gm2_analytics_log` table for faster lookups. Existing installations upgrade automatically.
 - **Project Description** and **Custom Prompts** fields under **SEO → Context**. The project description falls back to the site tagline or a snippet of post content if empty.
  - **Business Context Prompt** builder that compiles your Context answers into a single prompt for generating a short business summary.
 - Each context field now includes a guiding question so users know what to enter.


### PR DESCRIPTION
## Summary
- index analytics log by timestamp column and bump plugin version
- add upgrade routine to ensure index exists for prior installs
- note new database index in docs

## Testing
- `npm test`
- `make test` *(fails: Database credentials must be supplied via DB_NAME, DB_USER and DB_PASS)*

------
https://chatgpt.com/codex/tasks/task_e_689cafaa1b848327b6f929604e974d66