### PR TITLE
Add gradient, icon, badge and rating fields

### DIFF
--- a/admin/css/gm2-extra-fields.css
+++ b/admin/css/gm2-extra-fields.css
@@ -1,0 +1,34 @@
+.gm2-gradient-preview,
+.gm2-gradient-display {
+    width: 100px;
+    height: 20px;
+    border: 1px solid #ccc;
+    margin-top: 4px;
+}
+
+.gm2-icon-preview {
+    display: inline-block;
+    font-size: 24px;
+    margin-left: 5px;
+}
+
+.gm2-badge-preview,
+.gm2-badge {
+    display: inline-block;
+    padding: 2px 6px;
+    margin-left: 5px;
+    border-radius: 3px;
+    color: #fff;
+}
+
+.gm2-rating-picker .star,
+.gm2-rating-display .star {
+    font-size: 20px;
+    color: #ccc;
+    cursor: pointer;
+}
+
+.gm2-rating-picker .star.active,
+.gm2-rating-display .star.active {
+    color: #ffcc00;
+}

--- a/admin/js/gm2-extra-fields.js
+++ b/admin/js/gm2-extra-fields.js
@@ -1,0 +1,49 @@
+jQuery(function ($) {
+    $('.gm2-gradient-field').each(function () {
+        var $field = $(this);
+        function updateGradient() {
+            var start = $field.find('.gm2-gradient-start').val();
+            var end = $field.find('.gm2-gradient-end').val();
+            if (start && end) {
+                $field.find('.gm2-gradient-preview').css('background', 'linear-gradient(' + start + ',' + end + ')');
+            }
+        }
+        $field.find('.gm2-color').wpColorPicker({
+            change: updateGradient,
+            clear: updateGradient
+        });
+        updateGradient();
+    });
+
+    $('.gm2-icon-field').on('input', '.gm2-icon-input', function () {
+        var cls = $(this).val();
+        $(this).siblings('.gm2-icon-preview').attr('class', 'gm2-icon-preview dashicons ' + cls);
+    });
+
+    $('.gm2-badge-field').each(function () {
+        var $field = $(this);
+        function updateBadge() {
+            var text = $field.find('.gm2-badge-text').val();
+            var color = $field.find('.gm2-badge-color').val();
+            $field.find('.gm2-badge-preview').text(text).css('background-color', color);
+        }
+        $field.find('.gm2-badge-color').wpColorPicker({
+            change: updateBadge,
+            clear: updateBadge
+        });
+        $field.on('input', '.gm2-badge-text', updateBadge);
+        updateBadge();
+    });
+
+    $('.gm2-rating-picker').each(function () {
+        var $picker = $(this);
+        $picker.on('click', '.star', function () {
+            var val = $(this).data('value');
+            $picker.find('input[type="hidden"]').val(val);
+            $picker.find('.star').each(function () {
+                var $s = $(this);
+                $s.toggleClass('active', $s.data('value') <= val);
+            });
+        });
+    });
+});

--- a/docs/extra-fields.md
+++ b/docs/extra-fields.md
@@ -1,0 +1,52 @@
+# Additional Field Types
+
+The suite now includes several presentation-oriented field types that can be
+used within field group definitions.
+
+## Gradient
+
+Stores a pair of colors and renders a CSS linear gradient.
+
+```php
+[
+    'slug' => 'background',
+    'type' => 'gradient',
+    'label' => 'Background Gradient',
+]
+```
+
+## Icon
+
+Accepts a Dashicons class and displays the corresponding icon.
+
+```php
+[
+    'slug' => 'icon',
+    'type' => 'icon',
+    'label' => 'Icon',
+]
+```
+
+## Badge
+
+Combines text with a background color to output a small label.
+
+```php
+[
+    'slug' => 'badge',
+    'type' => 'badge',
+    'label' => 'Badge',
+]
+```
+
+## Rating
+
+Renders a star rating between zero and five.
+
+```php
+[
+    'slug' => 'rating',
+    'type' => 'rating',
+    'label' => 'Rating',
+]
+```

--- a/docs/field-definition-schema.md
+++ b/docs/field-definition-schema.md
@@ -4,7 +4,8 @@ Each field definition used by `gm2_render_field_group()` accepts the following k
 
 - `label` – Human‑readable label displayed with the field.
 - `slug` – Unique key used to store the value.
