### PR TITLE
Add Search Console indexing support

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -352,6 +352,15 @@ class Gm2_SEO_Admin {
 
         add_submenu_page(
             'gm2-seo',
+            esc_html__( 'Search Console', 'gm2-wordpress-suite' ),
+            esc_html__( 'Search Console', 'gm2-wordpress-suite' ),
+            'manage_options',
+            'gm2-search-console',
+            [$this, 'display_search_console_page']
+        );
+
+        add_submenu_page(
+            'gm2-seo',
             esc_html__( 'Robots.txt', 'gm2-wordpress-suite' ),
             esc_html__( 'Robots.txt', 'gm2-wordpress-suite' ),
             'manage_options',
@@ -412,6 +421,21 @@ class Gm2_SEO_Admin {
         ]);
         register_setting('gm2_seo_options', 'gm2_sc_query_limit', [
             'sanitize_callback' => 'absint',
+        ]);
+        register_setting('gm2_seo_options', 'gm2_sc_client_id', [
+            'sanitize_callback' => 'sanitize_text_field',
+        ]);
+        register_setting('gm2_seo_options', 'gm2_sc_client_secret', [
+            'sanitize_callback' => 'sanitize_text_field',
+        ]);
+        register_setting('gm2_seo_options', 'gm2_sc_refresh_token', [
+            'sanitize_callback' => 'sanitize_text_field',
+        ]);
+        register_setting('gm2_seo_options', 'gm2_sc_service_account_json', [
+            'sanitize_callback' => 'sanitize_text_field',
+        ]);
+        register_setting('gm2_seo_options', 'gm2_sc_auto', [
+            'sanitize_callback' => 'sanitize_text_field',
         ]);
         register_setting('gm2_seo_options', 'gm2_analytics_days', [
             'sanitize_callback' => 'absint',
@@ -6032,6 +6056,36 @@ class Gm2_SEO_Admin {
             return $data['data'];
         }
         return new \WP_Error('gm2_ai_error', is_array($data) && isset($data['data']) ? $data['data'] : 'error');
+    }
+
+    public function display_search_console_page() {
+        $notice = '';
+        if (isset($_POST['gm2_sc_nonce']) && wp_verify_nonce($_POST['gm2_sc_nonce'], 'gm2_sc_save')) {
+            $cid    = sanitize_text_field($_POST['gm2_sc_client_id'] ?? '');
+            $secret = sanitize_text_field($_POST['gm2_sc_client_secret'] ?? '');
+            $token  = sanitize_text_field($_POST['gm2_sc_refresh_token'] ?? '');
+            $json   = sanitize_text_field($_POST['gm2_sc_service_account_json'] ?? '');
+            $auto   = isset($_POST['gm2_sc_auto']) ? '1' : '0';
+            update_option('gm2_sc_client_id', $cid);
+            update_option('gm2_sc_client_secret', $secret);
+            update_option('gm2_sc_refresh_token', $token);
+            update_option('gm2_sc_service_account_json', $json);
+            update_option('gm2_sc_auto', $auto);
+            $notice = '<div class="updated notice"><p>' . esc_html__('Settings saved.', 'gm2-wordpress-suite') . '</p></div>';
+        }
+        echo '<div class="wrap"><h1>' . esc_html__('Search Console Settings', 'gm2-wordpress-suite') . '</h1>';
+        echo $notice;
+        echo '<form method="post">';
+        wp_nonce_field('gm2_sc_save', 'gm2_sc_nonce');
+        echo '<table class="form-table"><tbody>';
+        echo '<tr><th scope="row">' . esc_html__('Client ID', 'gm2-wordpress-suite') . '</th><td><input type="text" name="gm2_sc_client_id" value="' . esc_attr(get_option('gm2_sc_client_id', '')) . '" class="regular-text" /></td></tr>';
+        echo '<tr><th scope="row">' . esc_html__('Client Secret', 'gm2-wordpress-suite') . '</th><td><input type="text" name="gm2_sc_client_secret" value="' . esc_attr(get_option('gm2_sc_client_secret', '')) . '" class="regular-text" /></td></tr>';
+        echo '<tr><th scope="row">' . esc_html__('Refresh Token', 'gm2-wordpress-suite') . '</th><td><input type="text" name="gm2_sc_refresh_token" value="' . esc_attr(get_option('gm2_sc_refresh_token', '')) . '" class="regular-text" /></td></tr>';
+        echo '<tr><th scope="row">' . esc_html__('Service Account JSON', 'gm2-wordpress-suite') . '</th><td><input type="text" name="gm2_sc_service_account_json" value="' . esc_attr(get_option('gm2_sc_service_account_json', '')) . '" class="regular-text" /></td></tr>';
+        echo '<tr><th scope="row">' . esc_html__('Automatic Product Submissions', 'gm2-wordpress-suite') . '</th><td><label><input type="checkbox" name="gm2_sc_auto" value="1" ' . checked(get_option('gm2_sc_auto', '0'), '1', false) . '> ' . esc_html__('Enable', 'gm2-wordpress-suite') . '</label></td></tr>';
+        echo '</tbody></table>';
+        submit_button();
+        echo '</form></div>';
     }
 
     public function cron_process_ai_tax_queue() {

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -100,6 +100,7 @@ require_once GM2_PLUGIN_DIR . 'includes/Gm2_Capability_Manager.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_Workflow_Manager.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_Audit_Log.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_Ajax_Upload.php';
+require_once GM2_PLUGIN_DIR . 'includes/Gm2_Search_Console.php';
 
 \Gm2\Gm2_REST_Visibility::init();
 \Gm2\Gm2_REST_Rate_Limiter::init();
@@ -107,6 +108,7 @@ require_once GM2_PLUGIN_DIR . 'includes/Gm2_Ajax_Upload.php';
 \Gm2\Gm2_REST_Fields::init();
 \Gm2\Gm2_Webhooks::init();
 \Gm2\Gm2_Ajax_Upload::init();
+\Gm2\Gm2_Search_Console::init();
 
 function gm2_add_weekly_schedule($schedules) {
     if (!isset($schedules['weekly'])) {

--- a/includes/Gm2_Search_Console.php
+++ b/includes/Gm2_Search_Console.php
@@ -1,0 +1,106 @@
+<?php
+namespace Gm2;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Gm2_Search_Console {
+    public static function init() {
+        add_action('save_post_product', [__CLASS__, 'maybe_request_indexing'], 10, 1);
+    }
+
+    public static function maybe_request_indexing($post_id) {
+        if (get_option('gm2_sc_auto', '0') !== '1') {
+            return;
+        }
+        self::request_indexing($post_id);
+    }
+
+    public static function request_indexing($post_id) {
+        if (wp_is_post_revision($post_id)) {
+            return;
+        }
+        $post = get_post($post_id);
+        if (!$post || $post->post_status !== 'publish') {
+            return;
+        }
+        $url = get_permalink($post);
+        if (!$url) {
+            return;
+        }
+        $token = self::get_access_token();
+        if (!$token) {
+            return;
+        }
+        $body = wp_json_encode([
+            'url'  => $url,
+            'type' => 'URL_UPDATED',
+        ]);
+        wp_remote_post('https://indexing.googleapis.com/v3/urlNotifications:publish', [
+            'headers' => [
+                'Content-Type'  => 'application/json',
+                'Authorization' => 'Bearer ' . $token,
+            ],
+            'body'    => $body,
+            'timeout' => 20,
+        ]);
+    }
+
+    private static function get_access_token() {
+        $refresh = get_option('gm2_sc_refresh_token', '');
+        $client  = get_option('gm2_sc_client_id', '');
+        $secret  = get_option('gm2_sc_client_secret', '');
+        if ($refresh && $client && $secret) {
+            $resp = wp_remote_post('https://oauth2.googleapis.com/token', [
+                'body' => [
+                    'client_id'     => $client,
+                    'client_secret' => $secret,
+                    'refresh_token' => $refresh,
+                    'grant_type'    => 'refresh_token',
+                ],
+                'timeout' => 20,
+            ]);
+            if (!is_wp_error($resp)) {
+                $data = json_decode(wp_remote_retrieve_body($resp), true);
+                if (isset($data['access_token'])) {
+                    return $data['access_token'];
+                }
+            }
+        }
+        $json = get_option('gm2_sc_service_account_json', '');
+        if ($json && file_exists($json)) {
+            $creds = json_decode(file_get_contents($json), true);
+            if ($creds && !empty($creds['client_email']) && !empty($creds['private_key'])) {
+                $now = time();
+                $hdr = rtrim(strtr(base64_encode(json_encode(['alg' => 'RS256', 'typ' => 'JWT'])), '+/', '-_'), '=');
+                $clm = rtrim(strtr(base64_encode(json_encode([
+                    'iss'   => $creds['client_email'],
+                    'scope' => 'https://www.googleapis.com/auth/indexing',
+                    'aud'   => 'https://oauth2.googleapis.com/token',
+                    'exp'   => $now + 3600,
+                    'iat'   => $now,
+                ])), '+/', '-_'), '=');
+                $sig_data = $hdr . '.' . $clm;
+                if (!function_exists('openssl_sign')) {
+                    return '';
+                }
+                openssl_sign($sig_data, $signature, $creds['private_key'], 'sha256');
+                $sig = rtrim(strtr(base64_encode($signature), '+/', '-_'), '=');
+                $jwt = $sig_data . '.' . $sig;
+                $resp = wp_remote_post('https://oauth2.googleapis.com/token', [
+                    'body' => [
+                        'grant_type' => 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                        'assertion'  => $jwt,
+                    ],
+                    'timeout' => 20,
+                ]);
+                if (!is_wp_error($resp)) {
+                    $data = json_decode(wp_remote_retrieve_body($resp), true);
+                    return $data['access_token'] ?? '';
+                }
+            }
+        }
+        return '';
+    }
+}


### PR DESCRIPTION
## Summary
- integrate Google Search Console indexing API
- auto-request indexing for products on save
- add admin settings for Search Console credentials and auto-submit toggle

## Testing
- `npm test` *(fails: jest not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9f8cd17083278fe1d4d3483cb9f7