### PR TITLE
Add interactive CPT and taxonomy field editors

### DIFF
--- a/admin/js/gm2-custom-posts-admin.js
+++ b/admin/js/gm2-custom-posts-admin.js
@@ -1,84 +1,172 @@
 jQuery(function($){
-    var table = $('#gm2-fields-table tbody');
+    var fields = gm2CPTFields.fields || [];
+    var args   = gm2CPTFields.args || [];
 
-    function addRow(data){
-        data = data || {};
-        var row = $('<tr>\
-<td class="gm2-move-field"><span class="dashicons dashicons-move"></span></td>\
-<td><input type="text" class="gm2-field-label" /></td>\
-<td><input type="text" class="gm2-field-slug" /></td>\
-<td><select class="gm2-field-type">\
-<option value="text">Text</option>\
-<option value="number">Number</option>\
-<option value="checkbox">Checkbox</option>\
-<option value="select">Dropdown</option>\
-<option value="radio">Radio</option>\
-</select></td>\
-<td><input type="text" class="gm2-field-default" /></td>\
-<td><input type="text" class="gm2-field-options" placeholder="value:Label,value2:Label2" /></td>\
-<td><input type="text" class="gm2-cond-field" /></td>\
-<td><input type="text" class="gm2-cond-value" /></td>\
-<td><button type="button" class="button gm2-remove-field">Remove</button></td>\
+    function esc(str){ return $('<div>').text(str).html(); }
+
+    function renderFields(){
+        var tbody = $('#gm2-fields-table tbody').empty();
+        if(!fields.length){
+            tbody.append('<tr><td colspan="6">'+esc(gm2CPTFields.noFields || 'No fields')+'</td></tr>');
+            return;
+        }
+        $.each(fields, function(i, f){
+            var row = $('<tr>\
+<td>'+esc(f.label)+'</td>\
+<td>'+esc(f.slug)+'</td>\
+<td>'+esc(f.type)+'</td>\
+<td>'+esc(f.default || '')+'</td>\
+<td>'+esc(f.description || '')+'</td>\
+<td><button class="button gm2-edit-field" data-index="'+i+'">Edit</button> <button class="button gm2-delete-field" data-index="'+i+'">Delete</button></td>\
 </tr>');
-        table.append(row);
-        if(data.label){ row.find('.gm2-field-label').val(data.label); }
-        if(data.slug){ row.find('.gm2-field-slug').val(data.slug); }
-        if(data.type){ row.find('.gm2-field-type').val(data.type); }
-        if(data.default){ row.find('.gm2-field-default').val(data.default); }
-        if(data.options){ row.find('.gm2-field-options').val(data.options); }
-        if(data.conditional){
-            row.find('.gm2-cond-field').val(data.conditional.field || '');
-            row.find('.gm2-cond-value').val(data.conditional.value || '');
+            tbody.append(row);
+        });
+    }
+
+    function renderArgs(){
+        var tbody = $('#gm2-args-table tbody').empty();
+        if(!args.length){
+            tbody.append('<tr><td colspan="3">'+esc(gm2CPTFields.noArgs || 'No arguments')+'</td></tr>');
+            return;
+        }
+        $.each(args, function(i, a){
+            var val = a.value;
+            if($.isArray(val)){
+                val = val.join(', ');
+            } else if(val === true){
+                val = 'true';
+            } else if(val === false){
+                val = 'false';
+            }
+            var row = $('<tr>\
+<td>'+esc(a.key)+'</td>\
+<td>'+esc(val)+'</td>\
+<td><button class="button gm2-edit-arg" data-index="'+i+'">Edit</button> <button class="button gm2-delete-arg" data-index="'+i+'">Delete</button></td>\
+</tr>');
+            tbody.append(row);
+        });
+    }
+
+    function showFieldForm(data, index){
+        $('#gm2-field-index').val(index !== undefined ? index : '');
+        $('#gm2-field-label').val(data ? data.label : '');
+        $('#gm2-field-slug').val(data ? data.slug : '');
+        $('#gm2-field-type').val(data ? data.type : 'text');
+        $('#gm2-field-default').val(data ? data.default : '');
+        $('#gm2-field-description').val(data ? data.description : '');
+        $('#gm2-field-form').show();
+    }
+
+    function showArgControl(key, value){
+        var wrap = $('#gm2-arg-value-wrap').empty();
+        if(key === 'public' || key === 'hierarchical'){
+            var chk = $('<label><input type="checkbox" id="gm2-arg-value" value="1"/> '+key+'</label>');
+            if(value){ chk.find('input').prop('checked', true); }
+            wrap.append(chk);
+        }else if(key === 'supports'){
+            wrap.append('<input type="text" id="gm2-arg-value" class="regular-text" />');
+            $('#gm2-arg-value').val($.isArray(value) ? value.join(',') : value);
+        }else{
+            wrap.append('<input type="text" id="gm2-arg-value" class="regular-text" />');
+            $('#gm2-arg-value').val(value);
         }
     }
 
-    $('#gm2-add-field').on('click', function(){
-        addRow();
-    });
+    function showArgForm(data, index){
+        $('#gm2-arg-index').val(index !== undefined ? index : '');
+        $('#gm2-arg-key').prop('disabled', index !== undefined).val(data ? data.key : '');
+        showArgControl(data ? data.key : '', data ? data.value : '');
+        $('#gm2-arg-form').show();
+    }
 
-    table.on('click', '.gm2-remove-field', function(){
-        $(this).closest('tr').remove();
-    });
-
-    table.sortable({
-        handle: '.gm2-move-field',
-        helper: function(e, ui){
-            ui.children().each(function(){
-                $(this).width($(this).width());
-            });
-            return ui;
-        }
-    });
-
-    $('#gm2-fields-form').on('submit', function(e){
-        e.preventDefault();
-        var fields = [];
-        table.find('tr').each(function(){
-            var row = $(this);
-            fields.push({
-                label: row.find('.gm2-field-label').val(),
-                slug: row.find('.gm2-field-slug').val(),
-                type: row.find('.gm2-field-type').val(),
-                default: row.find('.gm2-field-default').val(),
-                options: row.find('.gm2-field-options').val(),
-                conditional: {
-                    field: row.find('.gm2-cond-field').val(),
-                    value: row.find('.gm2-cond-value').val()
-                }
-            });
-        });
+    function saveAll(cb){
         var data = {
             action: 'gm2_save_cpt_fields',
             nonce: gm2CPTFields.nonce,
-            slug: $('#gm2-fields-form input[name="pt_slug"]').val(),
-            fields: fields
+            slug: gm2CPTFields.slug,
+            fields: fields,
+            args: args
         };
         $.post(gm2CPTFields.ajax, data, function(resp){
             if(resp && resp.success){
-                alert('Fields saved');
+                fields = [];
+                $.each(resp.data.fields || {}, function(slug, f){
+                    fields.push({
+                        label: f.label || '',
+                        slug: slug,
+                        type: f.type || 'text',
+                        default: f.default || '',
+                        description: f.description || ''
+                    });
+                });
+                args = [];
+                $.each(resp.data.args || {}, function(key, val){
+                    args.push({ key: key, value: val });
+                });
+                renderFields();
+                renderArgs();
+                if(cb) cb(true);
             }else{
-                alert('Error saving fields');
+                alert('Error saving');
+                if(cb) cb(false);
             }
         });
+    }
+
+    // Field handlers
+    $('#gm2-add-field').on('click', function(){ showFieldForm(); });
+    $('#gm2-field-cancel').on('click', function(){ $('#gm2-field-form').hide(); });
+    $('#gm2-field-save').on('click', function(){
+        var idx = $('#gm2-field-index').val();
+        var obj = {
+            label: $('#gm2-field-label').val(),
+            slug: $('#gm2-field-slug').val(),
+            type: $('#gm2-field-type').val(),
+            default: $('#gm2-field-default').val(),
+            description: $('#gm2-field-description').val()
+        };
+        if(idx === ''){ fields.push(obj); } else { fields[idx] = obj; }
+        saveAll(function(){ $('#gm2-field-form').hide(); });
     });
+    $('#gm2-fields-table').on('click', '.gm2-edit-field', function(){
+        var idx = $(this).data('index');
+        showFieldForm(fields[idx], idx);
+    });
+    $('#gm2-fields-table').on('click', '.gm2-delete-field', function(){
+        var idx = $(this).data('index');
+        fields.splice(idx,1);
+        saveAll();
+    });
+
+    // Arg handlers
+    $('#gm2-add-arg').on('click', function(){ showArgForm(); });
+    $('#gm2-arg-cancel').on('click', function(){ $('#gm2-arg-form').hide(); });
+    $('#gm2-arg-save').on('click', function(){
+        var idx = $('#gm2-arg-index').val();
+        var key = $('#gm2-arg-key').val();
+        var val;
+        if(key === 'public' || key === 'hierarchical'){
+            val = $('#gm2-arg-value').is(':checked');
+        }else if(key === 'supports'){
+            val = $('#gm2-arg-value').val();
+        }else{
+            val = $('#gm2-arg-value').val();
+        }
+        var obj = { key: key, value: val };
+        if(idx === ''){ args.push(obj); } else { args[idx] = obj; }
+        saveAll(function(){ $('#gm2-arg-form').hide(); });
+    });
+    $('#gm2-args-table').on('click', '.gm2-edit-arg', function(){
+        var idx = $(this).data('index');
+        showArgForm(args[idx], idx);
+    });
+    $('#gm2-args-table').on('click', '.gm2-delete-arg', function(){
+        var idx = $(this).data('index');
+        args.splice(idx,1);
+        saveAll();
+    });
+
+    renderFields();
+    renderArgs();
 });
+

--- a/admin/js/gm2-custom-tax-admin.js
+++ b/admin/js/gm2-custom-tax-admin.js
@@ -1,0 +1,89 @@
+jQuery(function($){
+    var args = gm2TaxArgs.args || [];
+
+    function esc(str){ return $('<div>').text(str).html(); }
+
+    function renderArgs(){
+        var tbody = $('#gm2-tax-args-table tbody').empty();
+        if(!args.length){
+            tbody.append('<tr><td colspan="3">'+esc(gm2TaxArgs.noArgs || 'No arguments')+'</td></tr>');
+            return;
+        }
+        $.each(args, function(i, a){
+            var val = a.value;
+            if(val === true){ val = 'true'; }
+            if(val === false){ val = 'false'; }
+            tbody.append('<tr>\
+<td>'+esc(a.key)+'</td>\
+<td>'+esc($.isArray(val)? val.join(', ') : val)+'</td>\
+<td><button class="button gm2-tax-edit-arg" data-index="'+i+'">Edit</button> <button class="button gm2-tax-delete-arg" data-index="'+i+'">Delete</button></td>\
+</tr>');
+        });
+    }
+
+    function showArgControl(key, value){
+        var wrap = $('#gm2-tax-arg-value-wrap').empty();
+        if(key === 'public' || key === 'hierarchical'){
+            var chk = $('<label><input type="checkbox" id="gm2-tax-arg-value" value="1"/> '+key+'</label>');
+            if(value){ chk.find('input').prop('checked', true); }
+            wrap.append(chk);
+        }else{
+            wrap.append('<input type="text" id="gm2-tax-arg-value" class="regular-text" />');
+            $('#gm2-tax-arg-value').val(value);
+        }
+    }
+
+    function showArgForm(data, index){
+        $('#gm2-tax-arg-index').val(index !== undefined ? index : '');
+        $('#gm2-tax-arg-key').prop('disabled', index !== undefined).val(data ? data.key : '');
+        showArgControl(data ? data.key : '', data ? data.value : '');
+        $('#gm2-tax-arg-form').show();
+    }
+
+    function saveAll(cb){
+        var data = {
+            action: 'gm2_save_tax_args',
+            nonce: gm2TaxArgs.nonce,
+            slug: gm2TaxArgs.slug,
+            label: $('#gm2-tax-label').val(),
+            post_types: $('#gm2-tax-post-types').val(),
+            args: args
+        };
+        $.post(gm2TaxArgs.ajax, data, function(resp){
+            if(resp && resp.success){
+                args = [];
+                $.each(resp.data.args || {}, function(key, val){ args.push({ key:key, value:val }); });
+                renderArgs();
+                if(cb) cb(true);
+            }else{
+                alert('Error saving');
+                if(cb) cb(false);
+            }
+        });
+    }
+
+    $('#gm2-add-tax-arg').on('click', function(){ showArgForm(); });
+    $('#gm2-tax-arg-cancel').on('click', function(){ $('#gm2-tax-arg-form').hide(); });
+    $('#gm2-tax-arg-save').on('click', function(){
+        var idx = $('#gm2-tax-arg-index').val();
+        var key = $('#gm2-tax-arg-key').val();
+        var val = (key === 'public' || key === 'hierarchical') ? $('#gm2-tax-arg-value').is(':checked') : $('#gm2-tax-arg-value').val();
+        var obj = { key:key, value:val };
+        if(idx === ''){ args.push(obj); } else { args[idx] = obj; }
+        saveAll(function(){ $('#gm2-tax-arg-form').hide(); });
+    });
+    $('#gm2-tax-args-table').on('click', '.gm2-tax-edit-arg', function(){
+        var idx = $(this).data('index');
+        showArgForm(args[idx], idx);
+    });
+    $('#gm2-tax-args-table').on('click', '.gm2-tax-delete-arg', function(){
+        var idx = $(this).data('index');
+        args.splice(idx,1);
+        saveAll();
+    });
+
+    $('#gm2-tax-save').on('click', function(){ saveAll(); });
+
+    renderArgs();
+});
+


### PR DESCRIPTION
## Summary
- add admin tables with add/edit forms for CPT fields and registration args
- allow taxonomy argument editing with AJAX-backed forms
- persist field and argument changes into `gm2_custom_posts_config`

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f54012efc83279c8e5e7a1aa1a9fd