### PR TITLE
Add notice components to CPT wizard interface

### DIFF
--- a/admin/Gm2_Custom_Posts_Admin.php
+++ b/admin/Gm2_Custom_Posts_Admin.php
@@ -1468,7 +1468,7 @@ class Gm2_Custom_Posts_Admin {
             wp_enqueue_script(
                 'gm2-cpt-wizard',
                 GM2_PLUGIN_URL . 'admin/js/gm2-cpt-wizard.js',
-                [ 'wp-element', 'wp-components', 'wp-data', 'wp-i18n' ],
+                [ 'wp-element', 'wp-components', 'wp-data', 'wp-i18n', 'wp-notices' ],
                 file_exists($file) ? filemtime($file) : GM2_VERSION,
                 true
             );


### PR DESCRIPTION
## Summary
- add WP notice and snackbar lists to CPT wizard to display messages
- enqueue wp-notices dependency for wizard script

## Testing
- `npm test`
- `./vendor/bin/phpunit` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68a51306a4808327888d1e388ae2818a