### PR TITLE
Handle Elementor preview when enqueueing scripts

### DIFF
--- a/public/Gm2_Public.php
+++ b/public/Gm2_Public.php
@@ -46,16 +46,19 @@ class Gm2_Public {
 
         $in_edit_mode = false;
         if ( class_exists( '\\Elementor\\Plugin' ) ) {
-            $plugin = \Elementor\Plugin::$instance;
-            if ( $plugin ) {
-                if ( isset( $plugin->editor ) && method_exists( $plugin->editor, 'is_edit_mode' )
-                    && $plugin->editor->is_edit_mode() ) {
+            $elementor = \Elementor\Plugin::instance();
+            if ( $elementor ) {
+                if ( isset( $elementor->editor ) && method_exists( $elementor->editor, 'is_edit_mode' )
+                    && $elementor->editor->is_edit_mode() ) {
                     $in_edit_mode = true;
-                } elseif ( isset( $plugin->preview ) && method_exists( $plugin->preview, 'is_preview_mode' )
-                    && $plugin->preview->is_preview_mode() ) {
+                } elseif ( isset( $elementor->preview ) && method_exists( $elementor->preview, 'is_preview_mode' )
+                    && $elementor->preview->is_preview_mode() ) {
                     $in_edit_mode = true;
                 }
             }
+        }
+        if ( ! $in_edit_mode && isset( $_GET['elementor-preview'] ) ) {
+            $in_edit_mode = true;
         }
 
         if ((function_exists('is_product') && is_product()) || $in_edit_mode) {


### PR DESCRIPTION
## Summary
- Detect Elementor preview mode when enqueueing widget assets so forms render during design

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cfdd4aec88327a8e6bd48c9c12a91