### PR TITLE
Add async upload endpoint and queue media processing

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -99,12 +99,14 @@ require_once GM2_PLUGIN_DIR . 'includes/Gm2_Webhooks.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_Capability_Manager.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_Workflow_Manager.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_Audit_Log.php';
+require_once GM2_PLUGIN_DIR . 'includes/Gm2_Ajax_Upload.php';
 
 \Gm2\Gm2_REST_Visibility::init();
 \Gm2\Gm2_REST_Rate_Limiter::init();
 \Gm2\Gm2_REST_Media::init();
 \Gm2\Gm2_REST_Fields::init();
 \Gm2\Gm2_Webhooks::init();
+\Gm2\Gm2_Ajax_Upload::init();
 
 function gm2_add_weekly_schedule($schedules) {
     if (!isset($schedules['weekly'])) {

--- a/includes/Gm2_Ajax_Upload.php
+++ b/includes/Gm2_Ajax_Upload.php
@@ -1,0 +1,50 @@
+<?php
+namespace Gm2;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Gm2_Ajax_Upload {
+    public static function init(): void {
+        add_action('wp_ajax_gm2_async_upload', [ __CLASS__, 'handle' ]);
+    }
+
+    public static function handle(): void {
+        if (!current_user_can('upload_files')) {
+            wp_send_json_error(__('Permission denied.', 'gm2-wordpress-suite'), 403);
+        }
+
+        check_ajax_referer('gm2_async_upload', 'nonce');
+
+        if (empty($_FILES['file'])) {
+            wp_send_json_error(__('No file uploaded.', 'gm2-wordpress-suite'), 400);
+        }
+
+        require_once ABSPATH . 'wp-admin/includes/file.php';
+
+        $uploaded = wp_handle_upload($_FILES['file'], [ 'test_form' => false ]);
+        if (isset($uploaded['error'])) {
+            wp_send_json_error($uploaded['error'], 400);
+        }
+
+        $attachment = [
+            'post_mime_type' => $uploaded['type'],
+            'post_title'     => sanitize_file_name(basename($uploaded['file'])),
+            'post_content'   => '',
+            'post_status'    => 'inherit',
+        ];
+
+        $attachment_id = wp_insert_attachment($attachment, $uploaded['file']);
+        if (is_wp_error($attachment_id)) {
+            wp_send_json_error($attachment_id->get_error_message(), 500);
+        }
+
+        require_once ABSPATH . 'wp-admin/includes/image.php';
+
+        gm2_queue_thumbnail_regeneration($attachment_id);
+        gm2_queue_image_optimization($attachment_id);
+
+        wp_send_json_success([ 'attachment_id' => $attachment_id ]);
+    }
+}

--- a/includes/Gm2_REST_Media.php
+++ b/includes/Gm2_REST_Media.php
@@ -9,6 +9,7 @@ class Gm2_REST_Media {
     public static function init(): void {
         add_action('rest_api_init', [ __CLASS__, 'register_routes' ]);
         add_action('gm2_generate_thumbnails', [ __CLASS__, 'generate_thumbnails' ]);
+        add_action('gm2_optimize_image', [ __CLASS__, 'optimize_image' ]);
     }
 
     public static function register_routes(): void {
@@ -47,6 +48,14 @@ class Gm2_REST_Media {
         if (!is_wp_error($metadata)) {
             wp_update_attachment_metadata($id, $metadata);
         }
+    }
+
+    public static function optimize_image($id): void {
+        $file = get_attached_file($id);
+        if (!$file) {
+            return;
+        }
+        do_action('gm2_optimize_image_file', $file, $id);
     }
 
     public static function get_schema(): array {


### PR DESCRIPTION
## Summary
- add `gm2_async_upload` AJAX endpoint leveraging `wp_handle_upload`
- queue thumbnail regeneration and image optimization using Action Scheduler or WP-Cron
- centralize async scheduling with `gm2_enqueue_async_action`

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a1ffcf1883279ef2c43655920f5b