### PR TITLE
Fix Elementor class_exists namespace escapes

### DIFF
--- a/includes/Gm2_Elementor_Quantity_Discounts.php
+++ b/includes/Gm2_Elementor_Quantity_Discounts.php
@@ -22,12 +22,12 @@ class Gm2_Elementor_Quantity_Discounts {
     }
 
     public function register_widget( $widgets_manager = null ) {
-        if ( $widgets_manager === null && class_exists( '\\Elementor\\Plugin' ) ) {
+        if ( $widgets_manager === null && class_exists( '\Elementor\Plugin' ) ) {
             $widgets_manager = \Elementor\Plugin::$instance->widgets_manager;
         }
 
         // Only load the widget class if Elementor's Widget_Base exists.
-        if ( ! class_exists( '\\Elementor\\Widget_Base' ) ) {
+        if ( ! class_exists( '\Elementor\Widget_Base' ) ) {
             return;
         }
 

--- a/includes/Gm2_Elementor_Registration_Login.php
+++ b/includes/Gm2_Elementor_Registration_Login.php
@@ -20,10 +20,10 @@ class Gm2_Elementor_Registration_Login {
     }
 
     public function register_widget( $widgets_manager = null ) {
-        if ( $widgets_manager === null && class_exists( '\\Elementor\\Plugin' ) ) {
+        if ( $widgets_manager === null && class_exists( '\Elementor\Plugin' ) ) {
             $widgets_manager = \Elementor\Plugin::$instance->widgets_manager;
         }
-        if ( ! class_exists( '\\Elementor\\Widget_Base' ) ) {
+        if ( ! class_exists( '\Elementor\Widget_Base' ) ) {
             return;
         }
         if ( ! class_exists( GM2_Registration_Login_Widget::class ) ) {

--- a/includes/widgets/class-gm2-qd-widget.php
+++ b/includes/widgets/class-gm2-qd-widget.php
@@ -5,7 +5,7 @@ use Elementor\Icons_Manager;
 
 if (!defined('ABSPATH')) { exit; }
 
-if ( class_exists( '\\Elementor\\Widget_Base' ) ) {
+if ( class_exists( '\Elementor\Widget_Base' ) ) {
 class GM2_QD_Widget extends \Elementor\Widget_Base {
     public function get_name() {
         return 'gm2_quantity_discounts';
@@ -573,7 +573,7 @@ class GM2_QD_Widget extends \Elementor\Widget_Base {
 
     protected function render() {
         $in_edit_mode = false;
-        if ( class_exists( '\\Elementor\\Plugin' ) && \Elementor\Plugin::$instance->editor ) {
+        if ( class_exists( '\Elementor\Plugin' ) && \Elementor\Plugin::$instance->editor ) {
             $in_edit_mode = \Elementor\Plugin::$instance->editor->is_edit_mode();
         }
 

--- a/includes/widgets/class-gm2-registration-login-widget.php
+++ b/includes/widgets/class-gm2-registration-login-widget.php
@@ -9,7 +9,7 @@ use Elementor\Group_Control_Border;
 use Elementor\Group_Control_Box_Shadow;
 use Elementor\Group_Control_Typography;
 
-if ( class_exists('\\Elementor\\Widget_Base') ) {
+if ( class_exists('\Elementor\Widget_Base') ) {
 class GM2_Registration_Login_Widget extends \Elementor\Widget_Base {
     public function get_name() {
         return 'gm2_registration_login';
@@ -359,7 +359,7 @@ class GM2_Registration_Login_Widget extends \Elementor\Widget_Base {
     protected function render() {
         $in_edit_mode = (
             ( defined( 'ELEMENTOR_EDITOR' ) && ELEMENTOR_EDITOR ) ||
-            ( class_exists( '\\Elementor\\Plugin' )
+            ( class_exists( '\Elementor\Plugin' )
               && ( ( $p = \Elementor\Plugin::instance() )
                    && ( ( isset( $p->editor ) && method_exists( $p->editor, 'is_edit_mode' ) && $p->editor->is_edit_mode() )
                         || ( isset( $p->preview ) && method_exists( $p->preview, 'is_preview_mode' ) && $p->preview->is_preview_mode() ) ) ) )

--- a/tests/test-quantity-discounts.php
+++ b/tests/test-quantity-discounts.php
@@ -192,7 +192,7 @@ class QuantityDiscountsTest extends WP_UnitTestCase {
     public function test_widget_renders_in_edit_mode() {
         require_once GM2_PLUGIN_DIR . 'includes/widgets/class-gm2-qd-widget.php';
 
-        if ( ! class_exists( '\\Elementor\\Plugin' ) ) {
+        if ( ! class_exists( '\Elementor\Plugin' ) ) {
             eval('namespace Elementor; class Plugin { public static $instance; public $editor; public function __construct(){ self::$instance = $this; $this->editor = new class { public function is_edit_mode(){ return true; } }; } }');
         } else {
             \Elementor\Plugin::$instance = new class { public $editor; public function __construct(){ $this->editor = new class { public function is_edit_mode(){ return true; } }; } };
@@ -220,7 +220,7 @@ class QuantityDiscountsTest extends WP_UnitTestCase {
     public function test_widget_renders_with_preview_id() {
         require_once GM2_PLUGIN_DIR . 'includes/widgets/class-gm2-qd-widget.php';
 
-        if ( ! class_exists( '\\Elementor\\Plugin' ) ) {
+        if ( ! class_exists( '\Elementor\Plugin' ) ) {
             eval('namespace Elementor; class Plugin { public static $instance; public $editor; public function __construct(){ self::$instance = $this; $this->editor = new class { public function is_edit_mode(){ return true; } }; } }');
         } else {
             \Elementor\Plugin::$instance = new class { public $editor; public function __construct(){ $this->editor = new class { public function is_edit_mode(){ return true; } }; } };
@@ -251,7 +251,7 @@ class QuantityDiscountsTest extends WP_UnitTestCase {
     public function test_widget_outputs_br_in_label() {
         require_once GM2_PLUGIN_DIR . 'includes/widgets/class-gm2-qd-widget.php';
 
-        if ( ! class_exists( '\\Elementor\\Plugin' ) ) {
+        if ( ! class_exists( '\Elementor\Plugin' ) ) {
             eval('namespace Elementor; class Plugin { public static $instance; public $editor; public function __construct(){ self::$instance = $this; $this->editor = new class { public function is_edit_mode(){ return true; } }; } }');
         } else {
             \Elementor\Plugin::$instance = new class { public $editor; public function __construct(){ $this->editor = new class { public function is_edit_mode(){ return true; } }; } };


### PR DESCRIPTION
## Summary
- Ensure Elementor classes use single-escaped names in `class_exists` checks
- Update widgets and tests to reference `\Elementor` correctly

## Testing
- `phpunit` *(fails: Missing WordPress test suite)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d0db40f3c832795c0fcc2e05ef9e3