### PR TITLE
Introduce pluggable AI providers

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -2,6 +2,8 @@
 
 namespace Gm2;
 
+use Gm2\AI\ChatGPTProvider as Gm2_ChatGPT;
+
 if (!defined('ABSPATH')) {
     exit;
 }

--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -2,6 +2,8 @@
 
 namespace Gm2;
 
+use Gm2\AI\ChatGPTProvider as Gm2_ChatGPT;
+
 if (!defined('ABSPATH')) {
     exit;
 }

--- a/includes/AI/GemmaProvider.php
+++ b/includes/AI/GemmaProvider.php
@@ -1,0 +1,82 @@
+<?php
+namespace Gm2\AI;
+
+use WP_Error;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class GemmaProvider implements ProviderInterface {
+    private $api_key;
+    private $model;
+    private $temperature;
+    private $max_tokens;
+    private $endpoint;
+
+    public function __construct() {
+        $this->api_key   = get_option('gm2_gemma_api_key', '');
+        $this->model     = get_option('gm2_gemma_model', 'gemma-7b-it');
+        $temp            = get_option('gm2_gemma_temperature', '');
+        $this->temperature = $temp === '' ? 1.0 : floatval($temp);
+        $this->max_tokens = intval(get_option('gm2_gemma_max_tokens', ''));
+        $default_endpoint = 'https://generativelanguage.googleapis.com/v1beta/models/' . $this->model . ':generateContent';
+        $this->endpoint  = get_option('gm2_gemma_endpoint', $default_endpoint);
+    }
+
+    public function query(string $prompt): string|WP_Error {
+        if (get_option('gm2_enable_gemma', '1') !== '1') {
+            return new WP_Error('gemma_disabled', 'Gemma feature disabled');
+        }
+        if ($this->api_key === '') {
+            return new WP_Error('no_api_key', 'Gemma API key not set');
+        }
+
+        $payload = [
+            'contents' => [
+                [
+                    'parts' => [
+                        ['text' => $prompt],
+                    ],
+                ],
+            ],
+            'generationConfig' => [
+                'temperature' => $this->temperature,
+            ],
+        ];
+        if ($this->max_tokens > 0) {
+            $payload['generationConfig']['maxOutputTokens'] = $this->max_tokens;
+        }
+
+        $args = [
+            'headers' => [
+                'Content-Type'   => 'application/json',
+                'X-Goog-Api-Key' => $this->api_key,
+            ],
+            'body'    => wp_json_encode($payload),
+            'timeout' => 20,
+        ];
+
+        $response = wp_remote_post($this->endpoint, $args);
+
+        if (is_wp_error($response)) {
+            return $response;
+        }
+
+        $status = wp_remote_retrieve_response_code($response);
+        $body   = wp_remote_retrieve_body($response);
+
+        if ($status !== 200) {
+            $data    = json_decode($body, true);
+            $message = $data['error']['message'] ?? 'Non-200 response';
+            return new WP_Error('api_error', $message);
+        }
+
+        if ($body === '') {
+            return '';
+        }
+
+        $data = json_decode($body, true);
+        return $data['candidates'][0]['content']['parts'][0]['text'] ?? '';
+    }
+}

--- a/includes/AI/LlamaProvider.php
+++ b/includes/AI/LlamaProvider.php
@@ -1,0 +1,71 @@
+<?php
+namespace Gm2\AI;
+
+use WP_Error;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class LlamaProvider implements ProviderInterface {
+    private $api_key;
+    private $model;
+    private $temperature;
+    private $max_tokens;
+    private $endpoint;
+
+    public function __construct() {
+        $this->api_key   = get_option('gm2_llama_api_key', '');
+        $this->model     = get_option('gm2_llama_model', 'llama2');
+        $temp            = get_option('gm2_llama_temperature', '');
+        $this->temperature = $temp === '' ? 1.0 : floatval($temp);
+        $this->max_tokens = intval(get_option('gm2_llama_max_tokens', ''));
+        $this->endpoint  = get_option('gm2_llama_endpoint', 'https://api.llama.com/v1/chat/completions');
+    }
+
+    public function query(string $prompt): string|WP_Error {
+        if (get_option('gm2_enable_llama', '1') !== '1') {
+            return new WP_Error('llama_disabled', 'Llama feature disabled');
+        }
+        if ($this->api_key === '') {
+            return new WP_Error('no_api_key', 'Llama API key not set');
+        }
+        $payload = [
+            'model'     => $this->model,
+            'messages'  => [ [ 'role' => 'user', 'content' => $prompt ] ],
+            'temperature' => $this->temperature,
+        ];
+        if ($this->max_tokens > 0) {
+            $payload['max_tokens'] = $this->max_tokens;
+        }
+        $args = [
+            'headers' => [
+                'Authorization' => 'Bearer ' . $this->api_key,
+                'Content-Type'  => 'application/json',
+            ],
+            'body'    => wp_json_encode($payload),
+            'timeout' => 20,
+        ];
+        $response = wp_remote_post($this->endpoint, $args);
+
+        if (is_wp_error($response)) {
+            return $response;
+        }
+
+        $status = wp_remote_retrieve_response_code($response);
+        $body   = wp_remote_retrieve_body($response);
+
+        if ($status !== 200) {
+            $data    = json_decode($body, true);
+            $message = $data['error']['message'] ?? 'Non-200 response';
+            return new WP_Error('api_error', $message);
+        }
+
+        if ($body === '') {
+            return '';
+        }
+
+        $data = json_decode($body, true);
+        return $data['choices'][0]['message']['content'] ?? '';
+    }
+}

--- a/includes/AI/ProviderInterface.php
+++ b/includes/AI/ProviderInterface.php
@@ -1,0 +1,12 @@
+<?php
+namespace Gm2\AI;
+
+interface ProviderInterface {
+    /**
+     * Sends a prompt to the AI provider and returns the response text or an error.
+     *
+     * @param string $prompt Prompt to send to the provider.
+     * @return string|\WP_Error
+     */
+    public function query(string $prompt): string|\WP_Error;
+}

--- a/includes/autoload.php
+++ b/includes/autoload.php
@@ -8,6 +8,7 @@ spl_autoload_register(function ($class) {
         } else {
             $name = substr($class, 4);
         }
+        $name = str_replace('\\', '/', $name);
         foreach (['includes', 'admin', 'public'] as $dir) {
             $file = GM2_PLUGIN_DIR . $dir . '/' . $name . '.php';
             if (file_exists($file)) {

--- a/tests/test-chatgpt.php
+++ b/tests/test-chatgpt.php
@@ -1,5 +1,5 @@
 <?php
-use Gm2\Gm2_ChatGPT;
+use Gm2\AI\ChatGPTProvider as Gm2_ChatGPT;
 use Gm2\Gm2_Admin;
 
 class ChatGPTTest extends WP_UnitTestCase {


### PR DESCRIPTION
## Summary
- Add a generic `ProviderInterface` for AI providers
- Move ChatGPT implementation to `AI\ChatGPTProvider` and implement interface
- Add new Gemma and Llama providers with their REST endpoints
- Update autoloader for nested namespaces and alias ChatGPT usage

## Testing
- `npm test` *(fails: jest: not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b7113ba88327b000276e4a8e9678