### PR TITLE
Add schema tooltips and open-in-code helpers

### DIFF
--- a/admin/js/gm2-open-in-code.js
+++ b/admin/js/gm2-open-in-code.js
@@ -1,0 +1,12 @@
+jQuery(function($){
+    $(document).on('click', '.gm2-open-in-code__trigger', function(){
+        $(this).siblings('.gm2-open-in-code__modal').toggle();
+    });
+    $(document).on('click', '.gm2-open-in-code__copy', function(){
+        var target = $(this).data('target');
+        var text = $(this).closest('.gm2-open-in-code__modal').find('.gm2-open-in-code__' + target).val();
+        if (navigator.clipboard) {
+            navigator.clipboard.writeText(text);
+        }
+    });
+});

--- a/admin/js/gm2-schema-tooltips.js
+++ b/admin/js/gm2-schema-tooltips.js
@@ -1,0 +1,8 @@
+jQuery(function($){
+    $(document).on('mouseenter', '[data-schema]', function(){
+        var $el = $(this);
+        if(!$el.attr('title')) {
+            $el.attr('title', $el.data('schema'));
+        }
+    });
+});

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,39 @@
+# Gm2 WordPress Suite API
+
+This document describes helper functions and JavaScript utilities with typed signatures and usage examples.
+
+## PHP Hooks and Functions
+
+### `gm2_schema_tooltip( string $schema, string $label ): string`
+Wraps a label with inline schema information. The schema text is exposed as a tooltip in the UI.
+
+```php
+echo gm2_schema_tooltip( 'Product\\nname', 'Product Name' );
+```
+
+### `gm2_render_open_in_code( string $php_code, string $json_code ): string`
+Outputs an **Open in Code** button with PHP/JSON blocks and copy or download options.
+
+```php
+$php  = "<?php echo 'Hello';";
+$json = json_encode( ['hello' => 'world'] );
+
+echo gm2_render_open_in_code( $php, $json );
+```
+
+## JavaScript APIs
+
+### `gm2-schema-tooltips`
+Elements with a `data-schema` attribute automatically display the schema text via a native tooltip.
+
+```html
+<span class="gm2-schema-field" data-schema="Price including tax">Price</span>
+```
+
+### `gm2-open-in-code`
+Provides copy-to-clipboard and download buttons for code blocks rendered by `gm2_render_open_in_code()`.
+
+```js
+// Behaviour is attached to markup produced by the PHP helper; no direct API is exposed.
+```
+

--- a/docs/recipes/courses/README.md
+++ b/docs/recipes/courses/README.md
@@ -1,0 +1,12 @@
+# Courses Recipe
+
+Course listing with Open in Code output.
+
+```php
+register_post_type( 'gm2_course', [
+    'label' => 'Course',
+    'public' => true,
+] );
+
+echo gm2_render_open_in_code( '<?php // course php ?>', json_encode( ['type' => 'course'] ) );
+```

--- a/docs/recipes/directory/README.md
+++ b/docs/recipes/directory/README.md
@@ -1,0 +1,10 @@
+# Directory Recipe
+
+Minimal example showing how to register a Directory custom post type with schema annotations.
+
+```php
+register_post_type( 'gm2_directory', [
+    'label' => 'Directory',
+    'public' => true,
+] );
+```

--- a/docs/recipes/events/README.md
+++ b/docs/recipes/events/README.md
@@ -1,0 +1,12 @@
+# Events Recipe
+
+Registers an Event post type and demonstrates Open in Code for generated schema.
+
+```php
+register_post_type( 'gm2_event', [
+    'label' => 'Event',
+    'public' => true,
+] );
+
+echo gm2_render_open_in_code( '<?php // event php ?>', json_encode( ['type' => 'event'] ) );
+```

--- a/docs/recipes/jobs/README.md
+++ b/docs/recipes/jobs/README.md
@@ -1,0 +1,12 @@
+# Jobs Recipe
+
+Job board example using schema tooltips.
+
+```php
+register_post_type( 'gm2_job', [
+    'label' => 'Job',
+    'public' => true,
+] );
+
+echo gm2_schema_tooltip( 'Job location', 'Location' );
+```

--- a/docs/recipes/real-estate/README.md
+++ b/docs/recipes/real-estate/README.md
@@ -1,0 +1,12 @@
+# Real Estate Recipe
+
+Example snippet for real estate listings.
+
+```php
+register_post_type( 'gm2_property', [
+    'label' => 'Property',
+    'public' => true,
+] );
+
+echo gm2_schema_tooltip( 'Property price', 'Price' );
+```

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -59,6 +59,8 @@ require_once GM2_PLUGIN_DIR . 'includes/gm2-custom-tables.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-custom-posts-functions.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-query-builder.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-theme-tools.php';
+require_once GM2_PLUGIN_DIR . 'includes/gm2-open-in-code.php';
+require_once GM2_PLUGIN_DIR . 'includes/gm2-schema-tooltips.php';
 // Temporarily disable Recovery Email Queue.
 // require_once GM2_PLUGIN_DIR . 'includes/Gm2_Abandoned_Carts_Messaging.php';
 require_once GM2_PLUGIN_DIR . 'admin/Gm2_Abandoned_Carts_Admin.php';

