### PR TITLE
Use WordPress user ID for analytics cookie

### DIFF
--- a/includes/Gm2_Analytics.php
+++ b/includes/Gm2_Analytics.php
@@ -65,11 +65,23 @@ class Gm2_Analytics {
     }
 
     private function get_user_id() {
-        if (!isset($_COOKIE[self::COOKIE_NAME])) {
-            $id = wp_generate_uuid4();
+        $user_id = get_current_user_id();
+
+        if ($user_id) {
+            $id = (string) $user_id;
+        } else {
+            if (!isset($_COOKIE[self::COOKIE_NAME])) {
+                $id = wp_generate_uuid4();
+            } else {
+                $id = $_COOKIE[self::COOKIE_NAME];
+            }
+        }
+
+        if (!isset($_COOKIE[self::COOKIE_NAME]) || $_COOKIE[self::COOKIE_NAME] !== $id) {
             setcookie(self::COOKIE_NAME, $id, time() + YEAR_IN_SECONDS * 2, COOKIEPATH, COOKIE_DOMAIN);
             $_COOKIE[self::COOKIE_NAME] = $id;
         }
+
         return sanitize_text_field($_COOKIE[self::COOKIE_NAME]);
     }
 


### PR DESCRIPTION
## Summary
- Prefer WP user ID for analytics tracking and persist in gm2_analytics_id cookie
- Add test to verify logged-in users get cookie set to their ID

## Testing
- `npm test`
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689cdf2df2508327a197a3e968f1a2e7