### PR TITLE
Add injectable logger and verbose logging settings

### DIFF
--- a/admin/Gm2_Abandoned_Carts_Admin.php
+++ b/admin/Gm2_Abandoned_Carts_Admin.php
@@ -89,6 +89,36 @@ class Gm2_Abandoned_Carts_Admin {
         ]);
         echo '<div class="wrap"><h1>' . esc_html__('Abandoned Carts', 'gm2-wordpress-suite') . '</h1>';
 
+        $logging = get_option('gm2_ac_enable_logging', '0');
+        if (isset($_POST['gm2_ac_logging_nonce']) && wp_verify_nonce($_POST['gm2_ac_logging_nonce'], 'gm2_ac_logging_save')) {
+            $logging = isset($_POST['gm2_ac_enable_logging']) ? '1' : '0';
+            update_option('gm2_ac_enable_logging', $logging);
+            echo '<div class="updated notice"><p>' . esc_html__('Settings saved.', 'gm2-wordpress-suite') . '</p></div>';
+        }
+
+        echo '<h2>' . esc_html__('Logging', 'gm2-wordpress-suite') . '</h2>';
+        echo '<form method="post" style="margin-bottom:20px;">';
+        wp_nonce_field('gm2_ac_logging_save', 'gm2_ac_logging_nonce');
+        echo '<table class="form-table"><tbody>';
+        echo '<tr><th scope="row"><label for="gm2_ac_enable_logging">' . esc_html__('Enable Verbose Logging', 'gm2-wordpress-suite') . '</label></th>';
+        echo '<td><input type="checkbox" id="gm2_ac_enable_logging" name="gm2_ac_enable_logging" value="1"' . checked('1', $logging, false) . ' /></td></tr>';
+        echo '</tbody></table>';
+        submit_button();
+        echo '</form>';
+
+        if ($logging === '1') {
+            echo '<h2>' . esc_html__('Recent Logs', 'gm2-wordpress-suite') . '</h2>';
+            if (function_exists('wc_get_log_file_path')) {
+                $file = wc_get_log_file_path('gm2_abandoned_carts');
+                if (file_exists($file)) {
+                    $lines = array_slice(file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES), -100);
+                    echo '<pre class="gm2-ac-logs" style="background:#fff;border:1px solid #ccc;padding:10px;max-height:300px;overflow:auto;">' . esc_html(implode("\n", $lines)) . '</pre>';
+                } else {
+                    echo '<p>' . esc_html__('No logs found.', 'gm2-wordpress-suite') . '</p>';
+                }
+            }
+        }
+
         $minutes = absint(apply_filters('gm2_ac_mark_abandoned_interval', (int) get_option('gm2_ac_mark_abandoned_interval', 5)));
         if ($minutes < 1) {
             $minutes = 1;

--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -464,7 +464,8 @@ class Gm2_Admin {
                 $carts_exists = $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $carts_table));
                 $queue_exists = $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $queue_table));
                 if (!$carts_exists || !$queue_exists) {
-                    $ac = new Gm2_Abandoned_Carts();
+                    $logger = function_exists('wc_get_logger') ? wc_get_logger() : null;
+                    $ac = new Gm2_Abandoned_Carts($logger);
                     $ac->install();
                 }
             }

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -163,7 +163,8 @@ function gm2_activate_plugin() {
 
     gm2_custom_tables_maybe_install();
 
-    $ac = new Gm2_Abandoned_Carts();
+    $logger = function_exists('wc_get_logger') ? wc_get_logger() : null;
+    $ac = new Gm2_Abandoned_Carts($logger);
     $ac->install();
 
     add_option('gm2_enable_tariff', '1');
@@ -173,6 +174,7 @@ function gm2_activate_plugin() {
     add_option('gm2_enable_chatgpt', '1');
     add_option('gm2_enable_analytics', '1');
     add_option('gm2_enable_chatgpt_logging', '0');
+    add_option('gm2_ac_enable_logging', '0');
     add_option('gm2_enable_custom_posts', '1');
     add_option('gm2_enable_block_templates', '0');
     add_option('gm2_enable_theme_integration', '0');

--- a/includes/Gm2_Loader.php
+++ b/includes/Gm2_Loader.php
@@ -90,7 +90,8 @@ class Gm2_Loader {
             // Ensure the abandonment cron is always scheduled when the module is active.
             Gm2_Abandoned_Carts::schedule_event();
 
-            $ac = new Gm2_Abandoned_Carts();
+            $logger = function_exists('wc_get_logger') ? wc_get_logger() : null;
+            $ac = new Gm2_Abandoned_Carts($logger);
             $ac->run();
 
             // Temporarily disable Recovery Email Queue.

--- a/includes/cli/class-gm2-cli.php
+++ b/includes/cli/class-gm2-cli.php
@@ -60,7 +60,8 @@ class Gm2_CLI extends \WP_CLI_Command {
     public function ac( $args, $assoc_args ) {
         $sub = $args[0] ?? '';
         if ( $sub === 'migrate' ) {
-            $ac    = new Gm2_Abandoned_Carts();
+            $logger = function_exists('wc_get_logger') ? wc_get_logger() : null;
+            $ac    = new Gm2_Abandoned_Carts($logger);
             $count = $ac->migrate_recovered_carts();
             \WP_CLI::success( sprintf( '%d carts migrated.', $count ) );
             return;

--- a/uninstall.php
+++ b/uninstall.php
@@ -77,6 +77,7 @@ $option_names = array(
     'gm2_enable_google_oauth',
     'gm2_enable_chatgpt',
     'gm2_enable_chatgpt_logging',
+    'gm2_ac_enable_logging',
     'gm2_enable_custom_posts',
     'gm2_pagespeed_api_key',
     'gm2_pagespeed_scores',


### PR DESCRIPTION
## Summary
- allow injecting a PSR-3/WC_Logger into `Gm2_Abandoned_Carts`
- log failures with severity, context and optional debug filtering
- add admin option to enable verbose logging and view recent log entries

## Testing
- `npm test` *(fails: jest not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b5716a288327877a674ca56eb58d