### PR TITLE
Load login widget assets during Elementor previews

### DIFF
--- a/public/Gm2_Public.php
+++ b/public/Gm2_Public.php
@@ -46,9 +46,15 @@ class Gm2_Public {
 
         $in_edit_mode = false;
         if ( class_exists( '\\Elementor\\Plugin' ) ) {
-            $elementor = \Elementor\Plugin::instance();
-            if ( $elementor && isset( $elementor->editor ) && method_exists( $elementor->editor, 'is_edit_mode' ) ) {
-                $in_edit_mode = $elementor->editor->is_edit_mode();
+            $plugin = \Elementor\Plugin::$instance;
+            if ( $plugin ) {
+                if ( isset( $plugin->editor ) && method_exists( $plugin->editor, 'is_edit_mode' )
+                    && $plugin->editor->is_edit_mode() ) {
+                    $in_edit_mode = true;
+                } elseif ( isset( $plugin->preview ) && method_exists( $plugin->preview, 'is_preview_mode' )
+                    && $plugin->preview->is_preview_mode() ) {
+                    $in_edit_mode = true;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- ensure public scripts load when Elementor preview is active by checking editor and preview modes

## Testing
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cf9196f3083279e29ef43ee17e955