### PR TITLE
Group analytics logs by user with expandable event details

### DIFF
--- a/admin/Gm2_Analytics_Admin.php
+++ b/admin/Gm2_Analytics_Admin.php
@@ -86,16 +86,27 @@ class Gm2_Analytics_Admin {
         $per_page = 20;
         $paged = isset($_GET['paged']) ? max(1, absint($_GET['paged'])) : 1;
         $offset = ($paged - 1) * $per_page;
-        $where  = $wpdb->prepare("`timestamp` BETWEEN %s AND %s", $data['start'] . ' 00:00:00', $data['end'] . ' 23:59:59');
+
+        $base_where = $wpdb->prepare("`timestamp` BETWEEN %s AND %s", $data['start'] . ' 00:00:00', $data['end'] . ' 23:59:59');
         $user_filter = isset($_GET['log_user']) ? sanitize_text_field(wp_unslash($_GET['log_user'])) : '';
         $device_filter = isset($_GET['log_device']) ? sanitize_text_field(wp_unslash($_GET['log_device'])) : '';
-        if ($user_filter !== '') {
-            $where .= $wpdb->prepare(" AND user_id = %s", $user_filter);
-        }
+
         if ($device_filter !== '') {
-            $where .= $wpdb->prepare(" AND device = %s", $device_filter);
+            $base_where .= $wpdb->prepare(" AND device = %s", $device_filter);
         }
-        $logs = $wpdb->get_results("SELECT * FROM $table WHERE $where ORDER BY `timestamp` DESC LIMIT $per_page OFFSET $offset");
+
+        $summary_where = $base_where;
+        if ($user_filter !== '') {
+            $summary_where .= $wpdb->prepare(" AND user_id = %s", $user_filter);
+        }
+
+        $summary_sql = $wpdb->prepare(
+            "SELECT user_id, COUNT(*) AS events, COUNT(DISTINCT session_id) AS sessions, MAX(`timestamp`) AS last_time FROM $table WHERE $summary_where GROUP BY user_id ORDER BY last_time DESC LIMIT %d OFFSET %d",
+            $per_page,
+            $offset
+        );
+        $groups = $wpdb->get_results($summary_sql);
+
         echo '<h2>' . esc_html__('Activity Log', 'gm2-wordpress-suite') . '</h2>';
         echo '<form method="get"><input type="hidden" name="page" value="gm2-analytics" />';
         wp_nonce_field('gm2_activity_log_filter', 'gm2_activity_log_nonce');
@@ -105,16 +116,34 @@ class Gm2_Analytics_Admin {
         echo '<label>' . esc_html__('Device', 'gm2-wordpress-suite') . ': <select name="log_device"><option value="">' . esc_html__('All', 'gm2-wordpress-suite') . '</option><option value="desktop"' . selected($device_filter, 'desktop', false) . '>' . esc_html__('Desktop', 'gm2-wordpress-suite') . '</option><option value="mobile"' . selected($device_filter, 'mobile', false) . '>' . esc_html__('Mobile', 'gm2-wordpress-suite') . '</option></select></label> ';
         submit_button(esc_html__('Apply', 'gm2-wordpress-suite'), 'secondary', '', false);
         echo '</form>';
-        echo '<table class="widefat fixed"><thead><tr><th>' . esc_html__('Time', 'gm2-wordpress-suite') . '</th><th>' . esc_html__('Session', 'gm2-wordpress-suite') . '</th><th>' . esc_html__('User', 'gm2-wordpress-suite') . '</th><th>' . esc_html__('Device', 'gm2-wordpress-suite') . '</th><th>' . esc_html__('URL', 'gm2-wordpress-suite') . '</th><th>' . esc_html__('Referrer', 'gm2-wordpress-suite') . '</th></tr></thead><tbody>';
-        if ($logs) {
-            foreach ($logs as $log) {
-                echo '<tr><td>' . esc_html($log->timestamp) . '</td><td>' . esc_html($log->session_id) . '</td><td>' . esc_html($log->user_id) . '</td><td>' . esc_html($log->device) . '</td><td>' . esc_html($log->url) . '</td><td>' . esc_html($log->referrer) . '</td></tr>';
+
+        echo '<table class="widefat fixed gm2-activity-summary"><thead><tr><th></th><th>' . esc_html__('User', 'gm2-wordpress-suite') . '</th><th>' . esc_html__('Sessions', 'gm2-wordpress-suite') . '</th><th>' . esc_html__('Events', 'gm2-wordpress-suite') . '</th></tr></thead><tbody>';
+        if ($groups) {
+            foreach ($groups as $group) {
+                $uid      = $group->user_id;
+                $uid_attr = sanitize_title($uid);
+                echo '<tr class="gm2-summary-row"><td><button type="button" class="gm2-toggle-user-events" data-target="' . esc_attr($uid_attr) . '">+</button></td><td>' . esc_html($uid) . '</td><td>' . intval($group->sessions) . '</td><td>' . intval($group->events) . '</td></tr>';
+
+                $event_where = $base_where . $wpdb->prepare(" AND user_id = %s", $uid);
+                $events = $wpdb->get_results("SELECT `timestamp`, url, duration, event_type, element FROM $table WHERE $event_where ORDER BY `timestamp` DESC");
+
+                echo '<tr id="gm2-events-' . esc_attr($uid_attr) . '" class="gm2-user-events" style="display:none"><td colspan="4"><table class="widefat"><thead><tr><th>' . esc_html__('Time', 'gm2-wordpress-suite') . '</th><th>' . esc_html__('URL', 'gm2-wordpress-suite') . '</th><th>' . esc_html__('Duration', 'gm2-wordpress-suite') . '</th><th>' . esc_html__('Clicks', 'gm2-wordpress-suite') . '</th></tr></thead><tbody>';
+                if ($events) {
+                    foreach ($events as $event) {
+                        $click = $event->event_type === 'click' ? $event->element : '';
+                        echo '<tr><td>' . esc_html($event->timestamp) . '</td><td>' . esc_html($event->url) . '</td><td>' . intval($event->duration) . '</td><td>' . esc_html($click) . '</td></tr>';
+                    }
+                } else {
+                    echo '<tr><td colspan="4">' . esc_html__('No activity found.', 'gm2-wordpress-suite') . '</td></tr>';
+                }
+                echo '</tbody></table></td></tr>';
             }
         } else {
-            echo '<tr><td colspan="6">' . esc_html__('No activity found.', 'gm2-wordpress-suite') . '</td></tr>';
+            echo '<tr><td colspan="4">' . esc_html__('No activity found.', 'gm2-wordpress-suite') . '</td></tr>';
         }
         echo '</tbody></table>';
-        $total = (int) $wpdb->get_var("SELECT COUNT(*) FROM $table WHERE $where");
+
+        $total = (int) $wpdb->get_var("SELECT COUNT(DISTINCT user_id) FROM $table WHERE $summary_where");
         $total_pages = ceil($total / $per_page);
         if ($total_pages > 1) {
             $base_url = remove_query_arg('paged');

--- a/admin/js/gm2-analytics.js
+++ b/admin/js/gm2-analytics.js
@@ -89,5 +89,10 @@ jQuery(function($){
             });
         }
     }
+
+    $(document).on('click', '.gm2-toggle-user-events', function(){
+        var target = $(this).data('target');
+        $('#gm2-events-' + target).toggle();
+    });
 });
 


### PR DESCRIPTION
## Summary
- Group activity log by user and show sessions/events in an expandable summary table
- Add client-side toggle to reveal per-user event details

## Testing
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): No such file or directory)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ce35ffe8883278a3efdc1f08f2737