### PR TITLE
Mirror vendor scripts locally via host match and HTML buffering

### DIFF
--- a/tests/test-remote-mirror.php
+++ b/tests/test-remote-mirror.php
@@ -1,0 +1,48 @@
+<?php
+use Gm2\Gm2_Remote_Mirror;
+
+class RemoteMirrorTest extends WP_UnitTestCase {
+    private $mirror;
+
+    public function setUp(): void {
+        parent::setUp();
+        $this->mirror = Gm2_Remote_Mirror::init();
+        add_filter('pre_http_request', [$this, 'mock_http'], 10, 3);
+    }
+
+    public function tearDown(): void {
+        remove_filter('pre_http_request', [$this, 'mock_http'], 10);
+        parent::tearDown();
+    }
+
+    public function mock_http($pre, $args, $url) {
+        if (str_contains($url, 'connect.facebook.net')) {
+            return [
+                'headers'  => [],
+                'body'     => 'console.log("fb");',
+                'response' => ['code' => 200, 'message' => 'OK'],
+                'cookies'  => [],
+            ];
+        }
+        return $pre;
+    }
+
+    public function test_rewrite_enqueued_script() {
+        $src       = 'https://connect.facebook.net/en_US/fbevents.js';
+        $rewritten = apply_filters('script_loader_src', $src, 'fb');
+        $expected  = $this->mirror->get_local_url('facebook', 'fbevents.js');
+        $this->assertSame($expected, $rewritten);
+    }
+
+    public function test_replace_hardcoded_script() {
+        ob_start();
+        $this->mirror->start_buffer();
+        echo '<script src="https://connect.facebook.net/en_US/fbevents.js"></script>';
+        $this->mirror->end_buffer();
+        $output = ob_get_clean();
+        $this->assertStringContainsString(
+            $this->mirror->get_local_url('facebook', 'fbevents.js'),
+            $output
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Rewrite enqueued script URLs when their host matches a registered vendor and serve the cached local copy
- Buffer template output to replace hardcoded vendor `<script>` tags with local cached paths
- Add PHPUnit tests validating both rewrite paths

## Testing
- `npm test`
- `phpunit` *(fails: WordPress DB connection error)*

------
https://chatgpt.com/codex/tasks/task_e_68b22f6158fc83279fb2da0391014200