### PR TITLE
Add dynamic Gutenberg field controls and meta registration

### DIFF
--- a/admin/js/gm2-custom-posts-gutenberg.js
+++ b/admin/js/gm2-custom-posts-gutenberg.js
@@ -1,9 +1,54 @@
 (function(wp){
     const { registerPlugin } = wp.plugins;
     const { PluginSidebar } = wp.editPost;
-    const { PanelBody, TextControl } = wp.components;
+    const { PanelBody, TextControl, TextareaControl, SelectControl, ToggleControl, Button } = wp.components;
+    const { MediaUpload } = wp.blockEditor || wp.editor;
     const { useSelect, useDispatch } = wp.data;
     const { createElement: el } = wp.element;
+
+    const controlFactory = (field, value, onChange) => {
+        switch(field.type){
+            case 'select':
+                return el(SelectControl, {
+                    key: field.key,
+                    label: field.label,
+                    value: value || '',
+                    options: field.options || [],
+                    onChange
+                });
+            case 'checkbox':
+            case 'toggle':
+                return el(ToggleControl, {
+                    key: field.key,
+                    label: field.label,
+                    checked: !!value,
+                    onChange
+                });
+            case 'media':
+                return el('div', { key: field.key }, [
+                    el('p', {}, field.label),
+                    el(MediaUpload, {
+                        onSelect: m => onChange(m.id),
+                        value: value,
+                        render: ({ open }) => el(Button, { onClick: open, isSecondary: true }, value ? 'Change Media' : 'Select Media')
+                    })
+                ]);
+            case 'textarea':
+                return el(TextareaControl, {
+                    key: field.key,
+                    label: field.label,
+                    value: value || '',
+                    onChange
+                });
+            default:
+                return el(TextControl, {
+                    key: field.key,
+                    label: field.label,
+                    value: value || '',
+                    onChange
+                });
+        }
+    };
 
     const MetaPanel = () => {
         const meta = useSelect( select => select('core/editor').getEditedPostAttribute('meta'), [] );
@@ -11,12 +56,7 @@
         const fields = window.gm2BlockFields || [];
         return el(PluginSidebar, { name: 'gm2-meta', title: 'Gm2 Fields' },
             el(PanelBody, {},
-                fields.map(f => el(TextControl, {
-                    key: f.key,
-                    label: f.label,
-                    value: meta[f.key] || '',
-                    onChange: v => editPost({ meta: { [f.key]: v } })
-                }))
+                fields.map(f => controlFactory(f, meta[f.key], v => editPost({ meta: { [f.key]: v } })))
             )
         );
     };


### PR DESCRIPTION
## Summary
- Add component factory in Gutenberg sidebar to render Text, Textarea, Select, Toggle and Media controls based on field type
- Register custom post meta with matching type and sanitize callbacks and expose field config to JS
- Include wp-block-editor dependency for media fields

## Testing
- `npm test`
- `phpunit` *(fails: /tmp/wordpress-tests-lib/includes/functions.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_689fb201105083279e8f60974b8c24d4