### PR TITLE
Render WooCommerce register form directly

### DIFF
--- a/includes/widgets/class-gm2-registration-login-widget.php
+++ b/includes/widgets/class-gm2-registration-login-widget.php
@@ -426,11 +426,14 @@ class GM2_Registration_Login_Widget extends \Elementor\Widget_Base {
                 $register_style = ' style="display:none"';
             }
             echo '<div class="' . esc_attr( $register_classes ) . '"' . $register_style . '>';
-            if ( did_action( 'init' ) && class_exists( 'WooCommerce' ) ) {
-                if ( function_exists( 'woocommerce_register_form' ) ) {
-                    \woocommerce_register_form();
+            if ( did_action( 'init' ) && class_exists( 'WooCommerce' ) && function_exists( 'wc_get_template' ) ) {
+                ob_start();
+                wc_get_template( 'myaccount/form-login.php' );
+                $tpl = ob_get_clean();
+                if ( preg_match( '#<form[^>]*class="[^"]*woocommerce-form[^"]*register[^"]*"[^>]*>.*?</form>#s', $tpl, $m ) ) {
+                    echo $m[0];
                 } else {
-                    do_action( 'woocommerce_register_form' );
+                    echo $tpl;
                 }
             } else {
                 echo '<p class="gm2-woocommerce-placeholder">' . esc_html__( 'WooCommerce registration form will appear here', 'gm2-wordpress-suite' ) . '</p>';

--- a/tests/test-registration-login-widget.php
+++ b/tests/test-registration-login-widget.php
@@ -10,6 +10,11 @@ if (!function_exists('is_user_logged_in')) {
 if (!function_exists('woocommerce_login_form')) {
     function woocommerce_login_form($args = []) { echo '<form class="login"></form>'; }
 }
+if (!function_exists('wc_get_template')) {
+    function wc_get_template($template_name, $args = [], $template_path = '', $default_path = '') {
+        echo '<form class="woocommerce-form woocommerce-form-register register"></form>';
+    }
+}
 if (!class_exists('Elementor\\Widget_Base')) {
     eval('namespace Elementor; class Widget_Base {}');
 }
@@ -47,18 +52,13 @@ class RegistrationLoginWidgetTest extends WP_UnitTestCase {
 
     public function test_render_outputs_forms_and_restricts_role() {
         require_once GM2_PLUGIN_DIR . 'includes/widgets/class-gm2-registration-login-widget.php';
-        add_action('woocommerce_register_form', function(){ echo '<form class="register"></form>'; });
-        ob_start();
-        do_action('woocommerce_register_form'); // simulate hook output
-        $registration_html = ob_get_clean();
 
         $widget = new GM2_Registration_Login_Widget();
         ob_start();
         $widget->render();
         $html = ob_get_clean();
         $this->assertStringContainsString('class="login"', $html);
-        $this->assertStringContainsString('class="register"', $registration_html);
-        $this->assertStringContainsString('class="register"', $html);
+        $this->assertStringContainsString('woocommerce-form-register', $html);
 
         $user = new \WP_User(1, 'test');
         $user->add_role('editor');


### PR DESCRIPTION
## Summary
- Render WooCommerce registration form by capturing and extracting the template markup instead of using the `woocommerce_register_form` hook.
- Stub `wc_get_template` in tests and assert that the widget outputs the full registration form markup.

## Testing
- `npm test`
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689d1d9713908327aad96682d3815ed2