### PR TITLE
Add conditional display groups for custom fields and args

### DIFF
--- a/admin/js/conditions.js
+++ b/admin/js/conditions.js
@@ -1,0 +1,52 @@
+jQuery(function($){
+    window.gm2Conditions = {
+        init: function($wrap, opts){
+            opts = opts || {};
+            var targets = opts.targets || [];
+            var data = opts.data || [];
+            $wrap.off('.gm2cond');
+            $wrap.html('<div class="gm2-condition-groups"></div><p><button type="button" class="button gm2-add-condition-group">'+(opts.addGroupText||'Add Condition Group')+'</button></p>');
+            function addGroup(g){
+                var group = $('<div class="gm2-condition-group">\n<select class="gm2-group-relation"><option value="AND">AND</option><option value="OR">OR</option></select>\n<div class="gm2-condition-list"></div>\n<p><button type="button" class="button gm2-add-condition">'+(opts.addConditionText||'Add Condition')+'</button> <button type="button" class="button gm2-remove-condition-group">'+(opts.removeGroupText||'Remove Group')+'</button></p></div>');
+                if(g && g.relation){ group.find('.gm2-group-relation').val(g.relation); }
+                $wrap.find('.gm2-condition-groups').append(group);
+                $.each((g && g.conditions)||[], function(i,c){ addCondition(group, c); });
+            }
+            function addCondition($group, c){
+                var row = $('<div class="gm2-condition-row">\n<select class="gm2-condition-relation"><option value="AND">AND</option><option value="OR">OR</option></select>\n<select class="gm2-target"></select>\n<select class="gm2-operator"><option value="=">=</option><option value="!=">!=</option><option value=">">&gt;</option><option value="<">&lt;</option><option value="contains">contains</option></select>\n<input type="text" class="gm2-value" /> <button type="button" class="button gm2-remove-condition">'+(opts.removeConditionText||'Remove')+'</button></div>');
+                var tSel = row.find('.gm2-target');
+                $.each(targets, function(i,t){ tSel.append('<option value="'+t+'">'+t+'</option>'); });
+                if(c){
+                    row.find('.gm2-condition-relation').val(c.relation || 'AND');
+                    row.find('.gm2-target').val(c.target || '');
+                    row.find('.gm2-operator').val(c.operator || '=');
+                    row.find('.gm2-value').val(c.value || '');
+                }
+                $group.find('.gm2-condition-list').append(row);
+            }
+            $wrap.on('click.gm2cond', '.gm2-add-condition-group', function(){ addGroup(); });
+            $wrap.on('click.gm2cond', '.gm2-add-condition', function(){ addCondition($(this).closest('.gm2-condition-group')); });
+            $wrap.on('click.gm2cond', '.gm2-remove-condition', function(){ $(this).closest('.gm2-condition-row').remove(); });
+            $wrap.on('click.gm2cond', '.gm2-remove-condition-group', function(){ $(this).closest('.gm2-condition-group').remove(); });
+            $.each(data, function(i,g){ addGroup(g); });
+        },
+        getData: function($wrap){
+            var groups = [];
+            $wrap.find('.gm2-condition-group').each(function(){
+                var $g = $(this);
+                var g = { relation: $g.find('.gm2-group-relation').val(), conditions: [] };
+                $g.find('.gm2-condition-row').each(function(){
+                    var $r = $(this);
+                    g.conditions.push({
+                        relation: $r.find('.gm2-condition-relation').val(),
+                        target: $r.find('.gm2-target').val(),
+                        operator: $r.find('.gm2-operator').val(),
+                        value: $r.find('.gm2-value').val()
+                    });
+                });
+                groups.push(g);
+            });
+            return groups;
+        }
+    };
+});

--- a/admin/js/gm2-custom-posts-admin.js
+++ b/admin/js/gm2-custom-posts-admin.js
@@ -54,6 +54,9 @@ jQuery(function($){
         $('#gm2-field-type').val(data ? data.type : 'text');
         $('#gm2-field-default').val(data ? data.default : '');
         $('#gm2-field-description').val(data ? data.description : '');
+        var targets = fields.map(function(f){ return f.slug; });
+        targets.push('page_id','post_id');
+        gm2Conditions.init($('#gm2-field-conditions'), { targets: targets, data: data ? data.conditions : [] });
         $('#gm2-field-form').show();
     }
 
@@ -76,6 +79,9 @@ jQuery(function($){
         $('#gm2-arg-index').val(index !== undefined ? index : '');
         $('#gm2-arg-key').prop('disabled', index !== undefined).val(data ? data.key : '');
         showArgControl(data ? data.key : '', data ? data.value : '');
+        var targets = fields.map(function(f){ return f.slug; });
+        targets.push('page_id','post_id');
+        gm2Conditions.init($('#gm2-arg-conditions'), { targets: targets, data: data ? data.conditions : [] });
         $('#gm2-arg-form').show();
     }
 
@@ -96,12 +102,13 @@ jQuery(function($){
                         slug: slug,
                         type: f.type || 'text',
                         default: f.default || '',
-                        description: f.description || ''
+                        description: f.description || '',
+                        conditions: f.conditions || []
                     });
                 });
                 args = [];
                 $.each(resp.data.args || {}, function(key, val){
-                    args.push({ key: key, value: val });
+                    args.push({ key: key, value: val.value !== undefined ? val.value : val, conditions: val.conditions || [] });
                 });
                 renderFields();
                 renderArgs();
