### PR TITLE
Clear entry URL when last tab closes

### DIFF
--- a/public/js/gm2-ac-activity.js
+++ b/public/js/gm2-ac-activity.js
@@ -81,6 +81,15 @@
         document.cookie = `${ENTRY_KEY}=${encodeURIComponent(value)}; path=/`;
     }
 
+    function clearEntryUrl() {
+        try {
+            localStorage.removeItem(ENTRY_KEY);
+        } catch (e) {
+            // localStorage might be unavailable; ignore errors.
+        }
+        document.cookie = `${ENTRY_KEY}=; path=/; expires=${new Date(0).toUTCString()}`;
+    }
+
     let memoryTabCount = 0;
 
     function incrementTabs() {
@@ -168,11 +177,13 @@
     window.addEventListener('beforeunload', () => {
         if (decrementTabs()) {
             send('gm2_ac_mark_abandoned', pendingTargetUrl);
+            clearEntryUrl();
         }
     });
     window.addEventListener('pagehide', () => {
         if (decrementTabs()) {
             send('gm2_ac_mark_abandoned', pendingTargetUrl);
+            clearEntryUrl();
         }
     }, { once: true });
 })();


### PR DESCRIPTION
## Summary
- Add `clearEntryUrl` helper to remove `gm2_entry_url` from localStorage and cookies
- Reset entry URL when the last tab closes after sending abandonment signal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5126ec9c083278961f301e40f05d0