### PR TITLE
feat: add PII field support with retention and export routines

### DIFF
--- a/admin/Gm2_Custom_Posts_Admin.php
+++ b/admin/Gm2_Custom_Posts_Admin.php
@@ -1750,6 +1750,13 @@ class Gm2_Custom_Posts_Admin {
                 'label' => $field['label'] ?? $slug,
                 'type'  => $field_type,
             ];
+            if (!empty($field['pii'])) {
+                $field_config['pii'] = true;
+                if (!empty($field['retention'])) {
+                    $field_config['retention'] = (int) $field['retention'];
+                }
+                \Gm2\Gm2_Audit_Log::tag_field_as_pii($slug, $field['retention'] ?? null);
+            }
             if ($field_type === 'select' && !empty($field['options']) && is_array($field['options'])) {
                 $options = [];
                 foreach ($field['options'] as $val => $label) {

--- a/includes/gm2-custom-posts-functions.php
+++ b/includes/gm2-custom-posts-functions.php
@@ -650,6 +650,12 @@ function gm2_register_field_groups() {
         $locations = $group['location'] ?? [];
         $scope     = $group['scope'] ?? 'post_type';
 
+        foreach ($fields as $key => $field) {
+            if (!empty($field['pii'])) {
+                \Gm2\Gm2_Audit_Log::tag_field_as_pii($key, $field['retention'] ?? null);
+            }
+        }
+
         switch ($scope) {
             case 'taxonomy':
                 foreach (($group['objects'] ?? []) as $tax) {

--- a/tests/test-pii-retention.php
+++ b/tests/test-pii-retention.php
@@ -1,0 +1,39 @@
+<?php
+use Gm2\Gm2_Audit_Log;
+
+class PiiRetentionTest extends WP_UnitTestCase {
+    public function setUp(): void {
+        parent::setUp();
+        Gm2_Audit_Log::install();
+    }
+
+    public function test_purge_removes_old_pii_meta() {
+        global $wpdb;
+        $post_id = self::factory()->post->create();
+        update_post_meta($post_id, 'secret', 'top');
+        Gm2_Audit_Log::tag_field_as_pii('secret', 1);
+        $table = $wpdb->prefix . 'gm2_audit_log';
+        $wpdb->insert($table, [
+            'object_id' => $post_id,
+            'meta_key' => 'secret',
+            'old_value' => '',
+            'new_value' => 'top',
+            'user_id' => get_current_user_id(),
+            'changed_at' => gmdate('Y-m-d H:i:s', strtotime('-2 days')),
+            'pii' => 1,
+        ]);
+        Gm2_Audit_Log::purge();
+        $this->assertSame('', get_post_meta($post_id, 'secret', true));
+        $count = (int) $wpdb->get_var("SELECT COUNT(*) FROM $table");
+        $this->assertSame(0, $count);
+    }
+
+    public function test_export_pii_returns_data() {
+        $post_id = self::factory()->post->create();
+        update_post_meta($post_id, 'secret', 'top');
+        Gm2_Audit_Log::tag_field_as_pii('secret');
+        $data = Gm2_Audit_Log::export_pii($post_id);
+        $this->assertArrayHasKey('secret', $data);
+        $this->assertSame('top', $data['secret']);
+    }
+}


### PR DESCRIPTION
## Summary
- allow field definitions to flag PII with optional retention window
- add audit log helpers to export and purge PII data
- cover PII retention with new tests

## Testing
- `npm test`
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a0aef0666883278615e72edccb3b08