### PR TITLE
Add custom posts admin with option toggle

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -449,6 +449,7 @@ class Gm2_Admin {
             update_option('gm2_enable_chatgpt', empty($_POST['gm2_enable_chatgpt']) ? '0' : '1');
             update_option('gm2_enable_abandoned_carts', empty($_POST['gm2_enable_abandoned_carts']) ? '0' : '1');
             update_option('gm2_enable_analytics', empty($_POST['gm2_enable_analytics']) ? '0' : '1');
+            update_option('gm2_enable_custom_posts', empty($_POST['gm2_enable_custom_posts']) ? '0' : '1');
 
             $enabled = !empty($_POST['gm2_enable_abandoned_carts']);
             if ($enabled) {
@@ -473,6 +474,7 @@ class Gm2_Admin {
         $chatgpt = get_option('gm2_enable_chatgpt', '1') === '1';
         $abandoned = get_option('gm2_enable_abandoned_carts', '0') === '1';
         $analytics = get_option('gm2_enable_analytics', '1') === '1';
+        $custom_posts = get_option('gm2_enable_custom_posts', '1') === '1';
 
         echo '<div class="wrap">';
         echo '<h1>' . esc_html__( 'Gm2 Suite', 'gm2-wordpress-suite' ) . '</h1>';
@@ -485,6 +487,7 @@ class Gm2_Admin {
         echo '<tr><th scope="row">' . esc_html__( 'Google OAuth Setup', 'gm2-wordpress-suite' ) . '</th><td><label><input type="checkbox" name="gm2_enable_google_oauth"' . checked($oauth, true, false) . '> ' . esc_html__( 'Enabled', 'gm2-wordpress-suite' ) . '</label></td></tr>';
         echo '<tr><th scope="row">' . esc_html__( 'ChatGPT', 'gm2-wordpress-suite' ) . '</th><td><label><input type="checkbox" name="gm2_enable_chatgpt"' . checked($chatgpt, true, false) . '> ' . esc_html__( 'Enabled', 'gm2-wordpress-suite' ) . '</label></td></tr>';
         echo '<tr><th scope="row">' . esc_html__( 'Analytics', 'gm2-wordpress-suite' ) . '</th><td><label><input type="checkbox" name="gm2_enable_analytics"' . checked($analytics, true, false) . '> ' . esc_html__( 'Enabled', 'gm2-wordpress-suite' ) . '</label></td></tr>';
+        echo '<tr><th scope="row">' . esc_html__( 'Custom Posts', 'gm2-wordpress-suite' ) . '</th><td><label><input type="checkbox" name="gm2_enable_custom_posts"' . checked($custom_posts, true, false) . '> ' . esc_html__( 'Enabled', 'gm2-wordpress-suite' ) . '</label></td></tr>';
         echo '<tr><th scope="row">' . esc_html__( 'Abandoned Carts', 'gm2-wordpress-suite' ) . '</th><td><label><input type="checkbox" name="gm2_enable_abandoned_carts"' . checked($abandoned, true, false) . '> ' . esc_html__( 'Enabled', 'gm2-wordpress-suite' ) . '</label></td></tr>';
         echo '</tbody></table>';
         submit_button();

--- a/admin/Gm2_Custom_Posts_Admin.php
+++ b/admin/Gm2_Custom_Posts_Admin.php
@@ -1,0 +1,30 @@
+<?php
+namespace Gm2;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Gm2_Custom_Posts_Admin {
+    public function run() {
+        add_action('admin_menu', [ $this, 'add_menu' ]);
+    }
+
+    public function add_menu() {
+        add_menu_page(
+            esc_html__( 'Gm2 Custom Posts', 'gm2-wordpress-suite' ),
+            esc_html__( 'Gm2 Custom Posts', 'gm2-wordpress-suite' ),
+            'manage_options',
+            'gm2-custom-posts',
+            [ $this, 'display_page' ],
+            'dashicons-admin-post'
+        );
+    }
+
+    public function display_page() {
+        if (!current_user_can('manage_options')) {
+            wp_die( esc_html__( 'Permission denied', 'gm2-wordpress-suite' ) );
+        }
+        echo '<div class="wrap"><h1>' . esc_html__( 'Gm2 Custom Posts', 'gm2-wordpress-suite' ) . '</h1></div>';
+    }
+}

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -127,6 +127,7 @@ function gm2_activate_plugin() {
     add_option('gm2_enable_chatgpt', '1');
     add_option('gm2_enable_analytics', '1');
     add_option('gm2_enable_chatgpt_logging', '0');
+    add_option('gm2_enable_custom_posts', '1');
     add_option('gm2_analytics_retention_days', 30);
     add_option('gm2_sitemap_path', ABSPATH . 'sitemap.xml');
     add_option('gm2_sitemap_max_urls', 1000);

--- a/includes/Gm2_Loader.php
+++ b/includes/Gm2_Loader.php
@@ -34,6 +34,7 @@ class Gm2_Loader {
         $enable_ac        = get_option('gm2_enable_abandoned_carts', '1') === '1';
         $enable_phone_login = get_option('gm2_enable_phone_login', '0') === '1';
         $enable_analytics = get_option('gm2_enable_analytics', '1') === '1';
+        $enable_custom_posts = get_option('gm2_enable_custom_posts', '1') === '1';
 
         if (!$enable_ac && is_admin()) {
             add_action('admin_notices', function () {
@@ -57,6 +58,11 @@ class Gm2_Loader {
         if ($enable_analytics) {
             $analytics = new Gm2_Analytics();
             $analytics->run();
+        }
+
+        if ($enable_custom_posts && is_admin()) {
+            $cp_admin = new Gm2_Custom_Posts_Admin();
+            $cp_admin->run();
         }
 
         if ($enable_phone_login) {

--- a/uninstall.php
+++ b/uninstall.php
@@ -77,6 +77,7 @@ $option_names = array(
     'gm2_enable_google_oauth',
     'gm2_enable_chatgpt',
     'gm2_enable_chatgpt_logging',
+    'gm2_enable_custom_posts',
     'gm2_pagespeed_api_key',
     'gm2_pagespeed_scores',
     'gm2_bulk_ai_page_size',


### PR DESCRIPTION
## Summary
- add Gm2_Custom_Posts_Admin with menu page for managing custom posts
- introduce gm2_enable_custom_posts option and admin toggle
- load custom posts admin when enabled

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e018d9cb88327a799a74a728f0113