### PR TITLE
Respect field conditions in custom post types

### DIFF
--- a/admin/Gm2_Custom_Posts_Admin.php
+++ b/admin/Gm2_Custom_Posts_Admin.php
@@ -327,20 +327,24 @@ class Gm2_Custom_Posts_Admin {
     public function render_meta_box($post, $fields, $slug) {
         wp_nonce_field('gm2_save_custom_fields', 'gm2_custom_fields_nonce');
         foreach ($fields as $key => $field) {
-            $type  = $field['type'] ?? 'text';
-            $label = $field['label'] ?? $key;
-            $value = get_post_meta($post->ID, $key, true);
+            $type   = $field['type'] ?? 'text';
+            $label  = $field['label'] ?? $key;
+            $value  = get_post_meta($post->ID, $key, true);
             if ($value === '' && isset($field['default'])) {
                 $value = $field['default'];
             }
-            $cond  = $field['conditional'] ?? [];
-            $conds = $field['conditions'] ?? [];
+            $cond   = $field['conditional'] ?? [];
+            $conds  = $field['conditions'] ?? [];
             $options = $field['options'] ?? [];
+            $visible = gm2_evaluate_conditions($field, $post->ID);
             echo '<div class="gm2-field"';
             if (!empty($conds)) {
                 echo ' data-conditions="' . esc_attr(wp_json_encode($conds)) . '"';
             } elseif (!empty($cond['field']) && isset($cond['value'])) {
                 echo ' data-conditional-field="' . esc_attr($cond['field']) . '" data-conditional-value="' . esc_attr($cond['value']) . '"';
+            }
+            if (!$visible) {
+                echo ' style="display:none;"';
             }
             echo '>';
             echo '<p><label for="' . esc_attr($key) . '">' . esc_html($label) . '</label><br />';

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -55,6 +55,7 @@ require_once GM2_PLUGIN_DIR . 'includes/Gm2_SEO_Utils.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_CSV_Helper.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_Abandoned_Carts.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_Analytics.php';
+require_once GM2_PLUGIN_DIR . 'includes/gm2-custom-posts-functions.php';
 // Temporarily disable Recovery Email Queue.
 // require_once GM2_PLUGIN_DIR . 'includes/Gm2_Abandoned_Carts_Messaging.php';
 require_once GM2_PLUGIN_DIR . 'admin/Gm2_Abandoned_Carts_Admin.php';

--- a/includes/gm2-custom-posts-functions.php
+++ b/includes/gm2-custom-posts-functions.php
@@ -1,0 +1,98 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Evaluate condition groups for a field or argument.
+ *
+ * @param array $item    Field or arg array possibly containing `conditions` or `conditional` keys.
+ * @param int   $post_id Post ID context for meta lookup.
+ * @return bool True if conditions pass or none are defined.
+ */
+function gm2_evaluate_conditions($item, $post_id = 0) {
+    if (!is_array($item)) {
+        return true;
+    }
+
+    // Build groups from modern `conditions` or legacy `conditional`.
+    $groups = [];
+    if (!empty($item['conditions']) && is_array($item['conditions'])) {
+        $groups = $item['conditions'];
+    } elseif (!empty($item['conditional']['field']) && isset($item['conditional']['value'])) {
+        $groups = [
+            [
+                'relation'   => 'AND',
+                'conditions' => [
+                    [
+                        'relation' => 'AND',
+                        'target'   => $item['conditional']['field'],
+                        'operator' => '=',
+                        'value'    => (string) $item['conditional']['value'],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    if (empty($groups)) {
+        return true;
+    }
+
+    $result = null;
+    foreach ($groups as $group) {
+        $group_res = null;
+        foreach (($group['conditions'] ?? []) as $cond) {
+            $target = $cond['target'] ?? '';
+            if ($target === '') {
+                continue;
+            }
+            // Determine the current value from request or post meta.
+            if (isset($_REQUEST[$target])) {
+                $current = $_REQUEST[$target];
+                if (is_array($current)) {
+                    $current = reset($current);
+                }
+            } else {
+                $current = ($post_id) ? get_post_meta($post_id, $target, true) : '';
+            }
+            $current = (string) $current;
+            $expected = (string) ($cond['value'] ?? '');
+            $ok = false;
+            switch ($cond['operator'] ?? '=') {
+                case '!=':
+                    $ok = $current !== $expected;
+                    break;
+                case '>':
+                    $ok = floatval($current) > floatval($expected);
+                    break;
+                case '<':
+                    $ok = floatval($current) < floatval($expected);
+                    break;
+                case 'contains':
+                    $ok = strpos($current, $expected) !== false;
+                    break;
+                default:
+                    $ok = $current === $expected;
+                    break;
+            }
+            if ($group_res === null) {
+                $group_res = $ok;
+            } else {
+                $rel = strtoupper($cond['relation'] ?? 'AND');
+                $group_res = ($rel === 'OR') ? ($group_res || $ok) : ($group_res && $ok);
+            }
+        }
+        if ($group_res === null) {
+            $group_res = false;
+        }
+        if ($result === null) {
+            $result = $group_res;
+        } else {
+            $rel = strtoupper($group['relation'] ?? 'AND');
+            $result = ($rel === 'OR') ? ($result || $group_res) : ($result && $group_res);
+        }
+    }
+
+    return ($result === null) ? true : $result;
+}

--- a/public/Gm2_Custom_Posts_Public.php
+++ b/public/Gm2_Custom_Posts_Public.php
@@ -21,7 +21,14 @@ class Gm2_Custom_Posts_Public {
             foreach ($config['post_types'] as $slug => $pt) {
                 $args = [];
                 foreach (($pt['args'] ?? []) as $a_key => $a_val) {
-                    $args[$a_key] = is_array($a_val) && array_key_exists('value', $a_val) ? $a_val['value'] : $a_val;
+                    if (is_array($a_val)) {
+                        if (!gm2_evaluate_conditions($a_val)) {
+                            continue;
+                        }
+                        $args[$a_key] = array_key_exists('value', $a_val) ? $a_val['value'] : $a_val;
+                    } else {
+                        $args[$a_key] = $a_val;
+                    }
                 }
                 $label = $pt['label'] ?? ucfirst($slug);
                 $args['labels']['name'] = $label;
@@ -34,7 +41,14 @@ class Gm2_Custom_Posts_Public {
             foreach ($config['taxonomies'] as $slug => $tax) {
                 $args = [];
                 foreach (($tax['args'] ?? []) as $a_key => $a_val) {
-                    $args[$a_key] = is_array($a_val) && array_key_exists('value', $a_val) ? $a_val['value'] : $a_val;
+                    if (is_array($a_val)) {
+                        if (!gm2_evaluate_conditions($a_val)) {
+                            continue;
+                        }
+                        $args[$a_key] = array_key_exists('value', $a_val) ? $a_val['value'] : $a_val;
+                    } else {
+                        $args[$a_key] = $a_val;
+                    }
                 }
                 $label = $tax['label'] ?? ucfirst($slug);
                 $args['labels']['name'] = $label;
@@ -87,7 +101,10 @@ function gm2_render_custom_post_fields($post = null) {
     $fields = $config['post_types'][$ptype]['fields'];
     $out = '<div class="gm2-custom-fields">';
     foreach ($fields as $key => $field) {
-        $label = $field['label'] ?? $key;
+        if (!gm2_evaluate_conditions($field, $post->ID)) {
+            continue;
+        }
+        $label   = $field['label'] ?? $key;
         $display = gm2_get_custom_post_field($key, $post);
         if ($display === '') {
             continue;
@@ -109,6 +126,9 @@ function gm2_get_custom_post_field($key, $post = null) {
         return '';
     }
     $field = $config['post_types'][$ptype]['fields'][$key];
+    if (!gm2_evaluate_conditions($field, $post->ID)) {
+        return '';
+    }
     $value = get_post_meta($post->ID, $key, true);
     if ($value === '' || $value === null) {
         return '';


### PR DESCRIPTION
## Summary
- Evaluate condition groups for custom post type fields and args
- Hide metabox fields when conditions fail on the current post
- Skip rendering and registration for fields and args whose conditions are not met

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f58d1b3a4832799a12932812488aa