### PR TITLE
Track page duration and click events

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -150,6 +150,9 @@ function gm2_activate_plugin() {
         user_agent text NOT NULL,
         device varchar(20) NOT NULL,
         ip varchar(100) NOT NULL,
+        event_type varchar(20) NOT NULL DEFAULT '',
+        duration int NOT NULL DEFAULT 0,
+        element text DEFAULT NULL,
         PRIMARY KEY  (id),
         KEY session_id (session_id),
         KEY user_id (user_id),
@@ -184,11 +187,9 @@ register_deactivation_hook(__FILE__, 'gm2_deactivate_plugin');
 function gm2_upgrade_analytics_log_index() {
     global $wpdb;
     $table_name = $wpdb->prefix . 'gm2_analytics_log';
-    $index = $wpdb->get_results("SHOW INDEX FROM $table_name WHERE Key_name = 'timestamp'");
-    if (empty($index)) {
-        $charset_collate = $wpdb->get_charset_collate();
-        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-        $sql = "CREATE TABLE $table_name (
+    $charset_collate = $wpdb->get_charset_collate();
+    require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+    $sql = "CREATE TABLE $table_name (
             id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
             session_id varchar(64) NOT NULL,
             user_id varchar(64) NOT NULL,
@@ -198,13 +199,15 @@ function gm2_upgrade_analytics_log_index() {
             user_agent text NOT NULL,
             device varchar(20) NOT NULL,
             ip varchar(100) NOT NULL,
+            event_type varchar(20) NOT NULL DEFAULT '',
+            duration int NOT NULL DEFAULT 0,
+            element text DEFAULT NULL,
             PRIMARY KEY  (id),
             KEY session_id (session_id),
             KEY user_id (user_id),
             KEY `timestamp` (`timestamp`)
         ) $charset_collate;";
-        dbDelta($sql);
-    }
+    dbDelta($sql);
 }
 add_action('plugins_loaded', 'gm2_upgrade_analytics_log_index');
 

--- a/includes/Gm2_Analytics.php
+++ b/includes/Gm2_Analytics.php
@@ -61,6 +61,9 @@ class Gm2_Analytics {
             'user_agent' => $user_agent,
             'device'     => $device,
             'ip'         => $ip,
+            'event_type' => 'pageview',
+            'duration'   => 0,
+            'element'    => '',
         ]);
     }
 
