### PR TITLE
Avoid tracking external link destinations for abandonment events

### DIFF
--- a/public/js/gm2-ac-activity.js
+++ b/public/js/gm2-ac-activity.js
@@ -189,8 +189,10 @@
             return;
         }
         const href = anchor.href;
-        if (href && anchor.origin !== window.location.origin) {
+        if (href && anchor.origin === window.location.origin) {
             pendingTargetUrl = href;
+        } else {
+            pendingTargetUrl = undefined;
         }
     });
 

--- a/tests/js/gm2-ac-activity.test.js
+++ b/tests/js/gm2-ac-activity.test.js
@@ -37,7 +37,7 @@ test('records exit URL when localStorage is disabled', () => {
   jest.useRealTimers();
 });
 
-test('captures external link destination before navigation', () => {
+test('defaults to current URL when navigating to an external link', () => {
   jest.useFakeTimers();
   const dom = new JSDOM(`<!DOCTYPE html><body><a id="out" href="https://external.com/path">go</a></body>`, { url: 'https://example.com/page' });
   const { window } = dom;
@@ -68,7 +68,7 @@ test('captures external link destination before navigation', () => {
 
   expect(abandonCalls.length).toBe(1);
   const params = new URLSearchParams(abandonCalls[0][1].toString());
-  expect(params.get('url')).toBe('https://external.com/path');
+  expect(params.get('url')).toBe('https://example.com/page');
   jest.clearAllTimers();
   jest.useRealTimers();
 });


### PR DESCRIPTION
## Summary
- Keep pendingTargetUrl undefined when navigating to external links so gm2_ac_mark_abandoned falls back to the current page URL
- Update gm2-ac-activity test to expect default URL instead of external destination

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6b45fd96c8327bbc763743f6d815a