### PR TITLE
Ensure nonce field renders in custom post bulk delete form

### DIFF
--- a/admin/Gm2_Custom_Posts_Admin.php
+++ b/admin/Gm2_Custom_Posts_Admin.php
@@ -1061,7 +1061,7 @@ class Gm2_Custom_Posts_Admin {
         $table->prepare_items();
         echo '<form method="post" action="' . esc_url(admin_url('admin-post.php')) . '">';
         echo '<input type="hidden" name="action" value="gm2_delete_post_type" />';
-        wp_nonce_field( 'bulk-posts', '_wpnonce', true, false );
+        wp_nonce_field( 'bulk-posts' );
         $table->display();
         echo '</form>';
 


### PR DESCRIPTION
## Summary
- Print the bulk posts nonce field so the custom post type deletion form includes `_wpnonce`.

## Testing
- `npm test` *(fails: jest not found)*
- `phpunit` *(fails: command not found)*
- `make test` *(fails: database credentials must be supplied)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9e431d74832783ac3a03d584e090