### PR TITLE
Add formula evaluation to computed fields

### DIFF
--- a/includes/fields/class-field-computed.php
+++ b/includes/fields/class-field-computed.php
@@ -5,15 +5,79 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class GM2_Field_Computed extends GM2_Field {
     protected function render_field( $value, $object_id, $context_type ) {
-        $cb = $this->args['callback'] ?? null;
-        if ( is_callable( $cb ) ) {
-            $value = call_user_func( $cb, $object_id );
-        }
+        $value    = $this->calculate_value( $object_id, $context_type );
         $disabled = $this->args['disabled'] ?? false ? ' data-disabled="1"' : '';
         echo '<span class="gm2-computed" data-key="' . esc_attr( $this->key ) . '"' . $disabled . '>' . esc_html( $value ) . '</span>';
     }
 
     public function save( $object_id, $value, $context_type = 'post' ) {
-        // Computed fields are read-only.
+        $computed = $this->calculate_value( $object_id, $context_type );
+        if ( $computed !== null && $computed !== '' ) {
+            $this->update_value( $object_id, $computed, $context_type );
+        } else {
+            $this->delete_value( $object_id, $context_type );
+        }
+    }
+
+    protected function calculate_value( $object_id, $context_type ) {
+        $formula = $this->args['formula'] ?? null;
+        $cb      = $this->args['callback'] ?? null;
+
+        if ( $formula ) {
+            $value = $this->evaluate_formula( $formula, $object_id, $context_type );
+            if ( $value !== null ) {
+                return $value;
+            }
+        }
+
+        if ( is_callable( $cb ) ) {
+            return call_user_func( $cb, $object_id );
+        }
+
+        return null;
+    }
+
+    protected function evaluate_formula( $formula, $object_id, $context_type ) {
+        preg_match_all( '/{([A-Za-z0-9_\-]+)}/', $formula, $matches );
+        $replacements = array();
+        foreach ( $matches[1] as $key ) {
+            $val = $this->get_meta_value( $object_id, $key, $context_type );
+            if ( is_numeric( $val ) ) {
+                $replacements[ '{' . $key . '}' ] = $val;
+            } else {
+                $replacements[ '{' . $key . '}' ] = '\'' . str_replace( '\'', '\\' . '\'', (string) $val ) . '\'';
+            }
+        }
+        $expr = strtr( $formula, $replacements );
+
+        $without_strings = preg_replace( '/(["\']).*?\1/', '', $expr );
+        if ( preg_match( '/[^0-9+\-*\/().\'" ]/', $without_strings ) ) {
+            return null;
+        }
+
+        try {
+            // phpcs:ignore -- expression is sanitized above.
+            return eval( 'return ' . $expr . ';' );
+        } catch ( \Throwable $e ) {
+            return null;
+        }
+    }
+
+    protected function get_meta_value( $object_id, $key, $context_type ) {
+        switch ( $context_type ) {
+            case 'user':
+                return get_user_meta( $object_id, $key, true );
+            case 'term':
+                return get_term_meta( $object_id, $key, true );
+            case 'comment':
+                return get_comment_meta( $object_id, $key, true );
+            case 'option':
+                return get_option( $key );
+            case 'site':
+                return get_site_option( $key );
+            default:
+                return get_post_meta( $object_id, $key, true );
+        }
     }
 }
+

--- a/tests/test-field-computed.php
+++ b/tests/test-field-computed.php
@@ -1,0 +1,31 @@
+<?php
+
+class FieldComputedTest extends WP_UnitTestCase {
+    public function test_arithmetic_formula() {
+        $post_id = self::factory()->post->create();
+        update_post_meta( $post_id, 'a', 5 );
+        update_post_meta( $post_id, 'b', 2 );
+
+        $field = new GM2_Field_Computed( 'total', [ 'formula' => '{a} * {b} + 1' ] );
+        $field->save( $post_id, null );
+
+        $this->assertSame( 11, get_post_meta( $post_id, 'total', true ) );
+
+        ob_start();
+        $field->render_admin( '', $post_id, 'post' );
+        $out = ob_get_clean();
+        $this->assertStringContainsString( '11', $out );
+    }
+
+    public function test_string_formula() {
+        $post_id = self::factory()->post->create();
+        update_post_meta( $post_id, 'first', 'John' );
+        update_post_meta( $post_id, 'last', 'Doe' );
+
+        $field = new GM2_Field_Computed( 'full', [ 'formula' => "{first} . ' ' . {last}" ] );
+        $field->save( $post_id, null );
+
+        $this->assertSame( 'John Doe', get_post_meta( $post_id, 'full', true ) );
+    }
+}
+


### PR DESCRIPTION
## Summary
- extend computed field to parse simple expressions referencing other fields
- evaluate formulas on save and display with callback fallback and validation
- add tests covering arithmetic and string formulas

## Testing
- `vendor/bin/phpunit --filter FieldComputedTest` *(fails: WordPress &rsaquo; Error – Can't connect to MySQL server on 'localhost:3306')*


------
https://chatgpt.com/codex/tasks/task_e_68a37759102c832792c5bdd211bc6f41