### PR TITLE
Respect field capabilities for fields

### DIFF
--- a/includes/Gm2_REST_Fields.php
+++ b/includes/Gm2_REST_Fields.php
@@ -57,6 +57,9 @@ class Gm2_REST_Fields {
         $defs = $config['post_types'][$post->post_type]['fields'] ?? [];
         $data = [];
         foreach ($fields as $field) {
+            if (!Gm2_Capability_Manager::can_read_field($field, $id)) {
+                continue;
+            }
             $value = get_post_meta($id, $field, true);
             $mode = $format ?: ($defs[$field]['serialize'] ?? 'raw');
             if ($mode === 'rendered') {
@@ -120,11 +123,11 @@ class Gm2_REST_Fields {
                 'type'        => 'String',
                 'description' => sprintf(__('GM2 field %s', 'gm2-wordpress-suite'), $field),
                 'resolve'     => function ($post) use ($field) {
-                    if (isset($post->ID)) {
-                        $value = get_post_meta((int) $post->ID, $field, true);
-                        return is_scalar($value) ? (string) $value : $value;
+                    if (!isset($post->ID) || !Gm2_Capability_Manager::can_read_field($field, (int) $post->ID)) {
+                        return null;
                     }
-                    return null;
+                    $value = get_post_meta((int) $post->ID, $field, true);
+                    return is_scalar($value) ? (string) $value : $value;
                 },
             ]);
         }

--- a/includes/gm2-custom-posts-functions.php
+++ b/includes/gm2-custom-posts-functions.php
@@ -614,6 +614,9 @@ function gm2_render_field_group($fields, $object_id, $context_type = 'post') {
         return ($a['order'] ?? 0) <=> ($b['order'] ?? 0);
     });
     foreach ($fields as $key => $field) {
+        if (!\Gm2\Gm2_Capability_Manager::can_read_field($key, $object_id)) {
+            continue;
+        }
         $container = $field['container'] ?? '';
         if (in_array($container, [ 'tab', 'accordion' ], true)) {
             $defer = apply_filters('gm2_should_lazy_load_group', true, $key, $field, $object_id, $context_type);
@@ -835,6 +838,9 @@ function gm2_save_field_group($fields, $object_id, $context_type = 'post') {
         return;
     }
     foreach ($fields as $key => $field) {
+        if (!\Gm2\Gm2_Capability_Manager::can_edit_field($key, $object_id)) {
+            continue;
+        }
         $state = gm2_evaluate_conditions($field, $object_id);
         if (!$state['show']) {
             continue;


### PR DESCRIPTION
## Summary
- Skip rendering or saving field values when `Gm2_Capability_Manager` denies read/edit access
- Filter REST and GraphQL field exposure based on field-level permissions
- Add tests covering hidden fields and blocked saves for unauthorized users

## Testing
- `php -l includes/gm2-custom-posts-functions.php`
- `php -l includes/Gm2_REST_Fields.php`
- `php -l tests/test-taxonomy-permissions.php`
- `phpunit tests/test-taxonomy-permissions.php` *(fails: command not found)*
- `curl -L https://phar.phpunit.de/phpunit-9.phar -o phpunit.phar` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a5127cc883279e9d455965e50086