### PR TITLE
Add async media webhooks and thumbnail regeneration queue

### DIFF
--- a/admin/js/gm2-thumbnails.js
+++ b/admin/js/gm2-thumbnails.js
@@ -1,0 +1,22 @@
+jQuery(function($){
+    $('#gm2-start-thumb-regeneration').on('click', function(e){
+        e.preventDefault();
+        var $progress = $('#gm2-thumb-progress');
+        var $bar = $progress.find('progress');
+        var $percent = $progress.find('.percent');
+        $progress.show();
+        $bar.val(0);
+        $percent.text('0%');
+        $.post(ajaxurl, {
+            action: 'gm2_regenerate_thumbnails',
+            nonce: gm2Thumbs.nonce
+        }, function(resp){
+            if(resp && resp.success){
+                $bar.attr('max', resp.data.total).val(resp.data.total);
+                $percent.text('100%');
+            } else {
+                $percent.text('error');
+            }
+        });
+    });
+});

--- a/includes/Gm2_Webhooks.php
+++ b/includes/Gm2_Webhooks.php
@@ -13,6 +13,21 @@ class Gm2_Webhooks {
         add_action('save_post', [ __CLASS__, 'handle_save' ], 10, 3);
         add_action('deleted_post', [ __CLASS__, 'handle_delete' ], 10, 1);
         add_action('transition_post_status', [ __CLASS__, 'handle_transition' ], 10, 3);
+        add_action('add_attachment', [ __CLASS__, 'handle_add_attachment' ]);
+        add_action('gm2_webhook_media', [ __CLASS__, 'process_media_webhook' ]);
+    }
+
+    public static function handle_add_attachment(int $post_id) : void {
+        if (function_exists('as_enqueue_async_action')) {
+            as_enqueue_async_action('gm2_webhook_media', [ $post_id ], 'gm2');
+        } else {
+            wp_schedule_single_event(time(), 'gm2_webhook_media', [ $post_id ]);
+        }
+    }
+
+    public static function process_media_webhook(int $post_id) : void {
+        $post = get_post($post_id);
+        self::fire('media_upload', $post);
     }
 
     public static function handle_save(int $post_id, \WP_Post $post, bool $update) : void {

--- a/tests/AsyncJobSchedulingTest.php
+++ b/tests/AsyncJobSchedulingTest.php
@@ -1,0 +1,20 @@
+<?php
+use WP_UnitTestCase;
+use Gm2\Gm2_Webhooks;
+
+class AsyncJobSchedulingTest extends WP_UnitTestCase {
+    public function test_media_webhook_schedules_event() {
+        $file = DIR_TESTDATA . '/images/canola.jpg';
+        $attachment_id = self::factory()->attachment->create_upload_object($file);
+        Gm2_Webhooks::init();
+        do_action('add_attachment', $attachment_id);
+        $this->assertNotFalse(wp_next_scheduled('gm2_webhook_media', [ $attachment_id ]));
+    }
+
+    public function test_thumbnail_regeneration_schedules_event() {
+        $file = DIR_TESTDATA . '/images/canola.jpg';
+        $attachment_id = self::factory()->attachment->create_upload_object($file);
+        \gm2_queue_thumbnail_regeneration($attachment_id);
+        $this->assertNotFalse(wp_next_scheduled('gm2_generate_thumbnails', [ $attachment_id ]));
+    }
+}


### PR DESCRIPTION
## Summary
- Schedule media upload webhooks in background with Action Scheduler or WP-Cron
- Add thumbnail regeneration queue with admin progress UI
- Test async job scheduling for media webhooks and thumbnail regeneration

## Testing
- `npm test`
- `make test DB_NAME=wp_test DB_USER=root DB_PASS=pass` *(fails: mysqladmin command not found)*
- `/root/.local/share/mise/installs/php/8.4.11/.composer/vendor/bin/phpunit` *(fails: missing wordpress-tests-lib)*

------
https://chatgpt.com/codex/tasks/task_e_68a32e3e65308327babdb690f6059344