### PR TITLE
Add placeholder support to field renderers

### DIFF
--- a/includes/fields/class-field-audio.php
+++ b/includes/fields/class-field-audio.php
@@ -4,12 +4,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Audio extends GM2_Field {
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
         $button   = '<button class="button gm2-media-upload" data-target="' . esc_attr( $this->key ) . '"' . $disabled . '>' . esc_html__( 'Select Audio', 'gm2-wordpress-suite' ) . '</button>';
         $src      = $value ? wp_get_attachment_url( $value ) : '';
         $preview  = '<div class="gm2-media-preview">' . ( $src ? '<audio controls src="' . esc_url( $src ) . '"></audio>' : '' ) . '</div>';
-        echo '<div class="gm2-media-field"><input type="hidden" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '"' . $disabled . ' />' . $button . $preview . '</div>';
+        echo '<div class="gm2-media-field"><input type="hidden" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '"' . $disabled . $placeholder_attr . ' />' . $button . $preview . '</div>';
     }
 
     public function sanitize( $value ) {

--- a/includes/fields/class-field-badge.php
+++ b/includes/fields/class-field-badge.php
@@ -24,11 +24,12 @@ class GM2_Field_Badge extends GM2_Field {
         }
     }
 
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $value    = is_array( $value ) ? $value : array();
         $text     = $value['text'] ?? '';
         $color    = $value['color'] ?? '';
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
 
         if ( 'public' === $context_type ) {
             echo '<span class="gm2-badge" style="background-color:' . esc_attr( $color ) . '">' . esc_html( $text ) . '</span>';
@@ -36,8 +37,8 @@ class GM2_Field_Badge extends GM2_Field {
         }
 
         echo '<div class="gm2-badge-field">';
-        echo '<input type="text" class="gm2-badge-text" name="' . esc_attr( $this->key ) . '[text]" value="' . esc_attr( $text ) . '"' . $disabled . ' />';
-        echo '<input type="text" class="gm2-color gm2-badge-color" name="' . esc_attr( $this->key ) . '[color]" value="' . esc_attr( $color ) . '"' . $disabled . ' />';
+        echo '<input type="text" class="gm2-badge-text" name="' . esc_attr( $this->key ) . '[text]" value="' . esc_attr( $text ) . '"' . $disabled . $placeholder_attr . ' />';
+        echo '<input type="text" class="gm2-color gm2-badge-color" name="' . esc_attr( $this->key ) . '[color]" value="' . esc_attr( $color ) . '"' . $disabled . $placeholder_attr . ' />';
         echo '<span class="gm2-badge-preview" style="background-color:' . esc_attr( $color ) . '">' . esc_html( $text ) . '</span>';
         echo '</div>';
     }

