### PR TITLE
Lock generated templates and patterns

### DIFF
--- a/includes/gm2-theme-tools.php
+++ b/includes/gm2-theme-tools.php
@@ -154,9 +154,9 @@ function gm2_maybe_generate_block_templates() {
             continue;
         }
         $templates[] = 'single-' . $type;
-        gm2_ensure_block_template('single-' . $type, "<!-- wp:post-title /-->\n<!-- wp:post-content /-->\n");
+        gm2_ensure_block_template('single-' . $type, "<!-- wp:post-title /-->\n<!-- wp:post-content /-->\n", 'all');
         $templates[] = 'archive-' . $type;
-        gm2_ensure_block_template('archive-' . $type, "<!-- wp:query {\"inherit\":true} --><!-- wp:post-template --><!-- wp:post-title /--><!-- /wp:post-template --><!-- /wp:query -->\n");
+        gm2_ensure_block_template('archive-' . $type, "<!-- wp:query {\"inherit\":true} --><!-- wp:post-template --><!-- wp:post-title /--><!-- /wp:post-template --><!-- /wp:query -->\n", 'all');
     }
 
     $patterns = [];
@@ -178,8 +178,9 @@ add_action('init', 'gm2_maybe_generate_block_templates');
  *
  * @param string $slug    Template slug.
  * @param string $content Block template content.
+ * @param string $template_lock Lock setting for the template.
  */
-function gm2_ensure_block_template($slug, $content) {
+function gm2_ensure_block_template($slug, $content, $template_lock = 'all') {
     $exists = get_posts([
         'post_type'      => 'wp_template',
         'post_status'    => 'publish',
@@ -196,6 +197,7 @@ function gm2_ensure_block_template($slug, $content) {
         'post_title'  => ucwords(str_replace('-', ' ', $slug)),
         'post_content'=> $content,
         'tax_input'   => [ 'wp_theme' => get_stylesheet() ],
+        'meta_input'  => [ 'template_lock' => $template_lock ],
     ]);
 }
 
@@ -277,6 +279,7 @@ function gm2_register_field_group_patterns() {
             'title'       => $group['pattern'],
             'description' => $group['description'] ?? '',
             'content'     => $content,
+            'lock'        => 'all',
         ]);
     }
 }

--- a/tests/test-theme-tools.php
+++ b/tests/test-theme-tools.php
@@ -65,5 +65,33 @@ class ThemeToolsTest extends WP_UnitTestCase {
         $this->assertContains('archive-book', $templates);
         $this->assertContains('gm2/sample', $data['patterns']);
     }
+
+    public function test_generated_templates_are_locked() {
+        register_post_type('novel', ['public' => true]);
+        update_option('gm2_enable_block_templates', '1');
+
+        gm2_maybe_generate_block_templates();
+
+        $template = get_posts([
+            'post_type'      => 'wp_template',
+            'name'           => 'single-novel',
+            'post_status'    => 'publish',
+            'posts_per_page' => 1,
+        ]);
+        $this->assertNotEmpty($template);
+        $lock = get_post_meta($template[0]->ID, 'template_lock', true);
+        $this->assertSame('all', $lock);
+    }
+
+    public function test_registered_patterns_are_locked() {
+        update_option('gm2_field_groups', [
+            [ 'pattern' => 'locked', 'fields' => [] ],
+        ]);
+
+        gm2_register_field_group_patterns();
+        $pattern = WP_Block_Patterns_Registry::get_instance()->get_registered('gm2/locked');
+        $this->assertIsArray($pattern);
+        $this->assertSame('all', $pattern['lock']);
+    }
 }
 


### PR DESCRIPTION
## Summary
- Lock auto-created block templates by setting `template_lock` to `all`
- Register field group block patterns with `lock` set to `all`
- Test that generated templates and patterns are locked from structural edits

## Testing
- `phpunit --bootstrap /tmp/custom-bootstrap.php tests/test-theme-tools.php` *(fails: Error establishing a database connection)*

------
https://chatgpt.com/codex/tasks/task_e_68a3bfccc6d0832782c548a89b655303