### PR TITLE
docs: add cache audit documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,5 +234,22 @@ address, entry and exit pages, and timestamps for each session. Recovery emails
 are planned to be queued and processed by WP&nbsp;Cron via the `gm2_ac_process_queue`
 action, but this feature is currently disabled.
 
+## Cache Audit
+
+The **Cache Audit** screen under **SEO → Performance → Cache Audit** scans the
+homepage and all enqueued scripts and styles to analyze caching headers for
+scripts, styles, images, fonts and other resources. Each asset is requested via
+`HEAD` to record its TTL, `Cache-Control`, `ETag`, `Last-Modified` and size.
+Assets are flagged as **Needs Attention** when they lack a `Cache-Control`
+header, use a `max-age` under seven days, include a versioned URL without
+`immutable`, or omit both `ETag` and `Last-Modified` headers.
+
+Filter the table by asset type, host or status, click **Re-scan** to refresh
+results, or **Export CSV** to download `gm2-cache-audit.csv`. On multisite, a
+network admin can switch sites from a dropdown and audit each site
+individually. Access requires the `manage_options` capability (`manage_network`
+for multisite) and the last scan is stored in the
+`gm2_cache_audit_results` option with a `scanned_at` timestamp.
+
 
 

--- a/readme.txt
+++ b/readme.txt
@@ -23,6 +23,7 @@ Key features include:
 * Row-level "Select all" checkboxes apply suggestions per post
 * Updated rows are briefly highlighted after applying suggestions
 * Real-time Google Merchant Centre data via REST endpoint
+* Cache Audit screen checks caching headers and flags assets needing attention
 
 == Installation ==
 1. Upload the plugin files to the `/wp-content/plugins/gm2-wordpress-suite` directory.
@@ -63,6 +64,23 @@ The main **Gm2 Suite** page lets administrators enable or disable major modules.
 Check or uncheck **Tariff**, **SEO**, **Quantity Discounts**, **Google OAuth Setup**,
 **ChatGPT**, or **Abandoned Carts** and click *Save* to hide their menus and functionality. All
 features are enabled by default.
+
+== Cache Audit ==
+Open **SEO → Performance → Cache Audit** to review caching headers for front-end assets.
+The page scans the homepage and enqueued scripts and styles, issuing `HEAD` requests
+to record TTL, `Cache-Control`, `ETag`, `Last-Modified` and size for scripts, styles,
+images, fonts and other resources. Assets are marked *Needs Attention* when they:
+
+* lack a `Cache-Control` header,
+* use a `max-age` under seven days,
+* include a version query without `immutable`, or
+* omit both `ETag` and `Last-Modified`.
+
+Filter by asset type, host or status, click **Re-scan** to run the scan again or
+**Export CSV** to download `gm2-cache-audit.csv`. Network administrators can select
+individual sites from the Network Admin and audit each separately. Access requires
+`manage_options` (`manage_network` on multisite). Results, including the last run
+timestamp, are stored in the `gm2_cache_audit_results` option.
 
 == Google integration ==
 These credentials must be copied from your Google accounts:


### PR DESCRIPTION
## Summary
- document Cache Audit admin screen and scanning rules
- note CSV export, multisite support, and required capabilities

## Testing
- `npm test`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_68b22239e87c8327aadf45ebbf38fa8e