### PR TITLE
Hide WooCommerce default email field container

### DIFF
--- a/includes/Gm2_Phone_Auth.php
+++ b/includes/Gm2_Phone_Auth.php
@@ -49,7 +49,15 @@ class Gm2_Phone_Auth {
         // Hide any core email inputs that may still be rendered by WooCommerce.
         // Themes sometimes override the field markup or selector, so target
         // email inputs within common registration form containers.
-        echo '<style>.woocommerce-form-register input[type="email"],form.register input[type="email"]{display:none!important;}</style>';
+        echo '<style>
+            #reg_email_field,
+            label[for="reg_email"],
+            input#reg_email,
+            .woocommerce-form-register input[type="email"],
+            form.register input[type="email"] {
+                display:none!important;
+            }
+        </style>';
     }
 
     /**


### PR DESCRIPTION
## Summary
- Hide WooCommerce registration email field, container, and label via inline CSS

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d140cb5e883278f9a04d0e0c5f750