### PR TITLE
feat: add contextual help registry for custom posts

### DIFF
--- a/admin/js/gm2-help.js
+++ b/admin/js/gm2-help.js
@@ -1,0 +1,12 @@
+jQuery(function($){
+    if (typeof gm2CPTHelp === 'object') {
+        $.each(gm2CPTHelp, function(selector, text){
+            $(document).on('mouseenter', selector, function(){
+                var $el = $(this);
+                if (!$el.attr('title')) {
+                    $el.attr('title', text);
+                }
+            });
+        });
+    }
+});

--- a/docs/api.md
+++ b/docs/api.md
@@ -47,3 +47,22 @@ Provides copy-to-clipboard and download buttons for code blocks rendered by `gm2
 // Behaviour is attached to markup produced by the PHP helper; no direct API is exposed.
 ```
 
+### `Gm2_Custom_Posts_Admin::register_help( string $screen, string $content, array $tooltips = [] ): void`
+Registers contextual help for an admin screen. The `$tooltips` array maps CSS selectors to messages that appear as native tooltips. A "Help" tab is added automatically.
+
+```php
+$admin = new Gm2_Custom_Posts_Admin();
+$admin->register_help(
+    'toplevel_page_gm2-custom-posts',
+    __( 'Manage custom post types and taxonomies.', 'gm2-wordpress-suite' ),
+    [ 'input[name="pt_slug"]' => __( 'Unique identifier for the post type.', 'gm2-wordpress-suite' ) ]
+);
+```
+
+### `gm2-help`
+Elements targeted by the help registry receive their message as a tooltip.
+
+```js
+// Tooltips are applied automatically based on localized data.
+```
+

--- a/languages/gm2-wordpress-suite.pot
+++ b/languages/gm2-wordpress-suite.pot
@@ -3353,3 +3353,59 @@ msgstr ""
 #: public/Gm2_SEO_Public.php:135
 msgid "Review rating value"
 msgstr ""
+
+#: admin/Gm2_Custom_Posts_Admin.php:88
+msgid "Help"
+msgstr ""
+
+#: admin/Gm2_Custom_Posts_Admin.php:34
+msgid "Manage custom post types and taxonomies."
+msgstr ""
+
+#: admin/Gm2_Custom_Posts_Admin.php:36
+msgid "Unique identifier for the post type."
+msgstr ""
+
+#: admin/Gm2_Custom_Posts_Admin.php:37
+msgid "Unique identifier for the taxonomy."
+msgstr ""
+
+#: admin/Gm2_Custom_Posts_Admin.php:42
+msgid "Edit fields and registration arguments for the selected post type."
+msgstr ""
+
+#: admin/Gm2_Custom_Posts_Admin.php:44
+msgid "Add a new field."
+msgstr ""
+
+#: admin/Gm2_Custom_Posts_Admin.php:45
+msgid "Add a new argument."
+msgstr ""
+
+#: admin/Gm2_Custom_Posts_Admin.php:50
+msgid "Modify taxonomy settings and meta fields."
+msgstr ""
+
+#: admin/Gm2_Custom_Posts_Admin.php:52
+msgid "Add a new taxonomy argument."
+msgstr ""
+
+#: admin/Gm2_Custom_Posts_Admin.php:57
+msgid "Build reusable WP_Query snippets."
+msgstr ""
+
+#: admin/Gm2_Custom_Posts_Admin.php:59
+msgid "Save the configured query."
+msgstr ""
+
+#: admin/Gm2_Custom_Posts_Admin.php:64
+msgid "Interactive model builder for custom post types."
+msgstr ""
+
+#: admin/Gm2_Custom_Posts_Admin.php:68
+msgid "Automate actions with workflows and statuses."
+msgstr ""
+
+#: admin/Gm2_Custom_Posts_Admin.php:72
+msgid "Restrict who can edit specific fields."
+msgstr ""


### PR DESCRIPTION
## Summary
- add help registry to custom post admin screens with tooltips and contextual "Help" tab
- localize new help text
- document help registry usage

## Testing
- `npm test`
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a007090ccc832799fc0bb556960b32