@@ -123,7 +130,8 @@ jQuery(function($){
             slug: $('#gm2-field-slug').val(),
             type: $('#gm2-field-type').val(),
             default: $('#gm2-field-default').val(),
-            description: $('#gm2-field-description').val()
+            description: $('#gm2-field-description').val(),
+            conditions: gm2Conditions.getData($('#gm2-field-conditions'))
         };
         if(idx === ''){ fields.push(obj); } else { fields[idx] = obj; }
         saveAll(function(){ $('#gm2-field-form').hide(); });
@@ -152,7 +160,7 @@ jQuery(function($){
         }else{
             val = $('#gm2-arg-value').val();
         }
-        var obj = { key: key, value: val };
+        var obj = { key: key, value: val, conditions: gm2Conditions.getData($('#gm2-arg-conditions')) };
         if(idx === ''){ args.push(obj); } else { args[idx] = obj; }
         saveAll(function(){ $('#gm2-arg-form').hide(); });
     });

--- a/admin/js/gm2-custom-posts.js
+++ b/admin/js/gm2-custom-posts.js
@@ -1,26 +1,57 @@
 (function($){
+    function evaluate(groups){
+        var result = null;
+        $.each(groups, function(i, group){
+            var groupRes = null;
+            $.each(group.conditions || [], function(j, cond){
+                var $t = $('[name="'+cond.target+'"]');
+                if(!$t.length){ return; }
+                var v;
+                if($t.attr('type') === 'checkbox'){ v = $t.is(':checked') ? '1' : '0'; } else { v = $t.val(); }
+                var ok = false;
+                switch(cond.operator){
+                    case '!=': ok = String(v) !== String(cond.value); break;
+                    case '>': ok = parseFloat(v) > parseFloat(cond.value); break;
+                    case '<': ok = parseFloat(v) < parseFloat(cond.value); break;
+                    case 'contains': ok = String(v).indexOf(String(cond.value)) !== -1; break;
+                    default: ok = String(v) === String(cond.value); break;
+                }
+                if(groupRes === null){ groupRes = ok; }
+                else{ groupRes = cond.relation === 'OR' ? (groupRes || ok) : (groupRes && ok); }
+            });
+            if(groupRes === null){ groupRes = false; }
+            if(result === null){ result = groupRes; }
+            else{ result = group.relation === 'AND' ? (result && groupRes) : (result || groupRes); }
+        });
+        return result;
+    }
+
     function setupConditional(){
+        var items = [];
+        $('.gm2-field[data-conditions]').each(function(){
+            var $wrap = $(this);
+            var conds = $wrap.data('conditions');
+            items.push({el:$wrap, conds:conds});
+            $.each(conds, function(i,g){
+                $.each(g.conditions || [], function(j,c){
+                    $('[name="'+c.target+'"]').on('change', run);
+                });
+            });
+        });
         $('.gm2-field[data-conditional-field]').each(function(){
             var $wrap = $(this);
             var target = $wrap.data('conditional-field');
             var expected = $wrap.data('conditional-value');
-            var $controller = $('[name="'+target+'"]');
-            function check(){
-                var val;
-                if ($controller.attr('type') === 'checkbox') {
-                    val = $controller.is(':checked') ? '1' : '0';
-                } else {
-                    val = $controller.val();
-                }
-                if (String(val) === String(expected)) {
-                    $wrap.show();
-                } else {
-                    $wrap.hide();
-                }
-            }
-            $controller.on('change', check);
-            check();
+            var conds = [{ relation:'AND', conditions:[{ relation:'AND', target:target, operator:'=', value:String(expected) }] }];
+            items.push({el:$wrap, conds:conds});
+            $('[name="'+target+'"]').on('change', run);
         });
+        function run(){
+            $.each(items, function(i,it){
+                it.el.toggle( evaluate(it.conds) );
+            });
+        }
+        run();
     }
     $(document).ready(setupConditional);
 })(jQuery);

