### PR TITLE
Add CPT wizard scaffold and list table enhancements

### DIFF
--- a/admin/js/gm2-cpt-wizard.js
+++ b/admin/js/gm2-cpt-wizard.js
@@ -1,0 +1,61 @@
+(function(wp){
+    const { createElement: el, useState } = wp.element;
+    const { render } = wp.element;
+    const { Button, TextControl, PanelBody, Panel } = wp.components;
+
+    const Wizard = () => {
+        const [ step, setStep ] = useState(1);
+        const [ data, setData ] = useState({ slug: '', label: '' });
+
+        const next = () => setStep(step + 1);
+        const back = () => setStep(step - 1);
+
+        const StepOne = () => el('div', {},
+            el(TextControl, {
+                label: 'Post Type Slug',
+                value: data.slug,
+                onChange: v => setData({ ...data, slug: v })
+            }),
+            el(TextControl, {
+                label: 'Label',
+                value: data.label,
+                onChange: v => setData({ ...data, label: v })
+            })
+        );
+
+        const StepTwo = () => el('div', {},
+            el('p', null, 'Field builder coming soon.')
+        );
+
+        const StepThree = () => el('div', {},
+            el('pre', { className: 'gm2-cpt-review' }, JSON.stringify(data, null, 2))
+        );
+
+        const renderStep = () => {
+            if (step === 1) return el(StepOne);
+            if (step === 2) return el(StepTwo);
+            return el(StepThree);
+        };
+
+        return el('div', { className: 'gm2-cpt-wizard' },
+            el(Panel, {},
+                el(PanelBody, { title: 'CPT Wizard', initialOpen: true },
+                    renderStep(),
+                    el('div', { className: 'gm2-cpt-wizard-buttons' }, [
+                        step > 1 && el(Button, { onClick: back }, 'Back'),
+                        step < 3 && el(Button, { isPrimary: true, onClick: next }, 'Next'),
+                        step === 3 && el(Button, { isPrimary: true, onClick: () => alert('Save not implemented') }, 'Finish')
+                    ])
+                )
+            )
+        );
+    };
+
+    document.addEventListener('DOMContentLoaded', () => {
+        const root = document.getElementById('gm2-cpt-wizard-root');
+        if (root) {
+            render(el(Wizard), root);
+        }
+    });
+})(window.wp);
+

--- a/admin/js/gm2-custom-posts-admin.js
+++ b/admin/js/gm2-custom-posts-admin.js
@@ -56,6 +56,9 @@ jQuery(function($){
         $('#gm2-field-type').val(data ? data.type : 'text');
         $('#gm2-field-default').val(data ? data.default : '');
         $('#gm2-field-description').val(data ? data.description : '');
+        $('#gm2-field-cap').val(data ? data.capability : '');
+        $('#gm2-field-edit-cap').val(data ? data.edit_capability : '');
+        $('#gm2-field-help').val(data ? data.help : '');
         var targets = fields.map(function(f){ return f.slug; });
         targets.push('page_id','post_id');
         gm2Conditions.init($('#gm2-field-conditions'), { targets: targets, data: data ? data.conditions : [] });
@@ -137,6 +140,9 @@ jQuery(function($){
             type: $('#gm2-field-type').val(),
             default: $('#gm2-field-default').val(),
             description: $('#gm2-field-description').val(),
+            capability: $('#gm2-field-cap').val(),
+            edit_capability: $('#gm2-field-edit-cap').val(),
+            help: $('#gm2-field-help').val(),
             conditions: gm2Conditions.getData($('#gm2-field-conditions'))
         };
         if(idx === ''){ fields.push(obj); } else { fields[idx] = obj; }

--- a/admin/js/gm2-custom-posts-gutenberg.js
+++ b/admin/js/gm2-custom-posts-gutenberg.js
@@ -1,0 +1,29 @@
+(function(wp){
+    const { registerPlugin } = wp.plugins;
+    const { PluginSidebar } = wp.editPost;
+    const { PanelBody, TextControl } = wp.components;
+    const { useSelect, useDispatch } = wp.data;
+    const { createElement: el } = wp.element;
+
+    const MetaPanel = () => {
+        const meta = useSelect( select => select('core/editor').getEditedPostAttribute('meta'), [] );
+        const { editPost } = useDispatch('core/editor');
+        const fields = window.gm2BlockFields || [];
+        return el(PluginSidebar, { name: 'gm2-meta', title: 'Gm2 Fields' },
+            el(PanelBody, {},
+                fields.map(f => el(TextControl, {
+                    key: f.key,
+                    label: f.label,
+                    value: meta[f.key] || '',
+                    onChange: v => editPost({ meta: { [f.key]: v } })
+                }))
+            )
+        );
+    };
+
+    registerPlugin('gm2-meta', {
+        icon: 'admin-post',
+        render: MetaPanel
+    });
+})(window.wp);
+

--- a/admin/js/gm2-list-table.js
+++ b/admin/js/gm2-list-table.js
@@ -1,0 +1,20 @@
+jQuery(function($){
+    if (typeof inlineEditPost !== 'undefined') {
+        var wp_inline_edit = inlineEditPost.edit;
+        inlineEditPost.edit = function(id){
+            wp_inline_edit.apply(this, arguments);
+            var postId = 0;
+            if (typeof(id) === 'object') {
+                postId = parseInt(this.getId(id));
+            }
+            if (postId > 0 && window.gm2ListTable) {
+                var $row = $('#post-' + postId);
+                window.gm2ListTable.fields.forEach(function(f){
+                    var val = $row.find('.column-' + f.slug).text().trim();
+                    $('#edit-' + postId).find('input[name="' + f.slug + '"]').val(val);
+                });
+            }
+        };
+    }
+});
+


### PR DESCRIPTION
## Summary
- add CPT model builder admin page and capability-aware field settings
- introduce Gutenberg sidebar integration and list table hooks
- scaffold React wizard and supporting admin scripts

## Testing
- `npm test`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*


------
https://chatgpt.com/codex/tasks/task_e_689f7456a7188327a2cb0d6a7d94c042