### PR TITLE
Add version history and restore UI for custom post configs

### DIFF
--- a/admin/gm2-config-history.php
+++ b/admin/gm2-config-history.php
@@ -1,0 +1,55 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Admin UI to view and restore configuration history.
+ */
+function gm2_config_history_page() {
+    if (!current_user_can('manage_options')) {
+        wp_die(esc_html__('Permission denied', 'gm2-wordpress-suite'));
+    }
+
+    $options = [ 'gm2_custom_posts_config', 'gm2_field_groups' ];
+
+    if (!empty($_POST['restore_option']) && !empty($_POST['version'])) {
+        check_admin_referer('gm2_restore_option');
+        $opt = sanitize_key($_POST['restore_option']);
+        $ver = intval($_POST['version']);
+        if (gm2_restore_option_version($opt, $ver)) {
+            echo '<div class="notice notice-success"><p>' . esc_html__('Version restored.', 'gm2-wordpress-suite') . '</p></div>';
+        } else {
+            echo '<div class="notice notice-error"><p>' . esc_html__('Failed to restore version.', 'gm2-wordpress-suite') . '</p></div>';
+        }
+    }
+
+    echo '<div class="wrap"><h1>' . esc_html__('GM2 Config History', 'gm2-wordpress-suite') . '</h1>';
+    foreach ($options as $option) {
+        $history = gm2_get_option_history($option);
+        echo '<h2>' . esc_html($option) . '</h2>';
+        if ($history) {
+            echo '<table class="widefat"><thead><tr><th>' . esc_html__('Version', 'gm2-wordpress-suite') . '</th><th>' . esc_html__('Date', 'gm2-wordpress-suite') . '</th><th>' . esc_html__('Actions', 'gm2-wordpress-suite') . '</th></tr></thead><tbody>';
+            foreach ($history as $item) {
+                $date = wp_date(get_option('date_format') . ' ' . get_option('time_format'), $item['timestamp']);
+                echo '<tr><td>' . esc_html($item['version']) . '</td><td>' . esc_html($date) . '</td><td>';
+                echo '<form method="post" style="display:inline">';
+                wp_nonce_field('gm2_restore_option');
+                echo '<input type="hidden" name="restore_option" value="' . esc_attr($option) . '" />';
+                echo '<input type="hidden" name="version" value="' . esc_attr($item['version']) . '" />';
+                echo '<button type="submit" class="button">' . esc_html__('Restore', 'gm2-wordpress-suite') . '</button>';
+                echo '</form>';
+                echo '</td></tr>';
+            }
+            echo '</tbody></table>';
+        } else {
+            echo '<p>' . esc_html__('No history found.', 'gm2-wordpress-suite') . '</p>';
+        }
+    }
+    echo '</div>';
+}
+
+function gm2_register_config_history_page() {
+    add_submenu_page('gm2-custom-posts', __('Config History', 'gm2-wordpress-suite'), __('Config History', 'gm2-wordpress-suite'), 'manage_options', 'gm2_config_history', 'gm2_config_history_page');
+}
+add_action('admin_menu', 'gm2_register_config_history_page');

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -79,6 +79,7 @@ require_once GM2_PLUGIN_DIR . 'includes/gm2-open-in-code.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-field-renderers.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-schema-tooltips.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-model-export.php';
+require_once GM2_PLUGIN_DIR . 'includes/gm2-config-versions.php';
 // Temporarily disable Recovery Email Queue.
 // require_once GM2_PLUGIN_DIR . 'includes/Gm2_Abandoned_Carts_Messaging.php';
 require_once GM2_PLUGIN_DIR . 'admin/Gm2_Abandoned_Carts_Admin.php';
@@ -87,6 +88,7 @@ require_once GM2_PLUGIN_DIR . 'admin/class-gm2-ac-table.php';
 require_once GM2_PLUGIN_DIR . 'admin/class-gm2-bulk-ai-list-table.php';
 require_once GM2_PLUGIN_DIR . 'admin/class-gm2-bulk-ai-tax-list-table.php';
 require_once GM2_PLUGIN_DIR . 'admin/Gm2_Model_Export_Admin.php';
