### PR TITLE
Improve CPT wizard notifications and error handling

### DIFF
--- a/admin/Gm2_Custom_Posts_Admin.php
+++ b/admin/Gm2_Custom_Posts_Admin.php
@@ -1754,18 +1754,27 @@ class Gm2_Custom_Posts_Admin {
 
     public function ajax_save_cpt_model() {
         if (!$this->can_manage()) {
-            wp_send_json_error('permission');
+            wp_send_json_error([
+                'code'    => 'permission',
+                'message' => __( 'You do not have permission to save models.', 'gm2-wordpress-suite' ),
+            ]);
         }
         $nonce = $_POST['nonce'] ?? '';
         if (!wp_verify_nonce($nonce, 'gm2_save_cpt_model')) {
-            wp_send_json_error('nonce');
+            wp_send_json_error([
+                'code'    => 'nonce',
+                'message' => __( 'Security check failed. Please refresh and try again.', 'gm2-wordpress-suite' ),
+            ]);
         }
         $slug   = sanitize_key($_POST['slug'] ?? '');
         $label  = sanitize_text_field($_POST['label'] ?? '');
         $fields = json_decode(wp_unslash($_POST['fields'] ?? ''), true);
         $taxes  = json_decode(wp_unslash($_POST['taxonomies'] ?? ''), true);
         if (!$slug || !is_array($fields) || !is_array($taxes)) {
-            wp_send_json_error('data');
+            wp_send_json_error([
+                'code'    => 'data',
+                'message' => __( 'Invalid data provided.', 'gm2-wordpress-suite' ),
+            ]);
         }
         $config = $this->get_config();
         $sanitized_fields = $this->sanitize_fields_array($fields);

--- a/admin/js/gm2-cpt-wizard.js
+++ b/admin/js/gm2-cpt-wizard.js
@@ -48,6 +48,12 @@
         const [ rawSlug, setRawSlug ] = useState('');
         const [ currentModel, setCurrentModel ] = useState('');
         const [ stepOneErrors, setStepOneErrors ] = useState({});
+        const [ showNewButton, setShowNewButton ] = useState(false);
+        const errorMap = {
+            permission: 'You do not have permission to save models.',
+            nonce: 'Security check failed. Please refresh and try again.',
+            data: 'Invalid data provided. Please check your inputs and try again.'
+        };
 
         const validateStepOne = () => {
             const errs = {};
@@ -333,16 +339,25 @@
                     const model = { ...saved, taxonomies: data.taxonomies };
                     const updated = { ...existing, [slug]: model };
                     setExisting(updated);
-                    loadModel(slug, updated);
-                    dispatch('core/notices').createNotice('success', 'Model saved', { type: 'snackbar' });
+                    dispatch('core/notices').createNotice('success', 'Model saved', { isDismissible: true });
+                    loadModel('');
+                    setStep(1);
+                    setShowNewButton(true);
                 } else {
-                    dispatch('core/notices').createNotice('error', 'Error saving', { type: 'snackbar' });
+                    const code = resp && resp.data && (resp.data.code || resp.data) || '';
+                    const msg = resp && resp.data && resp.data.message ? resp.data.message : (errorMap[code] || 'Error saving');
+                    dispatch('core/notices').createNotice('error', msg, { isDismissible: true });
                 }
             }).catch(() => {
-                dispatch('core/notices').createNotice('error', 'Error saving', { type: 'snackbar' });
+                dispatch('core/notices').createNotice('error', 'Error saving', { isDismissible: true });
             });
         };
 
+        if(showNewButton){
+            return el('div', { className: 'gm2-cpt-wizard' },
+                el(Button, { isPrimary: true, onClick: () => setShowNewButton(false) }, 'Create New Model')
+            );
+        }
         return el('div', { className: 'gm2-cpt-wizard' },
             el(Panel, {},
                 el(PanelBody, { title: 'CPT Wizard', initialOpen: true },


### PR DESCRIPTION
## Summary
- Display persistent success notices, reset CPT wizard state, and provide a Create New Model button
- Surface backend error codes with friendly messages in the wizard
- Return descriptive messages from `ajax_save_cpt_model` failures

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a50f63757c83279825ee5d72efd41f