### PR TITLE
Add analytics request and admin log tests

### DIFF
--- a/tests/ActivityLogFilterPaginationTest.php
+++ b/tests/ActivityLogFilterPaginationTest.php
@@ -1,0 +1,67 @@
+<?php
+use WP_UnitTestCase;
+use Gm2\Gm2_Analytics_Admin;
+
+require_once dirname(__DIR__) . '/admin/Gm2_Analytics_Admin.php';
+
+class ActivityLogFilterPaginationTest extends WP_UnitTestCase {
+    private string $table;
+    private array $orig_get;
+
+    protected function setUp(): void {
+        parent::setUp();
+        global $wpdb;
+        $this->orig_get = $_GET;
+        $this->table = $wpdb->prefix . 'gm2_analytics_log';
+        $wpdb->query("DROP TABLE IF EXISTS {$this->table}");
+        $wpdb->query("CREATE TABLE {$this->table} (id bigint(20) unsigned NOT NULL AUTO_INCREMENT, session_id varchar(64) NOT NULL, user_id varchar(64) NOT NULL, url text NOT NULL, referrer text, `timestamp` datetime NOT NULL, user_agent text NOT NULL, device varchar(20) NOT NULL, ip varchar(100) NOT NULL, PRIMARY KEY(id))");
+    }
+
+    protected function tearDown(): void {
+        $_GET = $this->orig_get;
+        parent::tearDown();
+    }
+
+    public function test_filters_by_user_and_device() {
+        global $wpdb;
+        $now = gmdate('Y-m-d H:i:s');
+        $wpdb->insert($this->table, [ 'session_id' => 's1', 'user_id' => 'u1', 'url' => '/', 'referrer' => '', 'timestamp' => $now, 'user_agent' => 'UA', 'device' => 'desktop', 'ip' => '0.0.0.0' ]);
+        $wpdb->insert($this->table, [ 'session_id' => 's2', 'user_id' => 'u2', 'url' => '/two', 'referrer' => '', 'timestamp' => $now, 'user_agent' => 'UA', 'device' => 'mobile', 'ip' => '0.0.0.0' ]);
+
+        $_GET['log_user'] = 'u2';
+        $_GET['log_device'] = 'mobile';
+        $_GET['gm2_activity_log_nonce'] = wp_create_nonce('gm2_activity_log_filter');
+
+        $admin = new Gm2_Analytics_Admin();
+        $ref = new ReflectionClass(Gm2_Analytics_Admin::class);
+        $method = $ref->getMethod('render_activity_log');
+        $method->setAccessible(true);
+        ob_start();
+        $method->invoke($admin, ['start' => gmdate('Y-m-d', strtotime('-1 day')), 'end' => gmdate('Y-m-d')]);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('u2', $output);
+        $this->assertStringNotContainsString('u1', $output);
+    }
+
+    public function test_pagination_outputs_links() {
+        global $wpdb;
+        $now = gmdate('Y-m-d H:i:s');
+        for ($i = 1; $i <= 25; $i++) {
+            $wpdb->insert($this->table, [ 'session_id' => "s{$i}", 'user_id' => "u{$i}", 'url' => '/p', 'referrer' => '', 'timestamp' => $now, 'user_agent' => 'UA', 'device' => 'desktop', 'ip' => '0.0.0.0' ]);
+        }
+        $_GET['paged'] = '2';
+        $_GET['gm2_activity_log_nonce'] = wp_create_nonce('gm2_activity_log_filter');
+
+        $admin = new Gm2_Analytics_Admin();
+        $ref = new ReflectionClass(Gm2_Analytics_Admin::class);
+        $method = $ref->getMethod('render_activity_log');
+        $method->setAccessible(true);
+        ob_start();
+        $method->invoke($admin, ['start' => gmdate('Y-m-d', strtotime('-1 day')), 'end' => gmdate('Y-m-d')]);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('class="tablenav-page current">2</span>', $output);
+        $this->assertStringContainsString('paged=1', $output);
+    }
+}

--- a/tests/CronCleanupIntegrationTest.php
+++ b/tests/CronCleanupIntegrationTest.php
@@ -1,0 +1,36 @@
+<?php
+use WP_UnitTestCase;
+
+class CronCleanupIntegrationTest extends WP_UnitTestCase {
+    private string $table;
+
+    protected function setUp(): void {
+        parent::setUp();
+        global $wpdb;
+        $this->table = $wpdb->prefix . 'gm2_analytics_log';
+        $wpdb->query("DROP TABLE IF EXISTS {$this->table}");
+        $wpdb->query("CREATE TABLE {$this->table} (id bigint(20) unsigned NOT NULL AUTO_INCREMENT, session_id varchar(64) NOT NULL, user_id varchar(64) NOT NULL, url text NOT NULL, referrer text, `timestamp` datetime NOT NULL, user_agent text NOT NULL, device varchar(20) NOT NULL, ip varchar(100) NOT NULL, PRIMARY KEY(id))");
+    }
+
+    public function test_cron_event_purges_old_logs_and_unschedules_on_deactivate() {
+        global $wpdb;
+        // Schedule the purge event and ensure it exists.
+        wp_schedule_event(time() - HOUR_IN_SECONDS, 'daily', 'gm2_analytics_purge');
+        $this->assertNotFalse(wp_next_scheduled('gm2_analytics_purge'));
+
+        // Insert new and old rows.
+        $wpdb->insert($this->table, [ 'session_id' => 'new', 'user_id' => 'u1', 'url' => '/', 'referrer' => '', 'timestamp' => gmdate('Y-m-d H:i:s'), 'user_agent' => 'UA', 'device' => 'desktop', 'ip' => '0.0.0.0' ]);
+        $wpdb->insert($this->table, [ 'session_id' => 'old', 'user_id' => 'u2', 'url' => '/old', 'referrer' => '', 'timestamp' => gmdate('Y-m-d H:i:s', time() - 40 * DAY_IN_SECONDS), 'user_agent' => 'UA', 'device' => 'desktop', 'ip' => '0.0.0.0' ]);
+
+        update_option('gm2_analytics_retention_days', 30);
+        do_action('gm2_analytics_purge');
+
+        $sessions = $wpdb->get_col("SELECT session_id FROM {$this->table}");
+        sort($sessions);
+        $this->assertSame(['new'], $sessions);
+
+        // Deactivate plugin to unschedule the event.
+        gm2_deactivate_plugin();
+        $this->assertFalse(wp_next_scheduled('gm2_analytics_purge'));
+    }
+}


### PR DESCRIPTION
## Summary
- expand analytics unit tests for AJAX handling and URL/referrer logging
- add admin activity log filtering and pagination tests
- verify cron event purges old analytics logs

## Testing
- `phpunit --no-configuration tests/AnalyticsTest.php`
- `phpunit tests/ActivityLogFilterPaginationTest.php tests/CronCleanupIntegrationTest.php`


------
https://chatgpt.com/codex/tasks/task_e_689cb8a157c48327a55dbade3e462c5f