-- `type` – Field type such as `text`, `textarea`, `select` or `checkbox`.
+- `type` – Field type such as `text`, `textarea`, `select`, `checkbox`,
+  or design helpers like `gradient`, `icon`, `badge` and `rating`.
 - `default` – Optional default value.
 - `description` – Short description shown in field listings.
 - `instructions` – Additional help text rendered below the field.

--- a/includes/fields/class-field-badge.php
+++ b/includes/fields/class-field-badge.php
@@ -1,0 +1,56 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class GM2_Field_Badge extends GM2_Field {
+    private static $assets_hooked = false;
+
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args );
+        if ( ! self::$assets_hooked ) {
+            add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
+            add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
+            self::$assets_hooked = true;
+        }
+    }
+
+    public static function enqueue_assets() {
+        wp_enqueue_style( 'wp-color-picker' );
+        wp_enqueue_script( 'wp-color-picker' );
+        if ( defined( 'GM2_PLUGIN_URL' ) ) {
+            wp_enqueue_style( 'gm2-extra-fields', GM2_PLUGIN_URL . 'admin/css/gm2-extra-fields.css', array( 'wp-color-picker' ), defined( 'GM2_VERSION' ) ? GM2_VERSION : false );
+            wp_enqueue_script( 'gm2-extra-fields', GM2_PLUGIN_URL . 'admin/js/gm2-extra-fields.js', array( 'jquery', 'wp-color-picker' ), defined( 'GM2_VERSION' ) ? GM2_VERSION : false, true );
+        }
+    }
+
+    protected function render_field( $value, $object_id, $context_type ) {
+        $value    = is_array( $value ) ? $value : array();
+        $text     = $value['text'] ?? '';
+        $color    = $value['color'] ?? '';
+        $disabled = disabled( $this->args['disabled'] ?? false, true, false );
+
+        if ( 'public' === $context_type ) {
+            echo '<span class="gm2-badge" style="background-color:' . esc_attr( $color ) . '">' . esc_html( $text ) . '</span>';
+            return;
+        }
+
+        echo '<div class="gm2-badge-field">';
+        echo '<input type="text" class="gm2-badge-text" name="' . esc_attr( $this->key ) . '[text]" value="' . esc_attr( $text ) . '"' . $disabled . ' />';
+        echo '<input type="text" class="gm2-color gm2-badge-color" name="' . esc_attr( $this->key ) . '[color]" value="' . esc_attr( $color ) . '"' . $disabled . ' />';
+        echo '<span class="gm2-badge-preview" style="background-color:' . esc_attr( $color ) . '">' . esc_html( $text ) . '</span>';
+        echo '</div>';
+    }
+
+    public function sanitize( $value ) {
+        if ( ! is_array( $value ) ) {
+            return array( 'text' => '', 'color' => '' );
+        }
+        $text  = sanitize_text_field( $value['text'] ?? '' );
+        $color = sanitize_hex_color( $value['color'] ?? '' );
+        return array(
+            'text'  => $text,
+            'color' => $color ? $color : '',
+        );
+    }
+}

--- a/includes/fields/class-field-gradient.php
+++ b/includes/fields/class-field-gradient.php
@@ -1,0 +1,57 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class GM2_Field_Gradient extends GM2_Field {
+    private static $assets_hooked = false;
+
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args );
+        if ( ! self::$assets_hooked ) {
+            add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
+            add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
+            self::$assets_hooked = true;
+        }
+    }
+
+    public static function enqueue_assets() {
+        wp_enqueue_style( 'wp-color-picker' );
+        wp_enqueue_script( 'wp-color-picker' );
+        if ( defined( 'GM2_PLUGIN_URL' ) ) {
+            wp_enqueue_style( 'gm2-extra-fields', GM2_PLUGIN_URL . 'admin/css/gm2-extra-fields.css', array( 'wp-color-picker' ), defined( 'GM2_VERSION' ) ? GM2_VERSION : false );
+            wp_enqueue_script( 'gm2-extra-fields', GM2_PLUGIN_URL . 'admin/js/gm2-extra-fields.js', array( 'jquery', 'wp-color-picker' ), defined( 'GM2_VERSION' ) ? GM2_VERSION : false, true );
+        }
+    }
+
+    protected function render_field( $value, $object_id, $context_type ) {
+        $value    = is_array( $value ) ? $value : array();
+        $start    = $value['start'] ?? '';
+        $end      = $value['end'] ?? '';
+        $disabled = disabled( $this->args['disabled'] ?? false, true, false );
+
+        if ( 'public' === $context_type ) {
+            $style = ( $start && $end ) ? ' style="background: linear-gradient(' . esc_attr( $start ) . ',' . esc_attr( $end ) . ');"' : '';
+            echo '<div class="gm2-gradient-display"' . $style . '></div>';
+            return;
+        }
+
+        echo '<div class="gm2-gradient-field">';
+        echo '<input type="text" class="gm2-color gm2-gradient-start" name="' . esc_attr( $this->key ) . '[start]" value="' . esc_attr( $start ) . '"' . $disabled . ' />';
+        echo '<input type="text" class="gm2-color gm2-gradient-end" name="' . esc_attr( $this->key ) . '[end]" value="' . esc_attr( $end ) . '"' . $disabled . ' />';
+        echo '<div class="gm2-gradient-preview"></div>';
+        echo '</div>';
+    }
+
+    public function sanitize( $value ) {
+        if ( ! is_array( $value ) ) {
+            return array( 'start' => '', 'end' => '' );
+        }
+        $start = sanitize_hex_color( $value['start'] ?? '' );
+        $end   = sanitize_hex_color( $value['end'] ?? '' );
+        return array(
+            'start' => $start ? $start : '',
+            'end'   => $end ? $end : '',
+        );
+    }
+}

