### PR TITLE
feat: improve abandoned cart summary accessibility

### DIFF
--- a/admin/Gm2_Abandoned_Carts_Admin.php
+++ b/admin/Gm2_Abandoned_Carts_Admin.php
@@ -135,13 +135,13 @@ class Gm2_Abandoned_Carts_Admin {
         }
 
         $summary = $this->get_summary_data();
-        echo '<div id="gm2-ac-summary" class="gm2-ac-summary">';
-        echo '<p><strong>' . esc_html__('Total Carts', 'gm2-wordpress-suite') . ':</strong> <span id="gm2-ac-total">' . intval($summary['total']) . '</span></p>';
-        echo '<p><strong>' . esc_html__('Pending', 'gm2-wordpress-suite') . ':</strong> <span id="gm2-ac-pending">' . intval($summary['pending']) . '</span></p>';
-        echo '<p><strong>' . esc_html__('Abandoned', 'gm2-wordpress-suite') . ':</strong> <span id="gm2-ac-abandoned">' . intval($summary['abandoned']) . '</span></p>';
-        echo '<p><strong>' . esc_html__('Recovered', 'gm2-wordpress-suite') . ':</strong> <span id="gm2-ac-recovered">' . intval($summary['recovered']) . '</span></p>';
-        echo '<p><strong>' . esc_html__('Potential Revenue', 'gm2-wordpress-suite') . ':</strong> <span id="gm2-ac-potential">' . esc_html(wc_price($summary['potential_revenue'])) . '</span></p>';
-        echo '<p><strong>' . esc_html__('Recovered Revenue', 'gm2-wordpress-suite') . ':</strong> <span id="gm2-ac-recovered-revenue">' . esc_html(wc_price($summary['recovered_revenue'])) . '</span></p>';
+        echo '<div id="gm2-ac-summary" class="gm2-ac-summary" role="status" aria-live="polite">';
+        echo '<p><strong>' . esc_html__('Total Carts', 'gm2-wordpress-suite') . ':</strong> <span id="gm2-ac-total"><span class="screen-reader-text">' . esc_html__('Total Carts', 'gm2-wordpress-suite') . ':</span><span class="count">' . intval($summary['total']) . '</span></span></p>';
+        echo '<p><strong>' . esc_html__('Pending', 'gm2-wordpress-suite') . ':</strong> <span id="gm2-ac-pending"><span class="screen-reader-text">' . esc_html__('Pending', 'gm2-wordpress-suite') . ':</span><span class="count">' . intval($summary['pending']) . '</span></span></p>';
+        echo '<p><strong>' . esc_html__('Abandoned', 'gm2-wordpress-suite') . ':</strong> <span id="gm2-ac-abandoned"><span class="screen-reader-text">' . esc_html__('Abandoned', 'gm2-wordpress-suite') . ':</span><span class="count">' . intval($summary['abandoned']) . '</span></span></p>';
+        echo '<p><strong>' . esc_html__('Recovered', 'gm2-wordpress-suite') . ':</strong> <span id="gm2-ac-recovered"><span class="screen-reader-text">' . esc_html__('Recovered', 'gm2-wordpress-suite') . ':</span><span class="count">' . intval($summary['recovered']) . '</span></span></p>';
+        echo '<p><strong>' . esc_html__('Potential Revenue', 'gm2-wordpress-suite') . ':</strong> <span id="gm2-ac-potential"><span class="screen-reader-text">' . esc_html__('Potential Revenue', 'gm2-wordpress-suite') . ':</span><span class="count">' . esc_html(wc_price($summary['potential_revenue'])) . '</span></span></p>';
+        echo '<p><strong>' . esc_html__('Recovered Revenue', 'gm2-wordpress-suite') . ':</strong> <span id="gm2-ac-recovered-revenue"><span class="screen-reader-text">' . esc_html__('Recovered Revenue', 'gm2-wordpress-suite') . ':</span><span class="count">' . esc_html(wc_price($summary['recovered_revenue'])) . '</span></span></p>';
         echo '</div>';
         echo '<button type="button" class="button" id="gm2-ac-refresh-summary">' . esc_html__( 'Refresh Summary', 'gm2-wordpress-suite' ) . '</button>';
 

--- a/admin/js/gm2-ac-live-updates.js
+++ b/admin/js/gm2-ac-live-updates.js
@@ -36,23 +36,23 @@ jQuery(function($){
     });
 
     function refreshSummary(){
-        var $summary = $('#gm2-ac-summary');
+        var summary = document.getElementById('gm2-ac-summary');
         $.post(gm2AcLive.ajax_url, {
             action: 'gm2_ac_refresh_summary',
             nonce: gm2AcLive.summary_nonce
         }).done(function(response){
             if(response && response.success && response.data){
-                $('#gm2-ac-total').text(response.data.total);
-                $('#gm2-ac-pending').text(response.data.pending);
-                $('#gm2-ac-abandoned').text(response.data.abandoned);
-                $('#gm2-ac-recovered').text(response.data.recovered);
-                $('#gm2-ac-potential').text(response.data.potential_revenue);
-                $('#gm2-ac-recovered-revenue').text(response.data.recovered_revenue);
+                document.querySelector('#gm2-ac-total .count').textContent = response.data.total;
+                document.querySelector('#gm2-ac-pending .count').textContent = response.data.pending;
+                document.querySelector('#gm2-ac-abandoned .count').textContent = response.data.abandoned;
+                document.querySelector('#gm2-ac-recovered .count').textContent = response.data.recovered;
+                document.querySelector('#gm2-ac-potential .count').textContent = response.data.potential_revenue;
+                document.querySelector('#gm2-ac-recovered-revenue .count').textContent = response.data.recovered_revenue;
             }
         }).fail(function(){
             showError('Failed to refresh summary.');
         }).always(function(){
-            $summary.removeClass('loading');
+            summary.classList.remove('loading');
         });
     }
 


### PR DESCRIPTION
## Summary
- expose abandoned cart metrics in a polite status region
- announce updated totals by updating textContent with labels

## Testing
- `npm test`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*


------
https://chatgpt.com/codex/tasks/task_e_68a7b80a67cc8327a726363dcc93c634