### PR TITLE
Add Gemma and Llama provider tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ bash bin/build-plugin.sh
 
 This script creates a `gm2-wordpress-suite.zip` file that includes the plugin and its bundled dependencies.
 
+## AI Providers
+
+The suite can generate content using multiple AI services. Select **ChatGPT**, **Gemma**, or **Llama** from the **Gm2 → AI Settings** page and enter the corresponding API key and optional endpoint. The chosen provider is used throughout the plugin for AI-powered features.
+
 ## Running Tests
 
 The PHPUnit tests rely on the official WordPress test suite. Before running the tests you must install the suite using the helper script provided in `bin`.
@@ -102,7 +106,7 @@ Generate the sitemap:
 wp gm2 sitemap generate
 ```
 
-Clear cached AI data and ChatGPT logs:
+Clear cached AI data and AI provider logs:
 
 ```bash
 wp gm2 ai clear

--- a/readme.txt
+++ b/readme.txt
@@ -8,11 +8,11 @@ License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
 == Description ==
-A powerful suite of WordPress enhancements including admin tools, frontend optimizations, and ChatGPT-powered content generation.
+A powerful suite of WordPress enhancements including admin tools, frontend optimizations, and AI-powered content generation via ChatGPT, Gemma, or Llama.
 
 Key features include:
 * SEO tools with breadcrumbs, caching and structured data
-* ChatGPT-powered content generation and keyword research
+* AI-powered content generation and keyword research via ChatGPT, Gemma, or Llama
 * WooCommerce quantity discounts with a dedicated Elementor widget (requires WooCommerce)
 * Registration and login Elementor widget with optional Google login (requires WooCommerce and Site Kit)
 * Abandoned cart tracking grouped by IP with email/phone capture, a Cart Settings page for selecting an Elementor popup, browsing-time and revisit metrics, an activity log, and recovery emails
@@ -29,8 +29,7 @@ Key features include:
 2. Activate the plugin through the 'Plugins' screen in WordPress.
 3. Use the Gm2 Suite menu in the admin sidebar to configure settings. First
    visit **Gm2 → Google OAuth Setup** to enter your client ID and secret, then
-   open **Gm2 → ChatGPT** to provide your OpenAI API key and choose a model from
-   the dropdown.
+   open **Gm2 → AI Settings** to choose an AI provider (ChatGPT, Gemma, or Llama) and supply the corresponding API key and endpoint.
    Finally, use **SEO → Connect Google Account** to authorize your Google account. After connecting, you will be able to select your Analytics Measurement ID and Ads Customer ID from dropdown menus.
 4. The plugin relies on WordPress's built-in HTTP API and has no external
    dependencies.
@@ -56,7 +55,7 @@ archive with `bash bin/build-plugin.sh`. This command packages the plugin with
 all dependencies into `gm2-wordpress-suite.zip` for installation via the
 **Plugins → Add New** screen.
 == Setup Wizard ==
-After activation the **Gm2 Setup Wizard** (`index.php?page=gm2-setup-wizard`) opens once to walk through entering your ChatGPT API key, Google OAuth credentials, sitemap settings and which modules to enable. The wizard is optional and can be launched again from the **Gm2 Suite** dashboard at any time.
+After activation the **Gm2 Setup Wizard** (`index.php?page=gm2-setup-wizard`) opens once to walk through entering your AI provider API key, Google OAuth credentials, sitemap settings and which modules to enable. The wizard is optional and can be launched again from the **Gm2 Suite** dashboard at any time.
 
 
 == Feature Toggles ==
@@ -147,17 +146,17 @@ Configuration:
 Enter your compression API key and enable the service from the SEO &gt; Performance screen.
 When enabled, uploaded images are sent to the API and replaced with the optimized result.
 
-== ChatGPT ==
-Configure the integration from **Gm2 → ChatGPT** in your WordPress admin area. Enter your
-OpenAI API key and adjust these options:
+== AI Providers ==
+Select your preferred AI service from **Gm2 → AI Settings**. Choose between **ChatGPT**, **Gemma**, or **Llama** and enter the required API key and endpoint.
 
