### PR TITLE
Reset exit URL when cart session restarts

### DIFF
--- a/tests/test-abandoned-carts.php
+++ b/tests/test-abandoned-carts.php
@@ -130,8 +130,8 @@ class AbandonedCartsTest extends WP_UnitTestCase {
         $this->assertNotEmpty($row['session_start']);
         $this->assertNull($row['abandoned_at']);
         $this->assertSame(0, $row['revisit_count']);
-        // exit_url should remain unchanged on active ping
-        $this->assertSame('https://initial.com', $row['exit_url']);
+        // A fresh session should reset the recorded exit_url
+        $this->assertSame('', $row['exit_url']);
 
         // Abandon the cart and ensure exit_url reflects the last visited page
         $_POST = [ 'nonce' => 'n', 'url' => 'https://example.com/page1' ];
@@ -143,7 +143,7 @@ class AbandonedCartsTest extends WP_UnitTestCase {
         $this->assertNull($row['session_start']);
         $this->assertSame('https://example.com/page1', $row['exit_url']);
 
-        // Reactivate the cart; exit_url should not change until abandonment
+        // Reactivate the cart; exit_url resets for the new session
         $_POST = [ 'nonce' => 'n', 'url' => 'https://example.com/page2' ];
         $_REQUEST = $_POST;
         \Gm2\Gm2_Abandoned_Carts::gm2_ac_mark_active();
@@ -152,7 +152,7 @@ class AbandonedCartsTest extends WP_UnitTestCase {
         $this->assertNull($row['abandoned_at']);
         $this->assertNotEmpty($row['session_start']);
         $this->assertSame(1, $row['revisit_count']);
-        $this->assertSame('https://example.com/page1', $row['exit_url']);
+        $this->assertSame('', $row['exit_url']);
 
         // Abandon without explicit URL; session value should persist
         $_POST = [ 'nonce' => 'n' ];


### PR DESCRIPTION
## Summary
- Reset entry and exit URLs when a cart session reactivates or restarts
- Leave exit URL empty until abandonment and avoid capture_cart overwriting it
- Update tests for new session handling

## Testing
- `npm test`
- `php -l includes/Gm2_Abandoned_Carts.php`
- `php -l tests/test-abandoned-carts.php`
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a510d8807c8327bbabdf142e2b4cba