### PR TITLE
Add modular custom field framework with relationship syncing

### DIFF
--- a/admin/js/gm2-custom-posts-admin.js
+++ b/admin/js/gm2-custom-posts-admin.js
@@ -181,6 +181,24 @@ jQuery(function($){
         saveAll();
     });
 
+    // Media uploader for media field type
+    $(document).on('click', '.gm2-media-upload', function(e){
+        e.preventDefault();
+        var target = $(this).data('target');
+        var frame = wp.media({ multiple: false });
+        frame.on('select', function(){
+            var attachment = frame.state().get('selection').first().toJSON();
+            $('[name="'+target+'"]').val(attachment.id);
+        });
+        frame.open();
+    });
+
+    // Basic sanitization for relationship fields
+    $(document).on('input', '.gm2-relationship', function(){
+        var val = $(this).val();
+        $(this).val(val.replace(/[^0-9,]/g,''));
+    });
+
     renderFields();
     renderArgs();
 });

--- a/includes/fields/class-field-base.php
+++ b/includes/fields/class-field-base.php
@@ -1,0 +1,91 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+abstract class GM2_Field {
+    protected $key;
+    protected $args;
+
+    public function __construct( $key, $args = array() ) {
+        $this->key  = $key;
+        $this->args = is_array( $args ) ? $args : array();
+    }
+
+    public function render_admin( $value, $object_id, $context_type ) {
+        $label = $this->args['label'] ?? $this->key;
+        echo '<p><label>' . esc_html( $label ) . '<br />';
+        $this->render_field( $value, $object_id, $context_type );
+        echo '</label></p>';
+        if ( ! empty( $this->args['instructions'] ) ) {
+            echo '<p class="description">' . esc_html( $this->args['instructions'] ) . '</p>';
+        }
+    }
+
+    public function render_public( $value ) {
+        echo '<div class="gm2-field gm2-field-' . esc_attr( $this->key ) . '">';
+        $this->render_field( $value, 0, 'public' );
+        echo '</div>';
+    }
+
+    protected function render_field( $value, $object_id, $context_type ) {
+        echo '<input type="text" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '" />';
+    }
+
+    public function sanitize( $value ) {
+        return sanitize_text_field( $value );
+    }
+
+    public function save( $object_id, $value, $context_type = 'post' ) {
+        $value = $this->sanitize( $value );
+        if ( $value === null || $value === '' ) {
+            $this->delete_value( $object_id, $context_type );
+        } else {
+            $this->update_value( $object_id, $value, $context_type );
+        }
+    }
+
+    protected function update_value( $object_id, $value, $context_type ) {
+        switch ( $context_type ) {
+            case 'user':
+                update_user_meta( $object_id, $this->key, $value );
+                break;
+            case 'term':
+                update_term_meta( $object_id, $this->key, $value );
+                break;
+            case 'comment':
+                update_comment_meta( $object_id, $this->key, $value );
+                break;
+            case 'option':
+                update_option( $this->key, $value );
+                break;
+            case 'site':
+                update_site_option( $this->key, $value );
+                break;
+            default:
+                update_post_meta( $object_id, $this->key, $value );
+        }
+    }
+
+    protected function delete_value( $object_id, $context_type ) {
+        switch ( $context_type ) {
+            case 'user':
+                delete_user_meta( $object_id, $this->key );
+                break;
+            case 'term':
+                delete_term_meta( $object_id, $this->key );
+                break;
+            case 'comment':
+                delete_comment_meta( $object_id, $this->key );
+                break;
+            case 'option':
+                delete_option( $this->key );
+                break;
+            case 'site':
+                delete_site_option( $this->key );
+                break;
+            default:
+                delete_post_meta( $object_id, $this->key );
+        }
+    }
+}

--- a/includes/fields/class-field-commerce.php
+++ b/includes/fields/class-field-commerce.php
@@ -1,0 +1,14 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class GM2_Field_Commerce extends GM2_Field {
+    protected function render_field( $value, $object_id, $context_type ) {
+        echo '<input type="text" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '" class="gm2-commerce" />';
+    }
+
+    public function sanitize( $value ) {
+        return is_numeric( $value ) ? $value : '';
+    }
+}

--- a/includes/fields/class-field-computed.php
+++ b/includes/fields/class-field-computed.php
@@ -1,0 +1,18 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class GM2_Field_Computed extends GM2_Field {
+    protected function render_field( $value, $object_id, $context_type ) {
+        $cb = $this->args['callback'] ?? null;
+        if ( is_callable( $cb ) ) {
+            $value = call_user_func( $cb, $object_id );
+        }
+        echo '<span class="gm2-computed" data-key="' . esc_attr( $this->key ) . '">' . esc_html( $value ) . '</span>';
+    }
+
+    public function save( $object_id, $value, $context_type = 'post' ) {
+        // Computed fields are read-only.
+    }
+}

