### PR TITLE
Add styling and validation for field group wizard

### DIFF
--- a/admin/Gm2_Custom_Posts_Admin.php
+++ b/admin/Gm2_Custom_Posts_Admin.php
@@ -1531,6 +1531,13 @@ class Gm2_Custom_Posts_Admin {
                 file_exists($file) ? filemtime($file) : GM2_VERSION,
                 true
             );
+            $css = GM2_PLUGIN_DIR . 'admin/css/gm2-fg-wizard.css';
+            wp_enqueue_style(
+                'gm2-fg-wizard',
+                GM2_PLUGIN_URL . 'admin/css/gm2-fg-wizard.css',
+                [],
+                file_exists($css) ? filemtime($css) : GM2_VERSION
+            );
             $groups = get_option('gm2_field_groups', []);
             if (!is_array($groups)) {
                 $groups = [];

--- a/admin/css/gm2-fg-wizard.css
+++ b/admin/css/gm2-fg-wizard.css
@@ -1,0 +1,58 @@
+.gm2-fg-wizard {
+    font-family: inherit;
+    margin-top: 1rem;
+}
+
+.gm2-fg-stepper {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 1rem;
+}
+
+.gm2-fg-stepper-label {
+    font-weight: 600;
+}
+
+.gm2-fg-stepper progress {
+    flex: 1 1 auto;
+    height: 8px;
+}
+
+.gm2-fg-wizard-buttons {
+    display: flex;
+    gap: 8px;
+    margin-top: 1rem;
+    justify-content: flex-end;
+}
+
+.gm2-fg-wizard-buttons .button {
+    margin-right: 0;
+}
+
+.gm2-fg-error {
+    color: #b32d2e;
+    margin-top: 0.5rem;
+}
+
+.gm2-field-item,
+.gm2-location-group {
+    margin-bottom: 1rem;
+}
+
+.gm2-fg-review-fields th,
+.gm2-fg-review-fields td {
+    padding: 4px 8px;
+}
+
+.gm2-location-help {
+    margin-bottom: 0.5rem;
+}
+
+@media (max-width: 782px) {
+    .gm2-fg-wizard-buttons {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add stylesheet for field group wizard layout and stepper visuals
- load wizard stylesheet in `enqueue_scripts`
- improve field group wizard UX with busy state, button disabling, and inline errors

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a533b2bd9c8327b965127f3914ca8f