### PR TITLE
Avoid mutating data when editing CPT fields and taxonomies

### DIFF
--- a/admin/js/gm2-cpt-wizard.js
+++ b/admin/js/gm2-cpt-wizard.js
@@ -135,7 +135,7 @@
                 setFieldError('');
             };
             const editField = (i) => {
-                setField(data.fields[i]);
+                setField({ ...data.fields[i] });
                 setEditIndex(i);
                 setFieldError('');
             };
@@ -214,7 +214,7 @@
                 setTaxError('');
             };
             const editTax = (i) => {
-                setTax(data.taxonomies[i]);
+                setTax({ ...data.taxonomies[i] });
                 setEditIndex(i);
                 setTaxError('');
             };


### PR DESCRIPTION
## Summary
- clone field objects in `editField` to prevent premature mutation
- clone taxonomy objects in `editTax` to keep underlying state intact until update

## Testing
- `npm test`
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): Failed to open stream)*

------
https://chatgpt.com/codex/tasks/task_e_68a50a057cf08327b3fd42ed4db8b486