### PR TITLE
Secure edit handlers for custom content types

### DIFF
--- a/admin/Gm2_Custom_Posts_Admin.php
+++ b/admin/Gm2_Custom_Posts_Admin.php
@@ -671,7 +671,11 @@ class Gm2_Custom_Posts_Admin {
         }
         $config = $this->get_config();
         if ($_SERVER['REQUEST_METHOD'] === 'GET') {
-            $slug = sanitize_key($_GET['slug'] ?? '');
+            $slug  = sanitize_key($_GET['slug'] ?? '');
+            $nonce = sanitize_text_field($_GET['_wpnonce'] ?? '');
+            if (!wp_verify_nonce($nonce, 'gm2_edit_post_type')) {
+                wp_send_json_error();
+            }
             if ($slug && isset($config['post_types'][$slug])) {
                 wp_send_json_success($config['post_types'][$slug]);
             }
@@ -783,7 +787,11 @@ class Gm2_Custom_Posts_Admin {
         }
         $config = $this->get_config();
         if ($_SERVER['REQUEST_METHOD'] === 'GET') {
-            $slug = sanitize_key($_GET['slug'] ?? '');
+            $slug  = sanitize_key($_GET['slug'] ?? '');
+            $nonce = sanitize_text_field($_GET['_wpnonce'] ?? '');
+            if (!wp_verify_nonce($nonce, 'gm2_edit_taxonomy')) {
+                wp_send_json_error();
+            }
             if ($slug && isset($config['taxonomies'][$slug])) {
                 wp_send_json_success($config['taxonomies'][$slug]);
             }
@@ -1647,7 +1655,7 @@ class Gm2_Custom_Posts_Admin {
                 true
             );
             wp_localize_script('gm2-cpt-overview', 'gm2CPTEdit', [
-                'nonce'    => wp_create_nonce('gm2_edit_post_type'),
+                'ptNonce'  => wp_create_nonce('gm2_edit_post_type'),
                 'taxNonce' => wp_create_nonce('gm2_edit_taxonomy'),
                 'ptUrl'    => admin_url('admin-post.php?action=gm2_edit_post_type'),
                 'taxUrl'   => admin_url('admin-post.php?action=gm2_edit_taxonomy'),

--- a/admin/js/gm2-cpt-overview.js
+++ b/admin/js/gm2-cpt-overview.js
@@ -1,7 +1,7 @@
 jQuery(function($){
     if(typeof gm2CPTEdit === 'undefined'){ return; }
     function fillPostType(slug){
-        $.get(gm2CPTEdit.ptUrl, { slug: slug, _wpnonce: gm2CPTEdit.nonce }, function(resp){
+        $.get(gm2CPTEdit.ptUrl, { slug: slug, _wpnonce: gm2CPTEdit.ptNonce }, function(resp){
             if(!resp || !resp.success){ return; }
             var data = resp.data || {};
             var form = $('#gm2-post-type-form');


### PR DESCRIPTION
## Summary
- Validate nonces when fetching post type and taxonomy definitions for editing
- Localize edit nonce to JavaScript and consume it when pre-populating forms

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac420d725c832787f46d18df029e10