### PR TITLE
Add critical CSS context handling

### DIFF
--- a/tests/test-critical-css.php
+++ b/tests/test-critical-css.php
@@ -1,0 +1,38 @@
+<?php
+class CriticalCssTest extends WP_UnitTestCase {
+    public function setUp(): void {
+        parent::setUp();
+        remove_all_actions('wp_head');
+        add_action('wp_head', 'wp_print_styles', 8);
+        AE_SEO_Render_Optimizer::update_option(AE_SEO_Critical_CSS::OPTION_ENABLE, '1');
+    }
+
+    public function tearDown(): void {
+        remove_all_actions('wp_head');
+        AE_SEO_Render_Optimizer::update_option(AE_SEO_Critical_CSS::OPTION_CSS_MAP, []);
+        parent::tearDown();
+    }
+
+    public function test_critical_css_precedes_stylesheet_links() {
+        self::go_to('/');
+        AE_SEO_Render_Optimizer::update_option(
+            AE_SEO_Critical_CSS::OPTION_CSS_MAP,
+            [ 'home' => '.foo{color:red;}' ]
+        );
+
+        $critical = new AE_SEO_Critical_CSS();
+        $critical->setup();
+
+        wp_enqueue_style('dummy', 'https://example.com/dummy.css');
+
+        ob_start();
+        do_action('wp_head');
+        $output = ob_get_clean();
+
+        $style_pos = strpos($output, '<style id="ae-seo-critical-css">');
+        $link_pos  = strpos($output, '<link rel=\'stylesheet\'');
+        $this->assertIsInt($style_pos);
+        $this->assertIsInt($link_pos);
+        $this->assertTrue($style_pos < $link_pos, 'Critical CSS block should appear before stylesheet links.');
+    }
+}


### PR DESCRIPTION
## Summary
- Output critical CSS in `wp_head` before enqueued styles and assert priority
- Select context-aware CSS or per-URL hash and emit `<style id="ae-seo-critical-css">`
- Add unit test ensuring critical CSS prints ahead of linked styles

## Testing
- `npm test`
- `phpunit tests/test-critical-css.php` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): Failed to open stream)*

------
https://chatgpt.com/codex/tasks/task_e_68b311b8f22483279f2d971330947bc2