### PR TITLE
Enable phone or email based WooCommerce registration

### DIFF
--- a/public/js/gm2-login-widget.js
+++ b/public/js/gm2-login-widget.js
@@ -8,6 +8,8 @@ jQuery(function($){
     if($wrap.data('show-remember') === 'no'){
       $wrap.find('input[name="rememberme"]').closest('p').hide();
     }
+    // Hide the default WooCommerce email field in the registration form
+    $wrap.find('.gm2-register-form input[type="email"]').closest('p').hide();
     $wrap.on('click','.gm2-show-register',function(e){e.preventDefault();$wrap.find('.gm2-login-form').hide().removeClass('active');$wrap.find('.gm2-register-form').show().addClass('active');});
     $wrap.on('click','.gm2-show-login',function(e){e.preventDefault();$wrap.find('.gm2-register-form').hide().removeClass('active');$wrap.find('.gm2-login-form').show().addClass('active');});
   });

--- a/tests/PhoneAuthRegistrationTest.php
+++ b/tests/PhoneAuthRegistrationTest.php
@@ -1,0 +1,49 @@
+<?php
+use Gm2\Gm2_Phone_Auth;
+
+if (!function_exists('wc_clean')) {
+    function wc_clean($var) {
+        return is_array($var) ? array_map('wc_clean', $var) : sanitize_text_field($var);
+    }
+}
+
+class PhoneAuthRegistrationTest extends WP_UnitTestCase {
+    protected $auth;
+
+    public function setUp(): void {
+        parent::setUp();
+        $this->auth = new Gm2_Phone_Auth();
+    }
+
+    public function test_registration_with_email() {
+        $_POST['contact'] = 'user@example.com';
+        $errors = new \WP_Error();
+        $errors = $this->auth->validate_contact_field('', '', $errors);
+        $this->assertFalse($errors->has_errors());
+        $this->assertSame('user@example.com', $_POST['email']);
+        $data = $this->auth->assign_contact_field([]);
+        $this->assertSame('user@example.com', $data['user_email']);
+        $this->assertArrayNotHasKey('meta_input', $data);
+    }
+
+    public function test_registration_with_phone_and_login() {
+        $_POST['contact'] = '+1234567890';
+        $errors = new \WP_Error();
+        $errors = $this->auth->validate_contact_field('', '', $errors);
+        $this->assertFalse($errors->has_errors());
+        $this->assertSame('+1234567890', $_POST['billing_phone']);
+        $this->assertSame('+1234567890@example.com', $_POST['email']);
+        $data = $this->auth->assign_contact_field([]);
+        $this->assertSame('+1234567890@example.com', $data['user_email']);
+        $this->assertSame('+1234567890', $data['meta_input']['billing_phone']);
+        $user_id = wp_insert_user([
+            'user_login' => 'phoneuser',
+            'user_pass'  => 'pass',
+            'user_email' => $data['user_email'],
+        ]);
+        update_user_meta($user_id, 'billing_phone', '+1234567890');
+        $user = $this->auth->authenticate(null, '+1234567890', 'pass');
+        $this->assertInstanceOf(\WP_User::class, $user);
+        $this->assertSame($user_id, $user->ID);
+    }
+}


### PR DESCRIPTION
## Summary
- remove WooCommerce's default email field and inject a single "Phone or Email" input for registration
- hide the core email input in the login widget script
- add tests covering registration using either an email address or phone number

## Testing
- `npm test`
- `vendor/bin/phpunit -- tests/PhoneAuthRegistrationTest.php` *(fails: Call to undefined method PHPUnit\Util\Test::parseTestMethodAnnotations())*

------
https://chatgpt.com/codex/tasks/task_e_689d0baccf208327b90c553103b6fc1b