### PR TITLE
Inspect activity property for cart logs

### DIFF
--- a/admin/js/gm2-ac-activity-log.js
+++ b/admin/js/gm2-ac-activity-log.js
@@ -21,13 +21,23 @@ jQuery(function($){
         }).done(function(response){
             var colspan = tr.children().length;
             var html = '<tr class="gm2-ac-activity-row"><td colspan="'+colspan+'">';
-            if(response.success && response.data.length){
+            var hasActivity = response.success && response.data && response.data.activity && response.data.activity.length;
+            var hasVisits = response.success && response.data && response.data.visits && response.data.visits.length;
+            if(hasActivity){
                 html += '<ul class="gm2-ac-activity-log">';
-                response.data.forEach(function(item){
+                response.data.activity.forEach(function(item){
                     html += '<li><strong>'+item.changed_at+'</strong> '+item.action+' '+item.sku+' x'+item.quantity+'</li>';
                 });
                 html += '</ul>';
-            } else {
+            }
+            if(hasVisits){
+                html += '<ul class="gm2-ac-activity-log gm2-ac-visit-log">';
+                response.data.visits.forEach(function(visit){
+                    html += '<li><strong>'+visit.visit_start+'</strong> '+visit.entry_url+' \u2192 '+visit.exit_url+'</li>';
+                });
+                html += '</ul>';
+            }
+            if(!hasActivity && !hasVisits){
                 html += '<em>'+gm2AcActivityLog.empty+'</em>';
             }
             html += '</td></tr>';

--- a/tests/js/gm2-ac-activity-log.test.js
+++ b/tests/js/gm2-ac-activity-log.test.js
@@ -1,0 +1,40 @@
+const { JSDOM } = require('jsdom');
+const jquery = require('jquery');
+
+test('renders activity items returned from ajax', async () => {
+  const dom = new JSDOM(`
+    <table id="log">
+      <tr id="row">
+        <td><a href="#" class="gm2-ac-activity-log-button" data-ip="1.2.3.4">Log</a></td>
+      </tr>
+    </table>
+  `, { url: 'http://localhost' });
+
+  const $ = jquery(dom.window);
+  Object.assign(global, { window: dom.window, document: dom.window.document, jQuery: $, $ });
+  global.gm2AcActivityLog = { ajax_url: '/ajax', nonce: 'nonce', empty: 'empty', error: 'error' };
+
+  $.post = jest.fn(() => $.Deferred().resolve({
+    success: true,
+    data: {
+      activity: [{ changed_at: '2024-01-01', action: 'add', sku: 'SKU1', quantity: 1 }]
+    }
+  }).promise());
+
+  jest.resetModules();
+  require('../../admin/js/gm2-ac-activity-log.js');
+
+  await new Promise(r => setTimeout(r, 0));
+  await new Promise(r => setTimeout(r, 0));
+
+  $('.gm2-ac-activity-log-button').trigger('click');
+
+  await new Promise(r => setTimeout(r, 0));
+
+  const text = $('.gm2-ac-activity-log li').text();
+  expect(text).toContain('2024-01-01');
+  expect(text).toContain('add');
+  expect(text).toContain('SKU1');
+  expect(text).toContain('x1');
+});
+


### PR DESCRIPTION
## Summary
- read cart activity from `response.data.activity` and optionally show visit details
- add unit test for rendering activity log

## Testing
- `npm test`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_68a516429d148327ba178eb7acde3e52