### PR TITLE
Add lazy-load hooks and async media thumbnail regeneration

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -2907,8 +2907,7 @@ class Gm2_SEO_Admin {
                 $new    = $dir . '/' . $name;
                 if ($new !== $file && @rename($file, $new)) {
                     update_attached_file($attachment_id, $new);
-                    $meta = wp_generate_attachment_metadata($attachment_id, $new);
-                    wp_update_attachment_metadata($attachment_id, $meta);
+                    \gm2_queue_thumbnail_regeneration($attachment_id);
                 }
             }
         }
@@ -2980,8 +2979,7 @@ class Gm2_SEO_Admin {
             $body = wp_remote_retrieve_body($response);
             if ($body !== '') {
                 file_put_contents($file, $body);
-                $metadata = wp_generate_attachment_metadata($attachment_id, $file);
-                wp_update_attachment_metadata($attachment_id, $metadata);
+                \gm2_queue_thumbnail_regeneration($attachment_id);
             }
         }
     }

--- a/includes/Gm2_REST_Media.php
+++ b/includes/Gm2_REST_Media.php
@@ -34,7 +34,7 @@ class Gm2_REST_Media {
         if (!wp_attachment_is_image($id)) {
             return new \WP_Error('gm2_invalid_attachment', __('Attachment must be an image.', 'gm2-wordpress-suite'), [ 'status' => 400 ]);
         }
-        wp_schedule_single_event(time(), 'gm2_generate_thumbnails', [ $id ]);
+        \gm2_queue_thumbnail_regeneration($id);
         return rest_ensure_response([ 'scheduled' => true ]);
     }
 


### PR DESCRIPTION
## Summary
- add lazy-load filter and placeholder for tab/accordion field groups
- queue attachment metadata regeneration asynchronously with Action Scheduler or WP-Cron
- hook async regeneration into media REST endpoint and upload routines

## Testing
- `npm test`
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689fc018c6a48327816119bfe118caad