### PR TITLE
Ensure abandoned cart cron is always scheduled

### DIFF
--- a/includes/Gm2_Abandoned_Carts.php
+++ b/includes/Gm2_Abandoned_Carts.php
@@ -837,8 +837,17 @@ class Gm2_Abandoned_Carts {
         if ($minutes < 1) {
             $minutes = 1;
         }
-        if (!wp_next_scheduled('gm2_ac_mark_abandoned_cron')) {
-            wp_schedule_event(time(), 'gm2_ac_' . $minutes . '_mins', 'gm2_ac_mark_abandoned_cron');
+
+        $hook     = 'gm2_ac_mark_abandoned_cron';
+        $schedule = 'gm2_ac_' . $minutes . '_mins';
+        $next     = wp_next_scheduled($hook);
+
+        // If the event is missing or on a different interval, reschedule it.
+        if (!$next || wp_get_schedule($hook) !== $schedule) {
+            if ($next) {
+                wp_unschedule_event($next, $hook);
+            }
+            wp_schedule_event(time(), $schedule, $hook);
         }
     }
 

--- a/includes/Gm2_Loader.php
+++ b/includes/Gm2_Loader.php
@@ -87,6 +87,9 @@ class Gm2_Loader {
         }
 
         if ($enable_ac) {
+            // Ensure the abandonment cron is always scheduled when the module is active.
+            Gm2_Abandoned_Carts::schedule_event();
+
             $ac = new Gm2_Abandoned_Carts();
             $ac->run();
 

--- a/tests/AbandonedCartsCronIntegrationTest.php
+++ b/tests/AbandonedCartsCronIntegrationTest.php
@@ -1,0 +1,32 @@
+<?php
+use WP_UnitTestCase;
+use Gm2\Gm2_Loader;
+use Gm2\Gm2_Abandoned_Carts;
+
+class AbandonedCartsCronIntegrationTest extends WP_UnitTestCase {
+    protected function tearDown(): void {
+        Gm2_Abandoned_Carts::clear_scheduled_event();
+        parent::tearDown();
+    }
+
+    public function test_event_scheduled_when_module_enabled() {
+        update_option('gm2_enable_abandoned_carts', '1');
+        Gm2_Abandoned_Carts::clear_scheduled_event();
+        $this->assertFalse(wp_next_scheduled('gm2_ac_mark_abandoned_cron'));
+
+        $loader = new Gm2_Loader();
+        $loader->run();
+
+        $this->assertNotFalse(wp_next_scheduled('gm2_ac_mark_abandoned_cron'));
+    }
+
+    public function test_event_present_after_interval_change() {
+        update_option('gm2_enable_abandoned_carts', '1');
+        Gm2_Abandoned_Carts::clear_scheduled_event();
+        Gm2_Abandoned_Carts::schedule_event();
+        $this->assertNotFalse(wp_next_scheduled('gm2_ac_mark_abandoned_cron'));
+
+        update_option('gm2_ac_mark_abandoned_interval', 10);
+        $this->assertNotFalse(wp_next_scheduled('gm2_ac_mark_abandoned_cron'));
+    }
+}


### PR DESCRIPTION
## Summary
- Schedule abandoned cart cron event on every request when the module is active
- Reschedule abandoned cart cron if missing or interval changes
- Add integration tests for cron scheduling when enabling module or changing interval

## Testing
- `npm test`
- `phpunit tests/AbandonedCartsCronIntegrationTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68a3c973a4c483279087bf09cf9d353a