-* **Model** – select the model to use from a dropdown. Options are fetched from
-  OpenAI when possible (defaults to `gpt-3.5-turbo`).
+When **ChatGPT** is selected you can also configure:
+
+* **Model** – defaults to `gpt-3.5-turbo`.
 * **Temperature** – controls randomness of responses.
 * **Max Tokens** – optional limit on the length of completions.
 * **API Endpoint** – URL of the chat completions API.
 
-Use the **Test Prompt** box on the same page to send a message and verify your
+Use the **Test Prompt** box on the same page (available for ChatGPT) to send a message and verify your
 settings before generating content.
 
 == SEO Guidelines ==
@@ -209,7 +208,7 @@ Example JSON response:
 ```
 
 == SEO Context ==
-Open the **Context** tab under **SEO** to store detailed business information used in AI prompts. Answer each question and the plugin will append your responses to every ChatGPT request:
+Open the **Context** tab under **SEO** to store detailed business information used in AI prompts. Answer each question and the plugin will append your responses to every AI request:
 
 * **Business Model** – How does the company make money (product sales, services, subscriptions, ads, affiliate, hybrid)?
 * **Industry Category** – Which industry best describes your business? If e-commerce, list main product categories and any flagship items. For services or SaaS, outline your core offerings and modules.
@@ -229,7 +228,7 @@ Open the **Context** tab under **SEO** to store detailed business information us
 * **Custom Prompts** – Default instructions appended to AI requests.
 * **Business Context Prompt** – One-click builder that combines your answers into a single prompt summarizing the business.
 
-To build the prompt, ensure the ChatGPT feature is enabled and save your API key and model under **Gm2 → ChatGPT**. Then return to **SEO → Context** and click **Generate AI Prompt** below the Business Context Prompt field. The plugin merges all of your Context answers and sends them to ChatGPT. The response is inserted into the textarea so you can tweak it before saving.
+To build the prompt, ensure your chosen AI provider is enabled and the API key saved under **Gm2 → AI Settings**. Then return to **SEO → Context** and click **Generate AI Prompt** below the Business Context Prompt field. The plugin merges all of your Context answers and sends them to the selected provider. The response is inserted into the textarea so you can tweak it before saving.
 
 == SEO Settings ==
 The SEO meta box appears when editing posts, pages, any public custom post types and taxonomy terms. In the

--- a/tests/js/gm2-context-prompt.test.js
+++ b/tests/js/gm2-context-prompt.test.js
@@ -25,6 +25,8 @@ test('displays server error message and re-enables button', async () => {
 
   const $ = jquery(dom.window);
   Object.assign(global, { window: dom.window, document: dom.window.document, jQuery: $, $ });
+  global.gm2AI = { provider: 'chatgpt' };
+  dom.window.gm2AI = global.gm2AI;
   global.gm2ChatGPT = { ajax_url: '/fake', nonce: 'n', error: 'Error' };
   dom.window.gm2ChatGPT = global.gm2ChatGPT;
 
@@ -66,6 +68,8 @@ test('shows message when response is 0', async () => {
 
   const $ = jquery(dom.window);
   Object.assign(global, { window: dom.window, document: dom.window.document, jQuery: $, $ });
+  global.gm2AI = { provider: 'chatgpt' };
+  dom.window.gm2AI = global.gm2AI;
   global.gm2ChatGPT = { ajax_url: '/fake', nonce: 'n', error: 'Error' };
   dom.window.gm2ChatGPT = global.gm2ChatGPT;
 

--- a/tests/test-gemma.php
+++ b/tests/test-gemma.php
@@ -1,0 +1,93 @@
+<?php
+use Gm2\AI\GemmaProvider as Gm2_Gemma;
+use Gm2\Gm2_Admin;
+
+class GemmaTest extends WP_UnitTestCase {
+    public function test_query_returns_response() {
+        update_option('gm2_gemma_api_key', 'key');
+        $endpoint = 'https://generativelanguage.googleapis.com/v1beta/models/gemma-7b-it:generateContent';
+        $filter = function($pre, $args, $url) use ($endpoint) {
+            if ($url === $endpoint) {
+                return [
+                    'response' => ['code' => 200],
+                    'body' => json_encode([
+                        'candidates' => [ [ 'content' => [ 'parts' => [ [ 'text' => 'hi' ] ] ] ] ]
+                    ])
+                ];
+            }
+            return false;
+        };
+        add_filter('pre_http_request', $filter, 10, 3);
+        $gemma = new Gm2_Gemma();
+        $res = $gemma->query('hello');
+        remove_filter('pre_http_request', $filter, 10);
+        $this->assertSame('hi', $res);
+    }
+
+    public function test_query_uses_custom_options() {
+        update_option('gm2_gemma_api_key', 'key');
+        update_option('gm2_gemma_temperature', '0.7');
+        update_option('gm2_gemma_max_tokens', '40');
+        update_option('gm2_gemma_endpoint', 'https://example.com/gemma');
+        $captured = null;
+        $filter = function($pre, $args, $url) use (&$captured) {
+            $captured = [$args, $url];
+            return [
+                'response' => ['code' => 200],
+                'body' => json_encode([
+                    'candidates' => [ [ 'content' => [ 'parts' => [ [ 'text' => 'hi' ] ] ] ] ]
+                ])
+            ];
+        };
+        add_filter('pre_http_request', $filter, 10, 3);
+        $gemma = new Gm2_Gemma();
+        $gemma->query('hello');
+        remove_filter('pre_http_request', $filter, 10);
+        list($args, $url) = $captured;
+        $body = json_decode($args['body'], true);
+        $this->assertSame('https://example.com/gemma', $url);
+        $this->assertSame(0.7, $body['generationConfig']['temperature']);
+        $this->assertSame(40, $body['generationConfig']['maxOutputTokens']);
+    }
+
+    public function test_gemma_page_contains_field() {
+        $admin = new Gm2_Admin();
+        ob_start();
+        $admin->display_ai_settings_page();
+        $out = ob_get_clean();
+        $this->assertStringContainsString('gm2_gemma_api_key', $out);
+        $this->assertStringContainsString('gm2_gemma_endpoint', $out);
+    }
+
+    public function test_form_saves_gemma_fields() {
+        $admin = new Gm2_Admin();
+        $user = self::factory()->user->create(['role' => 'administrator']);
+        wp_set_current_user($user);
+        $_POST['_wpnonce'] = wp_create_nonce('gm2_ai_settings');
+        $_POST['gm2_ai_provider'] = 'gemma';
+        $_POST['gm2_gemma_api_key'] = 'abc';
+        $_POST['gm2_gemma_endpoint'] = 'https://api.example.com';
+        $admin->handle_ai_settings_form();
+        $this->assertSame('abc', get_option('gm2_gemma_api_key'));
+        $this->assertSame('https://api.example.com', get_option('gm2_gemma_endpoint'));
+    }
+
+    public function test_error_when_gemma_disabled() {
+        update_option('gm2_gemma_api_key', 'key');
+        update_option('gm2_enable_gemma', '0');
+        $gemma = new Gm2_Gemma();
+        $res = $gemma->query('hi');
+        $this->assertInstanceOf('WP_Error', $res);
+        $this->assertSame('Gemma feature disabled', $res->get_error_message());
+        update_option('gm2_enable_gemma', '1');
+    }
+
+    public function test_error_when_api_key_missing() {
+        update_option('gm2_gemma_api_key', '');
+        $gemma = new Gm2_Gemma();
+        $res = $gemma->query('hi');
+        $this->assertInstanceOf('WP_Error', $res);
+        $this->assertSame('Gemma API key not set', $res->get_error_message());
+    }
+}
+

--- a/tests/test-llama.php
+++ b/tests/test-llama.php
@@ -1,0 +1,95 @@
+<?php
+use Gm2\AI\LlamaProvider as Gm2_Llama;
+use Gm2\Gm2_Admin;
+
+class LlamaTest extends WP_UnitTestCase {
+    public function test_query_returns_response() {
+        update_option('gm2_llama_api_key', 'key');
+        $endpoint = 'https://api.llama.com/v1/chat/completions';
+        $filter = function($pre, $args, $url) use ($endpoint) {
+            if ($url === $endpoint) {
+                return [
+                    'response' => ['code' => 200],
+                    'body' => json_encode([
+                        'choices' => [ [ 'message' => [ 'content' => 'hi' ] ] ]
+                    ])
+                ];
+            }
+            return false;
+        };
+        add_filter('pre_http_request', $filter, 10, 3);
+        $llama = new Gm2_Llama();
+        $res = $llama->query('hello');
+        remove_filter('pre_http_request', $filter, 10);
+        $this->assertSame('hi', $res);
+    }
+
+    public function test_query_uses_custom_options() {
+        update_option('gm2_llama_api_key', 'key');
+        update_option('gm2_llama_model', 'test-model');
+        update_option('gm2_llama_temperature', '0.3');
+        update_option('gm2_llama_max_tokens', '25');
+        update_option('gm2_llama_endpoint', 'https://example.com/llama');
+        $captured = null;
+        $filter = function($pre, $args, $url) use (&$captured) {
+            $captured = [$args, $url];
+            return [
+                'response' => ['code' => 200],
+                'body' => json_encode([
+                    'choices' => [ [ 'message' => [ 'content' => 'hi' ] ] ]
+                ])
+            ];
+        };
+        add_filter('pre_http_request', $filter, 10, 3);
+        $llama = new Gm2_Llama();
+        $llama->query('hello');
+        remove_filter('pre_http_request', $filter, 10);
+        list($args, $url) = $captured;
+        $body = json_decode($args['body'], true);
+        $this->assertSame('https://example.com/llama', $url);
+        $this->assertSame('test-model', $body['model']);
+        $this->assertSame(0.3, $body['temperature']);
+        $this->assertSame(25, $body['max_tokens']);
+    }
+
+    public function test_llama_page_contains_field() {
+        $admin = new Gm2_Admin();
+        ob_start();
+        $admin->display_ai_settings_page();
+        $out = ob_get_clean();
+        $this->assertStringContainsString('gm2_llama_api_key', $out);
+        $this->assertStringContainsString('gm2_llama_endpoint', $out);
+    }
+
+    public function test_form_saves_llama_fields() {
+        $admin = new Gm2_Admin();
+        $user = self::factory()->user->create(['role' => 'administrator']);
+        wp_set_current_user($user);
+        $_POST['_wpnonce'] = wp_create_nonce('gm2_ai_settings');
+        $_POST['gm2_ai_provider'] = 'llama';
+        $_POST['gm2_llama_api_key'] = 'abc';
+        $_POST['gm2_llama_endpoint'] = 'https://api.example.com';
+        $admin->handle_ai_settings_form();
+        $this->assertSame('abc', get_option('gm2_llama_api_key'));
+        $this->assertSame('https://api.example.com', get_option('gm2_llama_endpoint'));
+    }
+
+    public function test_error_when_llama_disabled() {
+        update_option('gm2_llama_api_key', 'key');
+        update_option('gm2_enable_llama', '0');
+        $llama = new Gm2_Llama();
+        $res = $llama->query('hi');
+        $this->assertInstanceOf('WP_Error', $res);
+        $this->assertSame('Llama feature disabled', $res->get_error_message());
+        update_option('gm2_enable_llama', '1');
+    }
+
+    public function test_error_when_api_key_missing() {
+        update_option('gm2_llama_api_key', '');
+        $llama = new Gm2_Llama();
+        $res = $llama->query('hi');
+        $this->assertInstanceOf('WP_Error', $res);
+        $this->assertSame('Llama API key not set', $res->get_error_message());
+    }
+}
+


### PR DESCRIPTION
## Summary
- add PHPUnit coverage for GemmaProvider and LlamaProvider
- support provider selection in JS tests
- document Gemma and Llama providers with selection workflow

## Testing
- `npm test -- tests/js/gm2-context-prompt.test.js`
- `php phpunit.phar --version` *(fails: Could not open input file)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c87514f88327b18f75818e253008