### PR TITLE
Support multiple selections in select field

### DIFF
--- a/admin/Gm2_Custom_Posts_Admin.php
+++ b/admin/Gm2_Custom_Posts_Admin.php
@@ -271,6 +271,7 @@ class Gm2_Custom_Posts_Admin {
         echo '<div id="gm2-field-date-options" style="display:none;"><p><label>' . esc_html__( 'Min Date', 'gm2-wordpress-suite' ) . '<br /><input type="date" id="gm2-field-date-min" class="regular-text" /></label></p><p><label>' . esc_html__( 'Max Date', 'gm2-wordpress-suite' ) . '<br /><input type="date" id="gm2-field-date-max" class="regular-text" /></label></p></div>';
         echo '<div id="gm2-field-wysiwyg-options" style="display:none;"><p><label><input type="checkbox" id="gm2-field-wysiwyg-media" value="1" /> ' . esc_html__( 'Show Media Buttons', 'gm2-wordpress-suite' ) . '</label></p><p><label>' . esc_html__( 'Rows', 'gm2-wordpress-suite' ) . '<br /><input type="number" id="gm2-field-wysiwyg-rows" class="small-text" /></label></p></div>';
         echo '<div id="gm2-field-repeater-options" style="display:none;"><p><label>' . esc_html__( 'Min Rows', 'gm2-wordpress-suite' ) . '<br /><input type="number" id="gm2-field-repeater-min" class="small-text" /></label></p><p><label>' . esc_html__( 'Max Rows', 'gm2-wordpress-suite' ) . '<br /><input type="number" id="gm2-field-repeater-max" class="small-text" /></label></p></div>';
+        echo '<div id="gm2-field-select-options" style="display:none;"><p><label><input type="checkbox" id="gm2-field-multiple" value="1" /> ' . esc_html__( 'Allow Multiple Selections', 'gm2-wordpress-suite' ) . '</label></p></div>';
         echo '<h3>' . esc_html__( 'Location Rules', 'gm2-wordpress-suite' ) . '</h3>';
         echo '<div id="gm2-field-location" class="gm2-conditions"><div class="gm2-condition-groups"></div><p><button type="button" class="button gm2-add-condition-group">' . esc_html__( 'Add Location Group', 'gm2-wordpress-suite' ) . '</button></p></div>';
         echo '<h3>' . esc_html__( 'Display Conditions', 'gm2-wordpress-suite' ) . '</h3>';
@@ -884,6 +885,8 @@ class Gm2_Custom_Posts_Admin {
             } elseif ($type === 'repeater') {
                 if (isset($field['min_rows'])) { $sanitized['min_rows'] = (int) $field['min_rows']; }
                 if (isset($field['max_rows'])) { $sanitized['max_rows'] = (int) $field['max_rows']; }
+            } elseif ($type === 'select') {
+                $sanitized['multiple'] = !empty($field['multiple']);
             }
             if (!empty($field['options']) && is_array($field['options'])) {
                 $opts = [];
@@ -1355,6 +1358,7 @@ class Gm2_Custom_Posts_Admin {
                     'quick_edit'   => !empty($f['quick_edit']),
                     'bulk_edit'    => !empty($f['bulk_edit']),
                     'filter'       => !empty($f['filter']),
+                    'multiple'     => !empty($f['multiple']),
                 ];
             }
             $args = [];

--- a/admin/js/gm2-custom-posts-admin.js
+++ b/admin/js/gm2-custom-posts-admin.js
@@ -62,6 +62,7 @@ jQuery(function($){
         $('#gm2-field-date-options').toggle(type === 'date');
         $('#gm2-field-wysiwyg-options').toggle(type === 'wysiwyg');
         $('#gm2-field-repeater-options').toggle(type === 'repeater');
+        $('#gm2-field-select-options').toggle(type === 'select');
     }
 
     function showFieldForm(data, index){
@@ -84,6 +85,7 @@ jQuery(function($){
         $('#gm2-field-quick-edit').prop('checked', data ? !!data.quick_edit : false);
         $('#gm2-field-bulk-edit').prop('checked', data ? !!data.bulk_edit : false);
         $('#gm2-field-filter').prop('checked', data ? !!data.filter : false);
+        $('#gm2-field-multiple').prop('checked', data ? !!data.multiple : false);
         $('#gm2-field-date-min').val(data ? data.date_min || '' : '');
         $('#gm2-field-date-max').val(data ? data.date_max || '' : '');
         $('#gm2-field-wysiwyg-media').prop('checked', data ? !!data.wysiwyg_media : false);
@@ -250,6 +252,8 @@ jQuery(function($){
         } else if(obj.type === 'repeater'){
             obj.min_rows = $('#gm2-field-repeater-min').val();
             obj.max_rows = $('#gm2-field-repeater-max').val();
+        } else if(obj.type === 'select'){
+            obj.multiple = $('#gm2-field-multiple').is(':checked');
         }
         if(idx === ''){ fields.push(obj); } else { fields[idx] = obj; }
         saveAll(function(){ $('#gm2-field-form').hide(); });

--- a/includes/fields/class-field-select.php
+++ b/includes/fields/class-field-select.php
@@ -5,12 +5,41 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class GM2_Field_Select extends GM2_Field {
     protected function render_field( $value, $object_id, $context_type ) {
-        $options = $this->args['options'] ?? array();
+        $options  = $this->args['options'] ?? array();
+        $multiple = ! empty( $this->args['multiple'] );
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
-        echo '<select name="' . esc_attr( $this->key ) . '"' . $disabled . '>';
+
+        $name    = esc_attr( $this->key ) . ( $multiple ? '[]' : '' );
+        $multi   = $multiple ? ' multiple' : '';
+        $current = $multiple ? (array) $value : $value;
+
+        echo '<select name="' . $name . '"' . $multi . $disabled . '>';
         foreach ( $options as $ov => $ol ) {
-            echo '<option value="' . esc_attr( $ov ) . '"' . selected( $value, $ov, false ) . '>' . esc_html( $ol ) . '</option>';
+            $selected = $multiple
+                ? selected( in_array( $ov, $current, true ), true, false )
+                : selected( $current, $ov, false );
+            echo '<option value="' . esc_attr( $ov ) . '"' . $selected . '>' . esc_html( $ol ) . '</option>';
         }
         echo '</select>';
+    }
+
+    public function sanitize( $value ) {
+        $multiple = ! empty( $this->args['multiple'] );
+        $options  = $this->args['options'] ?? array();
+
+        if ( $multiple ) {
+            $value = is_array( $value ) ? $value : array( $value );
+            $out   = array();
+            foreach ( $value as $v ) {
+                $v = sanitize_text_field( $v );
+                if ( array_key_exists( $v, $options ) ) {
+                    $out[] = $v;
+                }
+            }
+            return $out;
+        }
+
+        $value = sanitize_text_field( $value );
+        return array_key_exists( $value, $options ) ? $value : '';
     }
 }


### PR DESCRIPTION
## Summary
- allow GM2_Field_Select to render and sanitize multiple values
- add "Allow Multiple Selections" option when configuring select fields

## Testing
- `npm test`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_68a359d499308327b982e3187412c3c4