### PR TITLE
Ensure DB format strings for abandoned cart operations

### DIFF
--- a/admin/class-gm2-ac-table.php
+++ b/admin/class-gm2-ac-table.php
@@ -69,7 +69,8 @@ class GM2_AC_Table extends \WP_List_Table {
         global $wpdb;
         $table = $wpdb->prefix . $this->table_name;
         $placeholders = implode(',', array_fill(0, count($ids), '%d'));
-        $wpdb->query($wpdb->prepare("DELETE FROM $table WHERE id IN ($placeholders)", $ids));
+        $sql = "DELETE FROM $table WHERE id IN ($placeholders)";
+        $wpdb->query($wpdb->prepare($sql, ...$ids));
     }
 
     private function ensure_value($value) {

--- a/public/Gm2_Abandoned_Carts_Public.php
+++ b/public/Gm2_Abandoned_Carts_Public.php
@@ -145,16 +145,24 @@ class Gm2_Abandoned_Carts_Public {
             if (!empty($client_id)) {
                 $update['client_id'] = $client_id;
             }
+            $format = [ '%s', '%s', '%s', '%s' ];
+            if (!empty($client_id)) {
+                $format[] = '%s';
+            }
             $wpdb->update(
                 $table,
                 $update,
-                [ 'id' => $row->id ]
+                [ 'id' => $row->id ],
+                $format,
+                [ '%d' ]
             );
             if (empty($row->entry_url) && !empty($stored_entry)) {
                 $wpdb->update(
                     $table,
                     [ 'entry_url' => $stored_entry ],
-                    [ 'id' => $row->id ]
+                    [ 'id' => $row->id ],
+                    [ '%s' ],
+                    [ '%d' ]
                 );
             }
         } else {
@@ -188,7 +196,25 @@ class Gm2_Abandoned_Carts_Public {
             if (!empty($client_id)) {
                 $insert['client_id'] = $client_id;
             }
-            $wpdb->insert($table, $insert);
+            $format = [
+                '%s', // cart_token
+                '%d', // user_id
+                '%s', // cart_contents
+                '%s', // created_at
+                '%s', // ip_address
+                '%s', // user_agent
+                '%s', // browser
+                '%s', // location
+                '%s', // device
+                '%s', // entry_url
+                '%f', // cart_total
+                '%s', // email
+                '%s', // phone
+            ];
+            if (!empty($client_id)) {
+                $format[] = '%s';
+            }
+            $wpdb->insert($table, $insert, $format);
         }
 
         wp_send_json_success();

--- a/tests/ActivityLogPagingTest.php
+++ b/tests/ActivityLogPagingTest.php
@@ -68,7 +68,7 @@ namespace {
             $this->data[$this->prefix.'wc_ac_cart_activity']=[];
             $this->data[$this->prefix.'wc_ac_visit_log']=[];
         }
-        public function insert($table,$row){ $this->data[$table][]=$row; }
+        public function insert($table,$row,$format=null){ $this->data[$table][]=$row; }
         public function prepare($sql,...$args){ $this->last_sql=$sql; $this->last_args=$args; return $sql; }
         public function get_results($sql){
             if(strpos($this->last_sql,'wc_ac_cart_activity')!==false){

--- a/tests/BulkDeletionFormatTest.php
+++ b/tests/BulkDeletionFormatTest.php
@@ -1,0 +1,49 @@
+<?php
+namespace Gm2;
+
+use PHPUnit\Framework\TestCase;
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/../');
+}
+if (!class_exists('WP_List_Table')) {
+    class WP_List_Table {
+        public function __construct($args = []) {}
+    }
+}
+require_once __DIR__ . '/../admin/class-gm2-ac-table.php';
+
+class BulkDeletionFormatTest extends TestCase {
+    private $orig_wpdb;
+    protected function setUp(): void {
+        parent::setUp();
+        $this->orig_wpdb = $GLOBALS['wpdb'] ?? null;
+        $GLOBALS['wpdb'] = new FakeDB();
+        $_REQUEST['id'] = [1,2,3];
+    }
+    protected function tearDown(): void {
+        $GLOBALS['wpdb'] = $this->orig_wpdb;
+        parent::tearDown();
+    }
+    public function test_bulk_delete_uses_prepared_formats() {
+        $table = new class extends GM2_AC_Table {
+            public function current_action() { return 'delete'; }
+        };
+        $table->process_bulk_action();
+        $this->assertSame('DELETE FROM wp_wc_ac_carts WHERE id IN (%d,%d,%d)', $GLOBALS['wpdb']->last_prepare_query);
+        $this->assertSame([1,2,3], $GLOBALS['wpdb']->last_prepare_args);
+    }
+}
+
+class FakeDB {
+    public $prefix = 'wp_';
+    public $last_prepare_query;
+    public $last_prepare_args;
+    public function prepare($query, ...$args) {
+        $this->last_prepare_query = $query;
+        $this->last_prepare_args = $args;
+        return $query;
+    }
+    public function query($sql) {
+    }
+}

--- a/tests/CaptureCartActivityTest.php
+++ b/tests/CaptureCartActivityTest.php
@@ -119,12 +119,12 @@ class FakeDB {
         }
         return null;
     }
-    public function insert($table, $data) {
+    public function insert($table, $data, $format = null) {
         $data['id'] = count($this->data[$table]) + 1;
         $this->data[$table][] = $data;
         $this->insert_id = $data['id'];
     }
-    public function update($table, $data, $where) {
+    public function update($table, $data, $where, $format = null, $where_format = null) {
         foreach ($this->data[$table] as &$row) {
             $match = true; foreach ($where as $k=>$v) { if ($row[$k] !== $v) { $match=false; break; } }
             if ($match) { foreach ($data as $k=>$v) { $row[$k] = $v; } }

--- a/tests/test-abandoned-carts.php
+++ b/tests/test-abandoned-carts.php
@@ -132,6 +132,9 @@ class AbandonedCartsTest extends WP_UnitTestCase {
         $_REQUEST = $_POST;
         \Gm2\Gm2_Abandoned_Carts::gm2_ac_mark_active();
 
+        $expected_format = ['%s','%f','%s','%s','%s','%s','%s','%s'];
+        $this->assertSame($expected_format, $GLOBALS['wpdb']->last_update_format);
+
         $table = $GLOBALS['wpdb']->prefix . 'wc_ac_carts';
         $row = $GLOBALS['wpdb']->data[$table][0];
         $this->assertNotEmpty($row['session_start']);
@@ -194,6 +197,9 @@ class AbandonedCartsTest extends WP_UnitTestCase {
         $_POST = [ 'nonce' => 'n', 'url' => 'https://example.com/start' ];
         $_REQUEST = $_POST;
         \Gm2\Gm2_Abandoned_Carts::gm2_ac_mark_active();
+
+        $expected_insert = ['%s','%d','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%f','%d','%d'];
+        $this->assertSame($expected_insert, $GLOBALS['wpdb']->last_insert_format);
 
         $this->assertCount(1, $GLOBALS['wpdb']->data[$table]);
         $row = $GLOBALS['wpdb']->data[$table][0];
@@ -404,7 +410,11 @@ class AbandonedCartFakeDB {
         return null;
     }
 
-    public function insert($table, $data) {
+    public $last_insert_format;
+    public $last_update_format;
+
+    public function insert($table, $data, $format = null) {
+        $this->last_insert_format = $format;
         $this->data[$table][] = $data;
     }
 
@@ -423,7 +433,8 @@ class AbandonedCartFakeDB {
         }
     }
 
-    public function update($table, $data, $where) {
+    public function update($table, $data, $where, $format = null, $where_format = null) {
+        $this->last_update_format = $format;
         foreach ($this->data[$table] as &$row) {
             if ($row['id'] === $where['id']) {
                 foreach ($data as $k => $v) {


### PR DESCRIPTION
## Summary
- add explicit format arrays for abandoned cart inserts and updates
- enforce formatted bulk deletes in admin table
- test that DB interactions include expected format specifiers

## Testing
- `npm test`
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b28e2a388327bf8ef991ba9eaab9