### PR TITLE
Load Chart.js before analytics scripts

### DIFF
--- a/admin/Gm2_Analytics_Admin.php
+++ b/admin/Gm2_Analytics_Admin.php
@@ -29,9 +29,16 @@ class Gm2_Analytics_Admin {
         }
         $this->data = $this->get_analytics_data();
         wp_enqueue_script(
+            'chart-js',
+            'https://cdn.jsdelivr.net/npm/chart.js',
+            [],
+            '4.4.2',
+            true
+        );
+        wp_enqueue_script(
             'gm2-analytics',
             GM2_PLUGIN_URL . 'admin/js/gm2-analytics.js',
-            [ 'jquery' ],
+            [ 'jquery', 'chart-js' ],
             file_exists( GM2_PLUGIN_DIR . 'admin/js/gm2-analytics.js' ) ? filemtime( GM2_PLUGIN_DIR . 'admin/js/gm2-analytics.js' ) : GM2_VERSION,
             true
         );

--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -927,6 +927,20 @@ class Gm2_SEO_Admin {
                 $queries = $oauth->get_search_console_metrics($site, $limit);
                 $metrics = $oauth->get_analytics_metrics($prop, $days);
                 $trends  = $oauth->get_analytics_trends($prop, $days);
+                wp_enqueue_script(
+                    'chart-js',
+                    'https://cdn.jsdelivr.net/npm/chart.js',
+                    [],
+                    '4.4.2',
+                    true
+                );
+                wp_enqueue_script(
+                    'gm2-analytics',
+                    GM2_PLUGIN_URL . 'admin/js/gm2-analytics.js',
+                    [ 'jquery', 'chart-js' ],
+                    file_exists( GM2_PLUGIN_DIR . 'admin/js/gm2-analytics.js' ) ? filemtime( GM2_PLUGIN_DIR . 'admin/js/gm2-analytics.js' ) : GM2_VERSION,
+                    true
+                );
                 wp_localize_script(
                     'gm2-analytics',
                     'gm2Analytics',


### PR DESCRIPTION
## Summary
- enqueue Chart.js from CDN and declare it as dependency for gm2-analytics.js
- load Chart.js and gm2-analytics.js when analytics tab is viewed in SEO admin

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cf5391754832789299491b471230e