### PR TITLE
Add asset combiner with cache purge controls

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -50,6 +50,7 @@ class Gm2_SEO_Admin {
         add_action('admin_post_gm2_insert_cache_rules', [$this, 'handle_insert_cache_rules']);
         add_action('admin_post_gm2_remove_cache_rules', [$this, 'handle_remove_cache_rules']);
         add_action('admin_post_gm2_purge_critical_css', [$this, 'handle_purge_critical_css']);
+        add_action('admin_post_gm2_purge_optimizer_cache', [$this, 'handle_purge_optimizer_cache']);
         add_action('admin_post_gm2_redirects', [$this, 'handle_redirects_form']);
         add_action('admin_post_gm2_generate_nginx_cache', [$this, 'handle_generate_nginx_cache']);
         add_action('admin_post_gm2_verify_nginx_cache', [$this, 'handle_verify_nginx_cache']);
@@ -968,6 +969,9 @@ class Gm2_SEO_Admin {
             if (!empty($_GET['critical_css_purged'])) {
                 echo '<div class="updated notice"><p>' . esc_html__('Critical CSS purged.', 'gm2-wordpress-suite') . '</p></div>';
             }
+            if (!empty($_GET['optimizer_cache_purged'])) {
+                echo '<div class="updated notice"><p>' . esc_html__('Asset cache purged.', 'gm2-wordpress-suite') . '</p></div>';
+            }
             if (isset($_GET['nginx_cache_verified'])) {
                 if ($_GET['nginx_cache_verified']) {
                     echo '<div class="updated notice"><p>' . esc_html__('Headers verified.', 'gm2-wordpress-suite') . '</p></div>';
@@ -1116,6 +1120,12 @@ class Gm2_SEO_Admin {
             wp_nonce_field('gm2_purge_critical_css');
             echo '<input type="hidden" name="action" value="gm2_purge_critical_css" />';
             submit_button(esc_html__('Purge & Rebuild Critical CSS', 'gm2-wordpress-suite'), 'delete');
+            echo '</form>';
+
+            echo '<form method="post" action="' . admin_url('admin-post.php') . '">';
+            wp_nonce_field('gm2_purge_optimizer_cache');
+            echo '<input type="hidden" name="action" value="gm2_purge_optimizer_cache" />';
+            submit_button(esc_html__('Purge Combined Assets', 'gm2-wordpress-suite'), 'delete');
             echo '</form>';
         } elseif ($active === 'keywords') {
             $enabled = trim(get_option('gm2_gads_developer_token', '')) !== '' &&
@@ -2941,6 +2951,18 @@ class Gm2_SEO_Admin {
         check_admin_referer('gm2_purge_critical_css');
         delete_option('gm2_critical_css_store');
         wp_redirect(admin_url('admin.php?page=gm2-seo&tab=performance&critical_css_purged=1'));
+        exit;
+    }
+
+    public function handle_purge_optimizer_cache() {
+        if (!current_user_can('manage_options')) {
+            wp_die( esc_html__( 'Permission denied', 'gm2-wordpress-suite' ) );
+        }
+        check_admin_referer('gm2_purge_optimizer_cache');
+        if (class_exists('\\AE_SEO_Combine_Minify')) {
+            \AE_SEO_Combine_Minify::purge_cache();
+        }
+        wp_redirect(admin_url('admin.php?page=gm2-seo&tab=performance&optimizer_cache_purged=1'));
         exit;
     }
 

--- a/includes/render-optimizer/class-ae-seo-combine-minify.php
+++ b/includes/render-optimizer/class-ae-seo-combine-minify.php
@@ -26,6 +26,188 @@ class AE_SEO_Combine_Minify {
      * @return void
      */
     public function setup() {
-        // Placeholder for combine and minify logic.
+        if (is_admin() || $this->other_optimizers_active()) {
+            return;
+        }
+
+        add_filter('print_styles_array', [ $this, 'combine_styles' ], 20);
+        add_filter('print_scripts_array', [ $this, 'combine_scripts' ], 20);
+    }
+
+    private function other_optimizers_active() {
+        $constants = [ 'AUTOPTIMIZE_VERSION', 'W3TC', 'WP_ROCKET_VERSION' ];
+        foreach ($constants as $c) {
+            if (defined($c)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public function combine_styles($handles) {
+        global $wp_styles;
+        $local = [];
+        foreach ($handles as $h) {
+            $obj = $wp_styles->registered[$h] ?? null;
+            if (!$obj) {
+                continue;
+            }
+            if ($this->is_local($obj->src)) {
+                $local[] = $h;
+            }
+        }
+
+        if (count($local) < 2) {
+            return $handles;
+        }
+
+        $src = $this->build_combined_file($local, 'css');
+        if (!$src) {
+            return $handles;
+        }
+
+        $handle = 'ae-seo-combined-css';
+        wp_enqueue_style($handle, $src, [], null);
+        foreach ($local as $h) {
+            wp_dequeue_style($h);
+        }
+        $first = $this->first_index($handles, $local);
+        $handles = array_values(array_diff($handles, $local));
+        array_splice($handles, $first, 0, $handle);
+        return $handles;
+    }
+
+    public function combine_scripts($handles) {
+        global $wp_scripts;
+        $local = [];
+        foreach ($handles as $h) {
+            $obj = $wp_scripts->registered[$h] ?? null;
+            if (!$obj) {
+                continue;
+            }
+            if ($this->is_local($obj->src)) {
+                $local[] = $h;
+            }
+        }
+
+        if (count($local) < 2) {
+            return $handles;
+        }
+
+        $src = $this->build_combined_file($local, 'js');
+        if (!$src) {
+            return $handles;
+        }
+
+        $handle = 'ae-seo-combined-js';
+        $in_footer = isset($wp_scripts->groups[$local[0]]) && $wp_scripts->groups[$local[0]] > 0;
+        wp_enqueue_script($handle, $src, [], null, $in_footer);
+        foreach ($local as $h) {
+            wp_dequeue_script($h);
+        }
+        $first = $this->first_index($handles, $local);
+        $handles = array_values(array_diff($handles, $local));
+        array_splice($handles, $first, 0, $handle);
+        return $handles;
+    }
+
+    private function build_combined_file($handles, $type) {
+        $dir = WP_CONTENT_DIR . '/cache/ae-seo/';
+        wp_mkdir_p($dir);
+
+        $parts = [];
+        $content = '';
+        if ($type === 'css') {
+            global $wp_styles;
+            foreach ($handles as $h) {
+                $obj = $wp_styles->registered[$h];
+                $path = $this->local_path($obj->src);
+                if (!file_exists($path)) {
+                    continue;
+                }
+                $parts[] = $path . '|' . filemtime($path);
+                $content .= file_get_contents($path) . "\n";
+            }
+            $wrapped = '<style>' . $content . '</style>';
+        } else {
+            global $wp_scripts;
+            foreach ($handles as $h) {
+                $obj = $wp_scripts->registered[$h];
+                $path = $this->local_path($obj->src);
+                if (!file_exists($path)) {
+                    continue;
+                }
+                $parts[] = $path . '|' . filemtime($path);
+                $content .= file_get_contents($path) . ";\n";
+            }
+            $wrapped = '<script>' . $content . '</script>';
+        }
+
+        if (empty($parts)) {
+            return '';
+        }
+
+        $key = md5(implode(',', $parts));
+        $file = $dir . $key . '.' . $type;
+        if (!file_exists($file)) {
+            if ($type === 'css') {
+                add_filter('pre_option_gm2_minify_css', '__return_true');
+            } else {
+                add_filter('pre_option_gm2_minify_js', '__return_true');
+            }
+            $min = (new \Gm2\Gm2_SEO_Public())->minify_output($wrapped);
+            if ($type === 'css') {
+                remove_filter('pre_option_gm2_minify_css', '__return_true');
+            } else {
+                remove_filter('pre_option_gm2_minify_js', '__return_true');
+            }
+            $min = preg_replace('#^<' . $type . '>#', '', $min);
+            $min = preg_replace('#</' . $type . '>$#', '', $min);
+            file_put_contents($file, $min);
+        }
+        return content_url('cache/ae-seo/' . $key . '.' . $type);
+    }
+
+    private function is_local($src) {
+        if (!$src) {
+            return false;
+        }
+        if (strpos($src, '//') === 0) {
+            $src = (is_ssl() ? 'https:' : 'http:') . $src;
+        }
+        if (preg_match('#^https?://#', $src) && strpos($src, home_url()) !== 0) {
+            return false;
+        }
+        return true;
+    }
+
+    private function local_path($src) {
+        $src = preg_replace('#^https?://[^/]+#', '', $src);
+        $src = strtok($src, '?');
+        $src = ltrim($src, '/');
+        return ABSPATH . $src;
+    }
+
+    private function first_index($haystack, $needles) {
+        $index = count($haystack);
+        foreach ($needles as $n) {
+            $pos = array_search($n, $haystack, true);
+            if ($pos !== false && $pos < $index) {
+                $index = $pos;
+            }
+        }
+        return $index;
+    }
+
+    public static function purge_cache() {
+        $dir = WP_CONTENT_DIR . '/cache/ae-seo/';
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (glob($dir . '*') as $file) {
+            if (is_file($file)) {
+                @unlink($file);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- combine local styles and scripts, minify via existing minifier, and cache under `wp-content/cache/ae-seo/`
- skip combining when other optimizers run and expose cache purge control in admin

## Testing
- `npm test`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_68b304b309d0832786d49527684b842e