### PR TITLE
Include Gemma path options in uninstall cleanup

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -21,6 +21,7 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 // gm2_compression_api_key, gm2_compression_api_url, gm2_minify_html, gm2_minify_css,
 // gm2_minify_js, gm2_chatgpt_api_key, gm2_chatgpt_model, gm2_chatgpt_temperature,
 // gm2_chatgpt_max_tokens, gm2_chatgpt_endpoint, gm2_gemma_api_key, gm2_gemma_endpoint,
+// gm2_gemma_model_path, gm2_gemma_binary_path,
 // gm2_llama_api_key, gm2_llama_endpoint, gm2_llama_model_path, gm2_llama_binary_path, gm2_pagespeed_api_key, gm2_pagespeed_scores,
 // gm2_bulk_ai_page_size, gm2_bulk_ai_status, gm2_bulk_ai_post_type, gm2_bulk_ai_term.
 $option_names = array(
@@ -72,6 +73,8 @@ $option_names = array(
     'gm2_chatgpt_endpoint',
     'gm2_gemma_api_key',
     'gm2_gemma_endpoint',
+    'gm2_gemma_model_path',
+    'gm2_gemma_binary_path',
     'gm2_llama_api_key',
     'gm2_llama_endpoint',
     'gm2_llama_model_path',


### PR DESCRIPTION
## Summary
- Ensure Gemma model and binary path options are removed during plugin uninstall

## Testing
- `npm test` *(fails: jest not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1e56a8c08327b788650405a285d6