### PR TITLE
Sync contact field to hidden email for Elementor registration

### DIFF
--- a/includes/Gm2_Phone_Auth.php
+++ b/includes/Gm2_Phone_Auth.php
@@ -38,6 +38,7 @@ class Gm2_Phone_Auth {
             'label'    => __('Phone or Email', 'gm2-wordpress-suite'),
             'required' => true,
         ], $contact);
+        echo '<input type="email" name="email" id="gm2_hidden_email" style="display:none;" />';
     }
 
     /**

--- a/public/js/gm2-login-widget.js
+++ b/public/js/gm2-login-widget.js
@@ -31,5 +31,23 @@ jQuery(window).on('elementor/frontend/init', function() {
     'frontend/element_ready/gm2_registration_login.default',
     handlerFn
   );
+  elementorFrontend.hooks.addAction(
+    'frontend/element_ready/global',
+    function($scope) {
+      var $form = $scope.find('form.register');
+      if (!$form.length) {
+        return;
+      }
+      $form.on('submit', function() {
+        var contactVal = $form.find('input[name="contact"]').val() || '';
+        var $hidden = $form.find('#gm2_hidden_email');
+        if (contactVal.indexOf('@') !== -1) {
+          $hidden.val(contactVal);
+        } else {
+          $hidden.val('');
+        }
+      });
+    }
+  );
 });
 


### PR DESCRIPTION
## Summary
- Hide default WooCommerce email field and add hidden email input for phone auth registration
- Copy contact field into hidden email on Elementor forms when it contains an `@`

## Testing
- `npm test`
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): Failed to open stream)*

------
https://chatgpt.com/codex/tasks/task_e_689d1f399a3083278672b437a7f158fd