### PR TITLE
Use wp_safe_remote_get for external requests

### DIFF
--- a/includes/Gm2_Abandoned_Carts.php
+++ b/includes/Gm2_Abandoned_Carts.php
@@ -778,8 +778,14 @@ class Gm2_Abandoned_Carts {
             if (!empty($_SERVER['HTTP_CF_IPCOUNTRY'])) {
                 $location = sanitize_text_field(wp_unslash($_SERVER['HTTP_CF_IPCOUNTRY']));
             } elseif (!empty($ip)) {
-                $response = wp_remote_get('https://ipapi.co/' . rawurlencode($ip) . '/json/', ['timeout' => 2]);
-                if (!is_wp_error($response)) {
+                $response = wp_safe_remote_get(
+                    'https://ipapi.co/' . rawurlencode($ip) . '/json/',
+                    ['timeout' => 5]
+                );
+                if (
+                    !is_wp_error($response) &&
+                    200 === wp_remote_retrieve_response_code($response)
+                ) {
                     $body = wp_remote_retrieve_body($response);
                     $data = json_decode($body, true);
                     if (!empty($data['country'])) {
@@ -795,6 +801,9 @@ class Gm2_Abandoned_Carts {
                     }
                 }
             }
+        }
+        if (empty($location)) {
+            $location = 'Unknown';
         }
         return [ 'ip' => $ip, 'location' => $location ];
     }

--- a/includes/Gm2_ChatGPT.php
+++ b/includes/Gm2_ChatGPT.php
@@ -104,7 +104,7 @@ class Gm2_ChatGPT {
             'timeout' => 20,
         ];
 
-        $response = wp_remote_get('https://api.openai.com/v1/models', $args);
+        $response = wp_safe_remote_get('https://api.openai.com/v1/models', $args);
 
         if (is_wp_error($response)) {
             return $defaults;

--- a/includes/Gm2_Google_OAuth.php
+++ b/includes/Gm2_Google_OAuth.php
@@ -54,7 +54,7 @@ class Gm2_Google_OAuth {
         if (strtoupper($method) === 'POST') {
             $resp = wp_remote_post($url, $args);
         } else {
-            $resp = wp_remote_get($url, $args);
+            $resp = wp_safe_remote_get($url, $args);
         }
         if (is_wp_error($resp)) {
             return $resp;

--- a/includes/Gm2_PageSpeed.php
+++ b/includes/Gm2_PageSpeed.php
@@ -19,7 +19,7 @@ class Gm2_PageSpeed {
             'strategy' => $strategy,
             'key' => $this->api_key,
         ]);
-        $resp = wp_remote_get($api . '?' . $query, ['timeout' => 20]);
+        $resp = wp_safe_remote_get($api . '?' . $query, ['timeout' => 20]);
         if (is_wp_error($resp)) {
             return $resp;
         }

--- a/includes/Gm2_Sitemap.php
+++ b/includes/Gm2_Sitemap.php
@@ -169,7 +169,7 @@ class Gm2_Sitemap {
             'https://www.bing.com/ping?sitemap=' . rawurlencode($sitemap_url),
         ];
         foreach ($endpoints as $endpoint) {
-            wp_remote_get($endpoint);
+            wp_safe_remote_get($endpoint, ['timeout' => 5]);
         }
     }
 

--- a/tests/test-ip-location.php
+++ b/tests/test-ip-location.php
@@ -1,0 +1,69 @@
+<?php
+use Gm2\Gm2_Abandoned_Carts;
+use Gm2\Gm2_Analytics_Admin;
+
+class IpLocationTest extends WP_UnitTestCase {
+    public function test_abandoned_carts_handles_non_200() {
+        $_SERVER['REMOTE_ADDR'] = '1.2.3.4';
+        $filter = function($pre, $args, $url) {
+            if (false !== strpos($url, 'ipapi.co')) {
+                return [ 'response' => ['code' => 500], 'body' => '' ];
+            }
+            return $pre;
+        };
+        add_filter('pre_http_request', $filter, 10, 3);
+        $result = Gm2_Abandoned_Carts::get_ip_and_location();
+        remove_filter('pre_http_request', $filter, 10);
+        $this->assertSame('Unknown', $result['location']);
+    }
+
+    public function test_abandoned_carts_handles_timeout() {
+        $_SERVER['REMOTE_ADDR'] = '1.2.3.4';
+        $filter = function($pre, $args, $url) {
+            if (false !== strpos($url, 'ipapi.co')) {
+                return new WP_Error('http_request_timeout', 'timeout');
+            }
+            return $pre;
+        };
+        add_filter('pre_http_request', $filter, 10, 3);
+        $result = Gm2_Abandoned_Carts::get_ip_and_location();
+        remove_filter('pre_http_request', $filter, 10);
+        $this->assertSame('Unknown', $result['location']);
+    }
+
+    public function test_analytics_handles_non_200() {
+        $admin = new Gm2_Analytics_Admin();
+        $ip = '5.6.7.8';
+        delete_transient('gm2_geo_' . md5($ip));
+        $filter = function($pre, $args, $url) {
+            if (false !== strpos($url, 'ipapi.co')) {
+                return [ 'response' => ['code' => 404], 'body' => '' ];
+            }
+            return $pre;
+        };
+        add_filter('pre_http_request', $filter, 10, 3);
+        $ref = new ReflectionMethod(Gm2_Analytics_Admin::class, 'get_ip_country');
+        $ref->setAccessible(true);
+        $country = $ref->invoke($admin, $ip);
+        remove_filter('pre_http_request', $filter, 10);
+        $this->assertSame('Unknown', $country);
+    }
+
+    public function test_analytics_handles_timeout() {
+        $admin = new Gm2_Analytics_Admin();
+        $ip = '8.7.6.5';
+        delete_transient('gm2_geo_' . md5($ip));
+        $filter = function($pre, $args, $url) {
+            if (false !== strpos($url, 'ipapi.co')) {
+                return new WP_Error('http_request_timeout', 'timeout');
+            }
+            return $pre;
+        };
+        add_filter('pre_http_request', $filter, 10, 3);
+        $ref = new ReflectionMethod(Gm2_Analytics_Admin::class, 'get_ip_country');
+        $ref->setAccessible(true);
+        $country = $ref->invoke($admin, $ip);
+        remove_filter('pre_http_request', $filter, 10);
+        $this->assertSame('Unknown', $country);
+    }
+}


### PR DESCRIPTION
## Summary
- switch all `wp_remote_get` calls to `wp_safe_remote_get` with timeouts
- verify response codes and return `'Unknown'` on failed IP lookups
- add tests covering non-200 responses and timeouts

## Testing
- `npm test`
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): Failed to open stream)*
- `make test DB_NAME=wp_test DB_USER=root DB_PASS=root` *(fails: mysqladmin command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cb30a847483279d2503e065fd3617