### PR TITLE
Mark revisit entries in activity log

### DIFF
--- a/admin/js/gm2-ac-activity-log.js
+++ b/admin/js/gm2-ac-activity-log.js
@@ -33,14 +33,16 @@ jQuery(function($){
             }
             if(hasVisits){
                 response.data.visits.forEach(function(visit){
+                    var entryLabel = visit.is_revisit ? 'Revisit Entry URL ' : 'Entry URL ';
                     events.push({
                         time: new Date(visit.visit_start),
-                        html: '<li>'+visit.ip_address+' Entry @ <strong>'+visit.visit_start+'</strong> \u2192 Revisit Entry URL '+visit.entry_url+'</li>'
+                        html: '<li>'+visit.ip_address+' Entry @ <strong>'+visit.visit_start+'</strong> \u2192 '+entryLabel+visit.entry_url+'</li>'
                     });
                     if(visit.visit_end){
+                        var exitLabel = visit.is_revisit ? 'Revisit Exit URL ' : 'Exit URL ';
                         events.push({
                             time: new Date(visit.visit_end),
-                            html: '<li>'+visit.ip_address+' Exit @ <strong>'+visit.visit_end+'</strong> \u2192 Revisit Exit URL '+visit.exit_url+'</li>'
+                            html: '<li>'+visit.ip_address+' Exit @ <strong>'+visit.visit_end+'</strong> \u2192 '+exitLabel+visit.exit_url+'</li>'
                         });
                     }
                 });

--- a/tests/ActivityLogPagingTest.php
+++ b/tests/ActivityLogPagingTest.php
@@ -57,7 +57,10 @@ namespace {
             $this->assertCount(10, $result['data']['visits']);
             $this->assertSame('/p10', $result['data']['visits'][0]['entry_url']);
             $this->assertSame('127.0.0.10', $result['data']['visits'][0]['ip_address']);
-            $this->assertSame('/p1', end($result['data']['visits'])['entry_url']);
+            $this->assertTrue($result['data']['visits'][0]['is_revisit']);
+            $last_visit = end($result['data']['visits']);
+            $this->assertSame('/p1', $last_visit['entry_url']);
+            $this->assertFalse($last_visit['is_revisit']);
         }
     }
 
@@ -88,6 +91,15 @@ namespace {
                 return array_map(fn($r)=>(object)$r,$slice);
             }
             return [];
+        }
+        public function get_var($sql){
+            if(strpos($this->last_sql,'MIN(visit_start)')!==false){
+                $cart_id=$this->last_args[0];
+                $rows=array_filter($this->data[$this->prefix.'wc_ac_visit_log'], fn($r)=>$r['cart_id']==$cart_id);
+                usort($rows, fn($a,$b)=>strcmp($a['visit_start'],$b['visit_start']));
+                return $rows? $rows[0]['visit_start']: null;
+            }
+            return null;
         }
     }
 }


### PR DESCRIPTION
## Summary
- flag cart visit history with `is_revisit` to distinguish initial visit from returns
- show revisit labels in activity log admin UI
- test that visit data includes revisit info

## Testing
- `phpunit tests/ActivityLogPagingTest.php` *(fails: phpunit: No such file or directory)*
- `npm test` *(fails: npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9f65be4c8327bcb4b0050632defb