### PR TITLE
Allow disabling abandoned-cart inactivity tracking

### DIFF
--- a/public/Gm2_Abandoned_Carts_Public.php
+++ b/public/Gm2_Abandoned_Carts_Public.php
@@ -66,7 +66,14 @@ class Gm2_Abandoned_Carts_Public {
             GM2_VERSION,
             true
         );
-        $inactivity_ms = absint(apply_filters('gm2_ac_inactivity_ms', 5 * MINUTE_IN_SECONDS * 1000));
+        /**
+         * Filters the inactivity timeout (in milliseconds) before a cart is marked abandoned.
+         *
+         * Returning `0` disables inactivity tracking entirely.
+         *
+         * @param int|null $milliseconds Time in milliseconds. Default 5 minutes.
+         */
+        $inactivity_ms = apply_filters('gm2_ac_inactivity_ms', 5 * MINUTE_IN_SECONDS * 1000);
         wp_localize_script(
             'gm2-ac-activity',
             'gm2AcActivity',

--- a/public/js/gm2-ac-activity.js
+++ b/public/js/gm2-ac-activity.js
@@ -3,7 +3,9 @@
     const ENTRY_KEY = 'gm2_entry_url';
     const ajaxUrl = gm2AcActivity.ajax_url;
     const nonce = gm2AcActivity.nonce;
-    const inactivityMs = parseInt(gm2AcActivity.inactivity_ms, 10) || 5 * 60 * 1000;
+    const rawInactivity = gm2AcActivity.inactivity_ms;
+    const parsedInactivity = rawInactivity === null ? 0 : parseInt(rawInactivity, 10);
+    const inactivityMs = Number.isNaN(parsedInactivity) ? 5 * 60 * 1000 : parsedInactivity;
     const url = window.location.href;
     let pendingTargetUrl;
 
@@ -135,6 +137,9 @@
 
     let inactivityTimer;
     function resetInactivityTimer(shouldSend = true) {
+        if (inactivityMs <= 0) {
+            return;
+        }
         clearTimeout(inactivityTimer);
         if (shouldSend) {
             send('gm2_ac_mark_active');
@@ -146,7 +151,9 @@
             inactivityTimer.unref();
         }
     }
-    resetInactivityTimer();
+    if (inactivityMs > 0) {
+        resetInactivityTimer();
+    }
 
     document.body.addEventListener('added_to_cart', () => {
         resetInactivityTimer();


### PR DESCRIPTION
## Summary
- let `gm2_ac_inactivity_ms` filter return 0 or null to disable cart inactivity timer
- document filter behavior and pass raw value to JS

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a51c33e4e08327aa64e02c44aaa788