### PR TITLE
Use WordPress SSL detection for cart URLs

### DIFF
--- a/includes/Gm2_Abandoned_Carts.php
+++ b/includes/Gm2_Abandoned_Carts.php
@@ -261,7 +261,7 @@ class Gm2_Abandoned_Carts {
         }
         $host        = isset($_SERVER['HTTP_HOST']) ? sanitize_text_field(wp_unslash($_SERVER['HTTP_HOST'])) : '';
         $request_uri = isset($_SERVER['REQUEST_URI']) ? wp_unslash($_SERVER['REQUEST_URI']) : '/';
-        $scheme      = !empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off' ? 'https://' : 'http://';
+        $scheme      = is_ssl() ? 'https://' : 'http://';
         $current_url = esc_url_raw($scheme . $host . $request_uri);
 
         $stored_entry  = '';


### PR DESCRIPTION
## Summary
- rely on `is_ssl()` in cart capture to build URLs with correct protocol

## Testing
- `npm test`
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a6adccb36c832792850985b0b64255