### PR TITLE
Add workflow scheduling triggers and actions

### DIFF
--- a/tests/test-workflow-manager.php
+++ b/tests/test-workflow-manager.php
@@ -1,0 +1,37 @@
+<?php
+class WorkflowManagerTriggerTest extends WP_UnitTestCase {
+    protected function setUp(): void {
+        parent::setUp();
+        $ref = new ReflectionClass('\\Gm2\\Gm2_Workflow_Manager');
+        $prop = $ref->getProperty('triggers');
+        $prop->setAccessible(true);
+        $prop->setValue(null, []);
+    }
+
+    public function test_publish_trigger_executes_actions() {
+        $called = false;
+        \Gm2\Gm2_Workflow_Manager::register_trigger('publish', [
+            ['type' => 'recalculate_field', 'callback' => function() use (&$called) { $called = true; }]
+        ]);
+        \Gm2\Gm2_Workflow_Manager::on_status_change('publish', 'draft', (object)['ID' => 1]);
+        $this->assertTrue($called);
+    }
+
+    public function test_term_assign_trigger_executes_actions() {
+        $called = false;
+        \Gm2\Gm2_Workflow_Manager::register_trigger('term_assign', [
+            ['type' => 'recalculate_field', 'callback' => function() use (&$called) { $called = true; }]
+        ]);
+        \Gm2\Gm2_Workflow_Manager::on_term_assignment(1, ['a'], [], 'category', false, []);
+        $this->assertTrue($called);
+    }
+
+    public function test_field_change_trigger_executes_actions() {
+        $called = false;
+        \Gm2\Gm2_Workflow_Manager::register_trigger('field_change', [
+            ['type' => 'recalculate_field', 'callback' => function() use (&$called) { $called = true; }]
+        ]);
+        \Gm2\Gm2_Workflow_Manager::on_meta_update(1, 1, 'meta', 'value');
+        $this->assertTrue($called);
+    }
+}


### PR DESCRIPTION
## Summary
- expand workflow manager with publish, term assignment, and field change triggers
- support Slack, content expiration, and featured rotation action types
- test that registered workflow triggers execute their actions

## Testing
- `npm test`
- `phpunit tests/test-workflow-manager.php` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*


------
https://chatgpt.com/codex/tasks/task_e_68a33728611c83278dccfa9ce450bd4f