### PR TITLE
Use bulk-gm2-cpts nonce

### DIFF
--- a/admin/Gm2_Custom_Posts_Admin.php
+++ b/admin/Gm2_Custom_Posts_Admin.php
@@ -849,7 +849,7 @@ class Gm2_Custom_Posts_Admin {
             exit;
         }
         if (count($slugs) > 1 || $bulk_action === 'delete') {
-            check_admin_referer('bulk-posts');
+            check_admin_referer('bulk-gm2-cpts');
         } else {
             check_admin_referer('gm2_delete_post_type_' . $slugs[0]);
         }
@@ -1061,7 +1061,6 @@ class Gm2_Custom_Posts_Admin {
         $table->prepare_items();
         echo '<form method="post" action="' . esc_url(admin_url('admin-post.php')) . '">';
         echo '<input type="hidden" name="action" value="gm2_delete_post_type" />';
-        wp_nonce_field( 'bulk-posts' );
         $table->display();
         echo '</form>';
 


### PR DESCRIPTION
## Summary
- use `bulk-gm2-cpts` for bulk deletion nonce checks
- rely on `WP_List_Table` nonce output and remove redundant nonce field

## Testing
- `npm test`
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ada0850df883279008c45260850b62