--- a/admin/js/gm2-custom-tax-admin.js
+++ b/admin/js/gm2-custom-tax-admin.js
@@ -37,6 +37,9 @@ jQuery(function($){
         $('#gm2-tax-arg-index').val(index !== undefined ? index : '');
         $('#gm2-tax-arg-key').prop('disabled', index !== undefined).val(data ? data.key : '');
         showArgControl(data ? data.key : '', data ? data.value : '');
+        var targets = (gm2TaxArgs.fields || []).map(function(f){ return f.slug; });
+        targets.push('page_id','post_id');
+        gm2Conditions.init($('#gm2-tax-conditions'), { targets: targets, data: data ? data.conditions : [] });
         $('#gm2-tax-arg-form').show();
     }
 
@@ -52,7 +55,7 @@ jQuery(function($){
         $.post(gm2TaxArgs.ajax, data, function(resp){
             if(resp && resp.success){
                 args = [];
-                $.each(resp.data.args || {}, function(key, val){ args.push({ key:key, value:val }); });
+                $.each(resp.data.args || {}, function(key, val){ args.push({ key:key, value: val.value !== undefined ? val.value : val, conditions: val.conditions || [] }); });
                 renderArgs();
                 if(cb) cb(true);
             }else{
@@ -68,7 +71,7 @@ jQuery(function($){
         var idx = $('#gm2-tax-arg-index').val();
         var key = $('#gm2-tax-arg-key').val();
         var val = (key === 'public' || key === 'hierarchical') ? $('#gm2-tax-arg-value').is(':checked') : $('#gm2-tax-arg-value').val();
-        var obj = { key:key, value:val };
+        var obj = { key:key, value:val, conditions: gm2Conditions.getData($('#gm2-tax-conditions')) };
         if(idx === ''){ args.push(obj); } else { args[idx] = obj; }
         saveAll(function(){ $('#gm2-tax-arg-form').hide(); });
     });

--- a/public/Gm2_Custom_Posts_Public.php
+++ b/public/Gm2_Custom_Posts_Public.php
@@ -19,7 +19,10 @@ class Gm2_Custom_Posts_Public {
         }
         if (!empty($config['post_types'])) {
             foreach ($config['post_types'] as $slug => $pt) {
-                $args = $pt['args'] ?? [];
+                $args = [];
+                foreach (($pt['args'] ?? []) as $a_key => $a_val) {
+                    $args[$a_key] = is_array($a_val) && array_key_exists('value', $a_val) ? $a_val['value'] : $a_val;
+                }
                 $label = $pt['label'] ?? ucfirst($slug);
                 $args['labels']['name'] = $label;
                 $args['labels']['singular_name'] = $label;
@@ -29,7 +32,10 @@ class Gm2_Custom_Posts_Public {
         }
         if (!empty($config['taxonomies'])) {
             foreach ($config['taxonomies'] as $slug => $tax) {
-                $args = $tax['args'] ?? [];
+                $args = [];
+                foreach (($tax['args'] ?? []) as $a_key => $a_val) {
+                    $args[$a_key] = is_array($a_val) && array_key_exists('value', $a_val) ? $a_val['value'] : $a_val;
+                }
                 $label = $tax['label'] ?? ucfirst($slug);
                 $args['labels']['name'] = $label;
                 $args['labels']['singular_name'] = $label;

--- a/tests/test-custom-posts.php
+++ b/tests/test-custom-posts.php
@@ -20,9 +20,18 @@ class CustomPostsFieldsTest extends WP_UnitTestCase {
                         'extra' => [
                             'label' => 'Extra',
                             'type' => 'text',
-                            'conditional' => [
-                                'field' => 'show_extra',
-                                'value' => '1',
+                            'conditions' => [
+                                [
+                                    'relation' => 'AND',
+                                    'conditions' => [
+                                        [
+                                            'relation' => 'AND',
+                                            'target'   => 'show_extra',
+                                            'operator' => '=',
+                                            'value'    => '1',
+                                        ],
+                                    ],
+                                ],
                             ],
                         ],
                     ],
@@ -75,7 +84,12 @@ class CustomPostsFieldsTest extends WP_UnitTestCase {
         $admin->render_meta_box($post, $fields, 'book');
         $html = ob_get_clean();
 
-        $this->assertStringContainsString('data-conditional-field="show_extra"', $html);
-        $this->assertStringContainsString('data-conditional-value="1"', $html);
+        $this->assertStringContainsString('data-conditions=', $html);
+        preg_match('/data-conditions="([^"]+)"/', $html, $m);
+        $this->assertNotEmpty($m);
+        $decoded = json_decode(htmlspecialchars_decode($m[1]), true);
+        $this->assertSame('show_extra', $decoded[0]['conditions'][0]['target']);
+        $this->assertSame('=', $decoded[0]['conditions'][0]['operator']);
+        $this->assertSame('1', $decoded[0]['conditions'][0]['value']);
     }
 }


### PR DESCRIPTION
## Summary
- allow custom fields and registration args to define display condition groups
- add reusable JS helper for managing condition rows
- evaluate saved conditions when rendering meta boxes

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f5694747483279f4d49ab7759cfef