### PR TITLE
Fix cache audit rescan crash

### DIFF
--- a/includes/Gm2_Cache_Audit.php
+++ b/includes/Gm2_Cache_Audit.php
@@ -165,7 +165,7 @@ class Gm2_Cache_Audit {
             $scheme = is_ssl() ? 'https:' : 'http:';
             $url = $scheme . $url;
         } elseif (!preg_match('#^https?://#i', $url)) {
-            $url = wp_make_link_absolute($url, home_url('/'));
+            $url = \WP_Http::make_absolute_url($url, home_url('/'));
         }
         return $url;
     }


### PR DESCRIPTION
## Summary
- use `WP_Http::make_absolute_url` for cache audit URL normalization

## Testing
- `npm test`
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php) failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b245d04c3083279b384caf8b4cea3c