### PR TITLE
Add theme.json updates for generated templates and CLI hint

### DIFF
--- a/includes/cli/class-gm2-cli.php
+++ b/includes/cli/class-gm2-cli.php
@@ -108,7 +108,16 @@ class Gm2_CLI extends \WP_CLI_Command {
                 } else {
                     \WP_CLI::success( 'theme.json already exists at ' . $path );
                 }
-                \WP_CLI::line( 'Hint: update theme.json to reference custom templates and patterns.' );
+                $label = ucwords( str_replace( '-', ' ', $slug ) );
+                $sample = [
+                    'customTemplates' => [
+                        [ 'name' => 'single-' . $slug, 'title' => 'Single ' . $label ],
+                        [ 'name' => 'archive-' . $slug, 'title' => 'Archive ' . $label ],
+                    ],
+                    'patterns' => [ 'gm2/' . $slug ],
+                ];
+                \WP_CLI::line( 'Hint: add the following to theme.json to reference custom templates and patterns:' );
+                \WP_CLI::line( json_encode( $sample, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
                 break;
             default:
                 \WP_CLI::error( 'Usage: wp gm2 scaffold <twig|blade|theme-json> <slug>' );

--- a/tests/test-cli/scaffold-hint.php
+++ b/tests/test-cli/scaffold-hint.php
@@ -1,0 +1,38 @@
+<?php
+// Minimal stubs to test scaffold hint output.
+
+define('WP_CLI', true);
+define('GM2_PLUGIN_DIR', dirname(__DIR__, 2) . '/');
+
+if (!class_exists('WP_CLI')) {
+    class WP_CLI {
+        public static function error($msg) { throw new Exception($msg); }
+        public static function success($msg) { echo $msg, "\n"; }
+        public static function warning($msg) { echo $msg, "\n"; }
+        public static function line($msg) { echo $msg, "\n"; }
+        public static function add_command($name, $callable) {}
+    }
+}
+if (!class_exists('WP_CLI_Command')) {
+    class WP_CLI_Command {}
+}
+
+function trailingslashit($p) { return rtrim($p, '/\\') . '/'; }
+function get_stylesheet_directory() { return sys_get_temp_dir() . '/gm2-cli-scaffold'; }
+function wp_mkdir_p($dir) { if (!is_dir($dir)) { mkdir($dir, 0777, true); } }
+
+require dirname(__DIR__, 2) . '/includes/cli/class-gm2-cli.php';
+
+$dir = get_stylesheet_directory();
+wp_mkdir_p($dir);
+@unlink(trailingslashit($dir) . 'theme.json');
+
+$cli = new \Gm2\Gm2_CLI();
+ob_start();
+$cli->scaffold(['theme-json', 'book'], []);
+$output = ob_get_clean();
+if (strpos($output, 'customTemplates') === false || strpos($output, 'gm2/book') === false) {
+    throw new Exception('CLI scaffold hint missing.');
+}
+
+echo "CLI scaffold hint test completed\n";

--- a/tests/test-theme-tools.php
+++ b/tests/test-theme-tools.php
@@ -42,5 +42,28 @@ class ThemeToolsTest extends WP_UnitTestCase {
         $this->assertSame('#ff0000', $data['settings']['color']['palette'][0]['color']);
         $this->assertSame('Roboto', $data['settings']['typography']['fontFamilies'][0]['fontFamily']);
     }
+
+    public function test_theme_json_references_are_updated() {
+        // Ensure clean slate.
+        $theme_json = get_stylesheet_directory() . '/theme.json';
+        if (file_exists($theme_json)) {
+            unlink($theme_json);
+        }
+
+        register_post_type('book', ['public' => true]);
+        update_option('gm2_enable_block_templates', '1');
+        update_option('gm2_field_groups', [
+            [ 'pattern' => 'sample', 'fields' => [] ],
+        ]);
+
+        gm2_maybe_generate_block_templates();
+
+        $this->assertFileExists($theme_json);
+        $data = json_decode(file_get_contents($theme_json), true);
+        $templates = wp_list_pluck($data['customTemplates'], 'name');
+        $this->assertContains('single-book', $templates);
+        $this->assertContains('archive-book', $templates);
+        $this->assertContains('gm2/sample', $data['patterns']);
+    }
 }
 


### PR DESCRIPTION
## Summary
- add `gm2_update_theme_json_references()` to write template and pattern references to theme.json
- invoke theme.json updates when generating block templates
- enhance `wp gm2 scaffold theme-json` with sample snippet and add corresponding tests

## Testing
- `npm test`
- `phpunit` *(fails: command not found; phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b72733288327a1e3fa2bdcaac117