--- a/includes/gm2-open-in-code.php
+++ b/includes/gm2-open-in-code.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Open in Code helpers.
+ *
+ * Provides a small UI for viewing generated PHP or JSON and copying or downloading the code.
+ */
+
+if (!function_exists('gm2_render_open_in_code')) {
+    /**
+     * Render an "Open in Code" button with hidden PHP/JSON blocks.
+     *
+     * @param string $php_code  Generated PHP code.
+     * @param string $json_code Generated JSON code.
+     * @return string HTML output.
+     */
+    function gm2_render_open_in_code($php_code, $json_code)
+    {
+        $php  = htmlspecialchars($php_code, ENT_QUOTES, 'UTF-8');
+        $json = htmlspecialchars($json_code, ENT_QUOTES, 'UTF-8');
+
+        ob_start();
+        ?>
+        <div class="gm2-open-in-code">
+            <button type="button" class="gm2-open-in-code__trigger">
+                <?php esc_html_e('Open in Code', 'gm2-wordpress-suite'); ?>
+            </button>
+            <div class="gm2-open-in-code__modal" style="display:none;">
+                <textarea class="gm2-open-in-code__php" readonly><?php echo $php; ?></textarea>
+                <textarea class="gm2-open-in-code__json" readonly><?php echo $json; ?></textarea>
+                <button type="button" class="gm2-open-in-code__copy" data-target="php">
+                    <?php esc_html_e('Copy PHP', 'gm2-wordpress-suite'); ?>
+                </button>
+                <button type="button" class="gm2-open-in-code__copy" data-target="json">
+                    <?php esc_html_e('Copy JSON', 'gm2-wordpress-suite'); ?>
+                </button>
+                <a class="gm2-open-in-code__download" href="data:text/plain;charset=utf-8,<?php echo rawurlencode($php_code); ?>" download="code.php">
+                    <?php esc_html_e('Download PHP', 'gm2-wordpress-suite'); ?>
+                </a>
+                <a class="gm2-open-in-code__download" href="data:application/json;charset=utf-8,<?php echo rawurlencode($json_code); ?>" download="code.json">
+                    <?php esc_html_e('Download JSON', 'gm2-wordpress-suite'); ?>
+                </a>
+            </div>
+        </div>
+        <?php
+        return ob_get_clean();
+    }
+}
+
+if (!function_exists('gm2_enqueue_open_in_code_assets')) {
+    /**
+     * Enqueue scripts for the "Open in Code" UI.
+     */
+    function gm2_enqueue_open_in_code_assets()
+    {
+        wp_enqueue_script(
+            'gm2-open-in-code',
+            GM2_PLUGIN_URL . 'admin/js/gm2-open-in-code.js',
+            ['jquery'],
+            GM2_VERSION,
+            true
+        );
+    }
+    add_action('admin_enqueue_scripts', 'gm2_enqueue_open_in_code_assets');
+}

--- a/includes/gm2-schema-tooltips.php
+++ b/includes/gm2-schema-tooltips.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Inline schema tooltips and contextual help helpers.
+ */
+
+if (!function_exists('gm2_schema_tooltip')) {
+    /**
+     * Wrap a label with schema tooltip data.
+     *
+     * @param string $schema Schema description.
+     * @param string $label  Text to display.
+     * @return string HTML span with tooltip data.
+     */
+    function gm2_schema_tooltip($schema, $label)
+    {
+        $schema_attr = esc_attr($schema);
+        $label_text  = esc_html($label);
+        return '<span class="gm2-schema-field" data-schema="' . $schema_attr . '">' . $label_text . '</span>';
+    }
+}
+
+if (!function_exists('gm2_enqueue_schema_tooltips')) {
+    /**
+     * Enqueue script that enables schema tooltips.
+     */
+    function gm2_enqueue_schema_tooltips()
+    {
+        wp_enqueue_script(
+            'gm2-schema-tooltips',
+            GM2_PLUGIN_URL . 'admin/js/gm2-schema-tooltips.js',
+            ['jquery'],
+            GM2_VERSION,
+            true
+        );
+    }
+    add_action('admin_enqueue_scripts', 'gm2_enqueue_schema_tooltips');
+}


### PR DESCRIPTION
## Summary
- provide schema tooltip helper and enqueue script
- add "Open in Code" button generator with copy/download support
- document API and ship example recipes for Directory, Events, Real Estate, Jobs and Courses

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f86e6e3c88327b81daa815a399c8c