### PR TITLE
Improve cache audit fix error handling

### DIFF
--- a/admin/Gm2_Cache_Audit_Admin.php
+++ b/admin/Gm2_Cache_Audit_Admin.php
@@ -68,6 +68,8 @@ class Gm2_Cache_Audit_Admin {
                 'rescan_nonce' => wp_create_nonce('gm2_cache_audit_rescan'),
                 'export_nonce' => wp_create_nonce('gm2_cache_audit_export'),
                 'fix_nonce'   => wp_create_nonce('gm2_cache_audit_fix'),
+                'generic_error' => __( 'An error occurred.', 'gm2-wordpress-suite' ),
+                'bulk_halted'   => __( 'Bulk fix halted: %s', 'gm2-wordpress-suite' ),
                 'strings' => [
                     'filter' => __( 'Filter', 'gm2-wordpress-suite' ),
                     'rescan' => __( 'Re-scan', 'gm2-wordpress-suite' ),


### PR DESCRIPTION
## Summary
- announce and display cache audit fix errors using wp.a11y.speak and inline notices
- stop bulk processing when an asset fix fails
- localize generic error text for cache audit

## Testing
- `npm test`
- `phpunit` *(fails: /tmp/wordpress-tests-lib/includes/functions.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b30763eb00832784c67bae05d818a4