### PR TITLE
Add IP address index for abandoned carts

### DIFF
--- a/docs/caching.md
+++ b/docs/caching.md
@@ -4,8 +4,8 @@ The suite uses several techniques to reduce database load and speed up requests:
 
 - **Database indexes** – custom indexes are added to WordPress meta tables and
   to plugin tables such as `gm2_audit_log`, `wc_ac_carts` and
-  `wc_ac_email_queue`. These indexes target columns that are frequently queried
-  so lookups avoid full table scans.
+  `wc_ac_email_queue`. The `wc_ac_carts` table includes an `ip_address` index so
+  IP-based lookups avoid full table scans.
 - **Lazy metadata loading** – `gm2_get_meta_value()` now exposes the
   `gm2_lazy_load_meta_value` filter. When enabled for a field the function
   returns a lightweight `GM2_Lazy_Meta_Value` object that defers the actual

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@ See [model-cli.md](model-cli.md) for managing custom post types, taxonomies and 
 This release adds several new SEO and AI options:
 
 - Added an index on the `timestamp` column of the `gm2_analytics_log` table for faster lookups. Existing installations upgrade automatically.
+- Added an `ip_address` index to the `wc_ac_carts` table to speed up grouping cart sessions by visitor.
 - Additional database indexes for frequently queried meta keys and custom tables,
   plus lazy metadata loading via `gm2_get_meta_value()`. See
   [caching.md](caching.md) for details on the caching strategy.
@@ -95,7 +96,7 @@ Enable the module from **Gm2 → Dashboard** to begin tracking cart sessions. Ac
 
 Select an Elementor popup under **Gm2 → Cart Settings** to ask shoppers for an email address or phone number before they leave. The plugin records contact details from that popup and from the checkout billing fields so each cart is linked to an email and/or phone when available.
 
-The **Gm2 → Abandoned Carts** screen groups records by IP address so multiple visits from the same shopper appear as a single row with combined browsing time and revisit counts. Click a row’s **Cart Activity Log** link to view the add/remove/quantity events pulled from the activity table.
+The **Gm2 → Abandoned Carts** screen groups records by IP address so multiple visits from the same shopper appear as a single row with combined browsing time and revisit counts. An index on `ip_address` in the carts table speeds up these lookups. Click a row’s **Cart Activity Log** link to view the add/remove/quantity events pulled from the activity table.
 
 The activity log loads entries 50 at a time through the `gm2_ac_get_activity` AJAX action. Pass `page` and `per_page` values to paginate through activity and visit records; the admin UI requests additional pages as you scroll.
 

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -272,7 +272,7 @@ add_action('plugins_loaded', 'gm2_upgrade_analytics_log_index');
 function gm2_maybe_add_indexes() {
     global $wpdb;
 
-    if ((int) get_option('gm2_meta_indexes_version', 0) >= 1) {
+    if ((int) get_option('gm2_meta_indexes_version', 0) >= 2) {
         return;
     }
 
@@ -304,6 +304,10 @@ function gm2_maybe_add_indexes() {
             $wpdb->query( "ALTER TABLE $carts ADD INDEX $index ($cols)" );
         }
     }
+    $exists = $wpdb->get_results( "SHOW INDEX FROM $carts WHERE Key_name = 'ip_address'" );
+    if (empty($exists)) {
+        $wpdb->query( "ALTER TABLE $carts ADD INDEX ip_address (ip_address)" );
+    }
 
     $queue = $wpdb->prefix . 'wc_ac_email_queue';
     $exists = $wpdb->get_results( "SHOW INDEX FROM $queue WHERE Key_name = 'gm2_send_at'" );
@@ -311,7 +315,7 @@ function gm2_maybe_add_indexes() {
         $wpdb->query( "ALTER TABLE $queue ADD INDEX gm2_send_at (send_at, sent)" );
     }
 
-    update_option('gm2_meta_indexes_version', 1);
+    update_option('gm2_meta_indexes_version', 2);
 }
 
 add_action('plugins_loaded', 'gm2_maybe_add_indexes');

--- a/includes/Gm2_Abandoned_Carts.php
+++ b/includes/Gm2_Abandoned_Carts.php
@@ -39,7 +39,8 @@ class Gm2_Abandoned_Carts {
             cart_total decimal(10,2) DEFAULT 0,
             PRIMARY KEY  (id),
             KEY cart_token (cart_token),
-            KEY client_id (client_id)
+            KEY client_id (client_id),
+            KEY ip_address (ip_address)
         ) $charset_collate;";
 
         $queue_sql = "CREATE TABLE $queue (


### PR DESCRIPTION
## Summary
- index `ip_address` in abandoned cart table on install
- migrate existing installs to add the new `ip_address` index
- document new index in caching and release notes

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7aec672788327b7ec1db873b60f29