### PR TITLE
Add content capabilities, workflows and audit logging

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -69,6 +69,9 @@ require_once GM2_PLUGIN_DIR . 'admin/class-gm2-bulk-ai-tax-list-table.php';
 require_once GM2_PLUGIN_DIR . 'public/Gm2_Abandoned_Carts_Public.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_REST_Visibility.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_Webhooks.php';
+require_once GM2_PLUGIN_DIR . 'includes/Gm2_Capability_Manager.php';
+require_once GM2_PLUGIN_DIR . 'includes/Gm2_Workflow_Manager.php';
+require_once GM2_PLUGIN_DIR . 'includes/Gm2_Audit_Log.php';
 
 \Gm2\Gm2_REST_Visibility::init();
 \Gm2\Gm2_Webhooks::init();
@@ -172,6 +175,8 @@ function gm2_activate_plugin() {
         KEY `timestamp` (`timestamp`)
     ) $charset_collate;";
     dbDelta($sql);
+
+    \Gm2\Gm2_Audit_Log::install();
 
     Gm2_Abandoned_Carts::schedule_event();
 }

--- a/includes/Gm2_Audit_Log.php
+++ b/includes/Gm2_Audit_Log.php
@@ -1,0 +1,103 @@
+<?php
+namespace Gm2;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Gm2_Audit_Log {
+    public static function init() {
+        add_action('updated_post_meta', [__CLASS__, 'log_update'], 10, 4);
+        add_action('added_post_meta', [__CLASS__, 'log_add'], 10, 4);
+        add_action('deleted_post_meta', [__CLASS__, 'log_delete'], 10, 4);
+        add_action('gm2_audit_purge', [__CLASS__, 'purge']);
+        self::schedule_purge();
+    }
+
+    /**
+     * Create table and schedule purge on install.
+     */
+    public static function install() {
+        self::maybe_create_table();
+        self::schedule_purge();
+    }
+
+    protected static function table() {
+        global $wpdb;
+        return $wpdb->prefix . 'gm2_audit_log';
+    }
+
+    protected static function maybe_create_table() {
+        global $wpdb;
+        $table = self::table();
+        if ($wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $table)) !== $table) {
+            require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+            $charset_collate = $wpdb->get_charset_collate();
+            $sql = "CREATE TABLE $table (
+                id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+                object_id bigint(20) unsigned NOT NULL,
+                meta_key varchar(255) NOT NULL,
+                old_value longtext NULL,
+                new_value longtext NULL,
+                user_id bigint(20) unsigned NOT NULL,
+                changed_at datetime NOT NULL,
+                pii tinyint(1) NOT NULL DEFAULT 0,
+                PRIMARY KEY  (id),
+                KEY object_id (object_id)
+            ) $charset_collate;";
+            dbDelta($sql);
+        }
+    }
+
+    public static function log_change($object_id, $meta_key, $old, $new) {
+        self::maybe_create_table();
+        global $wpdb;
+        $pii_fields = get_option('gm2_pii_fields', []);
+        $pii = in_array($meta_key, $pii_fields, true) ? 1 : 0;
+        $wpdb->insert(self::table(), [
+            'object_id' => $object_id,
+            'meta_key' => $meta_key,
+            'old_value' => maybe_serialize($old),
+            'new_value' => maybe_serialize($new),
+            'user_id' => get_current_user_id(),
+            'changed_at' => current_time('mysql'),
+            'pii' => $pii,
+        ]);
+    }
+
+    public static function log_update($meta_id, $object_id, $meta_key, $_meta_value) {
+        $old = get_post_meta($object_id, $meta_key, true);
+        self::log_change($object_id, $meta_key, $old, $_meta_value);
+    }
+
+    public static function log_add($meta_id, $object_id, $meta_key, $_meta_value) {
+        self::log_change($object_id, $meta_key, '', $_meta_value);
+    }
+
+    public static function log_delete($meta_id, $object_id, $meta_key, $_meta_value) {
+        self::log_change($object_id, $meta_key, $_meta_value, '');
+    }
+
+    public static function tag_field_as_pii($field_key) {
+        $fields = get_option('gm2_pii_fields', []);
+        if (!in_array($field_key, $fields, true)) {
+            $fields[] = $field_key;
+            update_option('gm2_pii_fields', $fields);
+        }
+    }
+
+    public static function purge() {
+        global $wpdb;
+        $days = absint(get_option('gm2_audit_log_retention_days', 30));
+        $table = self::table();
+        $wpdb->query($wpdb->prepare("DELETE FROM $table WHERE changed_at < DATE_SUB(NOW(), INTERVAL %d DAY)", $days));
+    }
+
+    public static function schedule_purge() {
+        if (!wp_next_scheduled('gm2_audit_purge')) {
+            wp_schedule_event(time(), 'daily', 'gm2_audit_purge');
+        }
+    }
+}
+
+Gm2_Audit_Log::init();

