### PR TITLE
feat: register custom fields with WPGraphQL

### DIFF
--- a/tests/test-graphql.php
+++ b/tests/test-graphql.php
@@ -1,0 +1,21 @@
+<?php
+use Gm2\Gm2_REST_Fields;
+use Gm2\Gm2_REST_Visibility;
+
+class GraphQLRegistrationTest extends WP_UnitTestCase {
+    public function test_register_graphql_hooks() {
+        if (!class_exists('WPGraphQL')) {
+            $this->markTestSkipped('WPGraphQL not available.');
+        }
+        register_post_type('book');
+        register_taxonomy('genre', 'book');
+        update_option(Gm2_REST_Visibility::OPTION, [
+            'post_types' => [ 'book' => true ],
+            'taxonomies' => [ 'genre' => true ],
+            'fields' => [ 'isbn' => true ],
+        ]);
+        Gm2_REST_Fields::init();
+        do_action('graphql_register_types');
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
## Summary
- detect WPGraphQL and register CPTs, taxonomies, and custom fields in GraphQL with visibility checks
- add GraphQL registration test guarded by `class_exists('WPGraphQL')`

## Testing
- `npm test`
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a0abd035548327b364320a4797d22d