### PR TITLE
Automatically version local assets using mtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,16 @@ The Makefile includes a `test` target which automatically checks for the test su
 make test DB_NAME=wp_test DB_USER=root DB_PASS=pass
 ```
 
+## Automatic Asset Versioning
+
+Local stylesheets and scripts loaded through WordPress are automatically
+versioned with their file modification time. This ensures browsers receive
+updated assets whenever a file changes.
+
+To skip this behavior for a specific handle, pass `['no_auto_version' => true]`
+as the final argument when calling `wp_register_style()` or
+`wp_register_script()`. The original `ver` value will then be preserved.
+
 ## Sitemap Path Option
 
 The plugin stores the generated XML sitemap at `sitemap.xml` in the WordPress

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -101,6 +101,7 @@ require_once GM2_PLUGIN_DIR . 'includes/Gm2_Workflow_Manager.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_Audit_Log.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_Ajax_Upload.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_Search_Console.php';
+require_once GM2_PLUGIN_DIR . 'includes/Versioning_MTime.php';
 
 \Gm2\Gm2_REST_Visibility::init();
 \Gm2\Gm2_REST_Rate_Limiter::init();
@@ -109,6 +110,7 @@ require_once GM2_PLUGIN_DIR . 'includes/Gm2_Search_Console.php';
 \Gm2\Gm2_Webhooks::init();
 \Gm2\Gm2_Ajax_Upload::init();
 \Gm2\Gm2_Search_Console::init();
+\Gm2\Versioning_MTime::init();
 
 function gm2_add_weekly_schedule($schedules) {
     if (!isset($schedules['weekly'])) {

--- a/includes/Versioning_MTime.php
+++ b/includes/Versioning_MTime.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Gm2;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Replaces asset version query parameters with file modification times.
+ *
+ * Local CSS and JS URLs are automatically versioned using filemtime() so
+ * browsers receive updated files whenever they change.
+ *
+ * To opt out for a specific handle pass `['no_auto_version' => true]` as the
+ * final argument to wp_register_script() or wp_register_style().
+ */
+class Versioning_MTime {
+    /**
+     * Register hooks.
+     */
+    public static function init() : void {
+        add_filter('style_loader_src', [__CLASS__, 'update_src'], 10, 2);
+        add_filter('script_loader_src', [__CLASS__, 'update_src'], 10, 2);
+    }
+
+    /**
+     * Replace the `ver` query argument with filemtime for local files.
+     *
+     * @param string $src    Asset URL.
+     * @param string $handle Handle of the asset.
+     * @return string Updated URL.
+     */
+    public static function update_src(string $src, string $handle) : string {
+        if (self::is_opted_out($handle)) {
+            return $src;
+        }
+
+        $parts = wp_parse_url($src);
+        if (!$parts) {
+            return $src;
+        }
+
+        $asset_host = $parts['host'] ?? '';
+        $site_host  = wp_parse_url(home_url(), PHP_URL_HOST);
+        if ($asset_host && !self::hosts_match($asset_host, (string) $site_host)) {
+            // Third-party URL.
+            return $src;
+        }
+
+        $path = $parts['path'] ?? '';
+        if ($path === '') {
+            return $src;
+        }
+
+        $file_path = ABSPATH . ltrim($path, '/');
+        if (!file_exists($file_path)) {
+            return $src;
+        }
+
+        $mtime = filemtime($file_path);
+        if (!$mtime) {
+            return $src;
+        }
+
+        $src = remove_query_arg('ver', $src);
+        $src = add_query_arg('ver', (string) $mtime, $src);
+        return $src;
+    }
+
+    /**
+     * Determine if a handle has opted out of automatic versioning.
+     *
+     * @param string $handle Asset handle.
+     * @return bool
+     */
+    private static function is_opted_out(string $handle) : bool {
+        global $wp_scripts, $wp_styles;
+
+        $registered = null;
+        if ($wp_scripts instanceof \WP_Scripts && isset($wp_scripts->registered[$handle])) {
+            $registered = $wp_scripts->registered[$handle];
+        } elseif ($wp_styles instanceof \WP_Styles && isset($wp_styles->registered[$handle])) {
+            $registered = $wp_styles->registered[$handle];
+        }
+
+        if ($registered && !empty($registered->extra['no_auto_version'])) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Compare two hosts for equality in a case-insensitive manner.
+     */
+    private static function hosts_match(string $a, string $b) : bool {
+        return strcasecmp($a, $b) === 0;
+    }
+}


### PR DESCRIPTION
## Summary
- add `Versioning_MTime` to replace local asset `ver` query args with `filemtime`
- allow opting out via `no_auto_version` flag when registering scripts and styles
- document automatic asset versioning in README

## Testing
- `npm test`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_68b228b5f4808327bceaa39b85aa4058