### PR TITLE
Add Gm2 Cart top-level menu

### DIFF
--- a/admin/Gm2_Abandoned_Carts_Admin.php
+++ b/admin/Gm2_Abandoned_Carts_Admin.php
@@ -16,7 +16,7 @@ class Gm2_Abandoned_Carts_Admin {
 
     public function add_menu() {
         add_submenu_page(
-            'gm2',
+            'gm2-cart',
             __('Abandoned Carts', 'gm2-wordpress-suite'),
             __('Abandoned Carts', 'gm2-wordpress-suite'),
             'manage_options',
@@ -26,7 +26,7 @@ class Gm2_Abandoned_Carts_Admin {
     }
 
     public function enqueue_scripts($hook) {
-        if ($hook !== 'gm2_page_gm2-abandoned-carts') {
+        if ($hook !== 'gm2-cart_page_gm2-abandoned-carts') {
             return;
         }
         wp_enqueue_script(

--- a/admin/Gm2_Cart_Settings_Admin.php
+++ b/admin/Gm2_Cart_Settings_Admin.php
@@ -10,8 +10,17 @@ class Gm2_Cart_Settings_Admin {
     }
 
     public function add_admin_menu() {
+        add_menu_page(
+            esc_html__( 'Gm2 Cart', 'gm2-wordpress-suite' ),
+            esc_html__( 'Gm2 Cart', 'gm2-wordpress-suite' ),
+            'manage_options',
+            'gm2-cart',
+            '__return_null',
+            'dashicons-cart'
+        );
+
         add_submenu_page(
-            'gm2',
+            'gm2-cart',
             esc_html__( 'Cart Settings', 'gm2-wordpress-suite' ),
             esc_html__( 'Cart Settings', 'gm2-wordpress-suite' ),
             'manage_options',

--- a/admin/Gm2_Quantity_Discounts_Admin.php
+++ b/admin/Gm2_Quantity_Discounts_Admin.php
@@ -16,7 +16,7 @@ class Gm2_Quantity_Discounts_Admin {
     public function add_admin_menu() {
         if (get_option('gm2_enable_quantity_discounts', '1') === '1') {
             add_submenu_page(
-                'gm2',
+                'gm2-cart',
                 esc_html__( 'Quantity Discounts', 'gm2-wordpress-suite' ),
                 esc_html__( 'Quantity Discounts', 'gm2-wordpress-suite' ),
                 'manage_options',
@@ -27,7 +27,7 @@ class Gm2_Quantity_Discounts_Admin {
     }
 
     public function enqueue_scripts( $hook ) {
-        if ( $hook !== 'gm2_page_gm2-quantity-discounts' ) {
+        if ( $hook !== 'gm2-cart_page_gm2-quantity-discounts' ) {
             return;
         }
         wp_enqueue_style(

--- a/admin/Gm2_Recovered_Carts_Admin.php
+++ b/admin/Gm2_Recovered_Carts_Admin.php
@@ -14,7 +14,7 @@ class Gm2_Recovered_Carts_Admin {
 
     public function add_menu() {
         add_submenu_page(
-            'gm2',
+            'gm2-cart',
             __('Recovered Carts', 'gm2-wordpress-suite'),
             __('Recovered Carts', 'gm2-wordpress-suite'),
             'manage_options',

--- a/languages/gm2-wordpress-suite.pot
+++ b/languages/gm2-wordpress-suite.pot
@@ -543,7 +543,11 @@ msgstr ""
 msgid "Configure ChatGPT under %s."
 msgstr ""
 
-#: ../admin/Gm2_Cart_Settings_Admin.php:15, ../admin/Gm2_Cart_Settings_Admin.php:16, ../admin/Gm2_Cart_Settings_Admin.php:57
+#: ../admin/Gm2_Cart_Settings_Admin.php:14, ../admin/Gm2_Cart_Settings_Admin.php:15
+msgid "Gm2 Cart"
+msgstr ""
+
+#: ../admin/Gm2_Cart_Settings_Admin.php:24, ../admin/Gm2_Cart_Settings_Admin.php:25, ../admin/Gm2_Cart_Settings_Admin.php:66
 msgid "Cart Settings"
 msgstr ""
 


### PR DESCRIPTION
## Summary
- Add new `gm2-cart` top-level admin menu
- Move cart-related pages under the new menu
- Update translation template for menu label

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*
- `make test` *(fails: Database credentials must be supplied)*

------
https://chatgpt.com/codex/tasks/task_e_689f632078408327bedee6c6f5d73384