### PR TITLE
feat: modernize critical css settings

### DIFF
--- a/includes/render-optimizer/class-ae-seo-critical-css.php
+++ b/includes/render-optimizer/class-ae-seo-critical-css.php
@@ -49,12 +49,24 @@ class AE_SEO_Critical_CSS {
      */
     public function print_manual_css() {
         $map = AE_SEO_Render_Optimizer::get_option(self::OPTION_CSS_MAP, []);
-        $css = is_array($map) ? ($map['manual'] ?? '') : '';
-        if (empty($css)) {
+        if (!is_array($map)) {
             return;
         }
 
-        echo '<style id="gm2-critical-css">' . $css . '</style>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        $key = '';
+        if (is_front_page() || is_home()) {
+            $key = 'home';
+        } elseif (is_archive()) {
+            $key = 'archive';
+        } elseif (is_singular()) {
+            $key = 'single-' . get_post_type();
+        }
+
+        if ($key === '' || empty($map[$key])) {
+            return;
+        }
+
+        echo '<style id="gm2-critical-css">' . $map[$key] . '</style>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
     }
 
     /**


### PR DESCRIPTION
## Summary
- Revamp render optimizer settings UI with critical CSS strategy and async options
- Sanitize CSS length and store per-context critical CSS
- Output critical CSS based on current page context and add purge control

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b310a9e8308327b7b23edd1b9e7176