--- a/includes/fields/class-field-base.php
+++ b/includes/fields/class-field-base.php
@@ -15,19 +15,22 @@ abstract class GM2_Field {
     public function render_admin( $value, $object_id, $context_type ) {
         $label = $this->args['label'] ?? $this->key;
         echo '<p><label>' . esc_html( $label ) . '<br />';
-        $this->render_field( $value, $object_id, $context_type );
+        $placeholder = $this->args['placeholder'] ?? '';
+        $this->render_field( $value, $object_id, $context_type, $placeholder );
         echo '</label></p>';
     }
 
     public function render_public( $value ) {
         echo '<div class="gm2-field gm2-field-' . esc_attr( $this->key ) . '">';
-        $this->render_field( $value, 0, 'public' );
+        $placeholder = $this->args['placeholder'] ?? '';
+        $this->render_field( $value, 0, 'public', $placeholder );
         echo '</div>';
     }
 
-    protected function render_field( $value, $object_id, $context_type ) {
-        $disabled = disabled( $this->args['disabled'] ?? false, true, false );
-        echo '<input type="text" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '"' . $disabled . ' />';
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
+        $disabled         = disabled( $this->args['disabled'] ?? false, true, false );
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
+        echo '<input type="text" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '"' . $disabled . $placeholder_attr . ' />';
     }
 
     public function sanitize( $value ) {

--- a/includes/fields/class-field-checkbox.php
+++ b/includes/fields/class-field-checkbox.php
@@ -4,10 +4,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Checkbox extends GM2_Field {
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $checked  = checked( $value, '1', false );
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
-        echo '<input type="checkbox" name="' . esc_attr( $this->key ) . '" value="1"' . $checked . $disabled . ' />';
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
+        echo '<input type="checkbox" name="' . esc_attr( $this->key ) . '" value="1"' . $checked . $disabled . $placeholder_attr . ' />';
     }
 
     public function sanitize( $value ) {

--- a/includes/fields/class-field-code.php
+++ b/includes/fields/class-field-code.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Code extends GM2_Field {
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $language = $this->args['language'] ?? 'php';
         if ( $context_type === 'public' ) {
             echo gm2_render_code( (string) $value, $language );
@@ -12,7 +12,8 @@ class GM2_Field_Code extends GM2_Field {
         }
         $id       = $this->key;
         $settings = wp_enqueue_code_editor( array( 'file' => 'code.' . $language ) );
-        echo '<textarea id="' . esc_attr( $id ) . '" name="' . esc_attr( $this->key ) . '">' . esc_textarea( $value ) . '</textarea>';
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
+        echo '<textarea id="' . esc_attr( $id ) . '" name="' . esc_attr( $this->key ) . '"' . $placeholder_attr . '>' . esc_textarea( $value ) . '</textarea>';
         if ( $settings ) {
             $json = wp_json_encode( $settings );
             echo '<script>jQuery(function(){wp.codeEditor.initialize("' . esc_js( $id ) . '",' . $json . ');});</script>';

--- a/includes/fields/class-field-commerce.php
+++ b/includes/fields/class-field-commerce.php
@@ -4,9 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Commerce extends GM2_Field {
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
-        echo '<input type="text" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '" class="gm2-commerce"' . $disabled . ' />';
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
+        echo '<input type="text" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '" class="gm2-commerce"' . $disabled . $placeholder_attr . ' />';
     }
 
     public function sanitize( $value ) {

--- a/includes/fields/class-field-computed.php
+++ b/includes/fields/class-field-computed.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Computed extends GM2_Field {
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $value    = $this->calculate_value( $object_id, $context_type );
         $disabled = $this->args['disabled'] ?? false ? ' data-disabled="1"' : '';
         echo '<span class="gm2-computed" data-key="' . esc_attr( $this->key ) . '"' . $disabled . '>' . esc_html( $value ) . '</span>';

--- a/includes/fields/class-field-date.php
+++ b/includes/fields/class-field-date.php
@@ -4,11 +4,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Date extends GM2_Field {
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
         $min = isset( $this->args['date_min'] ) ? ' min="' . esc_attr( $this->args['date_min'] ) . '"' : '';
         $max = isset( $this->args['date_max'] ) ? ' max="' . esc_attr( $this->args['date_max'] ) . '"' : '';
-        echo '<input type="date" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '"' . $min . $max . $disabled . ' />';
+        echo '<input type="date" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '"' . $min . $max . $disabled . $placeholder_attr . ' />';
     }
 
     public function sanitize( $value ) {

--- a/includes/fields/class-field-daterange.php
+++ b/includes/fields/class-field-daterange.php
@@ -4,13 +4,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Daterange extends GM2_Field {
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
         $start = is_array( $value ) ? ( $value['start'] ?? '' ) : '';
         $end   = is_array( $value ) ? ( $value['end'] ?? '' ) : '';
-        echo '<input type="date" name="' . esc_attr( $this->key ) . '[start]" value="' . esc_attr( $start ) . '"' . $disabled . ' />';
+        echo '<input type="date" name="' . esc_attr( $this->key ) . '[start]" value="' . esc_attr( $start ) . '"' . $disabled . $placeholder_attr . ' />';
         echo ' - ';
-        echo '<input type="date" name="' . esc_attr( $this->key ) . '[end]" value="' . esc_attr( $end ) . '"' . $disabled . ' />';
+        echo '<input type="date" name="' . esc_attr( $this->key ) . '[end]" value="' . esc_attr( $end ) . '"' . $disabled . $placeholder_attr . ' />';
     }
 
     public function sanitize( $value ) {

--- a/includes/fields/class-field-datetime.php
+++ b/includes/fields/class-field-datetime.php
@@ -4,11 +4,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Datetime extends GM2_Field {
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
         $min = isset( $this->args['datetime_min'] ) ? ' min="' . esc_attr( $this->args['datetime_min'] ) . '"' : '';
         $max = isset( $this->args['datetime_max'] ) ? ' max="' . esc_attr( $this->args['datetime_max'] ) . '"' : '';
-        echo '<input type="datetime-local" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '"' . $min . $max . $disabled . ' />';
+        echo '<input type="datetime-local" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '"' . $min . $max . $disabled . $placeholder_attr . ' />';
     }
 
     public function sanitize( $value ) {

--- a/includes/fields/class-field-design.php
+++ b/includes/fields/class-field-design.php
@@ -4,9 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Design extends GM2_Field {
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
-        echo '<input type="text" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '" class="gm2-color"' . $disabled . ' />';
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
+        echo '<input type="text" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '" class="gm2-color"' . $disabled . $placeholder_attr . ' />';
     }
 
     public function sanitize( $value ) {

--- a/includes/fields/class-field-email.php
+++ b/includes/fields/class-field-email.php
@@ -4,9 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Email extends GM2_Field {
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
-        echo '<input type="email" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '"' . $disabled . ' />';
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
+        echo '<input type="email" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '"' . $disabled . $placeholder_attr . ' />';
     }
 
     public function sanitize( $value ) {

--- a/includes/fields/class-field-file.php
+++ b/includes/fields/class-field-file.php
@@ -4,13 +4,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_File extends GM2_Field {
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
         $button   = '<button class="button gm2-media-upload" data-target="' . esc_attr( $this->key ) . '"' . $disabled . '>' . esc_html__( 'Select File', 'gm2-wordpress-suite' ) . '</button>';
         $url      = $value ? wp_get_attachment_url( $value ) : '';
         $name     = $url ? wp_basename( $url ) : '';
         $preview  = '<div class="gm2-media-preview">' . ( $url ? '<a href="' . esc_url( $url ) . '" target="_blank" rel="noopener">' . esc_html( $name ) . '</a>' : '' ) . '</div>';
-        echo '<div class="gm2-media-field"><input type="hidden" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '"' . $disabled . ' />' . $button . $preview . '</div>';
+        echo '<div class="gm2-media-field"><input type="hidden" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '"' . $disabled . $placeholder_attr . ' />' . $button . $preview . '</div>';
     }
 
     public function sanitize( $value ) {

--- a/includes/fields/class-field-flexible.php
+++ b/includes/fields/class-field-flexible.php
@@ -39,7 +39,7 @@ class GM2_Field_Flexible extends GM2_Field {
      * @param int    $object_id   Current object ID.
      * @param string $context_type Context type.
      */
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $layouts  = $this->args['layouts'] ?? array();
         $value    = is_array( $value ) ? $value : array();
         $disabled = $this->args['disabled'] ?? false ? ' data-disabled="1"' : '';

--- a/includes/fields/class-field-gallery.php
+++ b/includes/fields/class-field-gallery.php
@@ -4,8 +4,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Gallery extends GM2_Field {
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
         $ids      = array_filter( array_map( 'absint', is_array( $value ) ? $value : explode( ',', (string) $value ) ) );
         $button   = '<button class="button gm2-gallery-upload" data-target="' . esc_attr( $this->key ) . '"' . $disabled . '>' . esc_html__( 'Select Images', 'gm2-wordpress-suite' ) . '</button>';
         $preview  = '<div class="gm2-media-preview">';
@@ -16,7 +17,7 @@ class GM2_Field_Gallery extends GM2_Field {
             }
         }
         $preview .= '</div>';
-        echo '<div class="gm2-media-field"><input type="hidden" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( implode( ',', $ids ) ) . '"' . $disabled . ' />' . $button . $preview . '</div>';
+        echo '<div class="gm2-media-field"><input type="hidden" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( implode( ',', $ids ) ) . '"' . $disabled . $placeholder_attr . ' />' . $button . $preview . '</div>';
     }
 
     public function sanitize( $value ) {

--- a/includes/fields/class-field-geospatial.php
+++ b/includes/fields/class-field-geospatial.php
@@ -26,12 +26,13 @@ class GM2_Field_Geospatial extends GM2_Field {
         }
     }
 
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $value   = is_array( $value ) ? $value : array();
         $lat     = $value['lat'] ?? '';
         $lng     = $value['lng'] ?? '';
         $address = $value['address'] ?? array();
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
 
         if ( 'public' === $context_type ) {
             echo '<div class="gm2-geo-address">' . esc_html( self::format_address( $address ) ) . '</div>';
@@ -40,9 +41,9 @@ class GM2_Field_Geospatial extends GM2_Field {
 
         echo '<div class="gm2-geo-field">';
         echo '<div id="' . esc_attr( $this->key ) . '-map" class="gm2-geo-map"></div>';
-        echo '<input type="hidden" name="' . esc_attr( $this->key ) . '[lat]" value="' . esc_attr( $lat ) . '"' . $disabled . ' />';
-        echo '<input type="hidden" name="' . esc_attr( $this->key ) . '[lng]" value="' . esc_attr( $lng ) . '"' . $disabled . ' />';
-        echo '<input type="hidden" class="gm2-geo-address-data" name="' . esc_attr( $this->key ) . '[address]" value="' . esc_attr( wp_json_encode( $address ) ) . '"' . $disabled . ' />';
+        echo '<input type="hidden" name="' . esc_attr( $this->key ) . '[lat]" value="' . esc_attr( $lat ) . '"' . $disabled . $placeholder_attr . ' />';
+        echo '<input type="hidden" name="' . esc_attr( $this->key ) . '[lng]" value="' . esc_attr( $lng ) . '"' . $disabled . $placeholder_attr . ' />';
+        echo '<input type="hidden" class="gm2-geo-address-data" name="' . esc_attr( $this->key ) . '[address]" value="' . esc_attr( wp_json_encode( $address ) ) . '"' . $disabled . $placeholder_attr . ' />';
         echo '<div class="gm2-geo-address">' . esc_html( self::format_address( $address ) ) . '</div>';
         echo '</div>';
     }

--- a/includes/fields/class-field-gradient.php
+++ b/includes/fields/class-field-gradient.php
@@ -24,11 +24,12 @@ class GM2_Field_Gradient extends GM2_Field {
         }
     }
 
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $value    = is_array( $value ) ? $value : array();
         $start    = $value['start'] ?? '';
         $end      = $value['end'] ?? '';
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
 
         if ( 'public' === $context_type ) {
             $style = ( $start && $end ) ? ' style="background: linear-gradient(' . esc_attr( $start ) . ',' . esc_attr( $end ) . ');"' : '';
@@ -37,8 +38,8 @@ class GM2_Field_Gradient extends GM2_Field {
         }
 
         echo '<div class="gm2-gradient-field">';
-        echo '<input type="text" class="gm2-color gm2-gradient-start" name="' . esc_attr( $this->key ) . '[start]" value="' . esc_attr( $start ) . '"' . $disabled . ' />';
-        echo '<input type="text" class="gm2-color gm2-gradient-end" name="' . esc_attr( $this->key ) . '[end]" value="' . esc_attr( $end ) . '"' . $disabled . ' />';
+        echo '<input type="text" class="gm2-color gm2-gradient-start" name="' . esc_attr( $this->key ) . '[start]" value="' . esc_attr( $start ) . '"' . $disabled . $placeholder_attr . ' />';
+        echo '<input type="text" class="gm2-color gm2-gradient-end" name="' . esc_attr( $this->key ) . '[end]" value="' . esc_attr( $end ) . '"' . $disabled . $placeholder_attr . ' />';
         echo '<div class="gm2-gradient-preview"></div>';
         echo '</div>';
     }

--- a/includes/fields/class-field-group.php
+++ b/includes/fields/class-field-group.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Group extends GM2_Field {
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = $this->args['disabled'] ?? false ? ' data-disabled="1"' : '';
         echo '<div class="gm2-field-group" data-key="' . esc_attr( $this->key ) . '"' . $disabled . '></div>';
     }

--- a/includes/fields/class-field-icon.php
+++ b/includes/fields/class-field-icon.php
@@ -22,9 +22,10 @@ class GM2_Field_Icon extends GM2_Field {
         }
     }
 
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $value    = is_string( $value ) ? $value : '';
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
 
         if ( 'public' === $context_type ) {
             echo '<span class="gm2-icon-preview dashicons ' . esc_attr( $value ) . '"></span>';
@@ -32,7 +33,7 @@ class GM2_Field_Icon extends GM2_Field {
         }
 
         echo '<div class="gm2-icon-field">';
-        echo '<input type="text" class="gm2-icon-input" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '"' . $disabled . ' />';
+        echo '<input type="text" class="gm2-icon-input" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '"' . $disabled . $placeholder_attr . ' />';
         echo '<span class="gm2-icon-preview dashicons ' . esc_attr( $value ) . '"></span>';
         echo '</div>';
     }

--- a/includes/fields/class-field-markdown.php
+++ b/includes/fields/class-field-markdown.php
@@ -4,14 +4,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Markdown extends GM2_Field {
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         if ( $context_type === 'public' ) {
             echo gm2_render_markdown( (string) $value );
             return;
         }
         $id       = $this->key;
         $settings = wp_enqueue_code_editor( array( 'file' => 'field.md' ) );
-        echo '<textarea id="' . esc_attr( $id ) . '" name="' . esc_attr( $this->key ) . '">' . esc_textarea( $value ) . '</textarea>';
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
+        echo '<textarea id="' . esc_attr( $id ) . '" name="' . esc_attr( $this->key ) . '"' . $placeholder_attr . '>' . esc_textarea( $value ) . '</textarea>';
         if ( $settings ) {
             $json = wp_json_encode( $settings );
             echo '<script>jQuery(function(){wp.codeEditor.initialize("' . esc_js( $id ) . '",' . $json . ');});</script>';

--- a/includes/fields/class-field-media.php
+++ b/includes/fields/class-field-media.php
@@ -4,12 +4,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Media extends GM2_Field {
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
         $button   = '<button class="button gm2-media-upload" data-target="' . esc_attr( $this->key ) . '"' . $disabled . '>' . esc_html__( 'Select Media', 'gm2-wordpress-suite' ) . '</button>';
         $src      = $value ? wp_get_attachment_image_url( $value, 'thumbnail' ) : '';
         $preview  = '<div class="gm2-media-preview">' . ( $src ? '<img src="' . esc_url( $src ) . '" alt="" />' : '' ) . '</div>';
-        echo '<div class="gm2-media-field"><input type="hidden" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '"' . $disabled . ' />' . $button . $preview . '</div>';
+        echo '<div class="gm2-media-field"><input type="hidden" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '"' . $disabled . $placeholder_attr . ' />' . $button . $preview . '</div>';
     }
 
     public function sanitize( $value ) {

--- a/includes/fields/class-field-message.php
+++ b/includes/fields/class-field-message.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Message extends GM2_Field {
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = $this->args['disabled'] ?? false ? ' data-disabled="1"' : '';
         echo '<div class="gm2-field-message"' . $disabled . '>' . esc_html( $this->args['message'] ?? '' ) . '</div>';
     }

--- a/includes/fields/class-field-number.php
+++ b/includes/fields/class-field-number.php
@@ -4,9 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Number extends GM2_Field {
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
-        echo '<input type="number" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '"' . $disabled . ' />';
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
+        echo '<input type="number" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '"' . $disabled . $placeholder_attr . ' />';
     }
 
     public function sanitize( $value ) {

--- a/includes/fields/class-field-oembed.php
+++ b/includes/fields/class-field-oembed.php
@@ -4,13 +4,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Oembed extends GM2_Field {
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         if ( $context_type === 'public' ) {
             echo gm2_render_oembed( (string) $value );
             return;
         }
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
-        echo '<input type="url" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '"' . $disabled . ' />';
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
+        echo '<input type="url" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '"' . $disabled . $placeholder_attr . ' />';
     }
 
     public function sanitize( $value ) {

--- a/includes/fields/class-field-phone.php
+++ b/includes/fields/class-field-phone.php
@@ -4,9 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Phone extends GM2_Field {
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
-        echo '<input type="tel" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '"' . $disabled . ' />';
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
+        echo '<input type="tel" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '"' . $disabled . $placeholder_attr . ' />';
     }
 
     public function sanitize( $value ) {

--- a/includes/fields/class-field-price.php
+++ b/includes/fields/class-field-price.php
@@ -4,10 +4,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Price extends GM2_Field {
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
         $currency = esc_html( get_option( 'gm2_currency', 'USD' ) );
-        echo '<input type="number" step="0.01" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '" class="gm2-price"' . $disabled . ' />';
+        echo '<input type="number" step="0.01" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '" class="gm2-price"' . $disabled . $placeholder_attr . ' />';
         echo ' <span class="gm2-price-currency">' . $currency . '</span>';
     }
 

--- a/includes/fields/class-field-radio.php
+++ b/includes/fields/class-field-radio.php
@@ -4,11 +4,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Radio extends GM2_Field {
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $options  = $this->args['options'] ?? array();
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
         foreach ( $options as $ov => $ol ) {
-            echo '<label><input type="radio" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $ov ) . '"' . checked( $value, $ov, false ) . $disabled . ' /> ' . esc_html( $ol ) . '</label><br />';
+            echo '<label><input type="radio" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $ov ) . '"' . checked( $value, $ov, false ) . $disabled . $placeholder_attr . ' /> ' . esc_html( $ol ) . '</label><br />';
         }
     }
 

--- a/includes/fields/class-field-rating.php
+++ b/includes/fields/class-field-rating.php
@@ -22,10 +22,11 @@ class GM2_Field_Rating extends GM2_Field {
         }
     }
 
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $value    = intval( $value );
         $value    = max( 0, min( 5, $value ) );
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
 
         if ( 'public' === $context_type ) {
             echo '<div class="gm2-rating-display">' . self::stars_html( $value ) . '</div>';

--- a/includes/fields/class-field-relationship.php
+++ b/includes/fields/class-field-relationship.php
@@ -26,10 +26,11 @@ class GM2_Field_Relationship extends GM2_Field {
         $this->sync     = in_array( $args['sync'] ?? 'two-way', array( 'none', 'one-way', 'two-way' ), true ) ? $args['sync'] : 'two-way';
     }
 
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $vals     = is_array( $value ) ? $value : ( $value ? array( $value ) : array() );
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
-        echo '<input type="text" name="' . esc_attr( $this->key ) . '[]" value="' . esc_attr( implode( ',', $vals ) ) . '" class="gm2-relationship"' . $disabled . ' />';
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
+        echo '<input type="text" name="' . esc_attr( $this->key ) . '[]" value="' . esc_attr( implode( ',', $vals ) ) . '" class="gm2-relationship"' . $disabled . $placeholder_attr . ' />';
     }
 
     public function sanitize( $value ) {

--- a/includes/fields/class-field-repeater.php
+++ b/includes/fields/class-field-repeater.php
@@ -4,14 +4,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Repeater extends GM2_Field {
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $value    = is_array( $value ) ? $value : array();
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
         echo '<div class="gm2-repeater" data-key="' . esc_attr( $this->key ) . '">';
         foreach ( $value as $row ) {
-            echo '<div class="gm2-repeater-row"><input type="text" name="' . esc_attr( $this->key ) . '[]" value="' . esc_attr( $row ) . '"' . $disabled . ' /> <button type="button" class="button gm2-repeater-remove">&times;</button></div>';
+            echo '<div class="gm2-repeater-row"><input type="text" name="' . esc_attr( $this->key ) . '[]" value="' . esc_attr( $row ) . '"' . $disabled . $placeholder_attr . ' /> <button type="button" class="button gm2-repeater-remove">&times;</button></div>';
         }
-        echo '<div class="gm2-repeater-row"><input type="text" name="' . esc_attr( $this->key ) . '[]" value=""' . $disabled . ' /> <button type="button" class="button gm2-repeater-remove">&times;</button></div>';
+        echo '<div class="gm2-repeater-row"><input type="text" name="' . esc_attr( $this->key ) . '[]" value=""' . $disabled . $placeholder_attr . ' /> <button type="button" class="button gm2-repeater-remove">&times;</button></div>';
         echo '<p><button type="button" class="button gm2-repeater-add" data-target="' . esc_attr( $this->key ) . '">' . esc_html__( 'Add Row', 'gm2-wordpress-suite' ) . '</button></p>';
         echo '</div>';
     }

--- a/includes/fields/class-field-select.php
+++ b/includes/fields/class-field-select.php
@@ -4,16 +4,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Select extends GM2_Field {
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $options  = $this->args['options'] ?? array();
         $multiple = ! empty( $this->args['multiple'] );
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
 
         $name    = esc_attr( $this->key ) . ( $multiple ? '[]' : '' );
         $multi   = $multiple ? ' multiple' : '';
         $current = $multiple ? (array) $value : $value;
 
-        echo '<select name="' . $name . '"' . $multi . $disabled . '>';
+        echo '<select name="' . $name . '"' . $multi . $disabled . $placeholder_attr . '>';
         foreach ( $options as $ov => $ol ) {
             $selected = $multiple
                 ? selected( in_array( $ov, $current, true ), true, false )

--- a/includes/fields/class-field-sku.php
+++ b/includes/fields/class-field-sku.php
@@ -4,9 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Sku extends GM2_Field {
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
-        echo '<input type="text" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '" class="gm2-sku"' . $disabled . ' />';
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
+        echo '<input type="text" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '" class="gm2-sku"' . $disabled . $placeholder_attr . ' />';
     }
 
     public function sanitize( $value ) {

--- a/includes/fields/class-field-stock.php
+++ b/includes/fields/class-field-stock.php
@@ -4,12 +4,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Stock extends GM2_Field {
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
         $min      = (int) get_option( 'gm2_stock_min', 0 );
         $max      = (int) get_option( 'gm2_stock_max', 0 );
         $max_attr = $max > 0 ? ' max="' . esc_attr( $max ) . '"' : '';
-        echo '<input type="number" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '" min="' . esc_attr( $min ) . '"' . $max_attr . ' class="gm2-stock"' . $disabled . ' />';
+        echo '<input type="number" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '" min="' . esc_attr( $min ) . '"' . $max_attr . ' class="gm2-stock"' . $disabled . $placeholder_attr . ' />';
     }
 
     public function sanitize( $value ) {

--- a/includes/fields/class-field-textarea.php
+++ b/includes/fields/class-field-textarea.php
@@ -4,8 +4,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Textarea extends GM2_Field {
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
-        echo '<textarea name="' . esc_attr( $this->key ) . '" rows="5" cols="40"' . $disabled . '>' . esc_textarea( $value ) . '</textarea>';
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
+        echo '<textarea name="' . esc_attr( $this->key ) . '" rows="5" cols="40"' . $disabled . $placeholder_attr . '>' . esc_textarea( $value ) . '</textarea>';
     }
 }

--- a/includes/fields/class-field-time.php
+++ b/includes/fields/class-field-time.php
@@ -4,11 +4,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Time extends GM2_Field {
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
         $min = isset( $this->args['time_min'] ) ? ' min="' . esc_attr( $this->args['time_min'] ) . '"' : '';
         $max = isset( $this->args['time_max'] ) ? ' max="' . esc_attr( $this->args['time_max'] ) . '"' : '';
-        echo '<input type="time" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '"' . $min . $max . $disabled . ' />';
+        echo '<input type="time" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '"' . $min . $max . $disabled . $placeholder_attr . ' />';
     }
 
     public function sanitize( $value ) {

--- a/includes/fields/class-field-toggle.php
+++ b/includes/fields/class-field-toggle.php
@@ -4,10 +4,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Toggle extends GM2_Field {
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $checked  = checked( $value, '1', false );
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
-        echo '<input type="checkbox" class="gm2-toggle" name="' . esc_attr( $this->key ) . '" value="1"' . $checked . $disabled . ' />';
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
+        echo '<input type="checkbox" class="gm2-toggle" name="' . esc_attr( $this->key ) . '" value="1"' . $checked . $disabled . $placeholder_attr . ' />';
     }
 
     public function sanitize( $value ) {

--- a/includes/fields/class-field-url.php
+++ b/includes/fields/class-field-url.php
@@ -4,9 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Url extends GM2_Field {
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
-        echo '<input type="url" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '"' . $disabled . ' />';
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
+        echo '<input type="url" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '"' . $disabled . $placeholder_attr . ' />';
     }
 
     public function sanitize( $value ) {

--- a/includes/fields/class-field-video.php
+++ b/includes/fields/class-field-video.php
@@ -4,12 +4,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Video extends GM2_Field {
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
         $button   = '<button class="button gm2-media-upload" data-target="' . esc_attr( $this->key ) . '"' . $disabled . '>' . esc_html__( 'Select Video', 'gm2-wordpress-suite' ) . '</button>';
         $src      = $value ? wp_get_attachment_url( $value ) : '';
         $preview  = '<div class="gm2-media-preview">' . ( $src ? '<video controls src="' . esc_url( $src ) . '" width="320"></video>' : '' ) . '</div>';
-        echo '<div class="gm2-media-field"><input type="hidden" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '"' . $disabled . ' />' . $button . $preview . '</div>';
+        echo '<div class="gm2-media-field"><input type="hidden" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '"' . $disabled . $placeholder_attr . ' />' . $button . $preview . '</div>';
     }
 
     public function sanitize( $value ) {

--- a/includes/fields/class-field-wysiwyg.php
+++ b/includes/fields/class-field-wysiwyg.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Wysiwyg extends GM2_Field {
-    protected function render_field( $value, $object_id, $context_type ) {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $settings = array(
             'textarea_name' => $this->key,
             'textarea_rows' => $this->args['wysiwyg_rows'] ?? 10,

--- a/tests/test-field-placeholder.php
+++ b/tests/test-field-placeholder.php
@@ -1,0 +1,27 @@
+<?php
+
+class FieldPlaceholderTest extends WP_UnitTestCase {
+    public function test_text_field_placeholder() {
+        $field = new GM2_Field_Text( 'text_field', [ 'placeholder' => 'Enter text' ] );
+        ob_start();
+        $field->render_admin( '', 0, 'post' );
+        $out = ob_get_clean();
+        $this->assertStringContainsString( 'placeholder="Enter text"', $out );
+    }
+
+    public function test_number_field_placeholder() {
+        $field = new GM2_Field_Number( 'number_field', [ 'placeholder' => 'Enter number' ] );
+        ob_start();
+        $field->render_admin( '', 0, 'post' );
+        $out = ob_get_clean();
+        $this->assertStringContainsString( 'placeholder="Enter number"', $out );
+    }
+
+    public function test_textarea_field_placeholder() {
+        $field = new GM2_Field_Textarea( 'textarea_field', [ 'placeholder' => 'Enter more text' ] );
+        ob_start();
+        $field->render_admin( '', 0, 'post' );
+        $out = ob_get_clean();
+        $this->assertStringContainsString( 'placeholder="Enter more text"', $out );
+    }
+}


### PR DESCRIPTION
## Summary
- allow field renderers to accept and output placeholder text
- propagate placeholder to specific field types and inputs
- test placeholder rendering for text, number, and textarea fields

## Testing
- `phpunit tests/test-field-placeholder.php` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `bash bin/install-wp-tests.sh wordpress_test root '' localhost latest` *(fails: Can't connect to server on 'localhost' (111))*

------
https://chatgpt.com/codex/tasks/task_e_68a3c3814ae88327b9bae1a702f438a3