### PR TITLE
feat: extend relationship field

### DIFF
--- a/admin/Gm2_Custom_Posts_Admin.php
+++ b/admin/Gm2_Custom_Posts_Admin.php
@@ -252,7 +252,7 @@ class Gm2_Custom_Posts_Admin {
         echo '<input type="hidden" id="gm2-field-index" />';
         echo '<p><label>' . esc_html__( 'Label', 'gm2-wordpress-suite' ) . '<br /><input type="text" id="gm2-field-label" class="regular-text" /></label></p>';
         echo '<p><label>' . esc_html__( 'Slug', 'gm2-wordpress-suite' ) . '<br /><input type="text" id="gm2-field-slug" class="regular-text" /></label></p>';
-        echo '<p><label>' . esc_html__( 'Type', 'gm2-wordpress-suite' ) . '<br /><select id="gm2-field-type"><option value="text">Text</option><option value="textarea">Textarea</option><option value="number">Number</option><option value="checkbox">Checkbox</option><option value="toggle">Toggle</option><option value="select">Dropdown</option><option value="radio">Radio</option><option value="media">Media</option><option value="file">File</option><option value="audio">Audio</option><option value="video">Video</option><option value="gallery">Gallery</option><option value="wysiwyg">WYSIWYG</option><option value="date">Date</option><option value="repeater">Repeater</option><option value="flexible">Flexible</option></select></label></p>';
+        echo '<p><label>' . esc_html__( 'Type', 'gm2-wordpress-suite' ) . '<br /><select id="gm2-field-type"><option value="text">Text</option><option value="textarea">Textarea</option><option value="number">Number</option><option value="checkbox">Checkbox</option><option value="toggle">Toggle</option><option value="select">Dropdown</option><option value="radio">Radio</option><option value="media">Media</option><option value="file">File</option><option value="audio">Audio</option><option value="video">Video</option><option value="gallery">Gallery</option><option value="wysiwyg">WYSIWYG</option><option value="date">Date</option><option value="repeater">Repeater</option><option value="flexible">Flexible</option><option value="relationship">Relationship</option></select></label></p>';
         echo '<p><label>' . esc_html__( 'Default', 'gm2-wordpress-suite' ) . '<br /><input type="text" id="gm2-field-default" class="regular-text" /></label></p>';
         echo '<p><label>' . esc_html__( 'Description', 'gm2-wordpress-suite' ) . '<br /><input type="text" id="gm2-field-description" class="regular-text" /></label></p>';
         echo '<p><label>' . esc_html__( 'Order', 'gm2-wordpress-suite' ) . '<br /><input type="number" id="gm2-field-order" class="small-text" /></label></p>';
@@ -273,6 +273,10 @@ class Gm2_Custom_Posts_Admin {
         echo '<div id="gm2-field-repeater-options" style="display:none;"><p><label>' . esc_html__( 'Min Rows', 'gm2-wordpress-suite' ) . '<br /><input type="number" id="gm2-field-repeater-min" class="small-text" /></label></p><p><label>' . esc_html__( 'Max Rows', 'gm2-wordpress-suite' ) . '<br /><input type="number" id="gm2-field-repeater-max" class="small-text" /></label></p></div>';
         echo '<div id="gm2-field-flexible-options" style="display:none;"><div id="gm2-flexible-types"></div><p><button type="button" class="button gm2-flex-type-add">' . esc_html__( 'Add Row Type', 'gm2-wordpress-suite' ) . '</button></p></div>';
         echo '<div id="gm2-field-select-options" style="display:none;"><p><label><input type="checkbox" id="gm2-field-multiple" value="1" /> ' . esc_html__( 'Allow Multiple Selections', 'gm2-wordpress-suite' ) . '</label></p></div>';
+        echo '<div id="gm2-field-relationship-options" style="display:none;">';
+        echo '<p><label>' . esc_html__( 'Relationship Type', 'gm2-wordpress-suite' ) . '<br /><select id="gm2-field-rel-type"><option value="post">' . esc_html__( 'Post', 'gm2-wordpress-suite' ) . '</option><option value="term">' . esc_html__( 'Term', 'gm2-wordpress-suite' ) . '</option><option value="user">' . esc_html__( 'User', 'gm2-wordpress-suite' ) . '</option><option value="role">' . esc_html__( 'Role', 'gm2-wordpress-suite' ) . '</option></select></label></p>';
+        echo '<p><label>' . esc_html__( 'Sync Strategy', 'gm2-wordpress-suite' ) . '<br /><select id="gm2-field-sync"><option value="two-way">' . esc_html__( 'Two-way', 'gm2-wordpress-suite' ) . '</option><option value="one-way">' . esc_html__( 'One-way', 'gm2-wordpress-suite' ) . '</option><option value="none">' . esc_html__( 'None', 'gm2-wordpress-suite' ) . '</option></select></label></p>';
+        echo '</div>';
         echo '<h3>' . esc_html__( 'Location Rules', 'gm2-wordpress-suite' ) . '</h3>';
         echo '<div id="gm2-field-location" class="gm2-conditions"><div class="gm2-condition-groups"></div><p><button type="button" class="button gm2-add-condition-group">' . esc_html__( 'Add Location Group', 'gm2-wordpress-suite' ) . '</button></p></div>';
         echo '<h3>' . esc_html__( 'Display Conditions', 'gm2-wordpress-suite' ) . '</h3>';
@@ -850,7 +854,7 @@ class Gm2_Custom_Posts_Admin {
             if (!$slug) {
                 continue;
             }
-            $type  = in_array($field['type'] ?? 'text', [ 'text', 'number', 'checkbox', 'select', 'radio', 'media', 'wysiwyg', 'date', 'repeater' ], true) ? $field['type'] : 'text';
+            $type  = in_array($field['type'] ?? 'text', [ 'text', 'number', 'checkbox', 'select', 'radio', 'media', 'wysiwyg', 'date', 'repeater', 'relationship' ], true) ? $field['type'] : 'text';
             $def   = sanitize_text_field($field['default'] ?? '');
             $order = isset($field['order']) ? (int) $field['order'] : 0;
             $container = in_array($field['container'] ?? '', [ 'tab', 'accordion' ], true) ? $field['container'] : '';
@@ -888,6 +892,11 @@ class Gm2_Custom_Posts_Admin {
                 if (isset($field['max_rows'])) { $sanitized['max_rows'] = (int) $field['max_rows']; }
             } elseif ($type === 'select') {
                 $sanitized['multiple'] = !empty($field['multiple']);
+            } elseif ($type === 'relationship') {
+                $rel_type = in_array($field['relationship_type'] ?? 'post', [ 'post', 'term', 'user', 'role' ], true ) ? $field['relationship_type'] : 'post';
+                $sync     = in_array($field['sync'] ?? 'two-way', [ 'none', 'one-way', 'two-way' ], true ) ? $field['sync'] : 'two-way';
+                $sanitized['relationship_type'] = $rel_type;
+                $sanitized['sync'] = $sync;
             }
             if (!empty($field['options']) && is_array($field['options'])) {
                 $opts = [];

--- a/admin/js/gm2-custom-posts-admin.js
+++ b/admin/js/gm2-custom-posts-admin.js
@@ -3,7 +3,7 @@ jQuery(function($){
     var args   = gm2CPTFields.args || [];
     var flexTypes = [];
 
-    // Ensure textarea, toggle and media-based field types are available in the selector.
+    // Ensure various field types are available in the selector.
     var typeSelect = $('#gm2-field-type');
     var opts = [
         {val:'textarea', label:'Textarea'},
@@ -11,7 +11,8 @@ jQuery(function($){
         {val:'file',     label:'File'},
         {val:'audio',    label:'Audio'},
         {val:'video',    label:'Video'},
-        {val:'gallery',  label:'Gallery'}
+        {val:'gallery',  label:'Gallery'},
+        {val:'relationship', label:'Relationship'}
     ];
     $.each(opts, function(i, o){
         if(!typeSelect.find('option[value="'+o.val+'"]').length){
@@ -89,6 +90,7 @@ jQuery(function($){
         $('#gm2-field-repeater-options').toggle(type === 'repeater');
         $('#gm2-field-flexible-options').toggle(type === 'flexible');
         $('#gm2-field-select-options').toggle(type === 'select');
+        $('#gm2-field-relationship-options').toggle(type === 'relationship');
     }
 
     function showFieldForm(data, index){
@@ -106,6 +108,8 @@ jQuery(function($){
         $('#gm2-field-cap').val(data ? data.capability : '');
         $('#gm2-field-edit-cap').val(data ? data.edit_capability : '');
         $('#gm2-field-help').val(data ? data.help : '');
+        $('#gm2-field-rel-type').val(data ? data.relationship_type || 'post' : 'post');
+        $('#gm2-field-sync').val(data ? data.sync || 'two-way' : 'two-way');
         $('#gm2-field-column').prop('checked', data ? !!data.column : false);
         $('#gm2-field-sortable').prop('checked', data ? !!data.sortable : false);
         $('#gm2-field-quick-edit').prop('checked', data ? !!data.quick_edit : false);
@@ -284,6 +288,9 @@ jQuery(function($){
             obj.layouts = flexTypes;
         } else if(obj.type === 'select'){
             obj.multiple = $('#gm2-field-multiple').is(':checked');
+        } else if(obj.type === 'relationship'){
+            obj.relationship_type = $('#gm2-field-rel-type').val();
+            obj.sync = $('#gm2-field-sync').val();
         }
         if(idx === ''){ fields.push(obj); } else { fields[idx] = obj; }
         saveAll(function(){ $('#gm2-field-form').hide(); });
@@ -403,7 +410,7 @@ jQuery(function($){
     // Basic sanitization for relationship fields
     $(document).on('input', '.gm2-relationship', function(){
         var val = $(this).val();
-        $(this).val(val.replace(/[^0-9,]/g,''));
+        $(this).val(val.replace(/[^0-9a-z_,]/gi,''));
     });
 
     function applyEnhancements(){

--- a/public/js/gm2-custom-posts.js
+++ b/public/js/gm2-custom-posts.js
@@ -2,6 +2,6 @@
     // Basic frontend helpers for custom post fields
     $(document).on('input', '.gm2-relationship', function(){
         var val = $(this).val();
-        $(this).val(val.replace(/[^0-9,]/g,''));
+        $(this).val(val.replace(/[^0-9a-z_,]/gi,''));
     });
 })(jQuery);

--- a/tests/test-relationship-field.php
+++ b/tests/test-relationship-field.php
@@ -1,0 +1,33 @@
+<?php
+class RelationshipFieldTest extends WP_UnitTestCase {
+    public function test_two_way_user_relationship() {
+        $u1 = self::factory()->user->create();
+        $u2 = self::factory()->user->create();
+        $field = new GM2_Field_Relationship('friends', array('relationship_type' => 'user', 'sync' => 'two-way'));
+        $field->save($u1, array($u2), 'user');
+        $this->assertEquals(array($u2), get_user_meta($u1, 'friends', true));
+        $this->assertEquals(array($u1), get_user_meta($u2, 'friends', true));
+    }
+
+    public function test_one_way_post_relationship() {
+        $p1 = self::factory()->post->create();
+        $p2 = self::factory()->post->create();
+        $field = new GM2_Field_Relationship('related', array('relationship_type' => 'post', 'sync' => 'one-way'));
+        $field->save($p1, array($p2), 'post');
+        $this->assertEquals(array($p2), get_post_meta($p1, 'related', true));
+        $this->assertEquals(array($p1), get_post_meta($p2, 'related', true));
+        // remove relation from p1; p2 should still reference p1
+        $field->save($p1, array(), 'post');
+        $this->assertEquals(array(), get_post_meta($p1, 'related', true));
+        $this->assertEquals(array($p1), get_post_meta($p2, 'related', true));
+    }
+
+    public function test_role_relationship_two_way() {
+        $p1 = self::factory()->post->create();
+        $field = new GM2_Field_Relationship('roles', array('relationship_type' => 'role', 'sync' => 'two-way'));
+        $field->save($p1, array('editor'), 'post');
+        $this->assertEquals(array('editor'), get_post_meta($p1, 'roles', true));
+        $this->assertEquals(array($p1), get_option('roles_role_editor'));
+        delete_option('roles_role_editor');
+    }
+}


### PR DESCRIPTION
## Summary
- handle posts, terms, users and roles in relationship field
- add configurable sync strategies for relationships
- expose relationship type and sync mode in admin UI

## Testing
- `npm test`
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): Failed to open stream)*

------
https://chatgpt.com/codex/tasks/task_e_68a36c44a0c88327b070b6e8e48b8cc9