### PR TITLE
Add model export/import tooling with CLI and admin UI

### DIFF
--- a/admin/Gm2_Model_Export_Admin.php
+++ b/admin/Gm2_Model_Export_Admin.php
@@ -1,0 +1,93 @@
+<?php
+namespace Gm2;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Gm2_Model_Export_Admin {
+    public function run() {
+        add_action('admin_menu', [ $this, 'add_tools_page' ]);
+    }
+
+    public function add_tools_page() {
+        add_management_page(
+            __('Gm2 Models', 'gm2-wordpress-suite'),
+            __('Gm2 Models', 'gm2-wordpress-suite'),
+            'manage_options',
+            'gm2-model-export',
+            [ $this, 'render_page' ]
+        );
+    }
+
+    public function render_page() {
+        if (!current_user_can('manage_options')) {
+            wp_die(esc_html__('Permission denied', 'gm2-wordpress-suite'));
+        }
+
+        $message = '';
+        if (!empty($_POST['gm2_export_models']) && check_admin_referer('gm2_export_models')) {
+            $format = sanitize_text_field($_POST['format'] ?? 'json');
+            $data   = \gm2_model_export($format);
+            if (is_wp_error($data)) {
+                $message = $data->get_error_message();
+            } else {
+                header('Content-Type: ' . ('yaml' === $format ? 'application/x-yaml' : 'application/json'));
+                header('Content-Disposition: attachment; filename=models.' . ('yaml' === $format ? 'yml' : 'json'));
+                echo $data;
+                exit;
+            }
+        } elseif (!empty($_POST['gm2_import_models']) && check_admin_referer('gm2_import_models')) {
+            $format = sanitize_text_field($_POST['format'] ?? 'json');
+            $raw    = wp_unslash($_POST['model_data'] ?? '');
+            $result = \gm2_model_import($raw, $format);
+            if (is_wp_error($result)) {
+                $message = $result->get_error_message();
+            } else {
+                $message = esc_html__('Models imported.', 'gm2-wordpress-suite');
+            }
+        } elseif (!empty($_POST['gm2_generate_plugin']) && check_admin_referer('gm2_generate_plugin')) {
+            $mu   = !empty($_POST['as_mu']);
+            $tmp  = tempnam(sys_get_temp_dir(), 'gm2_model_') . '.zip';
+            $data = \gm2_model_export('array');
+            $zip  = \gm2_model_generate_plugin($data, $tmp, $mu);
+            if (is_wp_error($zip)) {
+                $message = $zip->get_error_message();
+            } else {
+                header('Content-Type: application/zip');
+                header('Content-Disposition: attachment; filename=' . ($mu ? 'models-mu-plugin.zip' : 'models-plugin.zip'));
+                readfile($zip);
+                unlink($zip);
+                exit;
+            }
+        }
+
+        echo '<div class="wrap"><h1>' . esc_html__('Gm2 Model Export/Import', 'gm2-wordpress-suite') . '</h1>';
+        if ($message) {
+            echo '<div class="notice notice-info"><p>' . esc_html($message) . '</p></div>';
+        }
+
+        echo '<h2>' . esc_html__('Export', 'gm2-wordpress-suite') . '</h2>';
+        echo '<form method="post"><p>';
+        wp_nonce_field('gm2_export_models');
+        echo '<select name="format"><option value="json">JSON</option><option value="yaml">YAML</option></select> ';
+        echo '<button type="submit" name="gm2_export_models" class="button">' . esc_html__('Download', 'gm2-wordpress-suite') . '</button>';
+        echo '</p></form>';
+
+        echo '<h2>' . esc_html__('Import', 'gm2-wordpress-suite') . '</h2>';
+        echo '<form method="post"><p>';
+        wp_nonce_field('gm2_import_models');
+        echo '<select name="format"><option value="json">JSON</option><option value="yaml">YAML</option></select><br>';
+        echo '<textarea name="model_data" rows="10" cols="60"></textarea><br>';
+        echo '<button type="submit" name="gm2_import_models" class="button button-primary">' . esc_html__('Import', 'gm2-wordpress-suite') . '</button>';
+        echo '</p></form>';
+
+        echo '<h2>' . esc_html__('Generate Plugin', 'gm2-wordpress-suite') . '</h2>';
+        echo '<form method="post"><p>';
+        wp_nonce_field('gm2_generate_plugin');
+        echo '<label><input type="checkbox" name="as_mu" value="1"> ' . esc_html__('As MU-Plugin', 'gm2-wordpress-suite') . '</label> ';
+        echo '<button type="submit" name="gm2_generate_plugin" class="button">' . esc_html__('Generate', 'gm2-wordpress-suite') . '</button>';
+        echo '</p></form>';
+        echo '</div>';
+    }
+}

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -62,6 +62,7 @@ require_once GM2_PLUGIN_DIR . 'includes/gm2-theme-tools.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-open-in-code.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-field-renderers.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-schema-tooltips.php';
+require_once GM2_PLUGIN_DIR . 'includes/gm2-model-export.php';
 // Temporarily disable Recovery Email Queue.
 // require_once GM2_PLUGIN_DIR . 'includes/Gm2_Abandoned_Carts_Messaging.php';
 require_once GM2_PLUGIN_DIR . 'admin/Gm2_Abandoned_Carts_Admin.php';
@@ -69,6 +70,7 @@ require_once GM2_PLUGIN_DIR . 'admin/Gm2_Recovered_Carts_Admin.php';
 require_once GM2_PLUGIN_DIR . 'admin/class-gm2-ac-table.php';
 require_once GM2_PLUGIN_DIR . 'admin/class-gm2-bulk-ai-list-table.php';
 require_once GM2_PLUGIN_DIR . 'admin/class-gm2-bulk-ai-tax-list-table.php';
+require_once GM2_PLUGIN_DIR . 'admin/Gm2_Model_Export_Admin.php';
 require_once GM2_PLUGIN_DIR . 'public/Gm2_Abandoned_Carts_Public.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_REST_Visibility.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_REST_Rate_Limiter.php';

--- a/includes/Gm2_Loader.php
+++ b/includes/Gm2_Loader.php
@@ -74,6 +74,8 @@ class Gm2_Loader {
             if (is_admin()) {
                 $cp_admin = new Gm2_Custom_Posts_Admin();
                 $cp_admin->run();
+                $model_export = new Gm2_Model_Export_Admin();
+                $model_export->run();
             }
             $cp_public = new Gm2_Custom_Posts_Public();
             $cp_public->run();


### PR DESCRIPTION
## Summary
- add gm2-model-export module with JSON/YAML exporter, importer, and plugin generator
- expose model export/import and plugin generation via WP-CLI
- add Tools page to run exports, imports, and plugin generation in admin

## Testing
- `npm test`
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a3976a771c83278200e426f2559ff4