### PR TITLE
Add Twitter card configuration and dynamic image support

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -395,6 +395,12 @@ class Gm2_SEO_Admin {
         register_setting('gm2_seo_options', 'gm2_search_console_verification', [
             'sanitize_callback' => 'sanitize_text_field',
         ]);
+        register_setting('gm2_seo_options', 'gm2_twitter_site', [
+            'sanitize_callback' => 'sanitize_text_field',
+        ]);
+        register_setting('gm2_seo_options', 'gm2_twitter_creator', [
+            'sanitize_callback' => 'sanitize_text_field',
+        ]);
         register_setting('gm2_seo_options', 'gm2_gads_developer_token', [
             'sanitize_callback' => 'sanitize_text_field',
         ]);
@@ -555,6 +561,28 @@ class Gm2_SEO_Admin {
                 $value = get_option('gm2_ga_measurement_id', '');
                 echo '<input type="text" name="gm2_ga_measurement_id" value="' . esc_attr($value) . '" class="regular-text" />';
                 echo '<p class="description">Use <strong>SEO → Connect Google Account</strong> to fetch available IDs.</p>';
+            },
+            'gm2_seo',
+            'gm2_seo_main'
+        );
+
+        add_settings_field(
+            'gm2_twitter_site',
+            'Twitter Site',
+            function () {
+                $value = get_option('gm2_twitter_site', '');
+                echo '<input type="text" name="gm2_twitter_site" value="' . esc_attr($value) . '" class="regular-text" />';
+            },
+            'gm2_seo',
+            'gm2_seo_main'
+        );
+
+        add_settings_field(
+            'gm2_twitter_creator',
+            'Twitter Creator',
+            function () {
+                $value = get_option('gm2_twitter_creator', '');
+                echo '<input type="text" name="gm2_twitter_creator" value="' . esc_attr($value) . '" class="regular-text" />';
             },
             'gm2_seo',
             'gm2_seo_main'
@@ -2626,6 +2654,8 @@ class Gm2_SEO_Admin {
 
         $ga_id  = isset($_POST['gm2_ga_measurement_id']) ? sanitize_text_field($_POST['gm2_ga_measurement_id']) : '';
         $sc_ver = isset($_POST['gm2_search_console_verification']) ? sanitize_text_field($_POST['gm2_search_console_verification']) : '';
+        $tw_site = isset($_POST['gm2_twitter_site']) ? sanitize_text_field($_POST['gm2_twitter_site']) : '';
+        $tw_creator = isset($_POST['gm2_twitter_creator']) ? sanitize_text_field($_POST['gm2_twitter_creator']) : '';
         $token  = isset($_POST['gm2_gads_developer_token']) ? sanitize_text_field($_POST['gm2_gads_developer_token']) : '';
         $cust   = isset($_POST['gm2_gads_customer_id']) ? $this->sanitize_customer_id($_POST['gm2_gads_customer_id']) : '';
         $clean  = isset($_POST['gm2_clean_slugs']) ? '1' : '0';
@@ -2634,6 +2664,8 @@ class Gm2_SEO_Admin {
 
         update_option('gm2_ga_measurement_id', $ga_id);
         update_option('gm2_search_console_verification', $sc_ver);
+        update_option('gm2_twitter_site', $tw_site);
+        update_option('gm2_twitter_creator', $tw_creator);
         update_option('gm2_gads_developer_token', $token);
         update_option('gm2_gads_customer_id', $cust);
         update_option('gm2_clean_slugs', $clean);

--- a/public/Gm2_SEO_Public.php
+++ b/public/Gm2_SEO_Public.php
@@ -514,6 +514,9 @@ class Gm2_SEO_Public {
         }
         $og_image_url = $og_image_id ? wp_get_attachment_url($og_image_id) : '';
         $og_image_url = apply_filters('gm2_og_image_url', $og_image_url, $og_image_id, $data);
+        $card        = $og_image_url ? 'summary_large_image' : 'summary';
+        $twitter_site    = trim(get_option('gm2_twitter_site', ''));
+        $twitter_creator = trim(get_option('gm2_twitter_creator', ''));
 
         // Output the canonical link tag first if it isn't already hooked.
         if (!has_action('wp_head', [$this, 'output_canonical_url'])) {
@@ -547,9 +550,15 @@ class Gm2_SEO_Public {
             $html .= '<meta name="twitter:image" content="' . esc_url($og_image_url) . '" />' . "\n";
         }
 
-        $html .= '<meta name="twitter:card" content="summary" />' . "\n";
+        $html .= '<meta name="twitter:card" content="' . esc_attr($card) . '" />' . "\n";
         $html .= '<meta name="twitter:title" content="' . esc_attr($title) . '" />' . "\n";
         $html .= '<meta name="twitter:description" content="' . esc_attr($description) . '" />' . "\n";
+        if ($twitter_site) {
+            $html .= '<meta name="twitter:site" content="' . esc_attr($twitter_site) . '" />' . "\n";
+        }
+        if ($twitter_creator) {
+            $html .= '<meta name="twitter:creator" content="' . esc_attr($twitter_creator) . '" />' . "\n";
+        }
 
         echo apply_filters('gm2_meta_tags', $html, $data);
     }

--- a/uninstall.php
+++ b/uninstall.php
@@ -10,7 +10,7 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 // ChatGPT configuration. Taxonomy and post type specific
 // guideline options are removed further below.
 // Removed options: gm2_suite_settings, gm2_suite_version, gm2_content_rules,
-// gm2_ga_measurement_id, gm2_search_console_verification, gm2_gads_developer_token,
+// gm2_ga_measurement_id, gm2_search_console_verification, gm2_twitter_site, gm2_twitter_creator, gm2_gads_developer_token,
 // gm2_gads_client_id, gm2_gads_client_secret, gm2_gads_refresh_token, gm2_gads_customer_id,
 // gm2_gads_login_customer_id, gm2_gads_language, gm2_gads_geo_target, gm2_google_refresh_token,
 // gm2_google_access_token, gm2_google_expires_at, gm2_google_profile, gm2_redirects, gm2_404_logs,
@@ -31,6 +31,8 @@ $option_names = array(
     'gm2_guideline_rules',
     'gm2_ga_measurement_id',
     'gm2_search_console_verification',
+    'gm2_twitter_site',
+    'gm2_twitter_creator',
     'gm2_gads_developer_token',
     'gm2_gads_client_id',
     'gm2_gads_client_secret',


### PR DESCRIPTION
## Summary
- Detect OG image to choose appropriate Twitter card size
- Allow configuring `twitter:site` and `twitter:creator` via settings
- Clean up options on uninstall

## Testing
- `php -l public/Gm2_SEO_Public.php`
- `php -l admin/Gm2_SEO_Admin.php`
- `php -l uninstall.php`
- `phpunit` *(fails: command not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b20fd91fa08327846d3c0bfbe02436