--- a/includes/fields/class-field-icon.php
+++ b/includes/fields/class-field-icon.php
@@ -1,0 +1,43 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class GM2_Field_Icon extends GM2_Field {
+    private static $assets_hooked = false;
+
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args );
+        if ( ! self::$assets_hooked ) {
+            add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
+            add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
+            self::$assets_hooked = true;
+        }
+    }
+
+    public static function enqueue_assets() {
+        if ( defined( 'GM2_PLUGIN_URL' ) ) {
+            wp_enqueue_style( 'gm2-extra-fields', GM2_PLUGIN_URL . 'admin/css/gm2-extra-fields.css', array(), defined( 'GM2_VERSION' ) ? GM2_VERSION : false );
+            wp_enqueue_script( 'gm2-extra-fields', GM2_PLUGIN_URL . 'admin/js/gm2-extra-fields.js', array( 'jquery' ), defined( 'GM2_VERSION' ) ? GM2_VERSION : false, true );
+        }
+    }
+
+    protected function render_field( $value, $object_id, $context_type ) {
+        $value    = is_string( $value ) ? $value : '';
+        $disabled = disabled( $this->args['disabled'] ?? false, true, false );
+
+        if ( 'public' === $context_type ) {
+            echo '<span class="gm2-icon-preview dashicons ' . esc_attr( $value ) . '"></span>';
+            return;
+        }
+
+        echo '<div class="gm2-icon-field">';
+        echo '<input type="text" class="gm2-icon-input" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '"' . $disabled . ' />';
+        echo '<span class="gm2-icon-preview dashicons ' . esc_attr( $value ) . '"></span>';
+        echo '</div>';
+    }
+
+    public function sanitize( $value ) {
+        return sanitize_text_field( $value );
+    }
+}

--- a/includes/fields/class-field-rating.php
+++ b/includes/fields/class-field-rating.php
@@ -1,0 +1,63 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class GM2_Field_Rating extends GM2_Field {
+    private static $assets_hooked = false;
+
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args );
+        if ( ! self::$assets_hooked ) {
+            add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
+            add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
+            self::$assets_hooked = true;
+        }
+    }
+
+    public static function enqueue_assets() {
+        if ( defined( 'GM2_PLUGIN_URL' ) ) {
+            wp_enqueue_style( 'gm2-extra-fields', GM2_PLUGIN_URL . 'admin/css/gm2-extra-fields.css', array(), defined( 'GM2_VERSION' ) ? GM2_VERSION : false );
+            wp_enqueue_script( 'gm2-extra-fields', GM2_PLUGIN_URL . 'admin/js/gm2-extra-fields.js', array( 'jquery' ), defined( 'GM2_VERSION' ) ? GM2_VERSION : false, true );
+        }
+    }
+
+    protected function render_field( $value, $object_id, $context_type ) {
+        $value    = intval( $value );
+        $value    = max( 0, min( 5, $value ) );
+        $disabled = disabled( $this->args['disabled'] ?? false, true, false );
+
+        if ( 'public' === $context_type ) {
+            echo '<div class="gm2-rating-display">' . self::stars_html( $value ) . '</div>';
+            return;
+        }
+
+        echo '<div class="gm2-rating-picker" data-name="' . esc_attr( $this->key ) . '" data-value="' . esc_attr( $value ) . '"' . $disabled . '>';
+        for ( $i = 1; $i <= 5; $i++ ) {
+            $class = $i <= $value ? 'star active' : 'star';
+            echo '<span class="' . $class . '" data-value="' . $i . '">&#9733;</span>';
+        }
+        echo '<input type="hidden" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '" />';
+        echo '</div>';
+    }
+
+    private static function stars_html( $value ) {
+        $html = '';
+        for ( $i = 1; $i <= 5; $i++ ) {
+            $class = $i <= $value ? 'star active' : 'star';
+            $html .= '<span class="' . $class . '">&#9733;</span>';
+        }
+        return $html;
+    }
+
+    public function sanitize( $value ) {
+        $value = intval( $value );
+        if ( $value < 0 ) {
+            $value = 0;
+        }
+        if ( $value > 5 ) {
+            $value = 5;
+        }
+        return $value;
+    }
+}

