### PR TITLE
Extend custom post type configuration

### DIFF
--- a/admin/Gm2_Custom_Posts_Admin.php
+++ b/admin/Gm2_Custom_Posts_Admin.php
@@ -180,10 +180,83 @@ class Gm2_Custom_Posts_Admin {
                 $fields = [];
             }
             $fields = $this->sanitize_fields_array($fields);
+
+            $args_input = [];
+            $labels = json_decode(wp_unslash($_POST['pt_labels'] ?? ''), true);
+            if (is_array($labels)) {
+                $args_input[] = [ 'key' => 'labels', 'value' => $labels ];
+            }
+            $menu_icon = sanitize_text_field($_POST['pt_menu_icon'] ?? '');
+            if ($menu_icon !== '') {
+                $args_input[] = [ 'key' => 'menu_icon', 'value' => $menu_icon ];
+            }
+            $menu_position = isset($_POST['pt_menu_position']) ? sanitize_text_field($_POST['pt_menu_position']) : '';
+            if ($menu_position !== '') {
+                $args_input[] = [ 'key' => 'menu_position', 'value' => $menu_position ];
+            }
+            $supports = array_filter(array_map('sanitize_key', explode(',', $_POST['pt_supports'] ?? '')));
+            if ($supports) {
+                $args_input[] = [ 'key' => 'supports', 'value' => $supports ];
+            }
+            if (!empty($_POST['pt_hierarchical'])) {
+                $args_input[] = [ 'key' => 'hierarchical', 'value' => true ];
+            }
+            foreach ([ 'public', 'publicly_queryable', 'show_ui', 'show_in_menu', 'show_in_nav_menus', 'show_in_admin_bar', 'exclude_from_search', 'has_archive' ] as $vis_key) {
+                if (!empty($_POST['pt_' . $vis_key])) {
+                    $args_input[] = [ 'key' => $vis_key, 'value' => true ];
+                }
+            }
+            if (!empty($_POST['pt_show_in_rest'])) {
+                $args_input[] = [ 'key' => 'show_in_rest', 'value' => true ];
+            }
+            $rest_base = sanitize_key($_POST['pt_rest_base'] ?? '');
+            if ($rest_base !== '') {
+                $args_input[] = [ 'key' => 'rest_base', 'value' => $rest_base ];
+            }
+            $rest_controller = sanitize_text_field($_POST['pt_rest_controller_class'] ?? '');
+            if ($rest_controller !== '') {
+                $args_input[] = [ 'key' => 'rest_controller_class', 'value' => $rest_controller ];
+            }
+            $rewrite = [];
+            $rewrite_slug = sanitize_title_with_dashes($_POST['pt_rewrite_slug'] ?? '');
+            if ($rewrite_slug !== '') {
+                $rewrite['slug'] = $rewrite_slug;
+            }
+            foreach ( [ 'with_front', 'hierarchical', 'feeds', 'pages' ] as $r_key ) {
+                if (!empty($_POST['pt_rewrite_' . $r_key])) {
+                    $rewrite[$r_key] = true;
+                }
+            }
+            if (!empty($rewrite)) {
+                $args_input[] = [ 'key' => 'rewrite', 'value' => $rewrite ];
+            }
+            if (!empty($_POST['pt_map_meta_cap'])) {
+                $args_input[] = [ 'key' => 'map_meta_cap', 'value' => true ];
+            }
+            $cap_type = sanitize_text_field($_POST['pt_capability_type'] ?? '');
+            if ($cap_type !== '') {
+                $args_input[] = [ 'key' => 'capability_type', 'value' => $cap_type ];
+            }
+            $caps = json_decode(wp_unslash($_POST['pt_capabilities'] ?? ''), true);
+            if (is_array($caps)) {
+                $args_input[] = [ 'key' => 'capabilities', 'value' => $caps ];
+            }
+            $template = json_decode(wp_unslash($_POST['pt_template'] ?? ''), true);
+            if (is_array($template)) {
+                $args_input[] = [ 'key' => 'template', 'value' => $template ];
+            }
+            $template_lock = sanitize_text_field($_POST['pt_template_lock'] ?? '');
+            if ($template_lock !== '') {
+                $args_input[] = [ 'key' => 'template_lock', 'value' => $template_lock ];
+            }
+
+            $args = $this->sanitize_args_array($args_input);
+
             if ($slug) {
                 $config['post_types'][$slug] = [
                     'label'  => $label ?: ucfirst($slug),
                     'fields' => $fields,
+                    'args'   => $args,
                 ];
                 update_option('gm2_custom_posts_config', $config);
                 echo '<div class="notice notice-success"><p>' . esc_html__( 'Post type saved.', 'gm2-wordpress-suite' ) . '</p></div>';
@@ -246,6 +319,47 @@ class Gm2_Custom_Posts_Admin {
         echo '<input type="text" name="pt_slug" class="regular-text" /></label></p>';
         echo '<p><label>' . esc_html__( 'Label', 'gm2-wordpress-suite' ) . '<br />';
         echo '<input type="text" name="pt_label" class="regular-text" /></label></p>';
+        echo '<p><label>' . esc_html__( 'Labels (JSON)', 'gm2-wordpress-suite' ) . '<br />';
+        echo '<textarea name="pt_labels" class="large-text code" rows="5"></textarea></label></p>';
+        echo '<p><label>' . esc_html__( 'Menu Icon', 'gm2-wordpress-suite' ) . '<br />';
+        echo '<input type="text" name="pt_menu_icon" class="regular-text" /></label></p>';
+        echo '<p><label>' . esc_html__( 'Menu Position', 'gm2-wordpress-suite' ) . '<br />';
+        echo '<input type="number" name="pt_menu_position" class="small-text" /></label></p>';
+        echo '<p><label>' . esc_html__( 'Supports (comma separated)', 'gm2-wordpress-suite' ) . '<br />';
+        echo '<input type="text" name="pt_supports" class="regular-text" /></label></p>';
+        echo '<p><label><input type="checkbox" name="pt_hierarchical" value="1" /> ' . esc_html__( 'Hierarchical', 'gm2-wordpress-suite' ) . '</label></p>';
+        echo '<fieldset><legend>' . esc_html__( 'Visibility', 'gm2-wordpress-suite' ) . '</legend>';
+        foreach ([ 'public', 'publicly_queryable', 'show_ui', 'show_in_menu', 'show_in_nav_menus', 'show_in_admin_bar', 'exclude_from_search', 'has_archive' ] as $vis) {
+            echo '<label><input type="checkbox" name="pt_' . esc_attr($vis) . '" value="1" /> ' . esc_html( ucwords(str_replace('_', ' ', $vis)) ) . '</label><br />';
+        }
+        echo '</fieldset>';
+        echo '<fieldset><legend>' . esc_html__( 'REST API', 'gm2-wordpress-suite' ) . '</legend>';
+        echo '<p><label><input type="checkbox" name="pt_show_in_rest" value="1" /> ' . esc_html__( 'Show in REST', 'gm2-wordpress-suite' ) . '</label></p>';
+        echo '<p><label>' . esc_html__( 'REST Base', 'gm2-wordpress-suite' ) . '<br />';
+        echo '<input type="text" name="pt_rest_base" class="regular-text" /></label></p>';
+        echo '<p><label>' . esc_html__( 'REST Controller Class', 'gm2-wordpress-suite' ) . '<br />';
+        echo '<input type="text" name="pt_rest_controller_class" class="regular-text" /></label></p>';
+        echo '</fieldset>';
+        echo '<fieldset><legend>' . esc_html__( 'Rewrite', 'gm2-wordpress-suite' ) . '</legend>';
+        echo '<p><label>' . esc_html__( 'Slug', 'gm2-wordpress-suite' ) . '<br />';
+        echo '<input type="text" name="pt_rewrite_slug" class="regular-text" /></label></p>';
+        foreach ([ 'with_front', 'hierarchical', 'feeds', 'pages' ] as $rw ) {
+            echo '<label><input type="checkbox" name="pt_rewrite_' . esc_attr($rw) . '" value="1" /> ' . esc_html( ucwords(str_replace('_', ' ', $rw)) ) . '</label><br />';
+        }
+        echo '</fieldset>';
+        echo '<fieldset><legend>' . esc_html__( 'Capabilities', 'gm2-wordpress-suite' ) . '</legend>';
+        echo '<p><label><input type="checkbox" name="pt_map_meta_cap" value="1" /> ' . esc_html__( 'Map Meta Cap', 'gm2-wordpress-suite' ) . '</label></p>';
+        echo '<p><label>' . esc_html__( 'Capability Type', 'gm2-wordpress-suite' ) . '<br />';
+        echo '<input type="text" name="pt_capability_type" class="regular-text" /></label></p>';
+        echo '<p><label>' . esc_html__( 'Capabilities (JSON)', 'gm2-wordpress-suite' ) . '<br />';
+        echo '<textarea name="pt_capabilities" class="large-text code" rows="5"></textarea></label></p>';
+        echo '</fieldset>';
+        echo '<fieldset><legend>' . esc_html__( 'Templates', 'gm2-wordpress-suite' ) . '</legend>';
+        echo '<p><label>' . esc_html__( 'Template (JSON)', 'gm2-wordpress-suite' ) . '<br />';
+        echo '<textarea name="pt_template" class="large-text code" rows="5"></textarea></label></p>';
+        echo '<p><label>' . esc_html__( 'Template Lock', 'gm2-wordpress-suite' ) . '<br />';
+        echo '<input type="text" name="pt_template_lock" class="regular-text" /></label></p>';
+        echo '</fieldset>';
         echo '<p><label>' . esc_html__( 'Fields (JSON)', 'gm2-wordpress-suite' ) . '<br />';
         echo '<textarea name="pt_fields" class="large-text code" rows="5" placeholder="{\n  \"field_key\": {\n    \"label\": \"Field Label\",\n    \"type\": \"text\"\n  }\n}"></textarea></label></p>';
         echo '<p><input type="submit" name="gm2_add_post_type" class="button button-primary" value="' . esc_attr__( 'Save Post Type', 'gm2-wordpress-suite' ) . '" /></p>';
@@ -324,6 +438,7 @@ class Gm2_Custom_Posts_Admin {
         if (!is_array($args)) {
             return $sanitized_args;
         }
+        $bool_keys = [ 'public', 'hierarchical', 'publicly_queryable', 'show_ui', 'show_in_menu', 'show_in_nav_menus', 'show_in_admin_bar', 'exclude_from_search', 'has_archive', 'show_in_rest', 'map_meta_cap' ];
         foreach ($args as $arg) {
             $a_key = sanitize_key($arg['key'] ?? '');
             if (!$a_key) {
@@ -331,7 +446,7 @@ class Gm2_Custom_Posts_Admin {
             }
             $value = $arg['value'] ?? '';
             $conditions = $this->sanitize_conditions($arg['conditions'] ?? []);
-            if (in_array($a_key, [ 'public', 'hierarchical' ], true)) {
+            if (in_array($a_key, $bool_keys, true)) {
                 $val = !empty($value);
             } elseif ($a_key === 'supports') {
                 if (is_array($value)) {
@@ -339,6 +454,45 @@ class Gm2_Custom_Posts_Admin {
                 } else {
                     $val = array_filter(array_map('sanitize_key', explode(',', (string) $value)));
                 }
+            } elseif ($a_key === 'labels') {
+                if (is_string($value)) {
+                    $value = json_decode(wp_unslash($value), true);
+                }
+                $val = [];
+                if (is_array($value)) {
+                    foreach ($value as $k => $v) {
+                        $val[sanitize_key($k)] = sanitize_text_field($v);
+                    }
+                }
+            } elseif ($a_key === 'rewrite') {
+                if (is_string($value)) {
+                    $value = json_decode(wp_unslash($value), true);
+                }
+                $val = [];
+                if (is_array($value)) {
+                    $val['slug']         = sanitize_title_with_dashes($value['slug'] ?? '');
+                    $val['with_front']   = !empty($value['with_front']);
+                    $val['hierarchical'] = !empty($value['hierarchical']);
+                    $val['feeds']        = !empty($value['feeds']);
+                    $val['pages']        = !empty($value['pages']);
+                }
+            } elseif ($a_key === 'capabilities') {
+                if (is_string($value)) {
+                    $value = json_decode(wp_unslash($value), true);
+                }
+                $val = [];
+                if (is_array($value)) {
+                    foreach ($value as $k => $v) {
+                        $val[sanitize_key($k)] = sanitize_text_field($v);
+                    }
+                }
+            } elseif ($a_key === 'template') {
+                if (is_string($value)) {
+                    $value = json_decode(wp_unslash($value), true);
+                }
+                $val = is_array($value) ? $value : [];
+            } elseif ($a_key === 'menu_position') {
+                $val = is_numeric($value) ? (int) $value : 0;
             } else {
                 $val = sanitize_text_field($value);
             }

--- a/admin/js/gm2-custom-posts-admin.js
+++ b/admin/js/gm2-custom-posts-admin.js
@@ -37,6 +37,8 @@ jQuery(function($){
                 val = 'true';
             } else if(val === false){
                 val = 'false';
+            } else if(typeof val === 'object'){
+                val = JSON.stringify(val);
             }
             var row = $('<tr>\
 <td>'+esc(a.key)+'</td>\
@@ -62,7 +64,8 @@ jQuery(function($){
 
     function showArgControl(key, value){
         var wrap = $('#gm2-arg-value-wrap').empty();
-        if(key === 'public' || key === 'hierarchical'){
+        var boolKeys = ['public','hierarchical','publicly_queryable','show_ui','show_in_menu','show_in_nav_menus','show_in_admin_bar','exclude_from_search','has_archive','show_in_rest','map_meta_cap'];
+        if(boolKeys.indexOf(key) !== -1){
             var chk = $('<label><input type="checkbox" id="gm2-arg-value" value="1"/> '+key+'</label>');
             if(value){ chk.find('input').prop('checked', true); }
             wrap.append(chk);
@@ -71,6 +74,9 @@ jQuery(function($){
             $('#gm2-arg-value').val($.isArray(value) ? value.join(',') : value);
         }else{
             wrap.append('<input type="text" id="gm2-arg-value" class="regular-text" />');
+            if(typeof value === 'object'){
+                value = JSON.stringify(value);
+            }
             $('#gm2-arg-value').val(value);
         }
     }
@@ -153,7 +159,8 @@ jQuery(function($){
         var idx = $('#gm2-arg-index').val();
         var key = $('#gm2-arg-key').val();
         var val;
-        if(key === 'public' || key === 'hierarchical'){
+        var boolKeys = ['public','hierarchical','publicly_queryable','show_ui','show_in_menu','show_in_nav_menus','show_in_admin_bar','exclude_from_search','has_archive','show_in_rest','map_meta_cap'];
+        if(boolKeys.indexOf(key) !== -1){
             val = $('#gm2-arg-value').is(':checked');
         }else if(key === 'supports'){
             val = $('#gm2-arg-value').val();


### PR DESCRIPTION
## Summary
- collect comprehensive CPT arguments including labels, visibility toggles, REST and rewrite options
- register custom post types/taxonomies from stored configuration
- enhance CPT admin JS to handle additional argument types

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f6373a7408327b03ad6cbde45bf25