### PR TITLE
Clean up Gemma and Llama options on uninstall

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -20,7 +20,8 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 // gm2_schema_review, gm2_show_footer_breadcrumbs, gm2_auto_fill_alt, gm2_enable_compression,
 // gm2_compression_api_key, gm2_compression_api_url, gm2_minify_html, gm2_minify_css,
 // gm2_minify_js, gm2_chatgpt_api_key, gm2_chatgpt_model, gm2_chatgpt_temperature,
-// gm2_chatgpt_max_tokens, gm2_chatgpt_endpoint, gm2_pagespeed_api_key, gm2_pagespeed_scores,
+// gm2_chatgpt_max_tokens, gm2_chatgpt_endpoint, gm2_gemma_api_key, gm2_gemma_endpoint,
+// gm2_llama_api_key, gm2_llama_endpoint, gm2_pagespeed_api_key, gm2_pagespeed_scores,
 // gm2_bulk_ai_page_size, gm2_bulk_ai_status, gm2_bulk_ai_post_type, gm2_bulk_ai_term.
 $option_names = array(
     'gm2_suite_settings',
@@ -69,6 +70,10 @@ $option_names = array(
     'gm2_chatgpt_temperature',
     'gm2_chatgpt_max_tokens',
     'gm2_chatgpt_endpoint',
+    'gm2_gemma_api_key',
+    'gm2_gemma_endpoint',
+    'gm2_llama_api_key',
+    'gm2_llama_endpoint',
     'gm2_min_internal_links',
     'gm2_min_external_links',
     'gm2_enable_tariff',


### PR DESCRIPTION
## Summary
- ensure Gemma and Llama API credentials are removed when the plugin is uninstalled

## Testing
- `make test DB_NAME=wp_test DB_USER=root DB_PASS=pass` *(fails: mysqladmin command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c414447c8327b1fcb37ae9075624