### PR TITLE
Support template locking for CPT block templates

### DIFF
--- a/admin/Gm2_Custom_Posts_Admin.php
+++ b/admin/Gm2_Custom_Posts_Admin.php
@@ -704,8 +704,8 @@ class Gm2_Custom_Posts_Admin {
             if (is_array($template)) {
                 $args_input[] = [ 'key' => 'template', 'value' => $template ];
             }
-            $template_lock = sanitize_text_field($_POST['pt_template_lock'] ?? '');
-            if ($template_lock !== '') {
+            $template_lock = sanitize_key($_POST['pt_template_lock'] ?? '');
+            if (in_array($template_lock, [ 'all', 'insert' ], true)) {
                 $args_input[] = [ 'key' => 'template_lock', 'value' => $template_lock ];
             }
 
@@ -820,7 +820,11 @@ class Gm2_Custom_Posts_Admin {
         echo '<p><label>' . esc_html__( 'Template (JSON)', 'gm2-wordpress-suite' ) . '<br />';
         echo '<textarea name="pt_template" class="large-text code" rows="5"></textarea></label></p>';
         echo '<p><label>' . esc_html__( 'Template Lock', 'gm2-wordpress-suite' ) . '<br />';
-        echo '<input type="text" name="pt_template_lock" class="regular-text" /></label></p>';
+        echo '<select name="pt_template_lock" class="regular-text">';
+        echo '<option value="">' . esc_html__( 'None', 'gm2-wordpress-suite' ) . '</option>';
+        echo '<option value="insert">' . esc_html__( 'Insert', 'gm2-wordpress-suite' ) . '</option>';
+        echo '<option value="all">' . esc_html__( 'All', 'gm2-wordpress-suite' ) . '</option>';
+        echo '</select></label></p>';
         echo '</fieldset>';
         echo '<p><label>' . esc_html__( 'Fields (JSON)', 'gm2-wordpress-suite' ) . '<br />';
         echo '<textarea name="pt_fields" class="large-text code" rows="5" placeholder="{\n  \"field_key\": {\n    \"label\": \"Field Label\",\n    \"type\": \"text\"\n  }\n}"></textarea></label></p>';
@@ -1008,6 +1012,8 @@ class Gm2_Custom_Posts_Admin {
                     $value = json_decode(wp_unslash($value), true);
                 }
                 $val = is_array($value) ? $value : [];
+            } elseif ($a_key === 'template_lock') {
+                $val = in_array($value, [ 'all', 'insert' ], true) ? $value : false;
             } elseif ($a_key === 'menu_position') {
                 $val = is_numeric($value) ? (int) $value : 0;
             } elseif ($a_key === 'orderby') {

--- a/docs/recipes/directory/README.md
+++ b/docs/recipes/directory/README.md
@@ -6,6 +6,11 @@ Minimal example showing how to register a Directory custom post type with schema
 register_post_type( 'gm2_directory', [
     'label' => 'Directory',
     'public' => true,
+    'template' => [
+        [ 'core/image', [] ],
+        [ 'core/paragraph', [ 'placeholder' => 'Add business details...' ] ],
+    ],
+    'template_lock' => 'insert',
 ] );
 
 echo gm2_schema_tooltip( 'Business address', 'Address' );

--- a/includes/gm2-custom-posts-functions.php
+++ b/includes/gm2-custom-posts-functions.php
@@ -382,8 +382,23 @@ function gm2_register_custom_posts() {
                 $args['rewrite'] = $value;
             } elseif ($key === 'capabilities' && is_array($value)) {
                 $args['capabilities'] = $value;
-            } elseif ($key === 'template' && is_array($value)) {
-                $args['template'] = $value;
+            } elseif ($key === 'template') {
+                if (is_string($value)) {
+                    $decoded = json_decode(wp_unslash($value), true);
+                    if (is_array($decoded)) {
+                        $args['template'] = $decoded;
+                    }
+                } elseif (is_array($value)) {
+                    $args['template'] = $value;
+                }
+            } elseif ($key === 'template_lock') {
+                if (in_array($value, [ 'all', 'insert' ], true)) {
+                    $args['template_lock'] = $value;
+                } elseif ($value === true || $value === '1' || $value === 1) {
+                    $args['template_lock'] = 'all';
+                } elseif ($value === false || $value === '0' || $value === 0 || $value === '') {
+                    // Explicitly no lock; omit to fall back to default behaviour.
+                }
             } else {
                 $args[$key] = $value;
             }

--- a/tests/test-custom-posts.php
+++ b/tests/test-custom-posts.php
@@ -322,7 +322,7 @@ class CustomPostsFieldsTest extends WP_UnitTestCase {
                         'map_meta_cap' => [ 'value' => true ],
                         'capability_type' => [ 'value' => [ 'movie','movies' ] ],
                         'capabilities' => [ 'value' => [ 'edit_post' => 'edit_movie' ] ],
-                        'template' => [ 'value' => [ [ 'core/paragraph', [] ] ] ],
+                        'template' => [ 'value' => [ [ 'core/paragraph', [ 'placeholder' => 'Add summary...' ] ] ] ],
                         'template_lock' => [ 'value' => 'all' ],
                     ],
                 ],
@@ -357,7 +357,7 @@ class CustomPostsFieldsTest extends WP_UnitTestCase {
         $this->assertTrue($pt->map_meta_cap);
         $this->assertSame('movie', $pt->capability_type);
         $this->assertSame('edit_movie', $pt->cap->edit_post);
-        $this->assertSame([ [ 'core/paragraph', [] ] ], $pt->template);
+        $this->assertSame([ [ 'core/paragraph', [ 'placeholder' => 'Add summary...' ] ] ], $pt->template);
         $this->assertSame('all', $pt->template_lock);
     }
 }


### PR DESCRIPTION
## Summary
- Parse `template` and `template_lock` settings when registering custom post types so block templates and lock modes are applied.
- Allow selecting a template lock mode from the CPT editor and sanitize the saved value.
- Document and test registering CPTs with default block templates.

## Testing
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a37f39c7188327a18975ef9b34b0d1