--- a/includes/fields/loader.php
+++ b/includes/fields/loader.php
@@ -39,6 +39,10 @@ require_once __DIR__ . '/class-field-toggle.php';
 require_once __DIR__ . '/class-field-markdown.php';
 require_once __DIR__ . '/class-field-code.php';
 require_once __DIR__ . '/class-field-oembed.php';
+require_once __DIR__ . '/class-field-gradient.php';
+require_once __DIR__ . '/class-field-icon.php';
+require_once __DIR__ . '/class-field-badge.php';
+require_once __DIR__ . '/class-field-rating.php';
 
 $gm2_field_types = array();
 
@@ -88,5 +92,9 @@ function gm2_register_default_field_types() {
     gm2_register_field_type( 'markdown', 'GM2_Field_Markdown' );
     gm2_register_field_type( 'code', 'GM2_Field_Code' );
     gm2_register_field_type( 'oembed', 'GM2_Field_Oembed' );
+    gm2_register_field_type( 'gradient', 'GM2_Field_Gradient' );
+    gm2_register_field_type( 'icon', 'GM2_Field_Icon' );
+    gm2_register_field_type( 'badge', 'GM2_Field_Badge' );
+    gm2_register_field_type( 'rating', 'GM2_Field_Rating' );
 }
 add_action( 'init', 'gm2_register_default_field_types' );

--- a/tests/test-field-gradient-icon-badge-rating.php
+++ b/tests/test-field-gradient-icon-badge-rating.php
@@ -1,0 +1,32 @@
+<?php
+
+class FieldGradientIconBadgeRatingTest extends WP_UnitTestCase {
+    public function test_gradient_sanitization() {
+        $field = new GM2_Field_Gradient('grad');
+        $out = $field->sanitize(array('start' => '#ff0000', 'end' => '#00ff00'));
+        $this->assertSame(array('start' => '#ff0000', 'end' => '#00ff00'), $out);
+        $out = $field->sanitize(array('start' => 'bad', 'end' => '#00ff00'));
+        $this->assertSame(array('start' => '', 'end' => '#00ff00'), $out);
+    }
+
+    public function test_icon_sanitization() {
+        $field = new GM2_Field_Icon('icon');
+        $this->assertSame('dashicons-admin-site', $field->sanitize('dashicons-admin-site'));
+        $this->assertSame('script', $field->sanitize('<script>'));
+    }
+
+    public function test_badge_sanitization() {
+        $field = new GM2_Field_Badge('badge');
+        $out = $field->sanitize(array('text' => 'Sale', 'color' => '#123456'));
+        $this->assertSame(array('text' => 'Sale', 'color' => '#123456'), $out);
+        $out = $field->sanitize(array('text' => '<b>Sale</b>', 'color' => 'bad'));
+        $this->assertSame(array('text' => 'Sale', 'color' => ''), $out);
+    }
+
+    public function test_rating_sanitization() {
+        $field = new GM2_Field_Rating('rating');
+        $this->assertSame(3, $field->sanitize(3));
+        $this->assertSame(5, $field->sanitize(10));
+        $this->assertSame(0, $field->sanitize(-2));
+    }
+}


### PR DESCRIPTION
## Summary
- implement Gradient, Icon, Badge and Rating field types with sanitization and UI helpers
- bundle shared JS/CSS to support color pickers, icon previews and star ratings
- document and test new field types

## Testing
- `make test DB_NAME=wp_test DB_USER=root DB_PASS=root` *(fails: Can't connect to MySQL server)*
- `npm test`
- `phpunit` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3759f7ed0832786038b89788228ed