### PR TITLE
Add WooCommerce register form fallback

### DIFF
--- a/includes/widgets/class-gm2-registration-login-widget.php
+++ b/includes/widgets/class-gm2-registration-login-widget.php
@@ -400,7 +400,11 @@ class GM2_Registration_Login_Widget extends \Elementor\Widget_Base {
         }
         if ( $settings['show_register_form'] === 'yes' ) {
             echo '<div class="gm2-register-form" style="display:none">';
-            woocommerce_register_form();
+            if ( function_exists( 'woocommerce_register_form' ) ) {
+                \woocommerce_register_form();
+            } else {
+                do_action( 'woocommerce_register_form' );
+            }
             echo '</div>';
         }
         if ( $settings['show_google'] === 'yes' && apply_filters( 'gm2_sitekit_login_enabled', true ) && class_exists( 'Google\\Site_Kit\\Plugin' ) ) {


### PR DESCRIPTION
## Summary
- prevent fatal error when WooCommerce helper `woocommerce_register_form` is missing by falling back to `do_action`

## Testing
- `npm test`
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689d030169d08327b50962c9b498103e