+require_once GM2_PLUGIN_DIR . 'admin/gm2-config-history.php';
 require_once GM2_PLUGIN_DIR . 'public/Gm2_Abandoned_Carts_Public.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_REST_Visibility.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_REST_Rate_Limiter.php';

--- a/includes/gm2-config-versions.php
+++ b/includes/gm2-config-versions.php
@@ -1,0 +1,58 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Store versioned history of gm2 configuration options.
+ */
+function gm2_record_option_version($old_value, $value, $option) {
+    if ($old_value === $value) {
+        return;
+    }
+    $history_option = $option . '_history';
+    $history = get_option($history_option, []);
+    if (!is_array($history)) {
+        $history = [];
+    }
+    $last = end($history);
+    $version = isset($last['version']) ? (int) $last['version'] + 1 : 1;
+    $history[] = [
+        'version' => $version,
+        'timestamp' => time(),
+        'data' => $value,
+    ];
+    update_option($history_option, $history);
+}
+
+add_action('update_option_gm2_custom_posts_config', 'gm2_record_option_version', 10, 3);
+add_action('update_option_gm2_field_groups', 'gm2_record_option_version', 10, 3);
+
+/**
+ * Retrieve history for an option.
+ *
+ * @param string $option Option name.
+ * @return array
+ */
+function gm2_get_option_history($option) {
+    $history = get_option($option . '_history', []);
+    return is_array($history) ? $history : [];
+}
+
+/**
+ * Restore an option to a previous version.
+ *
+ * @param string $option  Option name.
+ * @param int    $version Version number to restore.
+ * @return bool True on success.
+ */
+function gm2_restore_option_version($option, $version) {
+    $history = gm2_get_option_history($option);
+    foreach ($history as $item) {
+        if ((int) ($item['version'] ?? 0) === (int) $version) {
+            update_option($option, $item['data']);
+            return true;
+        }
+    }
+    return false;
+}

--- a/tests/test-config-history.php
+++ b/tests/test-config-history.php
@@ -1,0 +1,37 @@
+<?php
+class ConfigHistoryTest extends WP_UnitTestCase {
+    public function setUp(): void {
+        parent::setUp();
+        delete_option('gm2_custom_posts_config');
+        delete_option('gm2_custom_posts_config_history');
+        delete_option('gm2_field_groups');
+        delete_option('gm2_field_groups_history');
+    }
+
+    public function tearDown(): void {
+        parent::tearDown();
+        delete_option('gm2_custom_posts_config');
+        delete_option('gm2_custom_posts_config_history');
+        delete_option('gm2_field_groups');
+        delete_option('gm2_field_groups_history');
+    }
+
+    public function test_history_and_restore_custom_posts() {
+        update_option('gm2_custom_posts_config', ['first' => 1]);
+        update_option('gm2_custom_posts_config', ['second' => 2]);
+        $history = gm2_get_option_history('gm2_custom_posts_config');
+        $this->assertCount(2, $history);
+        $this->assertSame(2, end($history)['version']);
+        gm2_restore_option_version('gm2_custom_posts_config', 1);
+        $this->assertSame(['first' => 1], get_option('gm2_custom_posts_config'));
+    }
+
+    public function test_history_and_restore_field_groups() {
+        update_option('gm2_field_groups', ['a' => 1]);
+        update_option('gm2_field_groups', ['b' => 2]);
+        $history = gm2_get_option_history('gm2_field_groups');
+        $this->assertCount(2, $history);
+        gm2_restore_option_version('gm2_field_groups', 1);
+        $this->assertSame(['a' => 1], get_option('gm2_field_groups'));
+    }
+}


### PR DESCRIPTION
## Summary
- track every change to `gm2_custom_posts_config` and `gm2_field_groups` with versioned history
- add admin page to inspect history and restore previous versions
- cover history and restore behavior with unit tests

## Testing
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): Failed to open stream)*

------
https://chatgpt.com/codex/tasks/task_e_68a39f0191208327b0dc1a2ad3519df5