@@ -96,13 +99,16 @@ class Gm2_Analytics {
 
     public function ajax_track() {
         check_ajax_referer('gm2_analytics', 'nonce');
-        $url      = isset($_POST['url']) ? esc_url_raw(wp_unslash($_POST['url'])) : '';
-        $referrer = isset($_POST['referrer']) ? esc_url_raw(wp_unslash($_POST['referrer'])) : '';
-        $this->log_event($url, $referrer);
+        $url        = isset($_POST['url']) ? esc_url_raw(wp_unslash($_POST['url'])) : '';
+        $referrer   = isset($_POST['referrer']) ? esc_url_raw(wp_unslash($_POST['referrer'])) : '';
+        $event_type = isset($_POST['event_type']) ? sanitize_text_field(wp_unslash($_POST['event_type'])) : '';
+        $duration   = isset($_POST['duration']) ? intval($_POST['duration']) : 0;
+        $element    = isset($_POST['element']) ? sanitize_text_field(wp_unslash($_POST['element'])) : '';
+        $this->log_event($url, $referrer, $event_type, $duration, $element);
         wp_send_json_success();
     }
 
-    private function log_event($url, $referrer = '') {
+    private function log_event($url, $referrer = '', $event_type = '', $duration = 0, $element = '') {
         $user_agent = isset($_SERVER['HTTP_USER_AGENT']) ? sanitize_text_field(wp_unslash($_SERVER['HTTP_USER_AGENT'])) : '';
 
         if ($this->should_skip_logging($user_agent)) {
@@ -124,6 +130,9 @@ class Gm2_Analytics {
             'user_agent' => $user_agent,
             'device'     => $device,
             'ip'         => $ip,
+            'event_type' => $event_type,
+            'duration'   => $duration,
+            'element'    => $element,
         ]);
     }
 
@@ -158,6 +167,9 @@ class Gm2_Analytics {
                 'user_agent' => $data['user_agent'],
                 'device'     => $data['device'],
                 'ip'         => $data['ip'],
+                'event_type' => $data['event_type'],
+                'duration'   => $data['duration'],
+                'element'    => $data['element'],
             ],
             [
                 '%s',
@@ -167,6 +179,9 @@ class Gm2_Analytics {
                 '%s',
                 '%s',
                 '%s',
+                '%s',
+                '%s',
+                '%d',
                 '%s',
             ]
         );

--- a/public/js/gm2-analytics-tracker.js
+++ b/public/js/gm2-analytics-tracker.js
@@ -3,23 +3,55 @@
         if (typeof gm2Analytics === 'undefined' || !gm2Analytics.ajax_url) {
             return;
         }
-        var params = new URLSearchParams({
-            action: 'gm2_analytics_track',
-            url: window.location.href,
-            referrer: document.referrer
-        });
-        if (gm2Analytics.nonce) {
-            params.append('nonce', gm2Analytics.nonce);
-        }
-        if (navigator.sendBeacon) {
-            navigator.sendBeacon(gm2Analytics.ajax_url, params);
-        } else {
-            fetch(gm2Analytics.ajax_url, {
-                method: 'POST',
-                credentials: 'same-origin',
-                headers: {'Content-Type': 'application/x-www-form-urlencoded'},
-                body: params.toString()
+
+        var startTime = Date.now();
+
+        function send(data) {
+            var params = new URLSearchParams({
+                action: 'gm2_analytics_track',
+                url: window.location.href,
+                referrer: document.referrer
             });
+            if (gm2Analytics.nonce) {
+                params.append('nonce', gm2Analytics.nonce);
+            }
+            for (var key in data) {
+                if (Object.prototype.hasOwnProperty.call(data, key) && data[key] !== undefined && data[key] !== null) {
+                    params.append(key, data[key]);
+                }
+            }
+            if (navigator.sendBeacon) {
+                navigator.sendBeacon(gm2Analytics.ajax_url, params);
+            } else {
+                fetch(gm2Analytics.ajax_url, {
+                    method: 'POST',
+                    credentials: 'same-origin',
+                    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+                    body: params.toString()
+                });
+            }
         }
+
+        function handleVisibility() {
+            if (document.visibilityState === 'hidden') {
+                var duration = Math.round((Date.now() - startTime) / 1000);
+                send({ event_type: 'pageview', duration: duration });
+            }
+        }
+
+        document.addEventListener('visibilitychange', handleVisibility);
+        window.addEventListener('pagehide', handleVisibility);
+
+        document.addEventListener('click', function(e){
+            var el = e.target;
+            while (el && el.tagName !== 'A') {
+                el = el.parentElement;
+            }
+            if (!el || el.tagName !== 'A') {
+                return;
+            }
+            var identifier = el.getAttribute('href') || el.getAttribute('id') || el.getAttribute('class') || '';
+            send({ event_type: 'click', element: identifier });
+        }, true);
     });
 })();

--- a/tests/ActivityLogFilterPaginationTest.php
+++ b/tests/ActivityLogFilterPaginationTest.php
@@ -14,7 +14,7 @@ class ActivityLogFilterPaginationTest extends WP_UnitTestCase {
         $this->orig_get = $_GET;
         $this->table = $wpdb->prefix . 'gm2_analytics_log';
         $wpdb->query("DROP TABLE IF EXISTS {$this->table}");
-        $wpdb->query("CREATE TABLE {$this->table} (id bigint(20) unsigned NOT NULL AUTO_INCREMENT, session_id varchar(64) NOT NULL, user_id varchar(64) NOT NULL, url text NOT NULL, referrer text, `timestamp` datetime NOT NULL, user_agent text NOT NULL, device varchar(20) NOT NULL, ip varchar(100) NOT NULL, PRIMARY KEY(id))");
+        $wpdb->query("CREATE TABLE {$this->table} (id bigint(20) unsigned NOT NULL AUTO_INCREMENT, session_id varchar(64) NOT NULL, user_id varchar(64) NOT NULL, url text NOT NULL, referrer text, `timestamp` datetime NOT NULL, user_agent text NOT NULL, device varchar(20) NOT NULL, ip varchar(100) NOT NULL, event_type varchar(20) NOT NULL DEFAULT '', duration int NOT NULL DEFAULT 0, element text, PRIMARY KEY(id))");
     }
 
     protected function tearDown(): void {
@@ -25,8 +25,8 @@ class ActivityLogFilterPaginationTest extends WP_UnitTestCase {
     public function test_filters_by_user_and_device() {
         global $wpdb;
         $now = gmdate('Y-m-d H:i:s');
-        $wpdb->insert($this->table, [ 'session_id' => 's1', 'user_id' => 'u1', 'url' => '/', 'referrer' => '', 'timestamp' => $now, 'user_agent' => 'UA', 'device' => 'desktop', 'ip' => '0.0.0.0' ]);
-        $wpdb->insert($this->table, [ 'session_id' => 's2', 'user_id' => 'u2', 'url' => '/two', 'referrer' => '', 'timestamp' => $now, 'user_agent' => 'UA', 'device' => 'mobile', 'ip' => '0.0.0.0' ]);
+        $wpdb->insert($this->table, [ 'session_id' => 's1', 'user_id' => 'u1', 'url' => '/', 'referrer' => '', 'timestamp' => $now, 'user_agent' => 'UA', 'device' => 'desktop', 'ip' => '0.0.0.0', 'event_type' => 'pageview', 'duration' => 0, 'element' => '' ]);
+        $wpdb->insert($this->table, [ 'session_id' => 's2', 'user_id' => 'u2', 'url' => '/two', 'referrer' => '', 'timestamp' => $now, 'user_agent' => 'UA', 'device' => 'mobile', 'ip' => '0.0.0.0', 'event_type' => 'pageview', 'duration' => 0, 'element' => '' ]);
 
         $_GET['log_user'] = 'u2';
         $_GET['log_device'] = 'mobile';
@@ -48,7 +48,7 @@ class ActivityLogFilterPaginationTest extends WP_UnitTestCase {
         global $wpdb;
         $now = gmdate('Y-m-d H:i:s');
         for ($i = 1; $i <= 25; $i++) {
-            $wpdb->insert($this->table, [ 'session_id' => "s{$i}", 'user_id' => "u{$i}", 'url' => '/p', 'referrer' => '', 'timestamp' => $now, 'user_agent' => 'UA', 'device' => 'desktop', 'ip' => '0.0.0.0' ]);
+            $wpdb->insert($this->table, [ 'session_id' => "s{$i}", 'user_id' => "u{$i}", 'url' => '/p', 'referrer' => '', 'timestamp' => $now, 'user_agent' => 'UA', 'device' => 'desktop', 'ip' => '0.0.0.0', 'event_type' => 'pageview', 'duration' => 0, 'element' => '' ]);
         }
         $_GET['paged'] = '2';
         $_GET['gm2_activity_log_nonce'] = wp_create_nonce('gm2_activity_log_filter');

--- a/tests/AnalyticsRetentionTest.php
+++ b/tests/AnalyticsRetentionTest.php
@@ -6,7 +6,7 @@ class AnalyticsRetentionTest extends WP_UnitTestCase {
         global $wpdb;
         $table = $wpdb->prefix . 'gm2_analytics_log';
         $wpdb->query("DROP TABLE IF EXISTS $table");
-        $wpdb->query("CREATE TABLE $table (id bigint(20) unsigned NOT NULL AUTO_INCREMENT, session_id varchar(64) NOT NULL, user_id varchar(64) NOT NULL, url text NOT NULL, referrer text, `timestamp` datetime NOT NULL, user_agent text NOT NULL, device varchar(20) NOT NULL, ip varchar(100) NOT NULL, PRIMARY KEY(id))");
+        $wpdb->query("CREATE TABLE $table (id bigint(20) unsigned NOT NULL AUTO_INCREMENT, session_id varchar(64) NOT NULL, user_id varchar(64) NOT NULL, url text NOT NULL, referrer text, `timestamp` datetime NOT NULL, user_agent text NOT NULL, device varchar(20) NOT NULL, ip varchar(100) NOT NULL, event_type varchar(20) NOT NULL DEFAULT '', duration int NOT NULL DEFAULT 0, element text, PRIMARY KEY(id))");
 
         $wpdb->insert($table, [
             'session_id' => 'new',
@@ -17,6 +17,9 @@ class AnalyticsRetentionTest extends WP_UnitTestCase {
             'user_agent' => 'UA',
             'device' => 'desktop',
             'ip' => '0.0.0.0',
+            'event_type' => 'pageview',
+            'duration' => 0,
+            'element' => '',
         ]);
         $wpdb->insert($table, [
             'session_id' => 'old',
@@ -27,6 +30,9 @@ class AnalyticsRetentionTest extends WP_UnitTestCase {
             'user_agent' => 'UA',
             'device' => 'desktop',
             'ip' => '0.0.0.0',
+            'event_type' => 'pageview',
+            'duration' => 0,
+            'element' => '',
         ]);
 
         update_option('gm2_analytics_retention_days', 30);

--- a/tests/CronCleanupIntegrationTest.php
+++ b/tests/CronCleanupIntegrationTest.php
@@ -9,7 +9,7 @@ class CronCleanupIntegrationTest extends WP_UnitTestCase {
         global $wpdb;
         $this->table = $wpdb->prefix . 'gm2_analytics_log';
         $wpdb->query("DROP TABLE IF EXISTS {$this->table}");
-        $wpdb->query("CREATE TABLE {$this->table} (id bigint(20) unsigned NOT NULL AUTO_INCREMENT, session_id varchar(64) NOT NULL, user_id varchar(64) NOT NULL, url text NOT NULL, referrer text, `timestamp` datetime NOT NULL, user_agent text NOT NULL, device varchar(20) NOT NULL, ip varchar(100) NOT NULL, PRIMARY KEY(id))");
+        $wpdb->query("CREATE TABLE {$this->table} (id bigint(20) unsigned NOT NULL AUTO_INCREMENT, session_id varchar(64) NOT NULL, user_id varchar(64) NOT NULL, url text NOT NULL, referrer text, `timestamp` datetime NOT NULL, user_agent text NOT NULL, device varchar(20) NOT NULL, ip varchar(100) NOT NULL, event_type varchar(20) NOT NULL DEFAULT '', duration int NOT NULL DEFAULT 0, element text, PRIMARY KEY(id))");
     }
 
     public function test_cron_event_purges_old_logs_and_unschedules_on_deactivate() {
@@ -19,8 +19,8 @@ class CronCleanupIntegrationTest extends WP_UnitTestCase {
         $this->assertNotFalse(wp_next_scheduled('gm2_analytics_purge'));
 
         // Insert new and old rows.
-        $wpdb->insert($this->table, [ 'session_id' => 'new', 'user_id' => 'u1', 'url' => '/', 'referrer' => '', 'timestamp' => gmdate('Y-m-d H:i:s'), 'user_agent' => 'UA', 'device' => 'desktop', 'ip' => '0.0.0.0' ]);
-        $wpdb->insert($this->table, [ 'session_id' => 'old', 'user_id' => 'u2', 'url' => '/old', 'referrer' => '', 'timestamp' => gmdate('Y-m-d H:i:s', time() - 40 * DAY_IN_SECONDS), 'user_agent' => 'UA', 'device' => 'desktop', 'ip' => '0.0.0.0' ]);
+        $wpdb->insert($this->table, [ 'session_id' => 'new', 'user_id' => 'u1', 'url' => '/', 'referrer' => '', 'timestamp' => gmdate('Y-m-d H:i:s'), 'user_agent' => 'UA', 'device' => 'desktop', 'ip' => '0.0.0.0', 'event_type' => 'pageview', 'duration' => 0, 'element' => '' ]);
+        $wpdb->insert($this->table, [ 'session_id' => 'old', 'user_id' => 'u2', 'url' => '/old', 'referrer' => '', 'timestamp' => gmdate('Y-m-d H:i:s', time() - 40 * DAY_IN_SECONDS), 'user_agent' => 'UA', 'device' => 'desktop', 'ip' => '0.0.0.0', 'event_type' => 'pageview', 'duration' => 0, 'element' => '' ]);
 
         update_option('gm2_analytics_retention_days', 30);
         do_action('gm2_analytics_purge');


### PR DESCRIPTION
## Summary
- track time on page and clicks in front-end analytics tracker
- log event type, duration, and element on server side
- expand analytics log table schema with event_type, duration, element

## Testing
- `npm test`
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689ce0ddaaf483278915bae55a2962cd