### PR TITLE
feat: track carts with client ids

### DIFF
--- a/public/js/gm2-ac-activity.js
+++ b/public/js/gm2-ac-activity.js
@@ -1,6 +1,7 @@
 (function () {
     const KEY = 'gm2AcTabCount';
     const ENTRY_KEY = 'gm2_entry_url';
+    const CLIENT_KEY = 'gm2_ac_client_id';
     const ajaxUrl = gm2AcActivity.ajax_url;
     const nonce = gm2AcActivity.nonce;
     const rawInactivity = gm2AcActivity.inactivity_ms;
@@ -9,8 +10,30 @@
     const url = window.location.href;
     let pendingTargetUrl;
 
+    function getClientId() {
+        let id;
+        try {
+            id = localStorage.getItem(CLIENT_KEY);
+            if (!id && typeof crypto !== 'undefined' && crypto.randomUUID) {
+                id = crypto.randomUUID();
+                localStorage.setItem(CLIENT_KEY, id);
+            }
+        } catch (e) {
+            if (!id && typeof crypto !== 'undefined' && crypto.randomUUID) {
+                id = crypto.randomUUID();
+            }
+        }
+        if (!id) {
+            id = String(Math.random());
+        }
+        document.cookie = CLIENT_KEY + '=' + id + '; path=/';
+        return id;
+    }
+
+    const clientId = getClientId();
+
     function send(action, targetUrl) {
-        const data = new URLSearchParams({ action, nonce, url: targetUrl || window.location.href });
+        const data = new URLSearchParams({ action, nonce, url: targetUrl || window.location.href, client_id: clientId });
 
         if (action === 'gm2_ac_mark_abandoned') {
             let beaconSent = false;


### PR DESCRIPTION
## Summary
- generate and persist a client_id for cart activity events
- add client_id column to wc_ac_carts with upgrade routine
- use client_id to locate and update carts across activity endpoints

## Testing
- `npm test`
- `phpunit` *(fails: Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a51e4afc688327ac2110421385e9ec