### PR TITLE
Hide default WooCommerce email field

### DIFF
--- a/includes/Gm2_Phone_Auth.php
+++ b/includes/Gm2_Phone_Auth.php
@@ -46,7 +46,10 @@ class Gm2_Phone_Auth {
      * not displayed when WooCommerce outputs it.
      */
     public function hide_default_email_field() {
-        echo '<style>#reg_email_field{display:none !important;}</style>';
+        // Hide any core email inputs that may still be rendered by WooCommerce.
+        // Themes sometimes override the field markup or selector, so target
+        // email inputs within common registration form containers.
+        echo '<style>.woocommerce-form-register input[type="email"],form.register input[type="email"]{display:none!important;}</style>';
     }
 
     /**


### PR DESCRIPTION
## Summary
- Hide core WooCommerce email input via CSS targeting generic registration form selectors
- Ensure login widget continues to hide any email inputs on registration tab

## Testing
- `phpunit` *(fails: command not found)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d0fb4d8b8832781df5a82b1eeb777