### PR TITLE
Add manual abandonment processing CLI and admin button

### DIFF
--- a/admin/js/gm2-ac-live-updates.js
+++ b/admin/js/gm2-ac-live-updates.js
@@ -13,4 +13,14 @@ jQuery(function($){
     }
     fetchCarts();
     setInterval(fetchCarts, 30000);
+
+    $('#gm2-ac-process').on('click', function(e){
+        e.preventDefault();
+        $.post(gm2AcLive.ajax_url, {
+            action: 'gm2_ac_process',
+            nonce: gm2AcLive.process_nonce
+        }).done(function(){
+            fetchCarts();
+        });
+    });
 });

--- a/docs/index.md
+++ b/docs/index.md
@@ -103,6 +103,8 @@ Developers can adjust the inactivity window using the `gm2_ac_mark_abandoned_int
 
 Use the `gm2_ac_skip_admin` filter to include administrator sessions while testing abandoned cart features. It defaults to `true` so admin carts are ignored unless the filter returns `false`.
 
+To finalize statuses on demand run `wp gm2 ac process` from the command line or click the **Process Pending Carts** button on the **Gm2 → Abandoned Carts** screen. Both trigger the same logic that WP‑Cron uses to mark inactive carts as abandoned.
+
 ## Exporting SEO Settings
 
 Use the **Export Settings** button on the SEO dashboard to download a `gm2-seo-settings.json` file containing all options that start with `gm2_`. The matching **Import Settings** form accepts the same JSON format and updates each option. The file is a simple key/value object:

--- a/includes/cli/class-gm2-cli.php
+++ b/includes/cli/class-gm2-cli.php
@@ -55,16 +55,24 @@ class Gm2_CLI extends \WP_CLI_Command {
      * ## SUBCOMMANDS
      *
      * migrate  Move recovered carts into wc_ac_recovered table
+     * process  Run the abandonment processor immediately
      */
     public function ac( $args, $assoc_args ) {
         $sub = $args[0] ?? '';
-        if ( $sub !== 'migrate' ) {
-            \WP_CLI::error( 'Usage: wp gm2 ac migrate' );
+        if ( $sub === 'migrate' ) {
+            $ac    = new Gm2_Abandoned_Carts();
+            $count = $ac->migrate_recovered_carts();
+            \WP_CLI::success( sprintf( '%d carts migrated.', $count ) );
+            return;
         }
 
-        $ac = new Gm2_Abandoned_Carts();
-        $count = $ac->migrate_recovered_carts();
-        \WP_CLI::success( sprintf( '%d carts migrated.', $count ) );
+        if ( $sub === 'process' ) {
+            Gm2_Abandoned_Carts::cron_mark_abandoned();
+            \WP_CLI::success( 'Abandoned carts processed.' );
+            return;
+        }
+
+        \WP_CLI::error( 'Usage: wp gm2 ac <migrate|process>' );
     }
 
     /**

--- a/tests/AbandonedCartProcessTest.php
+++ b/tests/AbandonedCartProcessTest.php
@@ -1,0 +1,37 @@
+<?php
+namespace Gm2 {
+    function current_user_can( $cap ) { return true; }
+    function check_ajax_referer( $action, $query_arg = false ) { return true; }
+    function wp_send_json_success( $data = null ) { $GLOBALS['gm2_ajax_success'] = true; return ['success'=>true]; }
+    function wp_send_json_error( $data = null ) { $GLOBALS['gm2_ajax_success'] = false; return ['success'=>false]; }
+    class Gm2_Abandoned_Carts {
+        public static $called = false;
+        public static function cron_mark_abandoned() { self::$called = true; }
+    }
+}
+namespace {
+    if ( ! defined( 'ABSPATH' ) ) {
+        define( 'ABSPATH', __DIR__ . '/../' );
+    }
+    if ( ! defined( 'GM2_PLUGIN_DIR' ) ) {
+        define( 'GM2_PLUGIN_DIR', dirname( __DIR__ ) . '/' );
+    }
+    if ( ! defined( 'GM2_PLUGIN_URL' ) ) {
+        define( 'GM2_PLUGIN_URL', '' );
+    }
+    if ( ! defined( 'GM2_VERSION' ) ) {
+        define( 'GM2_VERSION', '1.0' );
+    }
+
+    require_once dirname( __DIR__ ) . '/admin/Gm2_Abandoned_Carts_Admin.php';
+
+    class AbandonedCartProcessTest extends \PHPUnit\Framework\TestCase {
+        public function test_ajax_process_triggers_cron() {
+            $_POST['nonce'] = 'n';
+            $admin = new \Gm2\Gm2_Abandoned_Carts_Admin();
+            $admin->ajax_process();
+            $this->assertTrue( \Gm2\Gm2_Abandoned_Carts::$called );
+            $this->assertTrue( $GLOBALS['gm2_ajax_success'] );
+        }
+    }
+}

--- a/tests/test-cli/ac-process.php
+++ b/tests/test-cli/ac-process.php
@@ -1,0 +1,31 @@
+<?php
+// Minimal stub to verify the abandoned carts CLI processor.
+
+define( 'WP_CLI', true );
+
+define( 'GM2_PLUGIN_DIR', dirname( __DIR__, 2 ) . '/' );
+
+class WP_CLI {
+    public static function error( $msg ) { throw new Exception( $msg ); }
+    public static function success( $msg ) { echo $msg, "\n"; }
+    public static function add_command( $name, $callable ) {}
+}
+class WP_CLI_Command {}
+
+namespace Gm2 {
+    class Gm2_Abandoned_Carts {
+        public static $called = false;
+        public static function cron_mark_abandoned() { self::$called = true; }
+        public function migrate_recovered_carts() { return 0; }
+    }
+}
+
+require dirname( __DIR__, 2 ) . '/includes/cli/class-gm2-cli.php';
+
+$cli = new \Gm2\Gm2_CLI();
+$cli->ac( [ 'process' ], [] );
+if ( ! \Gm2\Gm2_Abandoned_Carts::$called ) {
+    throw new Exception( 'cron_mark_abandoned not called' );
+}
+
+echo "abandoned carts CLI process test completed\n";


### PR DESCRIPTION
## Summary
- add `gm2 ac process` WP‑CLI command to mark inactive carts as abandoned
- add Process Pending Carts admin button with AJAX handler
- document manual processing options and add related tests

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3cd295aa08327bd8b645faaa73459