### PR TITLE
Handle failed cart summary requests

### DIFF
--- a/admin/js/gm2-ac-live-updates.js
+++ b/admin/js/gm2-ac-live-updates.js
@@ -1,5 +1,11 @@
 jQuery(function($){
+    function showError(message){
+        var $notice = $('<div class="notice notice-error is-dismissible gm2-ac-error"><p>'+message+'</p></div>');
+        $('.gm2-ac-error').remove();
+        $('.wrap').prepend($notice);
+    }
     function fetchCarts(){
+        var $list = $('#the-list');
         $.post(gm2AcLive.ajax_url, {
             action: 'gm2_ac_get_carts',
             nonce: gm2AcLive.nonce,
@@ -9,6 +15,10 @@ jQuery(function($){
             if(response && response.success && response.data && response.data.rows){
                 $('#the-list').html(response.data.rows);
             }
+        }).fail(function(){
+            showError('Failed to load carts.');
+        }).always(function(){
+            $list.removeClass('loading');
         });
     }
     fetchCarts();
@@ -26,6 +36,7 @@ jQuery(function($){
     });
 
     function refreshSummary(){
+        var $summary = $('#gm2-ac-summary');
         $.post(gm2AcLive.ajax_url, {
             action: 'gm2_ac_refresh_summary',
             nonce: gm2AcLive.summary_nonce
@@ -38,6 +49,10 @@ jQuery(function($){
                 $('#gm2-ac-potential').text(response.data.potential_revenue);
                 $('#gm2-ac-recovered-revenue').text(response.data.recovered_revenue);
             }
+        }).fail(function(){
+            showError('Failed to refresh summary.');
+        }).always(function(){
+            $summary.removeClass('loading');
         });
     }
 


### PR DESCRIPTION
## Summary
- add reusable `showError` helper
- show admin notice when cart requests fail and clear loading states

## Testing
- `npm test`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_68a7b6f399788327af8d3e6a1e506401