### PR TITLE
Add configurable JS deferral with dependency awareness

### DIFF
--- a/includes/render-optimizer/class-ae-seo-defer-js.php
+++ b/includes/render-optimizer/class-ae-seo-defer-js.php
@@ -10,13 +10,39 @@ if (!defined('ABSPATH')) {
 }
 
 /**
- * Adds defer attributes to scripts.
+ * Adds defer/async attributes to scripts with dependency awareness.
  */
 class AE_SEO_Defer_JS {
+    /**
+     * Per-handle attribute overrides.
+     *
+     * @var array
+     */
+    private array $overrides = [];
+
+    /**
+     * Cached resolution map.
+     *
+     * @var array
+     */
+    private array $resolved = [];
+
+    /**
+     * Attributes provided by gm2_script_attributes.
+     *
+     * @var array
+     */
+    private array $existing = [];
+
     /**
      * Constructor.
      */
     public function __construct() {
+        add_option('gm2_defer_js_enabled', '1');
+        add_option('gm2_defer_js_allowlist', '');
+        add_option('gm2_defer_js_denylist', '');
+        add_option('gm2_defer_js_overrides', []);
+
         add_action('wp_enqueue_scripts', [ $this, 'setup' ], 5);
     }
 
@@ -26,18 +52,108 @@ class AE_SEO_Defer_JS {
      * @return void
      */
     public function setup() {
-        add_filter('script_loader_tag', [ $this, 'add_defer_attribute' ], 10, 2);
+        if (get_option('gm2_defer_js_enabled', '1') !== '1') {
+            return;
+        }
+
+        add_filter('script_loader_tag', [ $this, 'filter' ], 20, 3);
     }
 
     /**
-     * Add the defer attribute to script tags.
+     * Filter script tag attributes.
      *
      * @param string $tag    The script tag.
      * @param string $handle The script handle.
+     * @param string $src    The script source.
      * @return string
      */
-    public function add_defer_attribute($tag, $handle) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- WordPress filter signature.
-        // Placeholder for defer logic.
+    public function filter($tag, $handle, $src) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- WordPress filter signature.
+        $allow = array_filter(array_map('trim', explode(',', get_option('gm2_defer_js_allowlist', ''))));
+        $deny  = array_filter(array_map('trim', explode(',', get_option('gm2_defer_js_denylist', ''))));
+
+        if (!empty($allow) && !in_array($handle, $allow, true)) {
+            return $this->remove_attr($tag);
+        }
+
+        if (in_array($handle, $deny, true)) {
+            return $this->remove_attr($tag);
+        }
+
+        $this->existing  = get_option('gm2_script_attributes', []);
+        if (isset($this->existing[$handle])) {
+            // Already handled by gm2_script_attributes.
+            return $tag;
+        }
+
+        $this->overrides = get_option('gm2_defer_js_overrides', []);
+        $this->resolved  = [];
+
+        $attr = $this->determine_attribute($handle);
+
+        if ($attr === 'async' || $attr === 'defer') {
+            $tag = $this->remove_attr($tag);
+            if (strpos($tag, $attr) === false) {
+                $tag = str_replace('<script ', '<script ' . $attr . ' ', $tag);
+            }
+        } else {
+            $tag = $this->remove_attr($tag);
+        }
+
         return $tag;
     }
+
+    /**
+     * Remove async/defer attributes from a tag.
+     *
+     * @param string $tag The original tag.
+     * @return string
+     */
+    private function remove_attr(string $tag): string {
+        $tag = str_replace(' async', '', $tag);
+        $tag = str_replace(' defer', '', $tag);
+        return $tag;
+    }
+
+    /**
+     * Determine attribute for a handle considering dependencies.
+     *
+     * @param string $handle Script handle.
+     * @return string Attribute: async, defer, blocking or none.
+     */
+    private function determine_attribute(string $handle): string {
+        if (isset($this->resolved[$handle])) {
+            return $this->resolved[$handle];
+        }
+
+        if (isset($this->existing[$handle])) {
+            return $this->resolved[$handle] = $this->existing[$handle];
+        }
+
+        $this->resolved[$handle] = 'none';
+
+        $attr = $this->overrides[$handle] ?? 'defer';
+        if ($attr === 'blocking') {
+            return $this->resolved[$handle] = 'blocking';
+        }
+
+        global $wp_scripts;
+        if (!$wp_scripts instanceof \WP_Scripts) {
+            $wp_scripts = wp_scripts();
+        }
+        $registered = $wp_scripts->registered[$handle] ?? null;
+        if ($registered && !empty($registered->deps)) {
+            foreach ($registered->deps as $dep) {
+                $dep_attr = $this->determine_attribute($dep);
+                if ($dep_attr === 'blocking') {
+                    return $this->resolved[$handle] = 'blocking';
+                }
+                if ($dep_attr !== 'defer') {
+                    return $this->resolved[$handle] = 'none';
+                }
+            }
+        }
+
+        return $this->resolved[$handle] = $attr;
+    }
 }
