### PR TITLE
Optimize meta retrieval with lazy loading and DB indexes

### DIFF
--- a/docs/caching.md
+++ b/docs/caching.md
@@ -1,0 +1,18 @@
+# Caching and Lazy Loading
+
+The suite uses several techniques to reduce database load and speed up requests:
+
+- **Database indexes** – custom indexes are added to WordPress meta tables and
+  to plugin tables such as `gm2_audit_log`, `wc_ac_carts` and
+  `wc_ac_email_queue`. These indexes target columns that are frequently queried
+  so lookups avoid full table scans.
+- **Lazy metadata loading** – `gm2_get_meta_value()` now exposes the
+  `gm2_lazy_load_meta_value` filter. When enabled for a field the function
+  returns a lightweight `GM2_Lazy_Meta_Value` object that defers the actual
+  database read until the value is accessed.
+- **Object caching** – values retrieved through the custom tables API are stored
+  in WordPress's object cache (`wp_cache_set`/`wp_cache_get`) for the duration of
+  the request.
+
+A basic performance test (`tests/test-lazy-meta-value.php`) verifies that the
+lazy loader does not hit the database until the value is used.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,9 @@
 This release adds several new SEO and AI options:
 
 - Added an index on the `timestamp` column of the `gm2_analytics_log` table for faster lookups. Existing installations upgrade automatically.
+- Additional database indexes for frequently queried meta keys and custom tables,
+  plus lazy metadata loading via `gm2_get_meta_value()`. See
+  [caching.md](caching.md) for details on the caching strategy.
 - Developer option to scaffold basic Twig and Blade templates in `theme-integration/` using registered field groups.
 - **Project Description** and **Custom Prompts** fields under **SEO → Context**. The project description falls back to the site tagline or a snippet of post content if empty.
  - **Business Context Prompt** builder that compiles your Context answers into a single prompt for generating a short business summary.

--- a/tests/test-lazy-meta-value.php
+++ b/tests/test-lazy-meta-value.php
@@ -1,0 +1,27 @@
+<?php
+class LazyMetaValueTest extends WP_UnitTestCase {
+    public function test_value_is_lazy_loaded() {
+        $post_id = self::factory()->post->create();
+        update_post_meta($post_id, '_gm2_lazy', 'foo');
+
+        $calls = 0;
+        add_filter('gm2_lazy_load_meta_value', function($defer, $obj, $key) {
+            return $key === '_gm2_lazy';
+        }, 10, 3);
+        add_filter('gm2_lazy_meta_loader', function($resolver) use (&$calls) {
+            return function() use ($resolver, &$calls) {
+                $calls++;
+                return $resolver();
+            };
+        });
+
+        $value = gm2_get_meta_value($post_id, '_gm2_lazy', 'post', []);
+        $this->assertInstanceOf('GM2_Lazy_Meta_Value', $value);
+        $this->assertSame(0, $calls);
+        $this->assertSame('foo', $value->get());
+        $this->assertSame(1, $calls);
+
+        remove_all_filters('gm2_lazy_load_meta_value');
+        remove_all_filters('gm2_lazy_meta_loader');
+    }
+}


### PR DESCRIPTION
## Summary
- add `GM2_Lazy_Meta_Value` and filters to defer heavy meta lookups
- create `gm2_maybe_add_indexes()` to install indexes on meta and custom tables
- document caching strategy and add performance test for lazy loading

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3397b3af48327a9c544b1f5aa6377