### PR TITLE
Add nonce validation to activity log filters

### DIFF
--- a/admin/Gm2_Analytics_Admin.php
+++ b/admin/Gm2_Analytics_Admin.php
@@ -73,6 +73,15 @@ class Gm2_Analytics_Admin {
 
     private function render_activity_log($data) {
         global $wpdb;
+
+        // Verify nonce before processing any filter parameters.
+        if ( isset($_GET['log_user']) || isset($_GET['log_device']) || isset($_GET['paged']) ) {
+            $nonce = isset($_GET['gm2_activity_log_nonce']) ? sanitize_text_field( wp_unslash($_GET['gm2_activity_log_nonce']) ) : '';
+            if ( ! wp_verify_nonce( $nonce, 'gm2_activity_log_filter' ) ) {
+                return;
+            }
+        }
+
         $table = $wpdb->prefix . 'gm2_analytics_log';
         $per_page = 20;
         $paged = isset($_GET['paged']) ? max(1, absint($_GET['paged'])) : 1;
@@ -89,6 +98,7 @@ class Gm2_Analytics_Admin {
         $logs = $wpdb->get_results("SELECT * FROM $table WHERE $where ORDER BY `timestamp` DESC LIMIT $per_page OFFSET $offset");
         echo '<h2>' . esc_html__('Activity Log', 'gm2-wordpress-suite') . '</h2>';
         echo '<form method="get"><input type="hidden" name="page" value="gm2-analytics" />';
+        wp_nonce_field('gm2_activity_log_filter', 'gm2_activity_log_nonce');
         echo '<input type="hidden" name="start" value="' . esc_attr($data['start']) . '" />';
         echo '<input type="hidden" name="end" value="' . esc_attr($data['end']) . '" />';
         echo '<label>' . esc_html__('User', 'gm2-wordpress-suite') . ': <input type="text" name="log_user" value="' . esc_attr($user_filter) . '" /></label> ';

--- a/tests/ActivityLogNonceTest.php
+++ b/tests/ActivityLogNonceTest.php
@@ -1,0 +1,43 @@
+<?php
+namespace Gm2 {
+    // Use WordPress's wp_verify_nonce if available; otherwise, a simple stub.
+    if (!function_exists('wp_verify_nonce')) {
+        function wp_verify_nonce($nonce, $action = -1) {
+            return $nonce === 'good';
+        }
+    }
+}
+
+namespace {
+    if (!defined('ABSPATH')) {
+        define('ABSPATH', __DIR__ . '/../');
+    }
+    require_once dirname(__DIR__) . '/admin/Gm2_Analytics_Admin.php';
+
+    use Gm2\Gm2_Analytics_Admin;
+
+    class ActivityLogNonceTest extends \PHPUnit\Framework\TestCase {
+        private $orig_get;
+
+        protected function setUp(): void {
+            $this->orig_get = $_GET;
+        }
+
+        protected function tearDown(): void {
+            $_GET = $this->orig_get;
+        }
+
+        public function test_invalid_nonce_results_in_no_output() {
+            $_GET['log_user'] = '1';
+            $_GET['gm2_activity_log_nonce'] = 'bad';
+            $admin = new Gm2_Analytics_Admin();
+            $ref = new \ReflectionClass(Gm2_Analytics_Admin::class);
+            $method = $ref->getMethod('render_activity_log');
+            $method->setAccessible(true);
+            ob_start();
+            $method->invoke($admin, ['start' => '2024-01-01', 'end' => '2024-01-02']);
+            $output = ob_get_clean();
+            $this->assertSame('', $output);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add nonce field and verification to Analytics activity log filter
- Test that invalid nonces prevent activity log rendering

## Testing
- `phpunit tests/ActivityLogNonceTest.php` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): No such file or directory)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cb12601e8832786a8f020c7d3c503