### PR TITLE
feat: schedule remote mirror refresh

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -166,6 +166,10 @@ function gm2_activate_plugin() {
         wp_schedule_event(time(), 'daily', 'gm2_analytics_purge');
     }
 
+    if (!wp_next_scheduled('gm2_remote_mirror_refresh')) {
+        wp_schedule_event(time(), 'daily', 'gm2_remote_mirror_refresh');
+    }
+
     gm2_initialize_content_rules();
     gm2_initialize_guideline_rules();
     gm2_maybe_migrate_content_rules();
@@ -196,6 +200,7 @@ function gm2_activate_plugin() {
     add_option('gm2_ac_mark_abandoned_interval', 5);
     add_option('gm2_setup_complete', '0');
     add_option('gm2_do_activation_redirect', '1');
+    add_option('gm2_remote_mirror_vendors', []);
 
     global $wpdb;
     $table_name = $wpdb->prefix . 'gm2_analytics_log';

--- a/includes/Gm2_Remote_Mirror.php
+++ b/includes/Gm2_Remote_Mirror.php
@@ -13,6 +13,15 @@ class Gm2_Remote_Mirror {
     protected static $instance = null;
 
     /**
+     * Option key storing vendor enablement state.
+     * @var string
+     */
+    protected const OPTION_KEY = 'gm2_remote_mirror_vendors';
+
+    /** @var bool Tracks if rewrite hooks are applied */
+    protected $hooks_applied = false;
+
+    /**
      * Vendor registry.
      * @var array<string, array{urls: array<int, string>, tos: string}>
      */
@@ -37,6 +46,10 @@ class Gm2_Remote_Mirror {
     public static function init(): self {
         if (self::$instance === null) {
             self::$instance = new self();
+            self::$instance->maybe_schedule_refresh();
+            add_action('gm2_remote_mirror_refresh', [self::$instance, 'refresh_all']);
+            add_action('update_option_' . self::OPTION_KEY, [self::$instance, 'on_option_update'], 10, 2);
+            self::$instance->maybe_apply_hooks();
         }
         return self::$instance;
     }
@@ -49,6 +62,102 @@ class Gm2_Remote_Mirror {
             'urls' => $urls,
             'tos'  => $tos,
         ];
+    }
+
+    /**
+     * Determine if a vendor is enabled.
+     */
+    protected function is_vendor_enabled(string $vendor): bool {
+        $options = get_option(self::OPTION_KEY, []);
+        if (!is_array($options)) {
+            $options = [];
+        }
+        return !isset($options[$vendor]) || (bool) $options[$vendor];
+    }
+
+    /**
+     * Are any vendors enabled?
+     */
+    protected function has_enabled_vendors(): bool {
+        foreach (array_keys($this->vendors) as $vendor) {
+            if ($this->is_vendor_enabled($vendor)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Apply or remove rewrite hooks depending on enabled vendors.
+     */
+    protected function maybe_apply_hooks(): void {
+        if ($this->has_enabled_vendors()) {
+            if (!$this->hooks_applied) {
+                add_filter('script_loader_src', [$this, 'rewrite'], 10, 2);
+                $this->hooks_applied = true;
+            }
+        } else {
+            if ($this->hooks_applied) {
+                remove_filter('script_loader_src', [$this, 'rewrite'], 10);
+                $this->hooks_applied = false;
+            }
+        }
+    }
+
+    /**
+     * Schedule the daily refresh event if not already scheduled.
+     */
+    protected function maybe_schedule_refresh(): void {
+        if (!wp_next_scheduled('gm2_remote_mirror_refresh')) {
+            wp_schedule_event(time(), 'daily', 'gm2_remote_mirror_refresh');
+        }
+    }
+
+    /**
+     * Handle option updates.
+     */
+    public function on_option_update($old_value, $value): void {
+        $this->maybe_apply_hooks();
+        // Refresh immediately on option change.
+        $this->refresh_all();
+    }
+
+    /**
+     * Cron handler to refresh all enabled vendors.
+     */
+    public function refresh_all(): void {
+        foreach ($this->vendors as $vendor => $data) {
+            if (!$this->is_vendor_enabled($vendor)) {
+                continue;
+            }
+            foreach ($data['urls'] as $url) {
+                $this->fetch_and_cache($url, $vendor);
+            }
+        }
+    }
+
+    /**
+     * Rewrite script src to use locally cached versions when available.
+     */
+    public function rewrite(string $src, string $handle): string {
+        foreach ($this->vendors as $vendor => $data) {
+            if (!$this->is_vendor_enabled($vendor)) {
+                continue;
+            }
+            foreach ($data['urls'] as $remote_url) {
+                if (strpos($src, $remote_url) === 0) {
+                    $filename = basename(parse_url($remote_url, PHP_URL_PATH) ?? '');
+                    $result   = $this->fetch_and_cache($remote_url, $vendor);
+                    if (is_wp_error($result)) {
+                        return $src;
+                    }
+                    $local = $this->get_local_url($vendor, $filename);
+                    $query = substr($src, strlen($remote_url));
+                    return $local . $query;
+                }
+            }
+        }
+        return $src;
     }
 
     /**


### PR DESCRIPTION
## Summary
- add daily WP-Cron event to refresh remote mirror cache
- implement remote mirror refresh handler, option hooks, and rewrite management

## Testing
- `npm test`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*


------
https://chatgpt.com/codex/tasks/task_e_68b22e40994083279ac901b5b1dcefbd