### PR TITLE
Docs: note asset versioning, script attributes, cache headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,14 @@ Use the presets on **SEO → Performance → Script Loading**:
 Scripts that call `document.write` or expect synchronous execution should stay
 blocking. Deferring these scripts can break page output or tracking snippets.
 
+## Cache Headers
+
+On Apache or LiteSpeed the plugin automatically inserts long-lived caching
+rules into `.htaccess` using the `SEO_PLUGIN_CACHE_HEADERS` marker. Generated
+directives enable `Expires` and `Cache-Control` headers for common static assets
+like stylesheets, scripts, images and fonts. If the file is not writable the
+rules are returned so they can be added manually.
+
 ## Remote Script Mirroring
 
 The **Remote Mirror** feature caches third-party tracking scripts locally and rewrites

--- a/readme.txt
+++ b/readme.txt
@@ -25,6 +25,8 @@ Key features include:
 * Real-time Google Merchant Centre data via REST endpoint
 * Cache Audit screen checks caching headers and flags assets needing attention
 * Optional Pretty Versioned URLs convert `file.css?ver=123` into `file.v123.css` with Apache and Nginx rewrite rules
+* Auto versions local assets with file modification times to ensure browsers receive updates
+* Automatically writes long-lived cache headers to `.htaccess` on Apache and LiteSpeed
 * Remote mirror for vendor scripts like Facebook Pixel and gtag with SRI hashes and a daily refresh
 * Script Attributes manager with dependency-aware “Defer all third-party” and “Conservative” presets
 


### PR DESCRIPTION
## Summary
- Document automatic insertion of cache headers via `.htaccess`
- Highlight auto-versioning of local assets and script attribute presets in readme

## Testing
- `npm test`
- `~/.local/share/mise/installs/php/8.4.11/.composer/vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*


------
https://chatgpt.com/codex/tasks/task_e_68b24338fdf483278139bc288a852016