### PR TITLE
Add taxonomy term ordering support

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@ This release adds several new SEO and AI options:
 - Each context field now includes a guiding question so users know what to enter.
 - Additional context fields: **Core Offerings**, **Geographic Focus**, **Keyword Data**, **Competitor Landscape**, **Success Metrics** and **Buyer Personas**.
 - Additional meta fields on post and taxonomy edit screens for Search Intent, Focus Keyword Limit, Number of Words and an "Improve Readability" checkbox.
+- Taxonomy configuration now supports an `ordering` toggle. When enabled, term queries default to sorting by the `_gm2_order` meta value.
 - New helper functions `gm2_get_project_description()` and `gm2_ai_send_prompt()` supporting custom language models (`gpt-3.5-turbo` or `gpt-4`) and temperature settings.
 
 Existing prompt logic automatically includes these options via `gm2_get_seo_context()`.

--- a/tests/test-taxonomy-hooks.php
+++ b/tests/test-taxonomy-hooks.php
@@ -88,5 +88,35 @@ class TaxonomyHooksTest extends WP_UnitTestCase {
         unregister_taxonomy('genre');
         delete_option('gm2_custom_posts_config');
     }
+
+    public function test_terms_ordered_when_enabled() {
+        update_option('gm2_custom_posts_config', [
+            'post_types' => [],
+            'taxonomies' => [
+                'ordered' => [
+                    'label'      => 'Ordered',
+                    'post_types' => ['post'],
+                    'ordering'   => true,
+                    'default_terms' => [
+                        [ 'slug' => 'b-term', 'name' => 'B', 'order' => 1 ],
+                        [ 'slug' => 'a-term', 'name' => 'A', 'order' => 2 ],
+                    ],
+                ],
+            ],
+        ]);
+
+        gm2_register_custom_posts();
+
+        $terms = get_terms([
+            'taxonomy'   => 'ordered',
+            'hide_empty' => false,
+        ]);
+
+        $this->assertSame(['b-term', 'a-term'], wp_list_pluck($terms, 'slug'));
+
+        unregister_taxonomy('ordered');
+        delete_option('gm2_custom_posts_config');
+        remove_all_filters('pre_get_terms');
+    }
 }
 


### PR DESCRIPTION
## Summary
- order taxonomy term queries by `_gm2_order` when `ordering` enabled
- document new `ordering` toggle
- test taxonomy term ordering

## Testing
- `phpunit tests/test-taxonomy-hooks.php` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `bash bin/install-wp-tests.sh wordpress_test root '' localhost latest` *(fails: mysqladmin command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a9ea1b608327b50f464af2ddbca5