--- a/includes/Gm2_Capability_Manager.php
+++ b/includes/Gm2_Capability_Manager.php
@@ -1,0 +1,93 @@
+<?php
+namespace Gm2;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Gm2_Capability_Manager {
+    /**
+     * Initialize capability mapping hooks.
+     */
+    public static function init() {
+        add_filter('register_post_type_args', [__CLASS__, 'filter_cpt_caps'], 10, 2);
+        add_filter('register_taxonomy_args', [__CLASS__, 'filter_tax_caps'], 10, 2);
+        add_filter('user_has_cap', [__CLASS__, 'filter_user_caps'], 10, 3);
+    }
+
+    /**
+     * Merge custom capability mappings for post types from option `gm2_cpt_cap_map`.
+     */
+    public static function filter_cpt_caps($args, $post_type) {
+        $map = get_option('gm2_cpt_cap_map', []);
+        if (isset($map[$post_type]) && is_array($map[$post_type])) {
+            $args['capabilities'] = array_merge($args['capabilities'] ?? [], $map[$post_type]);
+        }
+        return $args;
+    }
+
+    /**
+     * Merge custom capability mappings for taxonomies from option `gm2_tax_cap_map`.
+     */
+    public static function filter_tax_caps($args, $taxonomy) {
+        $map = get_option('gm2_tax_cap_map', []);
+        if (isset($map[$taxonomy]) && is_array($map[$taxonomy])) {
+            $args['capabilities'] = array_merge($args['capabilities'] ?? [], $map[$taxonomy]);
+        }
+        return $args;
+    }
+
+    /**
+     * Enforce field-level capabilities stored in option `gm2_field_caps`.
+     */
+    public static function filter_user_caps($allcaps, $caps, $args) {
+        $cap = $args[0] ?? '';
+        $user_id = $args[1] ?? 0;
+        if (strpos($cap, 'gm2_field_') !== 0) {
+            return $allcaps;
+        }
+        $map = get_option('gm2_field_caps', []);
+        $pieces = explode('_', $cap, 4); // gm2_field_{read/edit}_{field}
+        $action = $pieces[2] ?? '';
+        $field = $pieces[3] ?? '';
+        if (!$field || !$action) {
+            return $allcaps;
+        }
+        $roles = $map[$field][$action] ?? [];
+        if (empty($roles)) {
+            // No roles restriction means allowed.
+            $allcaps[$cap] = true;
+            return $allcaps;
+        }
+        $user = get_userdata($user_id);
+        $allowed = false;
+        if ($user) {
+            foreach ((array) $user->roles as $role) {
+                if (in_array($role, $roles, true)) {
+                    $allowed = true;
+                    break;
+                }
+            }
+        }
+        $allcaps[$cap] = $allowed;
+        return $allcaps;
+    }
+
+    /**
+     * Check if current (or specified) user can read a field.
+     */
+    public static function can_read_field($field, $post_id = 0, $user_id = 0) {
+        $user_id = $user_id ?: get_current_user_id();
+        return user_can($user_id, "gm2_field_read_{$field}", $post_id);
+    }
+
+    /**
+     * Check if current (or specified) user can edit a field.
+     */
+    public static function can_edit_field($field, $post_id = 0, $user_id = 0) {
+        $user_id = $user_id ?: get_current_user_id();
+        return user_can($user_id, "gm2_field_edit_{$field}", $post_id);
+    }
+}
+
+Gm2_Capability_Manager::init();

--- a/includes/Gm2_Workflow_Manager.php
+++ b/includes/Gm2_Workflow_Manager.php
@@ -1,0 +1,66 @@
+<?php
+namespace Gm2;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Gm2_Workflow_Manager {
+    public static function init() {
+        add_action('gm2_transition_post_status', [__CLASS__, 'handle_transition'], 10, 2);
+    }
+
+    /**
+     * Register custom post statuses.
+     *
+     * @param array $statuses ['status' => 'Label']
+     */
+    public static function register_statuses($statuses) {
+        foreach ($statuses as $status => $label) {
+            register_post_status($status, [
+                'label'                     => $label,
+                'public'                    => false,
+                'show_in_admin_all_list'    => true,
+                'show_in_admin_status_list' => true,
+                'label_count'               => _n_noop("{$label} <span class='count'>(%s)</span>", "{$label} <span class='count'>(%s)</span>")
+            ]);
+        }
+    }
+
+    /**
+     * Schedule a status transition using WP-Cron.
+     */
+    public static function schedule_transition($post_id, $status, $timestamp) {
+        wp_schedule_single_event($timestamp, 'gm2_transition_post_status', [$post_id, $status]);
+    }
+
+    /**
+     * Perform the scheduled transition.
+     */
+    public static function handle_transition($post_id, $status) {
+        wp_update_post([
+            'ID'          => $post_id,
+            'post_status' => $status,
+        ]);
+    }
+
+    /**
+     * Add an editorial comment and notify mentioned users.
+     */
+    public static function add_editorial_comment($post_id, $message, $mentions = []) {
+        $comment_id = wp_insert_comment([
+            'comment_post_ID' => $post_id,
+            'comment_content' => $message,
+            'comment_type'    => 'gm2_editorial',
+            'user_id'         => get_current_user_id(),
+        ]);
+        if ($comment_id && !empty($mentions)) {
+            foreach ($mentions as $user_id) {
+                do_action('gm2_editorial_comment_mention', $comment_id, $user_id);
+            }
+        }
+        return $comment_id;
+    }
+}
+
+Gm2_Workflow_Manager::init();


### PR DESCRIPTION
## Summary
- load new managers for mapping CPT/taxonomy capabilities and field-level enforcement
- support custom statuses, scheduled transitions and editorial comments
- add audit log for meta changes with PII tagging and retention purge

## Testing
- `npm test`
- `phpunit` (fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): Failed to open stream)


------
https://chatgpt.com/codex/tasks/task_e_689f7ed8ccb083278861d75227a05e90