### PR TITLE
Add script attribute manager with dependency-aware async/defer

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -103,6 +103,7 @@ require_once GM2_PLUGIN_DIR . 'includes/Gm2_Capability_Manager.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_Workflow_Manager.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_Audit_Log.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_Ajax_Upload.php';
+require_once GM2_PLUGIN_DIR . 'includes/Gm2_Script_Attributes.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_Search_Console.php';
 require_once GM2_PLUGIN_DIR . 'includes/Versioning_MTime.php';
 
@@ -112,6 +113,7 @@ require_once GM2_PLUGIN_DIR . 'includes/Versioning_MTime.php';
 \Gm2\Gm2_REST_Fields::init();
 \Gm2\Gm2_Webhooks::init();
 \Gm2\Gm2_Ajax_Upload::init();
+\Gm2\Gm2_Script_Attributes::init();
 \Gm2\Gm2_Search_Console::init();
 \Gm2\Versioning_MTime::init();
 if (get_option('gm2_pretty_versioned_urls', '0') === '1') {

--- a/includes/Gm2_Script_Attributes.php
+++ b/includes/Gm2_Script_Attributes.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Gm2;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Gm2_Script_Attributes {
+    private array $attributes = [];
+    private array $resolved = [];
+
+    public static function init(): self {
+        return new self();
+    }
+
+    public function __construct() {
+        add_option('gm2_script_attributes', []);
+        add_filter('script_loader_tag', [$this, 'filter'], 10, 3);
+    }
+
+    public function filter(string $tag, string $handle, string $src): string {
+        $this->attributes = get_option('gm2_script_attributes', []);
+        $this->resolved   = [];
+        $attr = $this->determine_attribute($handle);
+
+        if ($attr === 'async' || $attr === 'defer') {
+            if (strpos($tag, $attr) === false) {
+                $tag = str_replace('<script ', '<script ' . $attr . ' ', $tag);
+            }
+        }
+        return $tag;
+    }
+
+    private function determine_attribute(string $handle): string {
+        if (isset($this->resolved[$handle])) {
+            return $this->resolved[$handle];
+        }
+        $this->resolved[$handle] = 'none';
+
+        $attr = $this->attributes[$handle] ?? 'defer';
+        if ($attr === 'blocking') {
+            return $this->resolved[$handle] = 'blocking';
+        }
+
+        global $wp_scripts;
+        if (!$wp_scripts instanceof \WP_Scripts) {
+            $wp_scripts = wp_scripts();
+        }
+        $registered = $wp_scripts->registered[$handle] ?? null;
+        if ($registered && !empty($registered->deps)) {
+            foreach ($registered->deps as $dep) {
+                $dep_attr = $this->determine_attribute($dep);
+                if ($dep_attr === 'blocking') {
+                    return $this->resolved[$handle] = 'blocking';
+                }
+                if ($dep_attr !== 'defer') {
+                    return $this->resolved[$handle] = 'none';
+                }
+            }
+        }
+
+        return $this->resolved[$handle] = $attr;
+    }
+}

--- a/tests/test-script-attributes.php
+++ b/tests/test-script-attributes.php
@@ -1,0 +1,93 @@
+<?php
+
+use Gm2\Gm2_Script_Attributes;
+
+class ScriptAttributesTest extends WP_UnitTestCase {
+    protected function tearDown(): void {
+        wp_dequeue_script('gm2-foo');
+        wp_deregister_script('gm2-foo');
+        wp_dequeue_script('gm2-bar');
+        wp_deregister_script('gm2-bar');
+        wp_scripts()->done = [];
+        delete_option('gm2_script_attributes');
+        parent::tearDown();
+    }
+
+    private function get_output(string $handle): string {
+        ob_start();
+        wp_print_scripts($handle);
+        return ob_get_clean();
+    }
+
+    private function extract_tag(string $html, string $handle): string {
+        preg_match("/\<script[^>]*id='" . preg_quote($handle, '/') . "-js'[^>]*>\<\/script>/", $html, $m);
+        return $m[0] ?? '';
+    }
+
+    public function test_unknown_handle_defaults_to_defer() {
+        update_option('gm2_script_attributes', []);
+        wp_register_script('gm2-foo', 'https://example.com/foo.js', [], null);
+        wp_enqueue_script('gm2-foo');
+        $html   = $this->get_output('gm2-foo');
+        $fooTag = $this->extract_tag($html, 'gm2-foo');
+        $this->assertStringContainsString('defer', $fooTag);
+    }
+
+    public function test_async_attribute_applied_with_deferred_dependencies() {
+        update_option('gm2_script_attributes', [
+            'gm2-foo' => 'async',
+            'gm2-bar' => 'defer',
+        ]);
+        wp_register_script('gm2-bar', 'https://example.com/bar.js', [], null);
+        wp_register_script('gm2-foo', 'https://example.com/foo.js', ['gm2-bar'], null);
+        wp_enqueue_script('gm2-foo');
+        $html   = $this->get_output('gm2-foo');
+        $barTag = $this->extract_tag($html, 'gm2-bar');
+        $fooTag = $this->extract_tag($html, 'gm2-foo');
+        $this->assertStringContainsString('defer', $barTag);
+        $this->assertStringContainsString('async', $fooTag);
+    }
+
+    public function test_blocking_handle_removes_attribute() {
+        update_option('gm2_script_attributes', [ 'gm2-foo' => 'blocking' ]);
+        wp_register_script('gm2-foo', 'https://example.com/foo.js', [], null);
+        wp_enqueue_script('gm2-foo');
+        $html   = $this->get_output('gm2-foo');
+        $fooTag = $this->extract_tag($html, 'gm2-foo');
+        $this->assertStringNotContainsString('async', $fooTag);
+        $this->assertStringNotContainsString('defer', $fooTag);
+    }
+
+    public function test_blocking_dependency_removes_attribute() {
+        update_option('gm2_script_attributes', [
+            'gm2-foo' => 'async',
+            'gm2-bar' => 'blocking',
+        ]);
+        wp_register_script('gm2-bar', 'https://example.com/bar.js', [], null);
+        wp_register_script('gm2-foo', 'https://example.com/foo.js', ['gm2-bar'], null);
+        wp_enqueue_script('gm2-foo');
+        $html   = $this->get_output('gm2-foo');
+        $barTag = $this->extract_tag($html, 'gm2-bar');
+        $fooTag = $this->extract_tag($html, 'gm2-foo');
+        $this->assertStringNotContainsString('async', $barTag);
+        $this->assertStringNotContainsString('defer', $barTag);
+        $this->assertStringNotContainsString('async', $fooTag);
+        $this->assertStringNotContainsString('defer', $fooTag);
+    }
+
+    public function test_non_deferred_dependency_removes_attribute() {
+        update_option('gm2_script_attributes', [
+            'gm2-foo' => 'defer',
+            'gm2-bar' => 'async',
+        ]);
+        wp_register_script('gm2-bar', 'https://example.com/bar.js', [], null);
+        wp_register_script('gm2-foo', 'https://example.com/foo.js', ['gm2-bar'], null);
+        wp_enqueue_script('gm2-foo');
+        $html   = $this->get_output('gm2-foo');
+        $barTag = $this->extract_tag($html, 'gm2-bar');
+        $fooTag = $this->extract_tag($html, 'gm2-foo');
+        $this->assertStringContainsString('async', $barTag);
+        $this->assertStringNotContainsString('async', $fooTag);
+        $this->assertStringNotContainsString('defer', $fooTag);
+    }
+}


### PR DESCRIPTION
## Summary
- add `Gm2_Script_Attributes` class to register script attribute options and inject async/defer
- load script attribute manager in main plugin bootstrap
- test attribute injection and dependency rules

## Testing
- `phpunit --filter ScriptAttributesTest` *(fails: Cannot declare class Gm2\Gm2_Abandoned_Carts, because the name is already in use)*

------
https://chatgpt.com/codex/tasks/task_e_68b236faf4bc8327af1e7188e11268b9