### PR TITLE
Allow editors to bypass login widget guard

### DIFF
--- a/includes/widgets/class-gm2-registration-login-widget.php
+++ b/includes/widgets/class-gm2-registration-login-widget.php
@@ -365,9 +365,10 @@ class GM2_Registration_Login_Widget extends \Elementor\Widget_Base {
                         || ( isset( $p->preview ) && method_exists( $p->preview, 'is_preview_mode' ) && $p->preview->is_preview_mode() ) ) ) )
             || ( wp_doing_ajax() && isset( $_REQUEST['action'] ) && 'elementor_ajax' === $_REQUEST['action'] )
             || isset( $_GET['elementor-preview'] )
+            || current_user_can( 'edit_posts' )
         );
 
-        if ( is_user_logged_in() && ! $in_edit_mode && ! current_user_can( 'edit_posts' ) ) {
+        if ( is_user_logged_in() && ! $in_edit_mode ) {
             echo '<div class="gm2-login-widget-logged">' .
                 esc_html__( 'You are already logged in.', 'gm2-wordpress-suite' ) .
                 '</div>';

--- a/tests/test-registration-login-widget.php
+++ b/tests/test-registration-login-widget.php
@@ -96,4 +96,19 @@ class RegistrationLoginWidgetTest extends WP_UnitTestCase {
         $this->assertStringContainsString('class="login"', $html);
         $this->assertStringNotContainsString('already logged in', strtolower($html));
     }
+
+    public function test_editor_bypasses_logged_in_guard() {
+        require_once GM2_PLUGIN_DIR . 'includes/widgets/class-gm2-registration-login-widget.php';
+        $editor_id = self::factory()->user->create([ 'role' => 'editor' ]);
+        wp_set_current_user($editor_id);
+        $GLOBALS['gm2_tests_is_user_logged_in'] = true;
+        $widget = new GM2_Registration_Login_Widget();
+        ob_start();
+        $widget->render();
+        $html = ob_get_clean();
+        unset($GLOBALS['gm2_tests_is_user_logged_in']);
+        wp_set_current_user(0);
+        $this->assertStringContainsString('class="login"', $html);
+        $this->assertStringNotContainsString('already logged in', strtolower($html));
+    }
 }


### PR DESCRIPTION
## Summary
- Treat editors as always in edit mode when rendering login widget
- Verify editors bypass logged-in guard via new unit test

## Testing
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `npm test`
- `make test` *(fails: Database credentials must be supplied via DB_NAME, DB_USER and DB_PASS)*

------
https://chatgpt.com/codex/tasks/task_e_689d115e906083278f424b71a498e2ca