### PR TITLE
Add markdown, code, and oEmbed field types with render helpers

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -60,6 +60,7 @@ require_once GM2_PLUGIN_DIR . 'includes/gm2-custom-posts-functions.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-query-builder.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-theme-tools.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-open-in-code.php';
+require_once GM2_PLUGIN_DIR . 'includes/gm2-field-renderers.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-schema-tooltips.php';
 // Temporarily disable Recovery Email Queue.
 // require_once GM2_PLUGIN_DIR . 'includes/Gm2_Abandoned_Carts_Messaging.php';

--- a/includes/fields/class-field-code.php
+++ b/includes/fields/class-field-code.php
@@ -1,0 +1,25 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class GM2_Field_Code extends GM2_Field {
+    protected function render_field( $value, $object_id, $context_type ) {
+        $language = $this->args['language'] ?? 'php';
+        if ( $context_type === 'public' ) {
+            echo gm2_render_code( (string) $value, $language );
+            return;
+        }
+        $id       = $this->key;
+        $settings = wp_enqueue_code_editor( array( 'file' => 'code.' . $language ) );
+        echo '<textarea id="' . esc_attr( $id ) . '" name="' . esc_attr( $this->key ) . '">' . esc_textarea( $value ) . '</textarea>';
+        if ( $settings ) {
+            $json = wp_json_encode( $settings );
+            echo '<script>jQuery(function(){wp.codeEditor.initialize("' . esc_js( $id ) . '",' . $json . ');});</script>';
+        }
+    }
+
+    public function sanitize( $value ) {
+        return (string) $value;
+    }
+}

--- a/includes/fields/class-field-markdown.php
+++ b/includes/fields/class-field-markdown.php
@@ -1,0 +1,24 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class GM2_Field_Markdown extends GM2_Field {
+    protected function render_field( $value, $object_id, $context_type ) {
+        if ( $context_type === 'public' ) {
+            echo gm2_render_markdown( (string) $value );
+            return;
+        }
+        $id       = $this->key;
+        $settings = wp_enqueue_code_editor( array( 'file' => 'field.md' ) );
+        echo '<textarea id="' . esc_attr( $id ) . '" name="' . esc_attr( $this->key ) . '">' . esc_textarea( $value ) . '</textarea>';
+        if ( $settings ) {
+            $json = wp_json_encode( $settings );
+            echo '<script>jQuery(function(){wp.codeEditor.initialize("' . esc_js( $id ) . '",' . $json . ');});</script>';
+        }
+    }
+
+    public function sanitize( $value ) {
+        return wp_kses_post( $value );
+    }
+}

--- a/includes/fields/class-field-oembed.php
+++ b/includes/fields/class-field-oembed.php
@@ -1,0 +1,19 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class GM2_Field_Oembed extends GM2_Field {
+    protected function render_field( $value, $object_id, $context_type ) {
+        if ( $context_type === 'public' ) {
+            echo gm2_render_oembed( (string) $value );
+            return;
+        }
+        $disabled = disabled( $this->args['disabled'] ?? false, true, false );
+        echo '<input type="url" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '"' . $disabled . ' />';
+    }
+
+    public function sanitize( $value ) {
+        return esc_url_raw( $value );
+    }
+}

--- a/includes/fields/loader.php
+++ b/includes/fields/loader.php
@@ -32,6 +32,9 @@ require_once __DIR__ . '/class-field-design.php';
 require_once __DIR__ . '/class-field-computed.php';
 require_once __DIR__ . '/class-field-message.php';
 require_once __DIR__ . '/class-field-toggle.php';
+require_once __DIR__ . '/class-field-markdown.php';
+require_once __DIR__ . '/class-field-code.php';
+require_once __DIR__ . '/class-field-oembed.php';
 
 $gm2_field_types = array();
 
@@ -74,5 +77,8 @@ function gm2_register_default_field_types() {
     gm2_register_field_type( 'computed', 'GM2_Field_Computed' );
     gm2_register_field_type( 'message', 'GM2_Field_Message' );
     gm2_register_field_type( 'toggle', 'GM2_Field_Toggle' );
+    gm2_register_field_type( 'markdown', 'GM2_Field_Markdown' );
+    gm2_register_field_type( 'code', 'GM2_Field_Code' );
+    gm2_register_field_type( 'oembed', 'GM2_Field_Oembed' );
 }
 add_action( 'init', 'gm2_register_default_field_types' );

--- a/includes/gm2-field-renderers.php
+++ b/includes/gm2-field-renderers.php
@@ -1,0 +1,37 @@
+<?php
+// Rendering helpers for custom field types.
+
+if ( ! function_exists( 'gm2_render_markdown' ) ) {
+    function gm2_render_markdown( $markdown ) {
+        if ( $markdown === null || $markdown === '' ) {
+            return '';
+        }
+        $html = (string) $markdown;
+        $html = preg_replace( '/\*\*(.+?)\*\*/s', '<strong>$1</strong>', $html );
+        $html = preg_replace( '/\*(.+?)\*/s', '<em>$1</em>', $html );
+        $html = preg_replace( '/`(.+?)`/s', '<code>$1</code>', $html );
+        $html = preg_replace( '/\[(.+?)\]\((https?:\/\/[^\s]+)\)/', '<a href="$2">$1</a>', $html );
+        $html = wpautop( $html );
+        return wp_kses_post( $html );
+    }
+}
+
+if ( ! function_exists( 'gm2_render_code' ) ) {
+    function gm2_render_code( $code, $language = '' ) {
+        $lang = $language ? ' class="language-' . esc_attr( $language ) . '"' : '';
+        return '<pre><code' . $lang . '>' . esc_html( (string) $code ) . '</code></pre>';
+    }
+}
+
+if ( ! function_exists( 'gm2_render_oembed' ) ) {
+    function gm2_render_oembed( $url ) {
+        if ( ! $url ) {
+            return '';
+        }
+        $embed = wp_oembed_get( $url );
+        if ( $embed ) {
+            return $embed;
+        }
+        return '<a href="' . esc_url( $url ) . '">' . esc_html( $url ) . '</a>';
+    }
+}

--- a/tests/test-field-markdown-code-oembed.php
+++ b/tests/test-field-markdown-code-oembed.php
@@ -1,0 +1,26 @@
+<?php
+
+class FieldMarkdownCodeOembedTest extends WP_UnitTestCase {
+    public function test_markdown_rendering() {
+        $html = gm2_render_markdown('Hello **World**');
+        $this->assertStringContainsString('<strong>World</strong>', $html);
+        $this->assertStringContainsString('<p>Hello', $html);
+    }
+
+    public function test_code_rendering_with_language() {
+        $html = gm2_render_code('<?php echo 1; ?>', 'php');
+        $this->assertSame('<pre><code class="language-php">&lt;?php echo 1; ?&gt;</code></pre>', $html);
+    }
+
+    public function test_oembed_rendering() {
+        $url = 'https://example.com/embed';
+        add_filter('pre_oembed_result', function($pre, $url_param) use ($url) {
+            if ($url_param === $url) {
+                return '<iframe src="' . esc_url($url) . '"></iframe>';
+            }
+            return $pre;
+        }, 10, 2);
+        $this->assertSame('<iframe src="' . esc_url($url) . '"></iframe>', gm2_render_oembed($url));
+        remove_all_filters('pre_oembed_result');
+    }
+}


### PR DESCRIPTION
## Summary
- add markdown, code, and oEmbed field classes
- register new field types and expose rendering helpers
- cover new helpers with unit tests

## Testing
- `npm test`
- `phpunit` *(fails: Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a365a0948c8327a42f7b9ad6d4bcff