### PR TITLE
Add REST visibility controls and webhooks

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -67,6 +67,11 @@ require_once GM2_PLUGIN_DIR . 'admin/class-gm2-ac-table.php';
 require_once GM2_PLUGIN_DIR . 'admin/class-gm2-bulk-ai-list-table.php';
 require_once GM2_PLUGIN_DIR . 'admin/class-gm2-bulk-ai-tax-list-table.php';
 require_once GM2_PLUGIN_DIR . 'public/Gm2_Abandoned_Carts_Public.php';
+require_once GM2_PLUGIN_DIR . 'includes/Gm2_REST_Visibility.php';
+require_once GM2_PLUGIN_DIR . 'includes/Gm2_Webhooks.php';
+
+\Gm2\Gm2_REST_Visibility::init();
+\Gm2\Gm2_Webhooks::init();
 
 function gm2_add_weekly_schedule($schedules) {
     if (!isset($schedules['weekly'])) {

--- a/includes/Gm2_REST_Visibility.php
+++ b/includes/Gm2_REST_Visibility.php
@@ -1,0 +1,130 @@
+<?php
+namespace Gm2;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Gm2_REST_Visibility {
+    const OPTION = 'gm2_rest_visibility';
+
+    public static function init() : void {
+        add_action('init', [ __CLASS__, 'apply_visibility' ], 20);
+        add_action('rest_api_init', [ __CLASS__, 'register_routes' ]);
+        if (class_exists('WPGraphQL')) {
+            add_action('graphql_register_types', [ __CLASS__, 'register_graphql' ]);
+        }
+    }
+
+    protected static function defaults() : array {
+        return [
+            'post_types' => [],
+            'taxonomies' => [],
+            'fields' => [],
+        ];
+    }
+
+    public static function get_visibility() : array {
+        $vis = get_option(self::OPTION, []);
+        return wp_parse_args(is_array($vis) ? $vis : [], self::defaults());
+    }
+
+    public static function apply_visibility() : void {
+        $vis = self::get_visibility();
+        if (!empty($vis['post_types'])) {
+            foreach ($vis['post_types'] as $type => $show) {
+                if (post_type_exists($type)) {
+                    global $wp_post_types;
+                    if (isset($wp_post_types[$type])) {
+                        $wp_post_types[$type]->show_in_rest = (bool) $show;
+                    }
+                }
+            }
+        }
+        if (!empty($vis['taxonomies'])) {
+            foreach ($vis['taxonomies'] as $tax => $show) {
+                if (taxonomy_exists($tax)) {
+                    global $wp_taxonomies;
+                    if (isset($wp_taxonomies[$tax])) {
+                        $wp_taxonomies[$tax]->show_in_rest = (bool) $show;
+                    }
+                }
+            }
+        }
+    }
+
+    public static function register_routes() : void {
+        register_rest_route('gm2/v1', '/visibility', [
+            [
+                'methods'  => \WP_REST_Server::READABLE,
+                'callback' => [ __CLASS__, 'rest_get' ],
+                'permission_callback' => '__return_true',
+                'args'     => [],
+                'schema'   => [ __CLASS__, 'get_schema' ],
+            ],
+            [
+                'methods'  => \WP_REST_Server::EDITABLE,
+                'callback' => [ __CLASS__, 'rest_update' ],
+                'permission_callback' => function () {
+                    return current_user_can('manage_options');
+                },
+                'args' => [
+                    'post_types' => [ 'type' => 'object' ],
+                    'taxonomies' => [ 'type' => 'object' ],
+                    'fields'     => [ 'type' => 'object' ],
+                ],
+                'schema'   => [ __CLASS__, 'get_schema' ],
+            ],
+        ]);
+    }
+
+    public static function rest_get(\WP_REST_Request $req) {
+        return rest_ensure_response(self::get_visibility());
+    }
+
+    public static function rest_update(\WP_REST_Request $req) {
+        $data = [
+            'post_types' => (array) $req->get_param('post_types'),
+            'taxonomies' => (array) $req->get_param('taxonomies'),
+            'fields'     => (array) $req->get_param('fields'),
+        ];
+        update_option(self::OPTION, $data);
+        self::apply_visibility();
+        return rest_ensure_response($data);
+    }
+
+    public static function get_schema() : array {
+        return [
+            '$schema' => 'http://json-schema.org/draft-04/schema#',
+            'title'   => 'gm2_rest_visibility',
+            'type'    => 'object',
+            'properties' => [
+                'post_types' => [
+                    'type' => 'object',
+                    'additionalProperties' => [ 'type' => 'boolean' ],
+                ],
+                'taxonomies' => [
+                    'type' => 'object',
+                    'additionalProperties' => [ 'type' => 'boolean' ],
+                ],
+                'fields' => [
+                    'type' => 'object',
+                    'additionalProperties' => [ 'type' => 'boolean' ],
+                ],
+            ],
+        ];
+    }
+
+    public static function register_graphql() : void {
+        if (!function_exists('register_graphql_field')) {
+            return;
+        }
+        register_graphql_field('RootQuery', 'gm2Visibility', [
+            'type'        => 'JSON',
+            'description' => __('GM2 REST visibility settings', 'gm2-wordpress-suite'),
+            'resolve'     => function () {
+                return self::get_visibility();
+            },
+        ]);
+    }
+}

--- a/includes/Gm2_Webhooks.php
+++ b/includes/Gm2_Webhooks.php
@@ -1,0 +1,81 @@
+<?php
+namespace Gm2;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Gm2_Webhooks {
+    const OPTION_URLS = 'gm2_webhook_urls';
+    const OPTION_MODE = 'gm2_webhook_mode';
+
+    public static function init() : void {
+        add_action('save_post', [ __CLASS__, 'handle_save' ], 10, 3);
+        add_action('deleted_post', [ __CLASS__, 'handle_delete' ], 10, 1);
+        add_action('transition_post_status', [ __CLASS__, 'handle_transition' ], 10, 3);
+    }
+
+    public static function handle_save(int $post_id, \WP_Post $post, bool $update) : void {
+        $action = $update ? 'update' : 'create';
+        self::fire($action, $post);
+    }
+
+    public static function handle_delete(int $post_id) : void {
+        $post = get_post($post_id);
+        self::fire('delete', $post);
+    }
+
+    public static function handle_transition(string $new_status, string $old_status, \WP_Post $post) : void {
+        if ($new_status !== $old_status) {
+            self::fire('transition', $post, [ 'from' => $old_status, 'to' => $new_status ]);
+        }
+    }
+
+    protected static function fire(string $event, ?\WP_Post $post, array $extra = []) : void {
+        $urls = (array) get_option(self::OPTION_URLS, []);
+        if (!$post || empty($urls)) {
+            return;
+        }
+        $mode = get_option(self::OPTION_MODE, 'raw');
+        $data = self::serialize_post($post, $mode);
+        $payload = [
+            'event' => $event,
+            'post_id' => $post->ID,
+            'post_type' => $post->post_type,
+            'data' => $data,
+            'extra' => $extra,
+        ];
+        foreach ($urls as $url) {
+            wp_remote_post($url, [
+                'headers' => [ 'Content-Type' => 'application/json' ],
+                'body'    => wp_json_encode($payload),
+                'timeout' => 5,
+            ]);
+        }
+    }
+
+    protected static function serialize_post(\WP_Post $post, string $mode) : array {
+        $data = [];
+        if ('rendered' === $mode) {
+            $data['content'] = apply_filters('the_content', $post->post_content);
+        } else {
+            $data['content'] = $post->post_content;
+        }
+        $data['title'] = $post->post_title;
+        $data['status'] = $post->post_status;
+        $data['type'] = $post->post_type;
+        if ('media' === $mode) {
+            $media = [];
+            $attachments = get_attached_media('', $post);
+            foreach ($attachments as $att) {
+                $media[] = [
+                    'id'  => $att->ID,
+                    'url' => wp_get_attachment_url($att->ID),
+                    'mime' => get_post_mime_type($att->ID),
+                ];
+            }
+            $data['media'] = $media;
+        }
+        return $data;
+    }
+}


### PR DESCRIPTION
## Summary
- add REST API visibility toggles for post types, taxonomies, and fields with schema
- auto-expose visibility settings via WPGraphQL when available
- trigger webhooks on post create, update, delete, and status transitions with configurable serialization modes

## Testing
- `npm test`
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f7d493a448327b821d7f0ba8c1c97