### PR TITLE
Handle cache audit fix fallback and UI updates

### DIFF
--- a/admin/Gm2_Cache_Audit_Admin.php
+++ b/admin/Gm2_Cache_Audit_Admin.php
@@ -328,10 +328,12 @@ class Gm2_Cache_Audit_Admin {
         $fix        = !empty($updated['needs_attention']) ? $this->suggested_fix($updated, $host_type) : '';
 
         wp_send_json_success([
-            'status' => $status,
-            'fix'    => $fix,
-            'url'    => $updated['url'] ?? $url,
-            'type'   => $updated['type'] ?? $type,
+            'status'          => $status,
+            'fix'             => $fix,
+            'url'             => $updated['url'] ?? $url,
+            'type'            => $updated['type'] ?? $type,
+            'ttl'             => $updated['ttl'] ?? null,
+            'needs_attention' => !empty($updated['needs_attention']),
         ]);
     }
 

--- a/admin/js/gm2-cache-audit.js
+++ b/admin/js/gm2-cache-audit.js
@@ -41,12 +41,19 @@ jQuery(function($){
             if (resp && resp.success && resp.data) {
                 $row.find('.gm2-cache-status').text(resp.data.status);
                 $row.find('.gm2-cache-fix').text(resp.data.fix);
-                if (!resp.data.fix) {
-                    $row.find('.gm2-cache-select').remove();
+                if (typeof resp.data.ttl !== 'undefined') {
+                    $row.find('td').eq(3).text(resp.data.ttl);
+                }
+                var $checkbox = $row.find('.gm2-cache-select');
+                if (resp.data.needs_attention) {
+                    if ($checkbox.length) {
+                        $checkbox.prop('checked', true);
+                    }
+                    $btn.prop('disabled', false);
+                } else {
+                    $checkbox.remove();
                     $btn.remove();
                     $('#gm2-cache-select-all').prop('checked', false);
-                } else {
-                    $btn.prop('disabled', false);
                 }
             } else {
                 var msg = resp && resp.data && resp.data.message ? resp.data.message : gm2CacheAudit.generic_error;
@@ -98,9 +105,14 @@ jQuery(function($){
                 if (resp && resp.success && resp.data) {
                     item.$row.find('.gm2-cache-status').text(resp.data.status);
                     item.$row.find('.gm2-cache-fix').text(resp.data.fix);
-                    if (!resp.data.fix) {
+                    if (typeof resp.data.ttl !== 'undefined') {
+                        item.$row.find('td').eq(3).text(resp.data.ttl);
+                    }
+                    if (resp.data.needs_attention) {
+                        item.$checkbox.prop('checked', true);
+                    } else {
                         item.$row.find('.gm2-cache-fix-now').remove();
-                        item.$row.find('.gm2-cache-select').remove();
+                        item.$checkbox.remove();
                     }
                 } else {
                     var msg = resp && resp.data && resp.data.message ? resp.data.message : gm2CacheAudit.generic_error;
@@ -118,7 +130,6 @@ jQuery(function($){
                 }
                 stopOnError = true;
             }).always(function(){
-                item.$checkbox.prop('checked', false);
                 processed++;
                 var percent = Math.round((processed / total) * 100);
                 $bar.css('width', percent + '%');


### PR DESCRIPTION
## Summary
- Keep cache audit assets when headers can't be verified and store the measured TTL for display.
- Surface `needs_attention` and TTL in AJAX responses.
- Persist row selection in the UI when issues remain and update displayed TTL values.

## Testing
- `npm test`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*


------
https://chatgpt.com/codex/tasks/task_e_68b31cb6d484832790117e7c419f8310