### PR TITLE
Add network Cache Audit page with site selector

### DIFF
--- a/admin/Gm2_Cache_Audit_Admin.php
+++ b/admin/Gm2_Cache_Audit_Admin.php
@@ -8,6 +8,7 @@ if (!defined('ABSPATH')) {
 class Gm2_Cache_Audit_Admin {
     public function run() {
         add_action('admin_menu', [ $this, 'add_menu' ]);
+        add_action('network_admin_menu', [ $this, 'add_network_menu' ]);
         add_action('admin_post_gm2_cache_audit_rescan', [ $this, 'handle_rescan' ]);
         add_action('admin_post_gm2_cache_audit_export', [ $this, 'handle_export' ]);
     }
@@ -23,13 +24,42 @@ class Gm2_Cache_Audit_Admin {
         );
     }
 
+    public function add_network_menu() {
+        add_menu_page(
+            __('SEO', 'gm2-wordpress-suite'),
+            __('SEO', 'gm2-wordpress-suite'),
+            'manage_network',
+            'gm2-seo',
+            '__return_null',
+            'dashicons-chart-area'
+        );
+        add_submenu_page(
+            'gm2-seo',
+            __('Cache Audit', 'gm2-wordpress-suite'),
+            __('Cache Audit', 'gm2-wordpress-suite'),
+            'manage_network',
+            'gm2-cache-audit',
+            [ $this, 'display_page' ]
+        );
+    }
+
     public function handle_rescan() {
-        if (!current_user_can('manage_options')) {
+        $cap = is_network_admin() ? 'manage_network' : 'manage_options';
+        if (!current_user_can($cap)) {
             wp_die(__('Access denied.', 'gm2-wordpress-suite'));
         }
         check_admin_referer('gm2_cache_audit_rescan');
+        $site_id = isset($_POST['site_id']) ? (int) $_POST['site_id'] : 0;
+        if ($site_id && is_network_admin()) {
+            switch_to_blog($site_id);
+        }
         Gm2_Cache_Audit::rescan();
-        wp_redirect(admin_url('admin.php?page=gm2-cache-audit&rescanned=1'));
+        if ($site_id && is_network_admin()) {
+            restore_current_blog();
+            wp_redirect(network_admin_url('admin.php?page=gm2-cache-audit&site_id=' . $site_id . '&rescanned=1'));
+        } else {
+            wp_redirect(admin_url('admin.php?page=gm2-cache-audit&rescanned=1'));
+        }
         exit;
     }
 
@@ -73,16 +103,41 @@ class Gm2_Cache_Audit_Admin {
     }
 
     public function display_page() {
+        $site_id = is_network_admin() ? (int) ($_GET['site_id'] ?? 0) : 0;
+        $switched = false;
+        echo '<div class="wrap"><h1>' . esc_html__('Cache Audit', 'gm2-wordpress-suite') . '</h1>';
+        if (is_network_admin()) {
+            echo '<form method="get" style="margin-bottom:10px;">';
+            echo '<input type="hidden" name="page" value="gm2-cache-audit" />';
+            echo '<select name="site_id">';
+            echo '<option value="0">' . esc_html__('Select Site', 'gm2-wordpress-suite') . '</option>';
+            foreach (get_sites(['number' => 0]) as $site) {
+                $label = $site->blogname ?: $site->domain . $site->path;
+                echo '<option value="' . esc_attr($site->blog_id) . '"' . selected($site_id, (int) $site->blog_id, false) . '>' . esc_html($label) . '</option>';
+            }
+            echo '</select> ';
+            submit_button(__('Load', 'gm2-wordpress-suite'), 'secondary', '', false);
+            echo '</form>';
+            if ($site_id) {
+                switch_to_blog($site_id);
+                $switched = true;
+            } else {
+                echo '</div>';
+                return;
+            }
+        }
         $results = Gm2_Cache_Audit::get_results();
         $assets  = $this->filter_assets($results['assets'] ?? []);
         $home_host = parse_url(home_url(), PHP_URL_HOST);
-        echo '<div class="wrap"><h1>' . esc_html__('Cache Audit', 'gm2-wordpress-suite') . '</h1>';
         if (!empty($_GET['rescanned'])) {
             echo '<div class="updated notice"><p>' . esc_html__('Scan complete.', 'gm2-wordpress-suite') . '</p></div>';
         }
 
         echo '<form method="get" style="margin-bottom:10px;">';
         echo '<input type="hidden" name="page" value="gm2-cache-audit" />';
+        if ($site_id) {
+            echo '<input type="hidden" name="site_id" value="' . esc_attr($site_id) . '" />';
+        }
         $type = isset($_GET['type']) ? sanitize_key($_GET['type']) : '';
         $host = isset($_GET['host']) ? sanitize_key($_GET['host']) : '';
         $status = isset($_GET['status']) ? sanitize_key($_GET['status']) : '';
@@ -105,14 +160,18 @@ class Gm2_Cache_Audit_Admin {
         submit_button(__('Filter', 'gm2-wordpress-suite'), 'secondary', '', false);
         echo '</form>';
 
+        $post_url = is_network_admin() ? network_admin_url('admin-post.php') : admin_url('admin-post.php');
         $export_url = wp_nonce_url(
-            admin_url('admin-post.php?action=gm2_cache_audit_export&type=' . $type . '&host=' . $host . '&status=' . $status),
+            $post_url . '?action=gm2_cache_audit_export&type=' . $type . '&host=' . $host . '&status=' . $status . ($site_id ? '&site_id=' . $site_id : ''),
             'gm2_cache_audit_export'
         );
         echo '<a href="' . esc_url($export_url) . '" class="button">' . esc_html__('Export CSV', 'gm2-wordpress-suite') . '</a> ';
-        echo '<form method="post" action="' . esc_url(admin_url('admin-post.php')) . '" style="display:inline;">';
+        echo '<form method="post" action="' . esc_url($post_url) . '" style="display:inline;">';
         wp_nonce_field('gm2_cache_audit_rescan');
         echo '<input type="hidden" name="action" value="gm2_cache_audit_rescan" />';
+        if ($site_id) {
+            echo '<input type="hidden" name="site_id" value="' . esc_attr($site_id) . '" />';
+        }
         submit_button(__('Re-scan', 'gm2-wordpress-suite'), 'secondary', '', false);
         echo '</form>';
 
@@ -157,17 +216,28 @@ class Gm2_Cache_Audit_Admin {
             }
         }
         echo '</tbody></table>';
+        if ($switched) {
+            restore_current_blog();
+        }
         echo '</div>';
     }
 
     public function handle_export() {
-        if (!current_user_can('manage_options')) {
+        $cap = is_network_admin() ? 'manage_network' : 'manage_options';
+        if (!current_user_can($cap)) {
             wp_die(__('Access denied.', 'gm2-wordpress-suite'));
         }
         check_admin_referer('gm2_cache_audit_export');
+        $site_id = isset($_GET['site_id']) ? (int) $_GET['site_id'] : 0;
+        if ($site_id && is_network_admin()) {
+            switch_to_blog($site_id);
+        }
         $results = Gm2_Cache_Audit::get_results();
         $assets  = $this->filter_assets($results['assets'] ?? []);
         $this->export_csv($assets);
+        if ($site_id && is_network_admin()) {
+            restore_current_blog();
+        }
         exit;
     }
 


### PR DESCRIPTION
## Summary
- Register Cache Audit submenu for network admins under SEO
- Allow selecting a site to view or rescan cache audit results using switch_to_blog

## Testing
- `npm test` *(fails: jest: not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b21da3ed008327987f80fca333766f