### PR TITLE
Handle end-of-data in activity log infinite scroll

### DIFF
--- a/admin/js/gm2-ac-activity-log.js
+++ b/admin/js/gm2-ac-activity-log.js
@@ -47,11 +47,13 @@ jQuery(function($){
             }
             if((hasActivity && response.data.activity.length === gm2AcActivityLog.per_page) || (hasVisits && response.data.visits.length === gm2AcActivityLog.per_page)){
                 wrap.data('page', page + 1);
+                wrap.data('end', false);
                 if(!wrap.find('.gm2-ac-load-more').length){
                     wrap.append('<button class="gm2-ac-load-more">'+gm2AcActivityLog.load_more+'</button>');
                 }
             } else {
                 wrap.find('.gm2-ac-load-more').remove();
+                wrap.data('end', true);
             }
         }).fail(function(){
             if(page === 1){
@@ -74,18 +76,19 @@ jQuery(function($){
         var row = $('<tr class="gm2-ac-activity-row"><td colspan="'+colspan+'"><div class="gm2-ac-activity-wrap" style="max-height:300px;overflow:auto;"></div></td></tr>');
         tr.after(row);
         var wrap = row.find('.gm2-ac-activity-wrap');
-        wrap.data({ ip: btn.data('ip'), page: 1, loading: false });
+        wrap.data({ ip: btn.data('ip'), page: 1, loading: false, end: false });
         loadPage(wrap);
         btn.prop('disabled', false);
     });
     $(document).on('click', '.gm2-ac-load-more', function(e){
         e.preventDefault();
         var wrap = $(this).closest('.gm2-ac-activity-wrap');
+        wrap.data('end', false);
         loadPage(wrap);
     });
     $(document).on('scroll', '.gm2-ac-activity-wrap', function(){
         var wrap = $(this);
-        if(wrap.data('loading')){
+        if(wrap.data('loading') || wrap.data('end')){
             return;
         }
         if(this.scrollTop + wrap.innerHeight() + 20 >= this.scrollHeight){

--- a/tests/js/gm2-ac-activity-log.test.js
+++ b/tests/js/gm2-ac-activity-log.test.js
@@ -52,3 +52,74 @@ test('paginates activity items', async () => {
   expect(items.eq(1).text()).toContain('SKU2');
 });
 
+test('stops auto-loading when no more results', async () => {
+  const dom = new JSDOM(`
+    <table id="log">
+      <tr id="row">
+        <td><a href="#" class="gm2-ac-activity-log-button" data-ip="1.2.3.4">Log</a></td>
+      </tr>
+    </table>
+  `, { url: 'http://localhost' });
+
+  const $ = jquery(dom.window);
+  Object.assign(global, { window: dom.window, document: dom.window.document, jQuery: $, $ });
+  global.gm2AcActivityLog = { ajax_url: '/ajax', nonce: 'nonce', empty: 'empty', error: 'error', load_more: 'more', per_page: 1 };
+
+  $.post = jest.fn()
+    .mockImplementationOnce(() => $.Deferred().resolve({
+      success: true,
+      data: {
+        activity: [{ changed_at: '2024-01-01', action: 'add', sku: 'SKU1', quantity: 1 }]
+      }
+    }).promise())
+    .mockImplementationOnce(() => $.Deferred().resolve({
+      success: true,
+      data: {
+        activity: []
+      }
+    }).promise())
+    .mockImplementationOnce(() => $.Deferred().resolve({
+      success: true,
+      data: {
+        activity: []
+      }
+    }).promise());
+
+  jest.resetModules();
+  require('../../admin/js/gm2-ac-activity-log.js');
+
+  const flush = () => new Promise(r => setTimeout(r, 0));
+  await flush();
+  await flush();
+
+  $('.gm2-ac-activity-log-button').trigger('click');
+
+  await flush();
+
+  // simulate scroll to load second page
+  const wrap = $('.gm2-ac-activity-wrap');
+  wrap[0].scrollTop = 100;
+  wrap[0].scrollHeight = 100;
+  wrap.trigger('scroll');
+
+  await flush();
+
+  expect($.post).toHaveBeenCalledTimes(2);
+
+  // append a manual load more button and trigger scroll again; should not load more due to end flag
+  wrap.append('<button class="gm2-ac-load-more">more</button>');
+  wrap[0].scrollTop = 100;
+  wrap.trigger('scroll');
+
+  await flush();
+
+  expect($.post).toHaveBeenCalledTimes(2);
+
+  // manual click resets end and allows another request
+  wrap.find('.gm2-ac-load-more').trigger('click');
+
+  await flush();
+
+  expect($.post).toHaveBeenCalledTimes(3);
+});
+


### PR DESCRIPTION
## Summary
- prevent auto-loading past the last page by tracking an `end` flag
- reset the `end` flag on manual load-more clicks
- test that infinite scroll stops when no more results are returned

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7c89c7edc8327b9a0c22fecad130f