### PR TITLE
Add CLI model management commands

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -83,3 +83,33 @@ Elements targeted by the help registry receive their message as a tooltip.
 // Tooltips are applied automatically based on localized data.
 ```
 
+## WP-CLI Model Commands
+
+Manage custom post types, taxonomies and fields via the command line.
+
+### Custom Post Types
+
+`wp gm2 model cpt create <slug> [--args=<json>]`
+
+`wp gm2 model cpt update <slug> [--args=<json>] [--version=<n>]`
+
+`wp gm2 model cpt delete <slug>`
+
+### Taxonomies
+
+`wp gm2 model taxonomy create <cpt> <slug> [--args=<json>]`
+
+`wp gm2 model taxonomy update <cpt> <slug> [--args=<json>]`
+
+`wp gm2 model taxonomy delete <cpt> <slug>`
+
+### Fields
+
+`wp gm2 model field create <cpt> <key> [--args=<json>]`
+
+`wp gm2 model field update <cpt> <key> [--args=<json>]`
+
+`wp gm2 model field delete <cpt> <key>`
+
+Each command updates the `gm2_models` option and runs migrations for the affected model.
+

--- a/tests/test-cli/model-cli.php
+++ b/tests/test-cli/model-cli.php
@@ -1,0 +1,62 @@
+<?php
+// Minimal stubs to exercise CLI commands without a full WordPress install.
+
+define( 'WP_CLI', true );
+define( 'GM2_PLUGIN_DIR', dirname( __DIR__, 2 ) . '/' );
+
+class WP_CLI {
+    public static function error( $msg ) { throw new Exception( $msg ); }
+    public static function success( $msg ) { echo $msg, "\n"; }
+    public static function warning( $msg ) { echo $msg, "\n"; }
+    public static function line( $msg ) { echo $msg, "\n"; }
+    public static function add_command( $name, $callable ) {}
+}
+class WP_CLI_Command {}
+
+// Option storage.
+$GLOBALS['gm2_options'] = [];
+function get_option( $name, $default = [] ) { return $GLOBALS['gm2_options'][$name] ?? $default; }
+function update_option( $name, $value ) { $GLOBALS['gm2_options'][$name] = $value; return true; }
+function delete_option( $name ) { unset( $GLOBALS['gm2_options'][$name] ); return true; }
+
+function gm2_run_model_migrations( $slug, $from, $to ) {
+    echo "migrate {$slug} {$from}->{$to}\n";
+}
+
+require dirname( __DIR__, 2 ) . '/includes/cli/class-gm2-model.php';
+
+$cli = new \Gm2\Gm2_Model_CLI();
+
+// CPT lifecycle.
+$cli->cpt_create( ['book'], ['args' => '{"label":"Books"}'] );
+$cli->cpt_update( ['book'], ['args' => '{"public":false}', 'version' => 2] );
+
+// Taxonomy lifecycle.
+$cli->taxonomy_create( ['book','genre'], [] );
+$cli->taxonomy_update( ['book','genre'], ['args' => '{"hierarchical":true}'] );
+
+// Field lifecycle.
+$cli->field_create( ['book','isbn'], ['args' => '{"type":"string"}'] );
+$cli->field_update( ['book','isbn'], ['args' => '{"description":"ISBN"}'] );
+$cli->field_delete( ['book','isbn'], [] );
+
+$models = get_option( 'gm2_models' );
+if ( empty( $models ) || $models[0]['slug'] !== 'book' ) {
+    throw new Exception( 'CPT not created as expected.' );
+}
+if ( empty( $models[0]['taxonomies'] ) || $models[0]['taxonomies'][0]['slug'] !== 'genre' ) {
+    throw new Exception( 'Taxonomy not created.' );
+}
+if ( ! empty( $models[0]['fields'] ) ) {
+    throw new Exception( 'Field delete failed.' );
+}
+
+// Cleanup.
+$cli->taxonomy_delete( ['book','genre'], [] );
+$cli->cpt_delete( ['book'], [] );
+
+if ( ! empty( get_option( 'gm2_models' ) ) ) {
+    throw new Exception( 'Model delete failed.' );
+}
+
+echo "CLI tests completed\n";


### PR DESCRIPTION
## Summary
- add `create`, `update`, and `delete` subcommands for CPTs, taxonomies, and fields
- update `gm2_models` option and trigger migrations when models change
- document new WP‑CLI model commands and provide CLI tests

## Testing
- `npm test`
- `php tests/test-cli/model-cli.php`


------
https://chatgpt.com/codex/tasks/task_e_68a33247347c832796a2853effc91cc6