### PR TITLE
refactor: rename critical CSS options

### DIFF
--- a/admin/views/settings-render-optimizer.php
+++ b/admin/views/settings-render-optimizer.php
@@ -3,13 +3,13 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-$critical    = get_option('ae_seo_critical_css', '0');
+$critical    = get_option('ae_seo_ro_enable_critical_css', '0');
 $defer       = get_option('ae_seo_defer_js', '0');
 $diff        = get_option('ae_seo_diff_serving', '0');
 $combine     = get_option('ae_seo_combine_minify', '0');
-$manual_css  = get_option('gm2_critical_css_manual', '');
-$allow_css   = get_option('gm2_critical_css_allowlist', '');
-$deny_css    = get_option('gm2_critical_css_denylist', '');
+$manual_map  = get_option('ae_seo_ro_critical_css_map', []);
+$manual_css  = is_array($manual_map) ? ($manual_map['manual'] ?? '') : '';
+$exclusions  = get_option('ae_seo_ro_critical_css_exclusions', '');
 $allow_js    = get_option('gm2_defer_js_allowlist', '');
 $deny_js     = get_option('gm2_defer_js_denylist', '');
 $overrides   = get_option('gm2_defer_js_overrides', []);
@@ -24,7 +24,7 @@ echo '<input type="hidden" name="action" value="gm2_render_optimizer_settings" /
 
 echo '<table class="form-table"><tbody>';
 
