### PR TITLE
Check Elementor preview and edit modes in login widget

### DIFF
--- a/includes/widgets/class-gm2-registration-login-widget.php
+++ b/includes/widgets/class-gm2-registration-login-widget.php
@@ -359,9 +359,15 @@ class GM2_Registration_Login_Widget extends \Elementor\Widget_Base {
     protected function render() {
         $in_edit_mode = false;
         if ( class_exists( '\\Elementor\\Plugin' ) ) {
-            $elementor = \Elementor\Plugin::instance(); // safe getter
-            if ( $elementor && isset( $elementor->editor ) && method_exists( $elementor->editor, 'is_edit_mode' ) ) {
-                $in_edit_mode = $elementor->editor->is_edit_mode();
+            $plugin = \Elementor\Plugin::$instance;
+            if ( $plugin ) {
+                if ( isset( $plugin->editor ) && method_exists( $plugin->editor, 'is_edit_mode' )
+                    && $plugin->editor->is_edit_mode() ) {
+                    $in_edit_mode = true;
+                } elseif ( isset( $plugin->preview ) && method_exists( $plugin->preview, 'is_preview_mode' )
+                    && $plugin->preview->is_preview_mode() ) {
+                    $in_edit_mode = true;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- Detect Elementor editor edit mode and preview mode to control login widget rendering

## Testing
- `php -l includes/widgets/class-gm2-registration-login-widget.php`
- `npm test`
- `phpunit` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689cf864602883278664f2cedbd68119