### PR TITLE
Add CPT wizard admin stylesheet

### DIFF
--- a/admin/Gm2_Custom_Posts_Admin.php
+++ b/admin/Gm2_Custom_Posts_Admin.php
@@ -1467,6 +1467,13 @@ class Gm2_Custom_Posts_Admin {
                 'ajax'   => admin_url('admin-ajax.php'),
                 'models' => $models,
             ]);
+            $css = GM2_PLUGIN_DIR . 'admin/css/gm2-cpt-wizard.css';
+            wp_enqueue_style(
+                'gm2-cpt-wizard',
+                GM2_PLUGIN_URL . 'admin/css/gm2-cpt-wizard.css',
+                [],
+                file_exists($css) ? filemtime($css) : GM2_VERSION
+            );
         }
 
         if ($hook === 'gm2-custom-posts_page_gm2_field_group_wizard') {

--- a/admin/css/gm2-cpt-wizard.css
+++ b/admin/css/gm2-cpt-wizard.css
@@ -1,0 +1,56 @@
+.gm2-cpt-wizard {
+    font-family: inherit;
+    margin-top: 1rem;
+}
+
+.gm2-cpt-stepper {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 1rem;
+}
+
+.gm2-cpt-step {
+    flex: 1 1 auto;
+    padding: 8px;
+    text-align: center;
+    background: #fff;
+    border: 1px solid #ccd0d4;
+    border-radius: 2px;
+    color: #555d66;
+}
+
+.gm2-cpt-step.active {
+    border-color: var(--wp-admin-theme-color);
+    color: var(--wp-admin-theme-color);
+}
+
+.gm2-cpt-step-number {
+    display: inline-block;
+    margin-right: 4px;
+    font-weight: 600;
+}
+
+.gm2-cpt-wizard-buttons {
+    display: flex;
+    gap: 8px;
+    margin-top: 1rem;
+}
+
+.gm2-cpt-wizard-buttons .button {
+    margin-right: 0;
+}
+
+.gm2-cpt-wizard ul {
+    margin-left: 1.5rem;
+    list-style: disc;
+}
+
+@media (max-width: 782px) {
+    .gm2-cpt-stepper {
+        flex-direction: column;
+    }
+    .gm2-cpt-wizard-buttons {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+}


### PR DESCRIPTION
## Summary
- add responsive layout and spacing styles for CPT wizard
- load CPT wizard styles when editing models in admin

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3cfd513e883278087bbb09a7017b2