### PR TITLE
Fix incorrect entry URL for Abandoned Carts

### DIFF
--- a/includes/Gm2_Abandoned_Carts.php
+++ b/includes/Gm2_Abandoned_Carts.php
@@ -256,8 +256,10 @@ class Gm2_Abandoned_Carts {
                 }
             }
         }
-        $request_uri = isset($_SERVER['REQUEST_URI']) ? esc_url_raw(wp_unslash($_SERVER['REQUEST_URI'])) : '/';
-        $current_url = home_url($request_uri);
+        $host        = isset($_SERVER['HTTP_HOST']) ? sanitize_text_field(wp_unslash($_SERVER['HTTP_HOST'])) : '';
+        $request_uri = isset($_SERVER['REQUEST_URI']) ? wp_unslash($_SERVER['REQUEST_URI']) : '/';
+        $scheme      = !empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off' ? 'https://' : 'http://';
+        $current_url = esc_url_raw($scheme . $host . $request_uri);
 
         $stored_entry  = '';
         $session_entry = $wc->session->get('gm2_entry_url');

--- a/public/Gm2_Abandoned_Carts_Public.php
+++ b/public/Gm2_Abandoned_Carts_Public.php
@@ -117,8 +117,10 @@ class Gm2_Abandoned_Carts_Public {
             $stored_entry = esc_url_raw(wp_unslash($_COOKIE['gm2_entry_url']));
         }
 
-        $request_uri = isset($_SERVER['REQUEST_URI']) ? esc_url_raw(wp_unslash($_SERVER['REQUEST_URI'])) : '/';
-        $current_url = $stored_entry ?: home_url($request_uri);
+        $host        = isset($_SERVER['HTTP_HOST']) ? sanitize_text_field(wp_unslash($_SERVER['HTTP_HOST'])) : '';
+        $request_uri = isset($_SERVER['REQUEST_URI']) ? wp_unslash($_SERVER['REQUEST_URI']) : '/';
+        $scheme      = !empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off' ? 'https://' : 'http://';
+        $current_url = $stored_entry ?: esc_url_raw($scheme . $host . $request_uri);
 
         $agent   = $_SERVER['HTTP_USER_AGENT'] ?? '';
         $browser = Gm2_Abandoned_Carts::get_browser($agent);

--- a/tests/test-abandoned-carts.php
+++ b/tests/test-abandoned-carts.php
@@ -226,6 +226,20 @@ class AbandonedCartsTest extends WP_UnitTestCase {
         $this->assertSame('http://example.com/landing', WC()->session->get('gm2_entry_url'));
     }
 
+    public function test_capture_cart_entry_url_uses_full_request_uri() {
+        $table = $GLOBALS['wpdb']->prefix . 'wc_ac_carts';
+        $GLOBALS['wpdb']->data[$table] = [];
+        global $wc_session_obj;
+        $wc_session_obj->cart = new FakeCart();
+        WC()->session->set('gm2_entry_url', null);
+        $_SERVER['HTTP_HOST'] = 'example.com';
+        $_SERVER['REQUEST_URI'] = '/shop/landing';
+        $ac = new \Gm2\Gm2_Abandoned_Carts();
+        $ac->capture_cart();
+        $row = $GLOBALS['wpdb']->data[$table][0];
+        $this->assertSame('http://example.com/shop/landing', $row['entry_url']);
+    }
+
     public function test_mark_cart_recovered_moves_row() {
         $ac = new \Gm2\Gm2_Abandoned_Carts();
         $ac->mark_cart_recovered(123);


### PR DESCRIPTION
## Summary
- build entry URL from request host and path for accurate cart tracking
- ensure contact capture uses the same URL format
- test entry URL generation with subdirectory installs

## Testing
- `npm test`
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a6a426ab9c83278b9c4e8f7431e196