### PR TITLE
Add block template scaffolding and helper functions

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -445,6 +445,7 @@ class Gm2_Admin {
             update_option('gm2_enable_abandoned_carts', empty($_POST['gm2_enable_abandoned_carts']) ? '0' : '1');
             update_option('gm2_enable_analytics', empty($_POST['gm2_enable_analytics']) ? '0' : '1');
             update_option('gm2_enable_custom_posts', empty($_POST['gm2_enable_custom_posts']) ? '0' : '1');
+            update_option('gm2_enable_block_templates', empty($_POST['gm2_enable_block_templates']) ? '0' : '1');
 
             $enabled = !empty($_POST['gm2_enable_abandoned_carts']);
             if ($enabled) {
@@ -470,6 +471,7 @@ class Gm2_Admin {
         $abandoned = get_option('gm2_enable_abandoned_carts', '0') === '1';
         $analytics = get_option('gm2_enable_analytics', '1') === '1';
         $custom_posts = get_option('gm2_enable_custom_posts', '1') === '1';
+        $block_templates = get_option('gm2_enable_block_templates', '0') === '1';
 
         echo '<div class="wrap">';
         echo '<h1>' . esc_html__( 'Gm2 Suite', 'gm2-wordpress-suite' ) . '</h1>';
@@ -483,6 +485,7 @@ class Gm2_Admin {
         echo '<tr><th scope="row">' . esc_html__( 'ChatGPT', 'gm2-wordpress-suite' ) . '</th><td><label><input type="checkbox" name="gm2_enable_chatgpt"' . checked($chatgpt, true, false) . '> ' . esc_html__( 'Enabled', 'gm2-wordpress-suite' ) . '</label></td></tr>';
         echo '<tr><th scope="row">' . esc_html__( 'Analytics', 'gm2-wordpress-suite' ) . '</th><td><label><input type="checkbox" name="gm2_enable_analytics"' . checked($analytics, true, false) . '> ' . esc_html__( 'Enabled', 'gm2-wordpress-suite' ) . '</label></td></tr>';
         echo '<tr><th scope="row">' . esc_html__( 'Custom Posts', 'gm2-wordpress-suite' ) . '</th><td><label><input type="checkbox" name="gm2_enable_custom_posts"' . checked($custom_posts, true, false) . '> ' . esc_html__( 'Enabled', 'gm2-wordpress-suite' ) . '</label></td></tr>';
+        echo '<tr><th scope="row">' . esc_html__( 'Block Templates', 'gm2-wordpress-suite' ) . '</th><td><label><input type="checkbox" name="gm2_enable_block_templates"' . checked($block_templates, true, false) . '> ' . esc_html__( 'Enabled', 'gm2-wordpress-suite' ) . '</label></td></tr>';
         echo '<tr><th scope="row">' . esc_html__( 'Abandoned Carts', 'gm2-wordpress-suite' ) . '</th><td><label><input type="checkbox" name="gm2_enable_abandoned_carts"' . checked($abandoned, true, false) . '> ' . esc_html__( 'Enabled', 'gm2-wordpress-suite' ) . '</label></td></tr>';
         echo '</tbody></table>';
         submit_button();

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -56,6 +56,7 @@ require_once GM2_PLUGIN_DIR . 'includes/Gm2_CSV_Helper.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_Abandoned_Carts.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_Analytics.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-custom-posts-functions.php';
+require_once GM2_PLUGIN_DIR . 'includes/gm2-theme-tools.php';
 // Temporarily disable Recovery Email Queue.
 // require_once GM2_PLUGIN_DIR . 'includes/Gm2_Abandoned_Carts_Messaging.php';
 require_once GM2_PLUGIN_DIR . 'admin/Gm2_Abandoned_Carts_Admin.php';
@@ -129,6 +130,7 @@ function gm2_activate_plugin() {
     add_option('gm2_enable_analytics', '1');
     add_option('gm2_enable_chatgpt_logging', '0');
     add_option('gm2_enable_custom_posts', '1');
+    add_option('gm2_enable_block_templates', '0');
     add_option('gm2_analytics_retention_days', 30);
     add_option('gm2_sitemap_path', ABSPATH . 'sitemap.xml');
     add_option('gm2_sitemap_max_urls', 1000);

--- a/includes/cli/class-gm2-cli.php
+++ b/includes/cli/class-gm2-cli.php
@@ -66,6 +66,54 @@ class Gm2_CLI extends \WP_CLI_Command {
         $count = $ac->migrate_recovered_carts();
         \WP_CLI::success( sprintf( '%d carts migrated.', $count ) );
     }
+
+    /**
+     * Scaffold theme assets such as Twig/Blade templates or theme.json.
+     *
+     * ## SUBCOMMANDS
+     *
+     * twig <slug>       Create a Twig template under templates/.
+     * blade <slug>      Create a Blade template under resources/views/.
+     * theme-json        Create a basic theme.json if one does not exist.
+     */
+    public function scaffold( $args, $assoc_args ) {
+        $type = $args[0] ?? '';
+        $slug = $args[1] ?? 'example';
+        $theme_dir = get_stylesheet_directory();
+
+        switch ( $type ) {
+            case 'twig':
+                $path = trailingslashit( $theme_dir ) . 'templates/' . $slug . '.twig';
+                if ( ! file_exists( dirname( $path ) ) ) {
+                    wp_mkdir_p( dirname( $path ) );
+                }
+                file_put_contents( $path, "{{ gm2_field('example') }}\n" );
+                \WP_CLI::success( 'Twig template created at ' . $path );
+                break;
+            case 'blade':
+                $path = trailingslashit( $theme_dir ) . 'resources/views/' . $slug . '.blade.php';
+                if ( ! file_exists( dirname( $path ) ) ) {
+                    wp_mkdir_p( dirname( $path ) );
+                }
+                file_put_contents( $path, "{{ gm2_field('example') }}\n" );
+                \WP_CLI::success( 'Blade template created at ' . $path );
+                break;
+            case 'theme-json':
+            case 'theme':
+                $path = trailingslashit( $theme_dir ) . 'theme.json';
+                if ( ! file_exists( $path ) ) {
+                    $contents = json_encode( [ '$schema' => 'https://schemas.wp.org/wp/6.4/theme.json' ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+                    file_put_contents( $path, $contents );
+                    \WP_CLI::success( 'theme.json created at ' . $path );
+                } else {
+                    \WP_CLI::success( 'theme.json already exists at ' . $path );
+                }
+                \WP_CLI::line( 'Hint: update theme.json to reference custom templates and patterns.' );
+                break;
+            default:
+                \WP_CLI::error( 'Usage: wp gm2 scaffold <twig|blade|theme-json> <slug>' );
+        }
+    }
 }
 
 \WP_CLI::add_command( 'gm2', __NAMESPACE__ . '\\Gm2_CLI' );

--- a/includes/gm2-theme-tools.php
+++ b/includes/gm2-theme-tools.php
@@ -1,0 +1,158 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Helper function to fetch a field value with optional default.
+ *
+ * @param string      $key          Meta field key.
+ * @param mixed       $default      Default value if meta is empty.
+ * @param int|null    $object_id    Object ID. Defaults to current post.
+ * @param string      $context_type Context type: post, term, user, option, site.
+ *
+ * @return mixed
+ */
+function gm2_field($key, $default = '', $object_id = null, $context_type = 'post') {
+    if (!$key) {
+        return $default;
+    }
+
+    if ($object_id === null) {
+        switch ($context_type) {
+            case 'post':
+                $object_id = get_the_ID();
+                break;
+            case 'term':
+                $object_id = get_queried_object_id();
+                break;
+            case 'user':
+                $user = wp_get_current_user();
+                $object_id = $user ? $user->ID : 0;
+                break;
+            default:
+                $object_id = 0;
+        }
+    }
+
+    $value = '';
+    switch ($context_type) {
+        case 'user':
+            $value = get_user_meta($object_id, $key, true);
+            break;
+        case 'term':
+            $value = get_term_meta($object_id, $key, true);
+            break;
+        case 'comment':
+            $value = get_comment_meta($object_id, $key, true);
+            break;
+        case 'option':
+            $value = get_option($key, $default);
+            break;
+        case 'site':
+            $value = get_site_option($key, $default);
+            break;
+        default:
+            $value = get_post_meta($object_id, $key, true);
+    }
+
+    if ($value !== '' && $value !== null) {
+        return $value;
+    }
+
+    $field = gm2_find_field_definition($key);
+    if ($field) {
+        return gm2_resolve_default($field, $object_id, $context_type);
+    }
+
+    return $default;
+}
+
+/**
+ * Locate a field definition from stored field groups.
+ *
+ * @param string $key Field key.
+ * @return array|null
+ */
+function gm2_find_field_definition($key) {
+    $groups = get_option('gm2_field_groups', []);
+    foreach ($groups as $group) {
+        if (!empty($group['fields'][$key])) {
+            return $group['fields'][$key];
+        }
+    }
+    return null;
+}
+
+/**
+ * Register block templates for custom post types and archives.
+ * Runs only when the feature is enabled via option.
+ */
+function gm2_maybe_generate_block_templates() {
+    if (get_option('gm2_enable_block_templates', '0') !== '1') {
+        return;
+    }
+
+    $post_types = get_post_types(['public' => true], 'names');
+    foreach ($post_types as $type) {
+        if (in_array($type, ['post', 'page', 'attachment'], true)) {
+            continue;
+        }
+        gm2_ensure_block_template('single-' . $type, "<!-- wp:post-title /-->\n<!-- wp:post-content /-->\n");
+        gm2_ensure_block_template('archive-' . $type, "<!-- wp:query {\"inherit\":true} --><!-- wp:post-template --><!-- wp:post-title /--><!-- /wp:post-template --><!-- /wp:query -->\n");
+    }
+}
+add_action('init', 'gm2_maybe_generate_block_templates');
+
+/**
+ * Create a wp_template post if it does not already exist.
+ *
+ * @param string $slug    Template slug.
+ * @param string $content Block template content.
+ */
+function gm2_ensure_block_template($slug, $content) {
+    $exists = get_posts([
+        'post_type'      => 'wp_template',
+        'post_status'    => 'publish',
+        'name'           => $slug,
+        'posts_per_page' => 1,
+    ]);
+    if ($exists) {
+        return;
+    }
+    wp_insert_post([
+        'post_type'   => 'wp_template',
+        'post_status' => 'publish',
+        'post_name'   => $slug,
+        'post_title'  => ucwords(str_replace('-', ' ', $slug)),
+        'post_content'=> $content,
+        'tax_input'   => [ 'wp_theme' => get_stylesheet() ],
+    ]);
+}
+
+/**
+ * Register simple block patterns based on configured field groups.
+ */
+function gm2_register_field_group_patterns() {
+    $groups = get_option('gm2_field_groups', []);
+    if (!is_array($groups)) {
+        return;
+    }
+    foreach ($groups as $group) {
+        if (empty($group['pattern'])) {
+            continue;
+        }
+        $slug = 'gm2/' . sanitize_key($group['pattern']);
+        $content = '';
+        foreach (($group['fields'] ?? []) as $field) {
+            $label = $field['label'] ?? ($field['name'] ?? '');
+            $content .= sprintf("<!-- wp:paragraph --><p>%s</p><!-- /wp:paragraph -->\n", esc_html($label));
+        }
+        register_block_pattern($slug, [
+            'title'       => $group['pattern'],
+            'description' => $group['description'] ?? '',
+            'content'     => $content,
+        ]);
+    }
+}
+add_action('init', 'gm2_register_field_group_patterns');


### PR DESCRIPTION
## Summary
- add `gm2_field()` helper and field group pattern registration
- generate starter block templates for custom post types when enabled
- expose Twig/Blade/theme.json scaffolding via `wp gm2 scaffold`
- add admin toggle for block template generation

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689f765855bc8327bb53a0b67a2692ea