### PR TITLE
Guard WooCommerce registration form rendering

### DIFF
--- a/includes/widgets/class-gm2-registration-login-widget.php
+++ b/includes/widgets/class-gm2-registration-login-widget.php
@@ -394,10 +394,14 @@ class GM2_Registration_Login_Widget extends \Elementor\Widget_Base {
         }
         if ( $settings['show_register_form'] === 'yes' ) {
             echo '<div class="gm2-register-form" style="display:none">';
-            if ( function_exists( 'woocommerce_register_form' ) ) {
-                \woocommerce_register_form();
+            if ( did_action( 'init' ) && class_exists( 'WooCommerce' ) ) {
+                if ( function_exists( 'woocommerce_register_form' ) ) {
+                    \woocommerce_register_form();
+                } else {
+                    do_action( 'woocommerce_register_form' );
+                }
             } else {
-                do_action( 'woocommerce_register_form' );
+                echo '<p class="gm2-woocommerce-placeholder">' . esc_html__( 'WooCommerce registration form will appear here', 'gm2-wordpress-suite' ) . '</p>';
             }
             echo '</div>';
         }


### PR DESCRIPTION
## Summary
- Ensure WooCommerce has initialized before rendering registration form
- Provide placeholder text when WooCommerce is unavailable

## Testing
- `npm test`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_689d129a258c8327abdefaadbd16cf05