### PR TITLE
Capture entry URL during contact capture

### DIFF
--- a/public/Gm2_Abandoned_Carts_Public.php
+++ b/public/Gm2_Abandoned_Carts_Public.php
@@ -106,6 +106,7 @@ class Gm2_Abandoned_Carts_Public {
 
         $token            = '';
         $session_entry_url = '';
+        $post_url         = isset($_POST['url']) ? esc_url_raw(wp_unslash($_POST['url'])) : '';
         $client_id        = isset($_POST['client_id']) ? sanitize_text_field(wp_unslash($_POST['client_id'])) : (isset($_COOKIE['gm2_ac_client_id']) ? sanitize_text_field(wp_unslash($_COOKIE['gm2_ac_client_id'])) : '');
         if (class_exists('WC_Session') && WC()->session) {
             $token            = WC()->session->get_customer_id();
@@ -123,6 +124,8 @@ class Gm2_Abandoned_Carts_Public {
             WC()->session->set('gm2_entry_url', null);
         } elseif (isset($_COOKIE['gm2_entry_url'])) {
             $stored_entry = esc_url_raw(wp_unslash($_COOKIE['gm2_entry_url']));
+        } elseif (!empty($post_url)) {
+            $stored_entry = $post_url;
         }
         if (empty($stored_entry)) {
             if (class_exists('WC_Session') && WC()->session) {

--- a/public/js/gm2-ac-email-capture.js
+++ b/public/js/gm2-ac-email-capture.js
@@ -15,7 +15,8 @@ jQuery(function($){
             action: 'gm2_ac_contact_capture',
             nonce: gm2AcEmailCapture.nonce,
             email: emailVal,
-            phone: phoneVal
+            phone: phoneVal,
+            url: window.location.href
         });
     };
     $email.add($phone).on('change input', function(){

--- a/public/js/gm2-ac-popup.js
+++ b/public/js/gm2-ac-popup.js
@@ -30,7 +30,8 @@ jQuery(function($){
             action: 'gm2_ac_contact_capture',
             nonce: gm2AcPopup.nonce,
             email: email,
-            phone: phone
+            phone: phone,
+            url: window.location.href
         });
     });
 });


### PR DESCRIPTION
## Summary
- include current page URL in email capture requests
- include current page URL in popup contact capture
- use posted URL as fallback entry URL in contact capture handler

## Testing
- `npm test`
- `make test` *(fails: Database credentials must be supplied via DB_NAME, DB_USER and DB_PASS.)*

------
https://chatgpt.com/codex/tasks/task_e_68ad922f4740832791d44d5f4c6546dd