### PR TITLE
Improve Elementor edit mode detection

### DIFF
--- a/public/Gm2_Public.php
+++ b/public/Gm2_Public.php
@@ -45,8 +45,11 @@ class Gm2_Public {
         );
 
         $in_edit_mode = false;
-        if (class_exists('\\Elementor\\Plugin') && \Elementor\Plugin::$instance->editor) {
-            $in_edit_mode = \Elementor\Plugin::$instance->editor->is_edit_mode();
+        if ( class_exists( '\\Elementor\\Plugin' ) ) {
+            $elementor = \Elementor\Plugin::instance();
+            if ( $elementor && isset( $elementor->editor ) && method_exists( $elementor->editor, 'is_edit_mode' ) ) {
+                $in_edit_mode = $elementor->editor->is_edit_mode();
+            }
         }
 
         if ((function_exists('is_product') && is_product()) || $in_edit_mode) {


### PR DESCRIPTION
## Summary
- handle Elementors editor presence before calling is_edit_mode in enqueue_scripts

## Testing
- `npm test`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_689cf3b1bdb083278471ae5e0411f3a4