### PR TITLE
Add LocalGemmaProvider for local Gemma inference

### DIFF
--- a/includes/AI/LocalGemmaProvider.php
+++ b/includes/AI/LocalGemmaProvider.php
@@ -1,0 +1,43 @@
+<?php
+namespace Gm2\AI;
+
+use WP_Error;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class LocalGemmaProvider implements ProviderInterface {
+    private string $binary;
+    private string $model;
+
+    public function __construct() {
+        $this->binary = get_option('gm2_gemma_binary_path', '/usr/local/bin/gemma');
+        $this->model  = get_option('gm2_gemma_model_path', '');
+    }
+
+    public function query(string $prompt, array $args = []): string|WP_Error {
+        $binary = $args['binary'] ?? $this->binary;
+        $model  = $args['model'] ?? $args['model_path'] ?? $this->model;
+        if ($binary === '' || !file_exists($binary)) {
+            return new WP_Error('binary_not_found', 'Gemma binary not found');
+        }
+        if ($model === '' || !file_exists($model)) {
+            return new WP_Error('model_not_found', 'Model file not found');
+        }
+        $temperature = isset($args['temperature']) ? floatval($args['temperature']) : 1.0;
+        $max_tokens  = isset($args['max_tokens']) ? intval($args['max_tokens']) : (isset($args['number-of-words']) ? intval($args['number-of-words']) : 0);
+        $command = escapeshellcmd($binary)
+            . ' -m ' . escapeshellarg($model)
+            . ' -p ' . escapeshellarg($prompt)
+            . ' --temp ' . escapeshellarg((string)$temperature);
+        if ($max_tokens > 0) {
+            $command .= ' -n ' . intval($max_tokens);
+        }
+        $output = shell_exec($command);
+        if ($output === null) {
+            return new WP_Error('execution_failed', 'Failed to execute Gemma binary');
+        }
+        return trim($output);
+    }
+}


### PR DESCRIPTION
## Summary
- add LocalGemmaProvider to run a Gemma binary locally
- read Gemma binary and model paths from WordPress options
- support temperature and token limits and surface WP_Error for missing paths

## Testing
- `npm test`
- attempted `wget -O phpunit.phar https://phar.phpunit.de/phpunit-9.6.15.phar` *(blocked: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0c61b1a88327a79b36158b4cb2e3