### PR TITLE
feat: enqueue cache audit assets

### DIFF
--- a/admin/css/gm2-cache-audit.css
+++ b/admin/css/gm2-cache-audit.css
@@ -1,0 +1,2 @@
+/* Styles for Cache Audit admin table */
+#gm2-cache-audit .spinner{ float:none; margin-top:4px; }

--- a/admin/js/gm2-cache-audit.js
+++ b/admin/js/gm2-cache-audit.js
@@ -1,0 +1,7 @@
+jQuery(function($){
+    // Placeholder for Cache Audit admin interactivity.
+    if (typeof gm2CacheAudit === 'undefined') {
+        return;
+    }
+    // Future enhancements for filters, rescan and CSV export will use gm2CacheAudit settings.
+});


### PR DESCRIPTION
## Summary
- enqueue Cache Audit admin assets and localize AJAX endpoints
- add placeholder JS and CSS bundles for Cache Audit table

## Testing
- `npm test`
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b22051d9108327a7b30e35de4f5b04