### PR TITLE
Skip setting entry URL during AJAX requests

### DIFF
--- a/includes/Gm2_Abandoned_Carts.php
+++ b/includes/Gm2_Abandoned_Carts.php
@@ -173,6 +173,9 @@ class Gm2_Abandoned_Carts {
     }
 
     public function maybe_set_entry_url() {
+        if (wp_doing_ajax() || wp_doing_cron() || defined('REST_REQUEST') || isset($_GET['wc-ajax'])) {
+            return;
+        }
         $skip_admin = apply_filters('gm2_ac_skip_admin', true);
         if (
             $skip_admin &&

--- a/tests/test-abandoned-carts.php
+++ b/tests/test-abandoned-carts.php
@@ -306,6 +306,20 @@ class AbandonedCartsTest extends WP_UnitTestCase {
         $this->assertSame('http://example.com/landing', WC()->session->get('gm2_entry_url'));
     }
 
+    public function test_maybe_set_entry_url_skips_ajax_requests() {
+        $table = $GLOBALS['wpdb']->prefix . 'wc_ac_carts';
+        $ac    = new \Gm2\Gm2_Abandoned_Carts();
+        $row_before     = $GLOBALS['wpdb']->data[$table][0];
+        $session_before = WC()->session->get('gm2_entry_url');
+        $_SERVER['REQUEST_URI'] = '/?wc-ajax=get_refreshed_fragments';
+        $GLOBALS['wp_doing_ajax'] = true;
+        $ac->maybe_set_entry_url();
+        unset($GLOBALS['wp_doing_ajax']);
+        $row_after = $GLOBALS['wpdb']->data[$table][0];
+        $this->assertSame($session_before, WC()->session->get('gm2_entry_url'));
+        $this->assertSame($row_before['entry_url'] ?? null, $row_after['entry_url'] ?? null);
+    }
+
     public function test_capture_cart_entry_url_uses_full_request_uri() {
         $table = $GLOBALS['wpdb']->prefix . 'wc_ac_carts';
         $GLOBALS['wpdb']->data[$table] = [];


### PR DESCRIPTION
## Summary
- prevent entry URL tracking during AJAX, cron, REST, and WooCommerce AJAX requests
- add PHPUnit coverage for skipping entry URL on AJAX requests

## Testing
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*


------
https://chatgpt.com/codex/tasks/task_e_68addca7889c8327bbf255dc025aecdb