### PR TITLE
Support new field attributes and admin UI behavior

### DIFF
--- a/admin/js/gm2-custom-posts-admin.js
+++ b/admin/js/gm2-custom-posts-admin.js
@@ -324,7 +324,58 @@ jQuery(function($){
         $(this).val(val.replace(/[^0-9,]/g,''));
     });
 
+    function applyEnhancements(){
+        $('.gm2-field[data-placeholder]').each(function(){
+            var ph = $(this).data('placeholder');
+            $(this).find('input, textarea, select').first().attr('placeholder', ph);
+        });
+        $('.gm2-field[data-admin-class]').each(function(){
+            var cls = $(this).data('admin-class');
+            $(this).find(':input').addClass(cls);
+        });
+        var tabs = [];
+        $('.gm2-field[data-tab]').each(function(){
+            var t = $(this).data('tab');
+            if(tabs.indexOf(t) === -1){ tabs.push(t); }
+        });
+        if(tabs.length){
+            var nav = $('<ul class="gm2-tab-nav"></ul>');
+            $.each(tabs, function(i, t){ nav.append('<li data-tab="'+t+'">'+t+'</li>'); });
+            var firstField = $('.gm2-field[data-tab]').first();
+            firstField.before(nav);
+            function showTab(tab){
+                $('.gm2-field[data-tab]').hide();
+                $('.gm2-field[data-tab="'+tab+'"]').show();
+                nav.find('li').removeClass('active');
+                nav.find('li[data-tab="'+tab+'"]').addClass('active');
+            }
+            nav.on('click', 'li', function(){
+                showTab($(this).data('tab'));
+            });
+            showTab(tabs[0]);
+        }
+        var accGroups = {};
+        $('.gm2-field[data-accordion]').each(function(){
+            var name = $(this).data('accordion');
+            if(!accGroups[name]){ accGroups[name] = []; }
+            accGroups[name].push(this);
+        });
+        $.each(accGroups, function(name, fields){
+            var first = $(fields[0]);
+            var wrap = $('<div class="gm2-accordion-group"></div>');
+            var header = $('<h3 class="gm2-accordion-header">'+name+'</h3>');
+            var content = $('<div class="gm2-accordion-content"></div>');
+            $(fields).each(function(){ content.append(this); });
+            wrap.append(header).append(content);
+            first.before(wrap);
+        });
+        $(document).on('click', '.gm2-accordion-header', function(){
+            $(this).next('.gm2-accordion-content').slideToggle();
+        });
+    }
+
     renderFields();
     renderArgs();
+    applyEnhancements();
 });
 

--- a/docs/field-definition-schema.md
+++ b/docs/field-definition-schema.md
@@ -1,0 +1,16 @@
+# Field Definition Schema
+
+Each field definition used by `gm2_render_field_group()` accepts the following keys:
+
+- `label` – Human‑readable label displayed with the field.
+- `slug` – Unique key used to store the value.
+- `type` – Field type such as `text`, `textarea`, `select` or `checkbox`.
+- `default` – Optional default value.
+- `description` – Short description shown in field listings.
+- `instructions` – Additional help text rendered below the field.
+- `placeholder` – Placeholder text applied to the input element.
+- `admin_class` – Extra CSS classes applied to the input when editing in the admin.
+- `tab` – Name of the tab grouping the field. Tabs are rendered as a navigation bar and only the active tab's fields are visible.
+- `accordion` – Name of the accordion group the field belongs to. Accordion headers toggle visibility of their fields.
+
+These keys allow field groups to provide richer guidance and layout controls within the admin interface.

--- a/includes/fields/class-field-base.php
+++ b/includes/fields/class-field-base.php
@@ -17,9 +17,6 @@ abstract class GM2_Field {
         echo '<p><label>' . esc_html( $label ) . '<br />';
         $this->render_field( $value, $object_id, $context_type );
         echo '</label></p>';
-        if ( ! empty( $this->args['instructions'] ) ) {
-            echo '<p class="description">' . esc_html( $this->args['instructions'] ) . '</p>';
-        }
     }
 
     public function render_public( $value ) {

--- a/includes/gm2-custom-posts-functions.php
+++ b/includes/gm2-custom-posts-functions.php
@@ -540,6 +540,9 @@ function gm2_render_field_group($fields, $object_id, $context_type = 'post') {
         if (!empty($field['class'])) {
             $wrapper .= ' ' . sanitize_html_class($field['class']);
         }
+        if (!empty($field['admin_class'])) {
+            $wrapper .= ' ' . sanitize_html_class($field['admin_class']);
+        }
         if (!empty($field['container'])) {
             $wrapper .= ' gm2-container-' . sanitize_html_class($field['container']);
         }
@@ -552,11 +555,26 @@ function gm2_render_field_group($fields, $object_id, $context_type = 'post') {
         if (!$visible) {
             echo ' style="display:none;"';
         }
+        if (!empty($field['tab'])) {
+            echo ' data-tab="' . esc_attr($field['tab']) . '"';
+        }
+        if (!empty($field['accordion'])) {
+            echo ' data-accordion="' . esc_attr($field['accordion']) . '"';
+        }
+        if (!empty($field['placeholder'])) {
+            echo ' data-placeholder="' . esc_attr($field['placeholder']) . '"';
+        }
+        if (!empty($field['admin_class'])) {
+            echo ' data-admin-class="' . esc_attr($field['admin_class']) . '"';
+        }
         echo '>';
         if ($class && class_exists($class)) {
             $obj   = new $class($key, $field);
             $value = gm2_get_meta_value($object_id, $key, $context_type, $field);
             $obj->render_admin($value, $object_id, $context_type);
+        }
+        if (!empty($field['instructions'])) {
+            echo '<p class="description">' . esc_html($field['instructions']) . '</p>';
         }
         echo '</div>';
     }


### PR DESCRIPTION
## Summary
- Render instructions, placeholders, tabs, accordion groups, and admin classes when displaying field groups.
- Enhance admin script to apply placeholders/CSS classes and wire up tab and accordion behaviors.
- Document new field-definition schema keys.

## Testing
- `npm test`
- `vendor/bin/phpunit` *(missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a3534fe884832783db98694f97bdba