### PR TITLE
Add Remote Mirror controls to performance settings

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -201,6 +201,7 @@ function gm2_activate_plugin() {
     add_option('gm2_setup_complete', '0');
     add_option('gm2_do_activation_redirect', '1');
     add_option('gm2_remote_mirror_vendors', []);
+    add_option('gm2_remote_mirror_custom_urls', []);
 
     global $wpdb;
     $table_name = $wpdb->prefix . 'gm2_analytics_log';

--- a/tests/test-remote-mirror.php
+++ b/tests/test-remote-mirror.php
@@ -6,8 +6,9 @@ class RemoteMirrorTest extends WP_UnitTestCase {
 
     public function setUp(): void {
         parent::setUp();
-        $this->mirror = Gm2_Remote_Mirror::init();
         add_filter('pre_http_request', [$this, 'mock_http'], 10, 3);
+        update_option('gm2_remote_mirror_vendors', ['facebook' => 1]);
+        $this->mirror = Gm2_Remote_Mirror::init();
     }
 
     public function tearDown(): void {


### PR DESCRIPTION
## Summary
- add Remote Mirror settings to Performance tab with vendor toggles, custom URLs and SHA-256 hashes
- persist mirror configuration and refresh cache immediately on save
- support custom script mirroring and explicit vendor enablement

## Testing
- `make test` *(fails: Database credentials must be supplied)*

------
https://chatgpt.com/codex/tasks/task_e_68b230eda67083278a83770e943f8044