### PR TITLE
Add WP-CLI model management subcommands and docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,7 @@
 # Gm2 WordPress Suite Updates
 
+See [model-cli.md](model-cli.md) for managing custom post types, taxonomies and fields via WP-CLI.
+
 This release adds several new SEO and AI options:
 
 - Added an index on the `timestamp` column of the `gm2_analytics_log` table for faster lookups. Existing installations upgrade automatically.

--- a/docs/model-cli.md
+++ b/docs/model-cli.md
@@ -1,0 +1,63 @@
+# Model WP-CLI commands
+
+Manage custom post types, taxonomies, and field groups from the command line.
+All commands are run with the `wp gm2 model` prefix.
+
+## Creating models
+
+### Custom post type
+
+```bash
+wp gm2 model create cpt <slug> [--args=<json>]
+```
+
+### Taxonomy
+
+```bash
+wp gm2 model create taxonomy <cpt> <slug> [--args=<json>]
+```
+
+### Field group
+
+```bash
+wp gm2 model create field <cpt> <key> [--args=<json>]
+```
+
+## Updating models
+
+```bash
+wp gm2 model update cpt <slug> [--args=<json>] [--version=<version>]
+wp gm2 model update taxonomy <cpt> <slug> [--args=<json>]
+wp gm2 model update field <cpt> <key> [--args=<json>]
+```
+
+`modify` is an alias for `update`.
+
+## Deleting models
+
+```bash
+wp gm2 model delete cpt <slug>
+wp gm2 model delete taxonomy <cpt> <slug>
+wp gm2 model delete field <cpt> <key>
+```
+
+## Migrations
+
+Run pending migrations for all models:
+
+```bash
+wp gm2 model migrate
+```
+
+## Exporting and importing
+
+```bash
+wp gm2 model export <file> [--format=<json|yaml>]
+wp gm2 model import <file> [--format=<json|yaml>]
+```
+
+## Seeding data
+
+```bash
+wp gm2 model seed
+```

--- a/includes/cli/class-gm2-model.php
+++ b/includes/cli/class-gm2-model.php
@@ -84,6 +84,120 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
     }
 
     /**
+     * Create a CPT, taxonomy or field group.
+     *
+     * ## OPTIONS
+     *
+     * <type>
+     * : Model type to create. Accepts `cpt`, `taxonomy` or `field`.
+     *
+     * [<args>...]
+     * : Additional arguments passed to the underlying command.
+     */
+    public function create( $args, $assoc_args ) {
+        $type = $args[0] ?? '';
+        if ( ! $type ) {
+            \WP_CLI::error( 'Usage: wp gm2 model create <cpt|taxonomy|field> ...' );
+        }
+
+        array_shift( $args );
+        switch ( $type ) {
+            case 'cpt':
+            case 'post-type':
+                $this->cpt_create( $args, $assoc_args );
+                break;
+            case 'taxonomy':
+                $this->taxonomy_create( $args, $assoc_args );
+                break;
+            case 'field':
+            case 'field-group':
+                $this->field_create( $args, $assoc_args );
+                break;
+            default:
+                \WP_CLI::error( 'Unknown type. Use cpt, taxonomy or field.' );
+        }
+    }
+
+    /**
+     * Update an existing CPT, taxonomy or field group.
+     *
+     * ## OPTIONS
+     *
+     * <type>
+     * : Model type to update. Accepts `cpt`, `taxonomy` or `field`.
+     *
+     * [<args>...]
+     * : Additional arguments passed to the underlying command.
+     */
+    public function update( $args, $assoc_args ) {
+        $type = $args[0] ?? '';
+        if ( ! $type ) {
+            \WP_CLI::error( 'Usage: wp gm2 model update <cpt|taxonomy|field> ...' );
+        }
+
+        array_shift( $args );
+        switch ( $type ) {
+            case 'cpt':
+            case 'post-type':
+                $this->cpt_update( $args, $assoc_args );
+                break;
+            case 'taxonomy':
+                $this->taxonomy_update( $args, $assoc_args );
+                break;
+            case 'field':
+            case 'field-group':
+                $this->field_update( $args, $assoc_args );
+                break;
+            default:
+                \WP_CLI::error( 'Unknown type. Use cpt, taxonomy or field.' );
+        }
+    }
+
+    /**
+     * Modify an existing CPT, taxonomy or field group.
+     *
+     * This is an alias of the `update` subcommand.
+     */
+    public function modify( $args, $assoc_args ) {
+        $this->update( $args, $assoc_args );
+    }
+
+    /**
+     * Delete a CPT, taxonomy or field group.
+     *
+     * ## OPTIONS
+     *
+     * <type>
+     * : Model type to delete. Accepts `cpt`, `taxonomy` or `field`.
+     *
+     * [<args>...]
+     * : Additional arguments passed to the underlying command.
+     */
+    public function delete( $args, $assoc_args ) {
+        $type = $args[0] ?? '';
+        if ( ! $type ) {
+            \WP_CLI::error( 'Usage: wp gm2 model delete <cpt|taxonomy|field> ...' );
+        }
+
+        array_shift( $args );
+        switch ( $type ) {
+            case 'cpt':
+            case 'post-type':
+                $this->cpt_delete( $args, $assoc_args );
+                break;
+            case 'taxonomy':
+                $this->taxonomy_delete( $args, $assoc_args );
+                break;
+            case 'field':
+            case 'field-group':
+                $this->field_delete( $args, $assoc_args );
+                break;
+            default:
+                \WP_CLI::error( 'Unknown type. Use cpt, taxonomy or field.' );
+        }
+    }
+
+    /**
      * Create a custom post type.
      *
      * ## OPTIONS


### PR DESCRIPTION
## Summary
- add generic `create`, `update`/`modify`, and `delete` WP‑CLI subcommands for managing CPTs, taxonomies, and fields
- document model management commands and link from docs index

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3913517e8832797a10f82de8a50ac