### PR TITLE
Add progress bar to Cache Audit bulk fixes

### DIFF
--- a/admin/Gm2_Cache_Audit_Admin.php
+++ b/admin/Gm2_Cache_Audit_Admin.php
@@ -227,6 +227,7 @@ class Gm2_Cache_Audit_Admin {
 
         // Bulk fix button.
         echo '<button type="button" class="button gm2-cache-bulk-fix">' . esc_html__( 'Bulk Fix', 'gm2-wordpress-suite' ) . '</button>';
+        echo '<div id="gm2-fix-progress"><div class="gm2-progress-bar"></div><span class="gm2-progress-text">0%</span></div>';
 
         echo '<table class="widefat striped"><thead><tr>';
         echo '<th><label><input type="checkbox" id="gm2-cache-select-all" /> ' . esc_html__( 'Select All', 'gm2-wordpress-suite' ) . '</label></th>';

--- a/admin/css/gm2-cache-audit.css
+++ b/admin/css/gm2-cache-audit.css
@@ -1,3 +1,29 @@
 /* Styles for Cache Audit admin table */
 #gm2-cache-audit .spinner{ float:none; margin-top:4px; }
 #gm2-cache-audit .gm2-shell-panel{ margin:20px 0; }
+
+#gm2-fix-progress{
+    position:relative;
+    display:none;
+    height:20px;
+    margin-top:10px;
+    background:#e1e1e1;
+}
+#gm2-fix-progress .gm2-progress-bar{
+    background:#0073aa;
+    height:100%;
+    width:0;
+    transition:width .3s ease;
+}
+#gm2-fix-progress .gm2-progress-text{
+    position:absolute;
+    top:0;
+    left:50%;
+    transform:translateX(-50%);
+    font-size:12px;
+    line-height:20px;
+    color:#fff;
+}
+#gm2-fix-progress.complete .gm2-progress-bar{
+    background:#46b450;
+}

--- a/admin/js/gm2-cache-audit.js
+++ b/admin/js/gm2-cache-audit.js
@@ -55,11 +55,14 @@ jQuery(function($){
         if (!items.length) {
             return;
         }
+        var total = items.length,
+            processed = 0,
+            $progress = $('#gm2-fix-progress').show().removeClass('complete'),
+            $bar = $progress.find('.gm2-progress-bar').width('0%'),
+            $text = $progress.find('.gm2-progress-text').text('0%');
         $bulkBtn.prop('disabled', true);
         function processNext(){
             if (!items.length) {
-                $bulkBtn.prop('disabled', false);
-                $('#gm2-cache-select-all').prop('checked', false);
                 return;
             }
             var item = items.shift();
@@ -76,7 +79,18 @@ jQuery(function($){
                 }
             }).always(function(){
                 item.$checkbox.prop('checked', false);
-                processNext();
+                processed++;
+                var percent = Math.round((processed / total) * 100);
+                $bar.css('width', percent + '%');
+                $text.text(percent + '%');
+                if (processed >= total) {
+                    $bulkBtn.prop('disabled', false);
+                    $('#gm2-cache-select-all').prop('checked', false);
+                    $progress.addClass('complete');
+                    setTimeout(function(){ $progress.fadeOut(); }, 1000);
+                } else {
+                    processNext();
+                }
             });
         }
         processNext();


### PR DESCRIPTION
## Summary
- add progress indicator markup next to Cache Audit bulk fix button
- style progress bar and success state
- update bulk fix JS to track and display progress

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2fd9d89d08327a382139bd1149dda