### PR TITLE
Handle missing entry URL in cart activity

### DIFF
--- a/includes/Gm2_Abandoned_Carts.php
+++ b/includes/Gm2_Abandoned_Carts.php
@@ -610,6 +610,15 @@ class Gm2_Abandoned_Carts {
         }
 
         $url       = esc_url_raw($_POST['url'] ?? '');
+        if (empty($url) || false !== strpos($url, '/admin-ajax.php')) {
+            $fallback = isset($_SERVER['HTTP_REFERER']) ? esc_url_raw(wp_unslash($_SERVER['HTTP_REFERER'])) : '';
+            if (empty($fallback) && class_exists('WC_Session') && WC()->session) {
+                $fallback = WC()->session->get('gm2_ac_last_seen_url');
+            }
+            if (!empty($fallback)) {
+                $url = $fallback;
+            }
+        }
         $client_id = isset($_POST['client_id']) ? sanitize_text_field(wp_unslash($_POST['client_id'])) : '';
         $token     = '';
         if (class_exists('WC_Session') && WC()->session) {


### PR DESCRIPTION
## Summary
- Fallback to HTTP referrer or session when gm2_ac_mark_active receives an empty or admin-ajax URL
- Test admin-ajax and empty URL fallbacks for entry URL persistence

## Testing
- `npm test`
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ad93690d208327968aad401452a71c