### PR TITLE
Allow third-party caching fixes to succeed

### DIFF
--- a/admin/Gm2_Cache_Audit_Admin.php
+++ b/admin/Gm2_Cache_Audit_Admin.php
@@ -314,11 +314,17 @@ class Gm2_Cache_Audit_Admin {
             wp_send_json_error($updated->get_error_message());
         }
 
+        $home_host = parse_url(home_url(), PHP_URL_HOST);
+        $asset_host = parse_url($updated['url'] ?? $url, PHP_URL_HOST);
+        $host_type  = ($asset_host && $asset_host === $home_host) ? 'same' : 'third';
+        $status     = !empty($updated['needs_attention']) ? __('Needs Attention', 'gm2-wordpress-suite') : __('Good', 'gm2-wordpress-suite');
+        $fix        = !empty($updated['needs_attention']) ? $this->suggested_fix($updated, $host_type) : '';
+
         wp_send_json_success([
-            'status' => __('Good', 'gm2-wordpress-suite'),
-            'fix'    => '',
-            'url'    => $url,
-            'type'   => $type,
+            'status' => $status,
+            'fix'    => $fix,
+            'url'    => $updated['url'] ?? $url,
+            'type'   => $updated['type'] ?? $type,
         ]);
     }
 

--- a/admin/js/gm2-cache-audit.js
+++ b/admin/js/gm2-cache-audit.js
@@ -38,7 +38,7 @@ jQuery(function($){
         $btn.prop('disabled', true);
         $.post(gm2CacheAudit.fix_url, data).done(function(resp){
             var $row = $btn.closest('tr');
-            if (resp && resp.success) {
+            if (resp && resp.success && resp.data) {
                 $row.find('.gm2-cache-status').text(resp.data.status);
                 $row.find('.gm2-cache-fix').text(resp.data.fix);
                 if (!resp.data.fix) {
@@ -95,7 +95,7 @@ jQuery(function($){
                 handle: item.handle
             };
             $.post(gm2CacheAudit.fix_url, data).done(function(resp){
-                if (resp && resp.success) {
+                if (resp && resp.success && resp.data) {
                     item.$row.find('.gm2-cache-status').text(resp.data.status);
                     item.$row.find('.gm2-cache-fix').text(resp.data.fix);
                     if (!resp.data.fix) {


### PR DESCRIPTION
## Summary
- apply script defer/async attributes before cache header remediation
- skip cache header verification for third-party assets and keep issues flagged
- recompute asset status and suggested fixes in ajax responses and JS handlers

## Testing
- `npm test`
- `phpunit` *(fails: cannot find wordpress-tests-lib)*

------
https://chatgpt.com/codex/tasks/task_e_68b31586b1ac8327b4d3274154c2b841