### PR TITLE
Add cache audit shell checks panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,16 @@ individually. Access requires the `manage_options` capability (`manage_network`
 for multisite) and the last scan is stored in the
 `gm2_cache_audit_results` option with a `scanned_at` timestamp.
 
+A small panel on this screen offers quick copy-ready checks:
+
+```
+curl -I https://example.com/wp-includes/js/jquery/jquery.min.js
+```
+
+Verify the `Cache-Control` header matches expectations. For repeat-view testing,
+open your browser DevTools with **Disable cache** unchecked, perform a hard
+reload, and confirm the file loads from disk cache.
+
 ## SEO Performance CLI
 
 Run `wp seo-perf` commands to audit a site and manage caching headers.

--- a/admin/Gm2_Cache_Audit_Admin.php
+++ b/admin/Gm2_Cache_Audit_Admin.php
@@ -170,6 +170,13 @@ class Gm2_Cache_Audit_Admin {
             echo '<div class="updated notice"><p>' . esc_html__('Scan complete.', 'gm2-wordpress-suite') . '</p></div>';
         }
 
+        echo '<div class="gm2-shell-panel notice notice-info" style="padding:15px;">';
+        echo '<p><strong>' . esc_html__('Quick cache checks', 'gm2-wordpress-suite') . '</strong></p>';
+        echo '<p><input type="text" class="large-text code" readonly value="curl -I https://example.com/wp-includes/js/jquery/jquery.min.js" /></p>';
+        echo '<p>' . esc_html__('Expect a Cache-Control header such as: max-age=31536000, public', 'gm2-wordpress-suite') . '</p>';
+        echo '<p>' . esc_html__('In DevTools, ensure "Disable cache" is unchecked, perform a hard reload, then confirm the file loads from disk cache on repeat view.', 'gm2-wordpress-suite') . '</p>';
+        echo '</div>';
+
         echo '<form method="get" style="margin-bottom:10px;">';
         echo '<input type="hidden" name="page" value="gm2-cache-audit" />';
         if ($site_id) {

--- a/admin/css/gm2-cache-audit.css
+++ b/admin/css/gm2-cache-audit.css
@@ -1,2 +1,3 @@
 /* Styles for Cache Audit admin table */
 #gm2-cache-audit .spinner{ float:none; margin-top:4px; }
+#gm2-cache-audit .gm2-shell-panel{ margin:20px 0; }

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Gm2 WordPress Suite
  * Description:       A powerful suite of tools and features for WordPress, by Gm2.
- * Version:           1.6.20
+ * Version:           1.6.21
  * Author:            Your Name or Team Gm2
  * Author URI:        https://yourwebsite.com
  * License:           GPL-2.0+
@@ -15,7 +15,7 @@
 defined('ABSPATH') or die('No script kiddies please!');
 
 // Define constants
-define('GM2_VERSION', '1.6.20');
+define('GM2_VERSION', '1.6.21');
 define('GM2_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('GM2_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('GM2_CHATGPT_LOG_FILE', GM2_PLUGIN_DIR . 'chatgpt.log');

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: gm2team
 Tags: admin, tools, suite, performance
 Requires at least: 6.0
 Tested up to: 6.5
-Stable tag: 1.6.20
+Stable tag: 1.6.21
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -84,6 +84,15 @@ Filter by asset type, host or status, click **Re-scan** to run the scan again or
 individual sites from the Network Admin and audit each separately. Access requires
 `manage_options` (`manage_network` on multisite). Results, including the last run
 timestamp, are stored in the `gm2_cache_audit_results` option.
+
+The screen also includes a quick shell panel with copy-ready checks:
+
+```
+curl -I https://example.com/wp-includes/js/jquery/jquery.min.js
+```
+
+Verify the `Cache-Control` header and, for repeat-view testing, keep **Disable cache**
+unchecked in DevTools, hard reload the page and confirm the file loads from disk cache.
 
 == SEO Performance CLI ==
 Run `wp seo-perf` commands to audit your site and manage caching headers.


### PR DESCRIPTION
## Summary
- add shell check panel to Cache Audit with curl and DevTools guidance
- document shell checks and bump plugin version

## Testing
- `npm test` (fails: jest not found)
- `phpunit` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68b2421e1b34832780748b51093ebbf5