-echo '<tr><th scope="row">' . esc_html__( 'Enable Critical CSS', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_seo_critical_css" value="1" ' . checked($critical, '1', false) . ' /></td></tr>';
+echo '<tr><th scope="row">' . esc_html__( 'Enable Critical CSS', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_seo_ro_enable_critical_css" value="1" ' . checked($critical, '1', false) . ' /></td></tr>';
 
 echo '<tr><th scope="row">' . esc_html__( 'Enable Defer JS', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_seo_defer_js" value="1" ' . checked($defer, '1', false) . ' /></td></tr>';
 
@@ -34,11 +34,9 @@ echo '<tr><th scope="row">' . esc_html__( 'Enable Combine & Minify', 'gm2-wordpr
 
 echo '<tr><th colspan="2"><h2>' . esc_html__( 'Critical CSS', 'gm2-wordpress-suite' ) . '</h2></th></tr>';
 
-echo '<tr><th scope="row">' . esc_html__( 'Manual Critical CSS', 'gm2-wordpress-suite' ) . '</th><td><textarea name="gm2_critical_css_manual" rows="5" class="large-text code">' . esc_textarea($manual_css) . '</textarea></td></tr>';
+echo '<tr><th scope="row">' . esc_html__( 'Manual Critical CSS', 'gm2-wordpress-suite' ) . '</th><td><textarea name="ae_seo_ro_manual_css" rows="5" class="large-text code">' . esc_textarea($manual_css) . '</textarea></td></tr>';
 
-echo '<tr><th scope="row">' . esc_html__( 'Allowlist Handles', 'gm2-wordpress-suite' ) . '</th><td><input type="text" name="gm2_critical_css_allowlist" value="' . esc_attr($allow_css) . '" class="regular-text" /><p class="description">' . esc_html__( 'Comma-separated style handles to inline.', 'gm2-wordpress-suite' ) . '</p></td></tr>';
-
-echo '<tr><th scope="row">' . esc_html__( 'Denylist Handles', 'gm2-wordpress-suite' ) . '</th><td><input type="text" name="gm2_critical_css_denylist" value="' . esc_attr($deny_css) . '" class="regular-text" /><p class="description">' . esc_html__( 'Comma-separated style handles to skip.', 'gm2-wordpress-suite' ) . '</p></td></tr>';
+echo '<tr><th scope="row">' . esc_html__( 'Excluded Handles', 'gm2-wordpress-suite' ) . '</th><td><input type="text" name="ae_seo_ro_critical_css_exclusions" value="' . esc_attr($exclusions) . '" class="regular-text" /><p class="description">' . esc_html__( 'Comma-separated style handles to skip.', 'gm2-wordpress-suite' ) . '</p></td></tr>';
 
 echo '<tr><th colspan="2"><h2>' . esc_html__( 'Defer JavaScript', 'gm2-wordpress-suite' ) . '</h2></th></tr>';
 

--- a/includes/render-optimizer/class-ae-seo-critical-css.php
+++ b/includes/render-optimizer/class-ae-seo-critical-css.php
@@ -14,6 +14,14 @@ if (!defined('ABSPATH')) {
  */
 class AE_SEO_Critical_CSS {
     /**
+     * Option names.
+     */
+    public const OPTION_ENABLE           = 'ae_seo_ro_enable_critical_css';
+    public const OPTION_STRATEGY         = 'ae_seo_ro_critical_strategy';
+    public const OPTION_CSS_MAP          = 'ae_seo_ro_critical_css_map';
+    public const OPTION_ASYNC_METHOD     = 'ae_seo_ro_async_css_method';
+    public const OPTION_EXCLUSIONS       = 'ae_seo_ro_critical_css_exclusions';
+    /**
      * Constructor.
      */
     public function __construct() {
@@ -40,7 +48,8 @@ class AE_SEO_Critical_CSS {
      * @return void
      */
     public function print_manual_css() {
-        $css = get_option('gm2_critical_css_manual', '');
+        $map = AE_SEO_Render_Optimizer::get_option(self::OPTION_CSS_MAP, []);
+        $css = is_array($map) ? ($map['manual'] ?? '') : '';
         if (empty($css)) {
             return;
         }
@@ -58,18 +67,14 @@ class AE_SEO_Critical_CSS {
      * @return string
      */
     public function filter_style_tag($html, $handle, $href, $media) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- WordPress filter signature.
-        $allow = array_filter(array_map('trim', explode(',', get_option('gm2_critical_css_allowlist', ''))));
-        $deny  = array_filter(array_map('trim', explode(',', get_option('gm2_critical_css_denylist', ''))));
-
-        if (!empty($allow) && !in_array($handle, $allow, true)) {
-            return $html;
-        }
+        $exclusions = AE_SEO_Render_Optimizer::get_option(self::OPTION_EXCLUSIONS, '');
+        $deny  = array_filter(array_map('trim', is_array($exclusions) ? $exclusions : explode(',', $exclusions)));
 
         if (in_array($handle, $deny, true)) {
             return $html;
         }
 
-        $store = get_option('gm2_critical_css_store', []);
+        $store = AE_SEO_Render_Optimizer::get_option(self::OPTION_CSS_MAP, []);
         if (empty($store[$handle])) {
             return $html;
         }

--- a/includes/render-optimizer/class-ae-seo-render-optimizer.php
+++ b/includes/render-optimizer/class-ae-seo-render-optimizer.php
@@ -9,10 +9,24 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+require_once __DIR__ . '/class-ae-seo-critical-css.php';
+
 /**
  * Bootstraps render optimization features.
  */
 class AE_SEO_Render_Optimizer {
+    /**
+     * Option defaults.
+     *
+     * @var array
+     */
+    private $defaults = [
+        AE_SEO_Critical_CSS::OPTION_ENABLE       => '0',
+        AE_SEO_Critical_CSS::OPTION_STRATEGY     => 'per_home_archive_single',
+        AE_SEO_Critical_CSS::OPTION_CSS_MAP      => [],
+        AE_SEO_Critical_CSS::OPTION_ASYNC_METHOD => 'preload_onload',
+        AE_SEO_Critical_CSS::OPTION_EXCLUSIONS   => [],
+    ];
     /**
      * Names of detected conflicting plugins.
      *
@@ -24,7 +38,62 @@ class AE_SEO_Render_Optimizer {
      * Constructor.
      */
     public function __construct() {
+        $this->register_option_defaults();
         add_action('init', [ $this, 'maybe_bootstrap' ]);
+    }
+
+    /**
+     * Register default options if they do not exist.
+     *
+     * @return void
+     */
+    private function register_option_defaults() {
+        foreach ($this->defaults as $option => $value) {
+            add_option($option, $value);
+        }
+    }
+
+    /**
+     * Retrieve an option value.
+     *
+     * @param string $option  Option name.
+     * @param mixed  $default Default value.
+     * @return mixed
+     */
+    public static function get_option($option, $default = false) {
+        return get_option($option, $default);
+    }
+
+    /**
+     * Update an option value.
+     *
+     * @param string $option Option name.
+     * @param mixed  $value  Option value.
+     * @return bool
+     */
+    public static function update_option($option, $value) {
+        return update_option($option, $value);
+    }
+
+    /**
+     * Add an option value.
+     *
+     * @param string $option Option name.
+     * @param mixed  $value  Option value.
+     * @return bool
+     */
+    public static function add_option($option, $value) {
+        return add_option($option, $value);
+    }
+
+    /**
+     * Delete an option.
+     *
+     * @param string $option Option name.
+     * @return bool
+     */
+    public static function delete_option($option) {
+        return delete_option($option);
     }
 
     /**
@@ -87,15 +156,15 @@ class AE_SEO_Render_Optimizer {
      */
     private function disable_features() {
         $options = [
-            'ae_seo_critical_css',
+            AE_SEO_Critical_CSS::OPTION_ENABLE,
             'ae_seo_defer_js',
             'ae_seo_diff_serving',
             'ae_seo_combine_minify',
         ];
 
         foreach ($options as $option) {
-            if (get_option($option, '0') !== '0') {
-                update_option($option, '0');
+            if (self::get_option($option, '0') !== '0') {
+                self::update_option($option, '0');
             }
         }
     }
@@ -128,7 +197,7 @@ class AE_SEO_Render_Optimizer {
      * @return void
      */
     private function load_features() {
-        if (get_option('ae_seo_critical_css', '0') === '1') {
+        if (self::get_option(AE_SEO_Critical_CSS::OPTION_ENABLE, '0') === '1') {
             require_once __DIR__ . '/class-ae-seo-critical-css.php';
             new AE_SEO_Critical_CSS();
         }


### PR DESCRIPTION
## Summary
- define new Render Optimizer critical CSS options
- register defaults and helpers for Render Optimizer options
- rename legacy gm2_critical_css_* settings to new ae_seo_ro_* names

## Testing
- `npm test` (fails: jest not found)
- `phpunit` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68b30f32a5108327a6e5c79374c777a0