### PR TITLE
Gate analytics module on saved option

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -13,7 +13,6 @@ class Gm2_Admin {
     private $cart_settings;
     private $oauth_enabled;
     private $chatgpt_enabled;
-    private $analytics;
 
     public function run() {
         $this->diagnostics = new Gm2_Diagnostics();
@@ -29,10 +28,6 @@ class Gm2_Admin {
         }
         $this->cart_settings = new Gm2_Cart_Settings_Admin();
         $this->cart_settings->register_hooks();
-        if (get_option('gm2_enable_analytics', '1') === '1') {
-            $this->analytics = new Gm2_Analytics_Admin();
-            $this->analytics->run();
-        }
         add_action('admin_enqueue_scripts', [$this, 'enqueue_admin_scripts']);
         add_action('wp_ajax_gm2_add_tariff', [$this, 'ajax_add_tariff']);
         add_action('wp_ajax_nopriv_gm2_add_tariff', [$this, 'ajax_add_tariff']);

--- a/includes/Gm2_Loader.php
+++ b/includes/Gm2_Loader.php
@@ -56,6 +56,11 @@ class Gm2_Loader {
         $public->run();
 
         if ($enable_analytics) {
+            if (is_admin()) {
+                $analytics_admin = new Gm2_Analytics_Admin();
+                $analytics_admin->run();
+            }
+
             $analytics = new Gm2_Analytics();
             $analytics->run();
         }


### PR DESCRIPTION
## Summary
- ensure dashboard form persists `gm2_enable_analytics`
- only load `Gm2_Analytics` and `Gm2_Analytics_Admin` when analytics is enabled

## Testing
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f484e42d88327a38e14c067207d16