### PR TITLE
Add Leaflet map picker for geospatial field

### DIFF
--- a/admin/css/gm2-geospatial.css
+++ b/admin/css/gm2-geospatial.css
@@ -1,0 +1,7 @@
+.gm2-geo-map {
+    height: 300px;
+    margin-bottom: 8px;
+}
+.gm2-geo-address {
+    font-size: 14px;
+}

--- a/admin/js/gm2-geospatial.js
+++ b/admin/js/gm2-geospatial.js
@@ -1,0 +1,44 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const fields = document.querySelectorAll('.gm2-geo-field');
+    fields.forEach(field => {
+        const mapEl = field.querySelector('.gm2-geo-map');
+        const latInput = field.querySelector('input[name$="[lat]"]');
+        const lngInput = field.querySelector('input[name$="[lng]"]');
+        const addrInput = field.querySelector('input[name$="[address]"]');
+        const addrDisplay = field.querySelector('.gm2-geo-address');
+        const lat = parseFloat(latInput.value) || 0;
+        const lng = parseFloat(lngInput.value) || 0;
+        const map = L.map(mapEl).setView([lat || 0, lng || 0], lat && lng ? 13 : 2);
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            attribution: '&copy; OpenStreetMap contributors'
+        }).addTo(map);
+        let marker = null;
+        if (lat && lng) {
+            marker = L.marker([lat, lng]).addTo(map);
+        }
+        function updateMarker(e) {
+            const coord = e.latlng;
+            latInput.value = coord.lat.toFixed(6);
+            lngInput.value = coord.lng.toFixed(6);
+            if (marker) {
+                marker.setLatLng(coord);
+            } else {
+                marker = L.marker(coord).addTo(map);
+            }
+            fetch('https://nominatim.openstreetmap.org/reverse?format=jsonv2&lat=' + coord.lat + '&lon=' + coord.lng)
+                .then(r => r.json())
+                .then(data => {
+                    addrInput.value = JSON.stringify(data.address || {});
+                    const addr = [
+                        data.address.road,
+                        data.address.city || data.address.town || data.address.village,
+                        data.address.state,
+                        data.address.postcode,
+                        data.address.country
+                    ].filter(Boolean).join(', ');
+                    addrDisplay.textContent = addr;
+                });
+        }
+        map.on('click', updateMarker);
+    });
+});

--- a/includes/fields/class-field-geospatial.php
+++ b/includes/fields/class-field-geospatial.php
@@ -4,8 +4,104 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Geospatial extends GM2_Field {
+    private static $assets_hooked = false;
+
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args );
+
+        if ( ! self::$assets_hooked ) {
+            add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
+            add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
+            self::$assets_hooked = true;
+        }
+    }
+
+    public static function enqueue_assets() {
+        wp_enqueue_style( 'leaflet', 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css', array(), '1.9.4' );
+        wp_enqueue_script( 'leaflet', 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.js', array(), '1.9.4', true );
+
+        if ( defined( 'GM2_PLUGIN_URL' ) ) {
+            wp_enqueue_style( 'gm2-geospatial', GM2_PLUGIN_URL . 'admin/css/gm2-geospatial.css', array(), defined( 'GM2_VERSION' ) ? GM2_VERSION : false );
+            wp_enqueue_script( 'gm2-geospatial', GM2_PLUGIN_URL . 'admin/js/gm2-geospatial.js', array( 'leaflet' ), defined( 'GM2_VERSION' ) ? GM2_VERSION : false, true );
+        }
+    }
+
     protected function render_field( $value, $object_id, $context_type ) {
+        $value   = is_array( $value ) ? $value : array();
+        $lat     = $value['lat'] ?? '';
+        $lng     = $value['lng'] ?? '';
+        $address = $value['address'] ?? array();
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
-        echo '<input type="text" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '" placeholder="lat,lng"' . $disabled . ' />';
+
+        if ( 'public' === $context_type ) {
+            echo '<div class="gm2-geo-address">' . esc_html( self::format_address( $address ) ) . '</div>';
+            return;
+        }
+
+        echo '<div class="gm2-geo-field">';
+        echo '<div id="' . esc_attr( $this->key ) . '-map" class="gm2-geo-map"></div>';
+        echo '<input type="hidden" name="' . esc_attr( $this->key ) . '[lat]" value="' . esc_attr( $lat ) . '"' . $disabled . ' />';
+        echo '<input type="hidden" name="' . esc_attr( $this->key ) . '[lng]" value="' . esc_attr( $lng ) . '"' . $disabled . ' />';
+        echo '<input type="hidden" class="gm2-geo-address-data" name="' . esc_attr( $this->key ) . '[address]" value="' . esc_attr( wp_json_encode( $address ) ) . '"' . $disabled . ' />';
+        echo '<div class="gm2-geo-address">' . esc_html( self::format_address( $address ) ) . '</div>';
+        echo '</div>';
+    }
+
+    public function sanitize( $value ) {
+        if ( ! is_array( $value ) ) {
+            return array();
+        }
+
+        $lat = isset( $value['lat'] ) ? floatval( $value['lat'] ) : 0;
+        $lng = isset( $value['lng'] ) ? floatval( $value['lng'] ) : 0;
+        $address = array();
+
+        if ( ! empty( $value['address'] ) ) {
+            $addr = is_string( $value['address'] ) ? json_decode( wp_unslash( $value['address'] ), true ) : $value['address'];
+            if ( is_array( $addr ) ) {
+                $address = array_map( 'sanitize_text_field', $addr );
+            }
+        }
+
+        return array(
+            'lat'     => $lat,
+            'lng'     => $lng,
+            'address' => $address,
+        );
+    }
+
+    public static function reverse_geocode( $lat, $lng ) {
+        $url = add_query_arg(
+            array(
+                'format'         => 'jsonv2',
+                'lat'            => $lat,
+                'lon'            => $lng,
+                'addressdetails' => 1,
+            ),
+            'https://nominatim.openstreetmap.org/reverse'
+        );
+
+        $response = wp_remote_get( $url, array( 'headers' => array( 'User-Agent' => 'gm2-wordpress-suite' ) ) );
+        if ( is_wp_error( $response ) ) {
+            return array();
+        }
+        $data = json_decode( wp_remote_retrieve_body( $response ), true );
+        return $data['address'] ?? array();
+    }
+
+    public static function format_address( $address ) {
+        if ( ! is_array( $address ) ) {
+            return '';
+        }
+        $parts = array_filter(
+            array(
+                $address['road'] ?? '',
+                $address['city'] ?? $address['town'] ?? $address['village'] ?? '',
+                $address['state'] ?? '',
+                $address['postcode'] ?? '',
+                $address['country'] ?? '',
+            )
+        );
+        return implode( ', ', $parts );
     }
 }


### PR DESCRIPTION
## Summary
- replace geospatial text input with Leaflet map picker and hidden fields
- enqueue Leaflet assets and custom scripts/styles
- capture lat/lng and address components, with helpers for reverse geocoding and formatted display

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a36e0dbaec83279db3c5d0942e42af