--- a/includes/fields/class-field-design.php
+++ b/includes/fields/class-field-design.php
@@ -1,0 +1,15 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class GM2_Field_Design extends GM2_Field {
+    protected function render_field( $value, $object_id, $context_type ) {
+        echo '<input type="text" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '" class="gm2-color" />';
+    }
+
+    public function sanitize( $value ) {
+        $clean = sanitize_hex_color( $value );
+        return $clean ? $clean : '';
+    }
+}

--- a/includes/fields/class-field-geospatial.php
+++ b/includes/fields/class-field-geospatial.php
@@ -1,0 +1,10 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class GM2_Field_Geospatial extends GM2_Field {
+    protected function render_field( $value, $object_id, $context_type ) {
+        echo '<input type="text" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '" placeholder="lat,lng" />';
+    }
+}

--- a/includes/fields/class-field-group.php
+++ b/includes/fields/class-field-group.php
@@ -1,0 +1,14 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class GM2_Field_Group extends GM2_Field {
+    protected function render_field( $value, $object_id, $context_type ) {
+        echo '<div class="gm2-field-group" data-key="' . esc_attr( $this->key ) . '"></div>';
+    }
+
+    public function save( $object_id, $value, $context_type = 'post' ) {
+        // Groups hold sub-fields; nothing to save directly.
+    }
+}

--- a/includes/fields/class-field-media.php
+++ b/includes/fields/class-field-media.php
@@ -1,0 +1,15 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class GM2_Field_Media extends GM2_Field {
+    protected function render_field( $value, $object_id, $context_type ) {
+        $button = '<button class="button gm2-media-upload" data-target="' . esc_attr( $this->key ) . '">' . esc_html__( 'Select Media', 'gm2-wordpress-suite' ) . '</button>';
+        echo '<input type="hidden" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '" />' . $button;
+    }
+
+    public function sanitize( $value ) {
+        return absint( $value );
+    }
+}

--- a/includes/fields/class-field-message.php
+++ b/includes/fields/class-field-message.php
@@ -1,0 +1,14 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class GM2_Field_Message extends GM2_Field {
+    protected function render_field( $value, $object_id, $context_type ) {
+        echo '<div class="gm2-field-message">' . esc_html( $this->args['message'] ?? '' ) . '</div>';
+    }
+
+    public function save( $object_id, $value, $context_type = 'post' ) {
+        // No data saved for message fields.
+    }
+}

--- a/includes/fields/class-field-number.php
+++ b/includes/fields/class-field-number.php
@@ -1,0 +1,14 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class GM2_Field_Number extends GM2_Field {
+    protected function render_field( $value, $object_id, $context_type ) {
+        echo '<input type="number" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '" />';
+    }
+
+    public function sanitize( $value ) {
+        return is_numeric( $value ) ? $value : '';
+    }
+}

--- a/includes/fields/class-field-relationship.php
+++ b/includes/fields/class-field-relationship.php
@@ -1,0 +1,38 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class GM2_Field_Relationship extends GM2_Field {
+    protected function render_field( $value, $object_id, $context_type ) {
+        $vals = is_array( $value ) ? $value : ( $value ? array( $value ) : array() );
+        echo '<input type="text" name="' . esc_attr( $this->key ) . '[]" value="' . esc_attr( implode( ',', $vals ) ) . '" class="gm2-relationship" />';
+    }
+
+    public function sanitize( $value ) {
+        $value = is_array( $value ) ? $value : array( $value );
+        return array_filter( array_map( 'absint', $value ) );
+    }
+
+    public function save( $object_id, $value, $context_type = 'post' ) {
+        $old = get_post_meta( $object_id, $this->key, true );
+        $old = is_array( $old ) ? $old : array();
+        $new = $this->sanitize( $value );
+        update_post_meta( $object_id, $this->key, $new );
+        $remove = array_diff( $old, $new );
+        foreach ( $remove as $rid ) {
+            $related = get_post_meta( $rid, $this->key, true );
+            $related = is_array( $related ) ? $related : array();
+            $related = array_diff( $related, array( $object_id ) );
+            update_post_meta( $rid, $this->key, $related );
+        }
+        foreach ( $new as $rid ) {
+            $related = get_post_meta( $rid, $this->key, true );
+            $related = is_array( $related ) ? $related : array();
+            if ( ! in_array( $object_id, $related, true ) ) {
+                $related[] = $object_id;
+                update_post_meta( $rid, $this->key, $related );
+            }
+        }
+    }
+}

