### PR TITLE
Support conditional disabling of custom post fields

### DIFF
--- a/admin/js/gm2-custom-posts.js
+++ b/admin/js/gm2-custom-posts.js
@@ -1,6 +1,7 @@
 (function($){
     function evaluate(groups){
         var result = null;
+        var disabled = false;
         $.each(groups, function(i, group){
             var groupRes = null;
             $.each(group.conditions || [], function(j, cond){
@@ -22,8 +23,22 @@
             if(groupRes === null){ groupRes = false; }
             if(result === null){ result = groupRes; }
             else{ result = group.relation === 'AND' ? (result && groupRes) : (result || groupRes); }
+            if(groupRes && group.action){
+                switch(group.action){
+                    case 'hide':
+                        result = false;
+                        break;
+                    case 'show':
+                        result = true;
+                        break;
+                    case 'disable':
+                        disabled = true;
+                        break;
+                }
+            }
         });
-        return result;
+        var visible = (result === null) ? true : !!result;
+        return { show: visible, disabled: disabled };
     }
 
     function setupConditional(){
@@ -48,7 +63,14 @@
         });
         function run(){
             $.each(items, function(i,it){
-                it.el.toggle( evaluate(it.conds) );
+                var state = evaluate(it.conds);
+                it.el.toggle(state.show);
+                it.el.find(':input').prop('disabled', state.disabled);
+                if(state.disabled){
+                    it.el.attr('data-disabled', '1');
+                }else{
+                    it.el.removeAttr('data-disabled');
+                }
             });
         }
         run();

--- a/includes/gm2-custom-posts-functions.php
+++ b/includes/gm2-custom-posts-functions.php
@@ -418,6 +418,9 @@ function gm2_render_field_group($fields, $object_id, $context_type = 'post') {
         $type  = $field['type'] ?? 'text';
         $class = gm2_get_field_type_class($type);
         echo '<div class="' . esc_attr($wrapper) . '" data-type="' . esc_attr($type) . '"';
+        if ($field['disabled']) {
+            echo ' data-disabled="1"';
+        }
         if (!$visible) {
             echo ' style="display:none;"';
         }

--- a/tests/test-custom-posts.php
+++ b/tests/test-custom-posts.php
@@ -162,4 +162,36 @@ class CustomPostsFieldsTest extends WP_UnitTestCase {
         $this->assertSame('show_extra', $saved['conditions'][0]['conditions'][0]['target']);
         $this->assertSame('=', $saved['conditions'][0]['conditions'][0]['operator']);
     }
+
+    public function test_render_field_group_outputs_disabled_flag() {
+        $_REQUEST['trig'] = '1';
+        $fields = [
+            'trig' => [
+                'type' => 'checkbox',
+            ],
+            'locked' => [
+                'type' => 'text',
+                'conditions' => [
+                    [
+                        'relation' => 'AND',
+                        'action'   => 'disable',
+                        'conditions' => [
+                            [
+                                'relation' => 'AND',
+                                'target'   => 'trig',
+                                'operator' => '=',
+                                'value'    => '1',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        ob_start();
+        gm2_render_field_group($fields, 0, 'post');
+        $html = ob_get_clean();
+        unset($_REQUEST['trig']);
+        $this->assertStringContainsString('data-disabled="1"', $html);
+        $this->assertMatchesRegularExpression('/<input[^>]*name="locked"[^>]*disabled/', $html);
+    }
 }


### PR DESCRIPTION
## Summary
- Apply conditional `disable` actions in JS evaluate/run so fields can be disabled or enabled dynamically
- Mark server-rendered fields with `data-disabled` when condition groups request disabling
- Cover server-side disabling output with tests

## Testing
- `phpunit` *(fails: mysqladmin command not found)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fb00f6e1883278588139eddaf95a6