### PR TITLE
Add field capability mappings with permissions screen and tests

### DIFF
--- a/includes/Gm2_Capability_Manager.php
+++ b/includes/Gm2_Capability_Manager.php
@@ -53,17 +53,17 @@ class Gm2_Capability_Manager {
         if (!$field || !$action) {
             return $allcaps;
         }
-        $roles = $map[$field][$action] ?? [];
-        if (empty($roles)) {
-            // No roles restriction means allowed.
+        $required = $map[$field][$action] ?? [];
+        if (empty($required)) {
+            // No restriction means allowed.
             $allcaps[$cap] = true;
             return $allcaps;
         }
         $user = get_userdata($user_id);
         $allowed = false;
         if ($user) {
-            foreach ((array) $user->roles as $role) {
-                if (in_array($role, $roles, true)) {
+            foreach ((array) $required as $need) {
+                if (in_array($need, (array) $user->roles, true) || !empty($user->allcaps[$need])) {
                     $allowed = true;
                     break;
                 }

--- a/tests/test-taxonomy-permissions.php
+++ b/tests/test-taxonomy-permissions.php
@@ -45,3 +45,26 @@ class TaxonomyContentRulesTest extends WP_Ajax_UnitTestCase {
     }
 }
 
+class FieldCapabilityPermissionsTest extends WP_UnitTestCase {
+    public function tearDown(): void {
+        parent::tearDown();
+        delete_option('gm2_field_caps');
+    }
+
+    public function test_role_based_field_capability() {
+        update_option('gm2_field_caps', ['foo' => ['edit' => ['administrator']]]);
+        $admin = self::factory()->user->create(['role' => 'administrator']);
+        $subscriber = self::factory()->user->create(['role' => 'subscriber']);
+        $this->assertTrue(user_can($admin, 'gm2_field_edit_foo'));
+        $this->assertFalse(user_can($subscriber, 'gm2_field_edit_foo'));
+    }
+
+    public function test_capability_based_field_capability() {
+        update_option('gm2_field_caps', ['bar' => ['edit' => ['edit_posts']]]);
+        $editor = self::factory()->user->create(['role' => 'editor']);
+        $subscriber = self::factory()->user->create(['role' => 'subscriber']);
+        $this->assertTrue(user_can($editor, 'gm2_field_edit_bar'));
+        $this->assertFalse(user_can($subscriber, 'gm2_field_edit_bar'));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Field Permissions admin screen for mapping roles/caps to fields
- persist field-role mappings in gm2_field_caps and enforce via capability manager
- test role and capability-based field access restrictions

## Testing
- `phpunit tests/test-taxonomy-permissions.php` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): No such file or directory)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fe0b12914832786631f4f91497f60