### PR TITLE
Refactor AI prompt routing with provider factory

### DIFF
--- a/admin/Gm2_Admin.php
+++ b/admin/Gm2_Admin.php
@@ -885,8 +885,7 @@ class Gm2_Admin {
         }
 
         $prompt = sanitize_textarea_field($_POST['prompt'] ?? '');
-        $chat   = new Gm2_ChatGPT();
-        $resp   = $chat->query($prompt);
+        $resp   = gm2_ai_send_prompt($prompt);
 
         if (is_wp_error($resp)) {
             wp_send_json_error($resp->get_error_message());

--- a/includes/AI/ChatGPTProvider.php
+++ b/includes/AI/ChatGPTProvider.php
@@ -23,20 +23,25 @@ class ChatGPTProvider implements ProviderInterface {
         $this->endpoint  = get_option('gm2_chatgpt_endpoint', 'https://api.openai.com/v1/chat/completions');
     }
 
-    public function query(string $prompt): string|WP_Error {
+    public function query(string $prompt, array $args = []): string|WP_Error {
         if (get_option('gm2_enable_chatgpt', '1') !== '1') {
             return new WP_Error('chatgpt_disabled', 'ChatGPT feature disabled');
         }
         if ($this->api_key === '') {
             return new WP_Error('no_api_key', 'ChatGPT API key not set');
         }
+
+        $model       = $args['language-model'] ?? $this->model;
+        $temperature = isset($args['temperature']) ? floatval($args['temperature']) : $this->temperature;
+        $max_tokens  = isset($args['number-of-words']) ? intval($args['number-of-words']) : $this->max_tokens;
+
         $payload = [
-            'model'     => $this->model,
-            'messages'  => [ [ 'role' => 'user', 'content' => $prompt ] ],
-            'temperature' => $this->temperature,
+            'model'       => $model,
+            'messages'    => [ [ 'role' => 'user', 'content' => $prompt ] ],
+            'temperature' => $temperature,
         ];
-        if ($this->max_tokens > 0) {
-            $payload['max_tokens'] = $this->max_tokens;
+        if ($max_tokens > 0) {
+            $payload['max_tokens'] = $max_tokens;
         }
         $args = [
             'headers' => [

--- a/includes/AI/GemmaProvider.php
+++ b/includes/AI/GemmaProvider.php
@@ -24,13 +24,16 @@ class GemmaProvider implements ProviderInterface {
         $this->endpoint  = get_option('gm2_gemma_endpoint', $default_endpoint);
     }
 
-    public function query(string $prompt): string|WP_Error {
+    public function query(string $prompt, array $args = []): string|WP_Error {
         if (get_option('gm2_enable_gemma', '1') !== '1') {
             return new WP_Error('gemma_disabled', 'Gemma feature disabled');
         }
         if ($this->api_key === '') {
             return new WP_Error('no_api_key', 'Gemma API key not set');
         }
+
+        $temperature = isset($args['temperature']) ? floatval($args['temperature']) : $this->temperature;
+        $max_tokens  = isset($args['number-of-words']) ? intval($args['number-of-words']) : $this->max_tokens;
 
         $payload = [
             'contents' => [
@@ -41,11 +44,11 @@ class GemmaProvider implements ProviderInterface {
                 ],
             ],
             'generationConfig' => [
-                'temperature' => $this->temperature,
+                'temperature' => $temperature,
             ],
         ];
-        if ($this->max_tokens > 0) {
-            $payload['generationConfig']['maxOutputTokens'] = $this->max_tokens;
+        if ($max_tokens > 0) {
+            $payload['generationConfig']['maxOutputTokens'] = $max_tokens;
         }
 
         $args = [

--- a/includes/AI/LlamaProvider.php
+++ b/includes/AI/LlamaProvider.php
@@ -23,20 +23,24 @@ class LlamaProvider implements ProviderInterface {
         $this->endpoint  = get_option('gm2_llama_endpoint', 'https://api.llama.com/v1/chat/completions');
     }
 
-    public function query(string $prompt): string|WP_Error {
+    public function query(string $prompt, array $args = []): string|WP_Error {
         if (get_option('gm2_enable_llama', '1') !== '1') {
             return new WP_Error('llama_disabled', 'Llama feature disabled');
         }
         if ($this->api_key === '') {
             return new WP_Error('no_api_key', 'Llama API key not set');
         }
+        $model       = $args['language-model'] ?? $this->model;
+        $temperature = isset($args['temperature']) ? floatval($args['temperature']) : $this->temperature;
+        $max_tokens  = isset($args['number-of-words']) ? intval($args['number-of-words']) : $this->max_tokens;
+
         $payload = [
-            'model'     => $this->model,
-            'messages'  => [ [ 'role' => 'user', 'content' => $prompt ] ],
-            'temperature' => $this->temperature,
+            'model'       => $model,
+            'messages'    => [ [ 'role' => 'user', 'content' => $prompt ] ],
+            'temperature' => $temperature,
         ];
-        if ($this->max_tokens > 0) {
-            $payload['max_tokens'] = $this->max_tokens;
+        if ($max_tokens > 0) {
+            $payload['max_tokens'] = $max_tokens;
         }
         $args = [
             'headers' => [

--- a/includes/AI/ProviderInterface.php
+++ b/includes/AI/ProviderInterface.php
@@ -6,7 +6,8 @@ interface ProviderInterface {
      * Sends a prompt to the AI provider and returns the response text or an error.
      *
      * @param string $prompt Prompt to send to the provider.
+     * @param array  $args   Optional arguments to influence the query.
      * @return string|\WP_Error
      */
-    public function query(string $prompt): string|\WP_Error;
+    public function query(string $prompt, array $args = []): string|\WP_Error;
 }

--- a/tests/test-ai-utils.php
+++ b/tests/test-ai-utils.php
@@ -3,6 +3,7 @@ use function Gm2\gm2_ai_send_prompt;
 
 class AiUtilsTest extends WP_UnitTestCase {
     public function test_gpt4_turbo_model_selected() {
+        update_option('gm2_ai_provider', 'chatgpt');
         update_option('gm2_chatgpt_api_key', 'key');
         $captured = null;
         $filter = function($pre, $args, $url) use (&$captured) {


### PR DESCRIPTION
## Summary
- load AI provider classes via `gm2_ai_send_prompt` factory and forward prompt arguments
- allow providers to accept extra query args
- switch admin utilities to use provider-agnostic `gm2_ai_send_prompt`

## Testing
- `npm test`
- `phpunit` *(fails: Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ba1722e483279e8c4b8d46d982a4