### PR TITLE
Add workflow management admin and scheduling capabilities

### DIFF
--- a/includes/Gm2_Workflow_Manager.php
+++ b/includes/Gm2_Workflow_Manager.php
@@ -21,6 +21,22 @@ class Gm2_Workflow_Manager {
         add_action('transition_post_status', [__CLASS__, 'on_status_change'], 10, 3);
         add_action('set_object_terms', [__CLASS__, 'on_term_assignment'], 10, 6);
         add_action('updated_post_meta', [__CLASS__, 'on_meta_update'], 10, 4);
+
+        $statuses = get_option('gm2_workflow_statuses', []);
+        if (is_array($statuses) && $statuses) {
+            self::register_statuses($statuses);
+        }
+
+        $workflows = get_option('gm2_workflows', []);
+        if (is_array($workflows)) {
+            foreach ($workflows as $workflow) {
+                $trigger = $workflow['trigger'] ?? '';
+                $actions = $workflow['actions'] ?? [];
+                if ($trigger && $actions) {
+                    self::register_trigger($trigger, $actions);
+                }
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- Add Workflows submenu under Gm2 Custom Posts to manage triggers and actions
- Provide forms for custom statuses and scheduling status transitions
- Load saved workflows and statuses during initialization

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fbdcd0a348327b744ed4cd4adb521