### PR TITLE
feat: add optional meta keywords tag

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -713,6 +713,7 @@ class Gm2_SEO_Admin {
             $variants       = get_option('gm2_noindex_variants', '0');
             $oos            = get_option('gm2_noindex_oos', '0');
             $canon_parent   = get_option('gm2_variation_canonical_parent', '0');
+            $meta_keywords  = get_option('gm2_meta_keywords_enabled', '0');
             if (!empty($_GET['updated'])) {
                 echo '<div class="updated notice"><p>' . esc_html__('Settings saved.', 'gm2-wordpress-suite') . '</p></div>';
             }
@@ -723,6 +724,7 @@ class Gm2_SEO_Admin {
             echo '<tr><th scope="row">' . esc_html__( 'Noindex product variants', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="gm2_noindex_variants" value="1" ' . checked($variants, '1', false) . '></td></tr>';
             echo '<tr><th scope="row">' . esc_html__( 'Noindex out-of-stock products', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="gm2_noindex_oos" value="1" ' . checked($oos, '1', false) . '></td></tr>';
             echo '<tr><th scope="row">' . esc_html__( 'Variation canonical points to parent', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="gm2_variation_canonical_parent" value="1" ' . checked($canon_parent, '1', false) . '></td></tr>';
+            echo '<tr><th scope="row">' . esc_html__( 'Enable meta keywords tag', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="gm2_meta_keywords_enabled" value="1" ' . checked($meta_keywords, '1', false) . '></td></tr>';
             echo '</tbody></table>';
             submit_button( esc_html__( 'Save Settings', 'gm2-wordpress-suite' ) );
             echo '</form>';
@@ -2447,6 +2449,9 @@ class Gm2_SEO_Admin {
 
         $canon_parent = isset($_POST['gm2_variation_canonical_parent']) ? '1' : '0';
         update_option('gm2_variation_canonical_parent', $canon_parent);
+
+        $meta_keywords = isset($_POST['gm2_meta_keywords_enabled']) ? '1' : '0';
+        update_option('gm2_meta_keywords_enabled', $meta_keywords);
 
         wp_redirect(admin_url('admin.php?page=gm2-seo&tab=meta&updated=1'));
         exit;

--- a/public/Gm2_SEO_Public.php
+++ b/public/Gm2_SEO_Public.php
@@ -491,21 +491,23 @@ class Gm2_SEO_Public {
             $robots[] = 'max-video-preview:' . $data['max_video_preview'];
         }
         $keywords = '';
-        $fw = trim($data['focus_keywords']);
-        $lt = trim($data['long_tail_keywords']);
-        if ($fw !== '' || $lt !== '') {
-            $parts = [];
-            foreach ([$fw, $lt] as $list) {
-                if ($list !== '') {
-                    foreach (explode(',', $list) as $k) {
-                        $k = trim($k);
-                        if ($k !== '') {
-                            $parts[] = $k;
+        if (get_option('gm2_meta_keywords_enabled', '0') === '1') {
+            $fw = trim($data['focus_keywords']);
+            $lt = trim($data['long_tail_keywords']);
+            if ($fw !== '' || $lt !== '') {
+                $parts = [];
+                foreach ([$fw, $lt] as $list) {
+                    if ($list !== '') {
+                        foreach (explode(',', $list) as $k) {
+                            $k = trim($k);
+                            if ($k !== '') {
+                                $parts[] = $k;
+                            }
                         }
                     }
                 }
+                $keywords = implode(', ', array_unique($parts));
             }
-            $keywords = implode(', ', array_unique($parts));
         }
         $canonical   = $data['canonical'];
         $og_image_id = $data['og_image'];


### PR DESCRIPTION
## Summary
- add `gm2_meta_keywords_enabled` option to gate meta keywords output
- expose "Enable meta keywords tag" checkbox under Meta Tags settings

## Testing
- `npm test`
- `php /usr/bin/phpunit tests` *(fails: missing /tmp/wordpress-tests-lib/includes/functions.php)*

------
https://chatgpt.com/codex/tasks/task_e_68b210f4249483279973240e3ff08fbe