### PR TITLE
Add gettext fallback for WooCommerce login label

### DIFF
--- a/includes/Gm2_Phone_Auth.php
+++ b/includes/Gm2_Phone_Auth.php
@@ -18,6 +18,12 @@ class Gm2_Phone_Auth {
         add_filter('woocommerce_login_username_label', function ($label) {
             return __('Phone or Email or Username', 'gm2-wordpress-suite');
         }, 20);
+        add_filter('gettext', function ($translated, $original, $domain) {
+            if ('Username or email address' === $original && 'woocommerce' === $domain) {
+                return __('Phone or Email or Username', 'gm2-wordpress-suite');
+            }
+            return $translated;
+        }, 20, 3);
     }
 
     public function render_registration_phone_field() {


### PR DESCRIPTION
## Summary
- ensure WooCommerce login label can display "Phone or Email or Username" by adding gettext filter
- confirmed Elementor login widget renders WooCommerce forms so translation filter applies

## Testing
- `npm test`
- `phpunit` *(fails: Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689cd619657c8327b1df883bcd22456c