### PR TITLE
Support date tokens in gm2_resolve_default

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -21,6 +21,16 @@ $json = json_encode( ['hello' => 'world'] );
 echo gm2_render_open_in_code( $php, $json );
 ```
 
+### `gm2_resolve_default( array $field, int $object_id = 0, string $context_type = 'post' ): mixed`
+Resolves a field's default value. Besides static values and callbacks, template
+strings may contain tokens such as `{post_id}` or `{date:Y-m-d}`. Date tokens are
+rendered using the site's timezone.
+
+```php
+$field = [ 'default_template' => 'Published on {date:Y-m-d}' ];
+$value = gm2_resolve_default( $field );
+```
+
 ## JavaScript APIs
 
 ### `gm2-schema-tooltips`

--- a/includes/gm2-custom-posts-functions.php
+++ b/includes/gm2-custom-posts-functions.php
@@ -158,10 +158,33 @@ function gm2_resolve_default($field, $object_id = 0, $context_type = 'post') {
                 $replacements['{post_slug}']  = $post->post_name;
             }
         }
-        return strtr($template, $replacements);
+        $template = strtr($template, $replacements);
+        return gm2_render_default_tokens($template);
     }
 
-    return $default;
+    return gm2_render_default_tokens($default);
+}
+
+/**
+ * Replace dynamic tokens within a default string.
+ *
+ * Currently supports date tokens of the form `{date:FORMAT}` which are
+ * formatted using the site's timezone.
+ *
+ * @param mixed $value Value containing tokens.
+ * @return mixed Value with tokens replaced.
+ */
+function gm2_render_default_tokens($value) {
+    if (!is_string($value)) {
+        return $value;
+    }
+
+    $value = preg_replace_callback('/{date:([^}]+)}/', function ($matches) {
+        $format = trim($matches[1]);
+        return wp_date($format, time(), wp_timezone());
+    }, $value);
+
+    return $value;
 }
 
 /**

--- a/tests/test-generated-fields.php
+++ b/tests/test-generated-fields.php
@@ -80,5 +80,18 @@ class GeneratedFieldsTest extends WP_UnitTestCase {
         $field->save($post_id, '0');
         $this->assertSame('', get_post_meta($post_id, 'gm2_toggle', true));
     }
+
+    public function test_date_token_renders_using_site_timezone() {
+        $prev_tz = get_option('timezone_string');
+        update_option('timezone_string', 'America/Chicago');
+
+        $field  = [ 'default_template' => '{date:Y-m-d}' ];
+        $value  = gm2_resolve_default($field);
+        $expect = wp_date('Y-m-d', time(), wp_timezone());
+
+        $this->assertSame($expect, $value);
+
+        update_option('timezone_string', $prev_tz);
+    }
 }
 


### PR DESCRIPTION
## Summary
- expand `gm2_resolve_default()` to replace `{date:FORMAT}` tokens using the site's timezone
- document field default token usage
- test template rendering of date tokens

## Testing
- `npm test`
- `phpunit tests/test-generated-fields.php` *(fails: WordPress test suite missing)*


------
https://chatgpt.com/codex/tasks/task_e_689fda86e88c83279bd09eb195af620a