### PR TITLE
feat: allow local gemma provider

### DIFF
--- a/includes/Gm2_SEO_Utils.php
+++ b/includes/Gm2_SEO_Utils.php
@@ -87,6 +87,7 @@ namespace {
         $map = [
             'chatgpt'     => '\\Gm2\\AI\\ChatGPTProvider',
             'gemma'       => '\\Gm2\\AI\\GemmaProvider',
+            'gemma_local' => '\\Gm2\\AI\\LocalGemmaProvider',
             'llama'       => '\\Gm2\\AI\\LlamaProvider',
             'llama_local' => '\\Gm2\\AI\\LocalLlamaProvider',
         ];


### PR DESCRIPTION
## Summary
- allow `gm2_ai_send_prompt` to use `gemma_local` via `LocalGemmaProvider`

## Testing
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae0d3cd12883278adbff8488aa2939