### PR TITLE
Add cache audit result persistence

### DIFF
--- a/includes/Gm2_Cache_Audit.php
+++ b/includes/Gm2_Cache_Audit.php
@@ -6,6 +6,28 @@ if (!defined('ABSPATH')) {
 }
 
 class Gm2_Cache_Audit {
+
+    const OPTION_NAME = 'gm2_cache_audit_results';
+
+    public static function get_results() {
+        $results = get_option(self::OPTION_NAME, []);
+        return is_array($results) ? $results : [];
+    }
+
+    public static function save_results($results) {
+        update_option(self::OPTION_NAME, $results);
+    }
+
+    public static function clear_results() {
+        delete_option(self::OPTION_NAME);
+    }
+
+    public static function rescan() {
+        $results = static::scan();
+        static::save_results($results);
+        return $results;
+    }
+
     public static function scan() {
         $scripts = wp_scripts();
         $styles  = wp_styles();

--- a/tests/test-cache-audit.php
+++ b/tests/test-cache-audit.php
@@ -1,0 +1,44 @@
+<?php
+use Gm2\Gm2_Cache_Audit;
+
+class CacheAuditMock extends Gm2_Cache_Audit {
+    public static $mock_results = [];
+    public static function scan() {
+        return self::$mock_results;
+    }
+}
+
+class CacheAuditTest extends WP_UnitTestCase {
+    public function test_save_and_get_results() {
+        $results = [
+            'scanned_at' => '2024-01-01 00:00:00',
+            'handles' => ['scripts' => [], 'styles' => []],
+            'assets' => [],
+        ];
+        Gm2_Cache_Audit::clear_results();
+        Gm2_Cache_Audit::save_results($results);
+        $this->assertSame($results, Gm2_Cache_Audit::get_results());
+    }
+
+    public function test_clear_results() {
+        $results = [
+            'scanned_at' => '2024-01-01 00:00:00',
+            'handles' => ['scripts' => [], 'styles' => []],
+            'assets' => [],
+        ];
+        Gm2_Cache_Audit::save_results($results);
+        Gm2_Cache_Audit::clear_results();
+        $this->assertSame([], Gm2_Cache_Audit::get_results());
+    }
+
+    public function test_rescan_updates_results() {
+        $mock_results = [
+            'scanned_at' => '2024-02-02 12:00:00',
+            'handles' => ['scripts' => [], 'styles' => []],
+            'assets' => [],
+        ];
+        CacheAuditMock::$mock_results = $mock_results;
+        CacheAuditMock::rescan();
+        $this->assertSame($mock_results, Gm2_Cache_Audit::get_results());
+    }
+}


### PR DESCRIPTION
## Summary
- persist cache audit scan results in `gm2_cache_audit_results` option
- add helpers to get, save, clear and rescan cache audit data
- test cache audit result storage and rescan routine

## Testing
- `npm test` *(fails: jest: not found)*
- `phpunit` *(fails: command not found)*
- `make test` *(fails: Database credentials must be supplied)*

------
https://chatgpt.com/codex/tasks/task_e_68b21a5ac4fc83278af1bd3bbfa9fe54