### PR TITLE
Add deletion capability for custom post types and taxonomies

### DIFF
--- a/admin/js/gm2-cpt-overview.js
+++ b/admin/js/gm2-cpt-overview.js
@@ -62,4 +62,7 @@ jQuery(function($){
         fillTaxonomy($(this).data('slug'));
         $('html, body').animate({ scrollTop: $('#gm2-tax-form').offset().top }, 200);
     });
+    $('.gm2-delete-pt-form, .gm2-delete-tax-form').on('submit', function(){
+        return confirm(gm2CPTEdit.deleteConfirm);
+    });
 });


### PR DESCRIPTION
## Summary
- Add delete actions and handlers for removing custom post types and taxonomies
- Display delete links with nonce-protected forms and success/error notices
- Confirm deletions via JavaScript prompt

## Testing
- `npm test`
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68abf9f0484c83279b5cad80fcb5e0e8