### PR TITLE
Initialize login widget via Elementor hooks

### DIFF
--- a/public/js/gm2-login-widget.js
+++ b/public/js/gm2-login-widget.js
@@ -1,16 +1,35 @@
-jQuery(function($){
-  $('.gm2-login-widget').each(function(){
-    var $wrap = $(this);
+jQuery(window).on('elementor/frontend/init', function() {
+  var handlerFn = function($scope) {
+    var $wrap = $scope.find('.gm2-login-widget').addBack('.gm2-login-widget');
     var loginPl = $wrap.data('login-placeholder');
     var passPl = $wrap.data('pass-placeholder');
-    if(loginPl){ $wrap.find('input[name="username"], input[name="user_login"]').attr('placeholder', loginPl); }
-    if(passPl){ $wrap.find('input[type="password"]').attr('placeholder', passPl); }
-    if($wrap.data('show-remember') === 'no'){
+    if (loginPl) {
+      $wrap
+        .find('input[name="username"], input[name="user_login"]')
+        .attr('placeholder', loginPl);
+    }
+    if (passPl) {
+      $wrap.find('input[type="password"]').attr('placeholder', passPl);
+    }
+    if ($wrap.data('show-remember') === 'no') {
       $wrap.find('input[name="rememberme"]').closest('p').hide();
     }
     // Hide the default WooCommerce email field in the registration form
     $wrap.find('.gm2-register-form input[type="email"]').closest('p').hide();
-    $wrap.on('click','.gm2-show-register',function(e){e.preventDefault();$wrap.find('.gm2-login-form').hide().removeClass('active');$wrap.find('.gm2-register-form').show().addClass('active');});
-    $wrap.on('click','.gm2-show-login',function(e){e.preventDefault();$wrap.find('.gm2-register-form').hide().removeClass('active');$wrap.find('.gm2-login-form').show().addClass('active');});
-  });
+    $wrap.on('click', '.gm2-show-register', function(e) {
+      e.preventDefault();
+      $wrap.find('.gm2-login-form').hide().removeClass('active');
+      $wrap.find('.gm2-register-form').show().addClass('active');
+    });
+    $wrap.on('click', '.gm2-show-login', function(e) {
+      e.preventDefault();
+      $wrap.find('.gm2-register-form').hide().removeClass('active');
+      $wrap.find('.gm2-login-form').show().addClass('active');
+    });
+  };
+  elementorFrontend.hooks.addAction(
+    'frontend/element_ready/gm2_registration_login.default',
+    handlerFn
+  );
 });
+


### PR DESCRIPTION
## Summary
- Wrap login widget initialization in `elementor/frontend/init` callback
- Register Elementor hook to handle `gm2_registration_login` widget instances

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d15c1e0e48327a6eb6ac716962a61