+

--- a/tests/test-defer-js.php
+++ b/tests/test-defer-js.php
@@ -1,0 +1,72 @@
+<?php
+
+require_once __DIR__ . '/../includes/render-optimizer/class-ae-seo-defer-js.php';
+
+class DeferJsTest extends WP_UnitTestCase {
+    protected function setUp(): void {
+        parent::setUp();
+        new AE_SEO_Defer_JS();
+    }
+
+    protected function tearDown(): void {
+        wp_dequeue_script('gm2-foo');
+        wp_deregister_script('gm2-foo');
+        wp_dequeue_script('gm2-bar');
+        wp_deregister_script('gm2-bar');
+        wp_dequeue_script('gm2-baz');
+        wp_deregister_script('gm2-baz');
+        wp_scripts()->done = [];
+
+        delete_option('gm2_defer_js_enabled');
+        delete_option('gm2_defer_js_allowlist');
+        delete_option('gm2_defer_js_denylist');
+        delete_option('gm2_defer_js_overrides');
+        delete_option('gm2_script_attributes');
+        parent::tearDown();
+    }
+
+    private function get_output(string $handle): string {
+        ob_start();
+        wp_print_scripts($handle);
+        return ob_get_clean();
+    }
+
+    private function extract_tag(string $html, string $handle): string {
+        preg_match("/\<script[^>]*id='" . preg_quote($handle, '/') . "-js'[^>]*>\<\/script>/", $html, $m);
+        return $m[0] ?? '';
+    }
+
+    public function test_allowlist_restricts_defer() {
+        update_option('gm2_defer_js_allowlist', 'gm2-foo');
+        wp_register_script('gm2-foo', 'https://example.com/foo.js', [], null);
+        wp_register_script('gm2-bar', 'https://example.com/bar.js', [], null);
+        wp_enqueue_script('gm2-foo');
+        wp_enqueue_script('gm2-bar');
+        $html   = $this->get_output('gm2-bar');
+        $fooTag = $this->extract_tag($html, 'gm2-foo');
+        $barTag = $this->extract_tag($html, 'gm2-bar');
+        $this->assertStringContainsString('defer', $fooTag);
+        $this->assertStringNotContainsString('defer', $barTag);
+    }
+
+    public function test_override_async_replaces_defer() {
+        update_option('gm2_defer_js_overrides', [ 'gm2-foo' => 'async' ]);
+        wp_register_script('gm2-foo', 'https://example.com/foo.js', [], null);
+        wp_enqueue_script('gm2-foo');
+        $html   = $this->get_output('gm2-foo');
+        $fooTag = $this->extract_tag($html, 'gm2-foo');
+        $this->assertStringContainsString('async', $fooTag);
+        $this->assertStringNotContainsString('defer', $fooTag);
+    }
+
+    public function test_dependency_with_blocking_attr_removes_defer() {
+        update_option('gm2_script_attributes', [ 'gm2-bar' => 'blocking' ]);
+        wp_register_script('gm2-bar', 'https://example.com/bar.js', [], null);
+        wp_register_script('gm2-foo', 'https://example.com/foo.js', ['gm2-bar'], null);
+        wp_enqueue_script('gm2-foo');
+        $html   = $this->get_output('gm2-foo');
+        $fooTag = $this->extract_tag($html, 'gm2-foo');
+        $this->assertStringNotContainsString('defer', $fooTag);
+    }
+}
+


### PR DESCRIPTION
## Summary
- Add `AE_SEO_Defer_JS` to apply defer/async with dependency resolution and allow/deny overrides
- Introduce allow/deny lists and per-handle overrides for script deferral
- Cover defer logic with unit tests

## Testing
- `npm test` *(fails: jest: not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3025b8f408327a6909df402349d4c