--- a/includes/fields/class-field-select.php
+++ b/includes/fields/class-field-select.php
@@ -1,0 +1,15 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class GM2_Field_Select extends GM2_Field {
+    protected function render_field( $value, $object_id, $context_type ) {
+        $options = $this->args['options'] ?? array();
+        echo '<select name="' . esc_attr( $this->key ) . '">';
+        foreach ( $options as $ov => $ol ) {
+            echo '<option value="' . esc_attr( $ov ) . '"' . selected( $value, $ov, false ) . '>' . esc_html( $ol ) . '</option>';
+        }
+        echo '</select>';
+    }
+}

--- a/includes/fields/class-field-text.php
+++ b/includes/fields/class-field-text.php
@@ -1,0 +1,8 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class GM2_Field_Text extends GM2_Field {
+    // Inherits base behavior
+}

--- a/includes/fields/class-field-textarea.php
+++ b/includes/fields/class-field-textarea.php
@@ -1,0 +1,10 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class GM2_Field_Textarea extends GM2_Field {
+    protected function render_field( $value, $object_id, $context_type ) {
+        echo '<textarea name="' . esc_attr( $this->key ) . '" rows="5" cols="40">' . esc_textarea( $value ) . '</textarea>';
+    }
+}

--- a/includes/fields/loader.php
+++ b/includes/fields/loader.php
@@ -1,0 +1,46 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+require_once __DIR__ . '/class-field-base.php';
+require_once __DIR__ . '/class-field-text.php';
+require_once __DIR__ . '/class-field-textarea.php';
+require_once __DIR__ . '/class-field-number.php';
+require_once __DIR__ . '/class-field-select.php';
+require_once __DIR__ . '/class-field-media.php';
+require_once __DIR__ . '/class-field-group.php';
+require_once __DIR__ . '/class-field-relationship.php';
+require_once __DIR__ . '/class-field-geospatial.php';
+require_once __DIR__ . '/class-field-commerce.php';
+require_once __DIR__ . '/class-field-design.php';
+require_once __DIR__ . '/class-field-computed.php';
+require_once __DIR__ . '/class-field-message.php';
+
+$gm2_field_types = array();
+
+function gm2_register_field_type( $type, $class ) {
+    global $gm2_field_types;
+    $gm2_field_types[ $type ] = $class;
+}
+
+function gm2_get_field_type_class( $type ) {
+    global $gm2_field_types;
+    return $gm2_field_types[ $type ] ?? null;
+}
+
+function gm2_register_default_field_types() {
+    gm2_register_field_type( 'text', 'GM2_Field_Text' );
+    gm2_register_field_type( 'textarea', 'GM2_Field_Textarea' );
+    gm2_register_field_type( 'number', 'GM2_Field_Number' );
+    gm2_register_field_type( 'select', 'GM2_Field_Select' );
+    gm2_register_field_type( 'media', 'GM2_Field_Media' );
+    gm2_register_field_type( 'group', 'GM2_Field_Group' );
+    gm2_register_field_type( 'relationship', 'GM2_Field_Relationship' );
+    gm2_register_field_type( 'geo', 'GM2_Field_Geospatial' );
+    gm2_register_field_type( 'commerce', 'GM2_Field_Commerce' );
+    gm2_register_field_type( 'design', 'GM2_Field_Design' );
+    gm2_register_field_type( 'computed', 'GM2_Field_Computed' );
+    gm2_register_field_type( 'message', 'GM2_Field_Message' );
+}
+add_action( 'init', 'gm2_register_default_field_types' );

--- a/public/js/gm2-custom-posts.js
+++ b/public/js/gm2-custom-posts.js
@@ -1,3 +1,7 @@
-(function(){
-    // Placeholder for custom post frontend behaviors.
-})();
+(function($){
+    // Basic frontend helpers for custom post fields
+    $(document).on('input', '.gm2-relationship', function(){
+        var val = $(this).val();
+        $(this).val(val.replace(/[^0-9,]/g,''));
+    });
+})(jQuery);


### PR DESCRIPTION
## Summary
- add extensible field type API with modular classes
- sync relationship fields bidirectionally
- enhance admin/public scripts for media and relationship field rendering

## Testing
- `npm test --silent | tail -n 20`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f6f7dd5788327a9a94493b002e8b7