### PR TITLE
Show fix options only for actionable cache issues

### DIFF
--- a/admin/Gm2_Cache_Audit_Admin.php
+++ b/admin/Gm2_Cache_Audit_Admin.php
@@ -261,7 +261,11 @@ class Gm2_Cache_Audit_Admin {
                 $size = $a['content_length'] ? round($a['content_length']/1024, 2) : '';
                 $url_trunc = esc_html(wp_html_excerpt($a['url'], 60, '&hellip;'));
                 echo '<tr>';
-                echo '<td><input type="checkbox" class="gm2-cache-select" data-url="' . esc_attr($a['url']) . '" data-type="' . esc_attr($a['type']) . '" data-handle="' . esc_attr($a['handle'] ?? '') . '" /></td>';
+                if ($a['needs_attention'] && !empty($fix)) {
+                    echo '<td><input type="checkbox" class="gm2-cache-select" data-url="' . esc_attr($a['url']) . '" data-type="' . esc_attr($a['type']) . '" data-handle="' . esc_attr($a['handle'] ?? '') . '" /></td>';
+                } else {
+                    echo '<td></td>';
+                }
                 echo '<td><a href="' . esc_url($a['url']) . '" target="_blank">' . $url_trunc . '</a></td>';
                 echo '<td>' . esc_html($a['type']) . '</td>';
                 echo '<td>' . esc_html($ttl) . '</td>';
@@ -271,7 +275,11 @@ class Gm2_Cache_Audit_Admin {
                 echo '<td>' . esc_html($size) . '</td>';
                 echo '<td class="gm2-cache-status">' . esc_html($status_label) . '</td>';
                 echo '<td class="gm2-cache-fix">' . esc_html($fix) . '</td>';
-                echo '<td><button type="button" class="button gm2-cache-fix-now" data-url="' . esc_attr($a['url']) . '" data-type="' . esc_attr($a['type']) . '" data-handle="' . esc_attr($a['handle'] ?? '') . '">' . esc_html__('Fix Now', 'gm2-wordpress-suite') . '</button></td>';
+                if ($a['needs_attention'] && !empty($fix)) {
+                    echo '<td><button type="button" class="button gm2-cache-fix-now" data-url="' . esc_attr($a['url']) . '" data-type="' . esc_attr($a['type']) . '" data-handle="' . esc_attr($a['handle'] ?? '') . '">' . esc_html__('Fix Now', 'gm2-wordpress-suite') . '</button></td>';
+                } else {
+                    echo '<td></td>';
+                }
                 echo '</tr>';
             }
         }

--- a/admin/js/gm2-cache-audit.js
+++ b/admin/js/gm2-cache-audit.js
@@ -41,7 +41,13 @@ jQuery(function($){
             if (resp && resp.success) {
                 $row.find('.gm2-cache-status').text(resp.data.status);
                 $row.find('.gm2-cache-fix').text(resp.data.fix);
-                $btn.remove();
+                if (!resp.data.fix) {
+                    $row.find('.gm2-cache-select').remove();
+                    $btn.remove();
+                    $('#gm2-cache-select-all').prop('checked', false);
+                } else {
+                    $btn.prop('disabled', false);
+                }
             } else {
                 var msg = resp && resp.data ? resp.data : gm2CacheAudit.generic_error;
                 showError($row, msg);
@@ -92,7 +98,10 @@ jQuery(function($){
                 if (resp && resp.success) {
                     item.$row.find('.gm2-cache-status').text(resp.data.status);
                     item.$row.find('.gm2-cache-fix').text(resp.data.fix);
-                    item.$row.find('.gm2-cache-fix-now').remove();
+                    if (!resp.data.fix) {
+                        item.$row.find('.gm2-cache-fix-now').remove();
+                        item.$row.find('.gm2-cache-select').remove();
+                    }
                 } else {
                     var msg = resp && resp.data ? resp.data : gm2CacheAudit.generic_error;
                     showError(item.$row, msg);


### PR DESCRIPTION
## Summary
- Hide cache fix checkbox/button unless the asset needs attention and a fix is suggested
- Drop fix button & checkbox after a fix resolves an asset, preventing further bulk attempts

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b30a93ba3c8327aa68d3a03646fef3