### PR TITLE
Add JS defer configuration and purge controls

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -35,6 +35,7 @@ class Gm2_SEO_Admin {
     }
     public function run() {
         add_option('ae_seo_ro_enable_critical_css', '0');
+        add_option('ae_seo_ro_enable_defer_js', '0');
         add_option('ae_seo_defer_js', '0');
         add_option('ae_seo_diff_serving', '0');
         add_option('ae_seo_combine_minify', '0');
@@ -47,6 +48,7 @@ class Gm2_SEO_Admin {
         add_option('gm2_defer_js_overrides', []);
         add_option('ae_seo_ro_defer_allow_domains', '');
         add_option('ae_seo_ro_defer_deny_domains', '');
+        add_option('ae_seo_ro_defer_respect_in_footer', '0');
         add_option('ae_seo_ro_defer_preserve_jquery', '1');
 
         add_action('admin_menu', [$this, 'add_settings_pages']);
@@ -65,6 +67,7 @@ class Gm2_SEO_Admin {
         add_action('admin_post_gm2_insert_cache_rules', [$this, 'handle_insert_cache_rules']);
         add_action('admin_post_gm2_remove_cache_rules', [$this, 'handle_remove_cache_rules']);
         add_action('admin_post_gm2_purge_critical_css', [$this, 'handle_purge_critical_css']);
+        add_action('admin_post_gm2_purge_js_map', [$this, 'handle_purge_js_map']);
         add_action('admin_post_gm2_purge_optimizer_cache', [$this, 'handle_purge_optimizer_cache']);
         add_action('admin_post_gm2_redirects', [$this, 'handle_redirects_form']);
         add_action('admin_post_gm2_generate_nginx_cache', [$this, 'handle_generate_nginx_cache']);
@@ -2896,11 +2899,24 @@ class Gm2_SEO_Admin {
         $exclusions = isset($_POST['ae_seo_ro_critical_css_exclusions']) ? sanitize_text_field($_POST['ae_seo_ro_critical_css_exclusions']) : '';
         update_option('ae_seo_ro_critical_css_exclusions', $exclusions);
 
+        $defer_js = isset($_POST['ae_seo_ro_enable_defer_js']) ? '1' : '0';
+        update_option('ae_seo_ro_enable_defer_js', $defer_js);
+        update_option('ae_seo_defer_js', $defer_js);
+
+        $allow_handles = isset($_POST['gm2_defer_js_allowlist']) ? sanitize_text_field($_POST['gm2_defer_js_allowlist']) : '';
+        update_option('gm2_defer_js_allowlist', $allow_handles);
+
+        $deny_handles = isset($_POST['gm2_defer_js_denylist']) ? sanitize_text_field($_POST['gm2_defer_js_denylist']) : '';
+        update_option('gm2_defer_js_denylist', $deny_handles);
+
         $allow_domains = isset($_POST['ae_seo_ro_defer_allow_domains']) ? sanitize_text_field($_POST['ae_seo_ro_defer_allow_domains']) : '';
         update_option('ae_seo_ro_defer_allow_domains', $allow_domains);
 
         $deny_domains = isset($_POST['ae_seo_ro_defer_deny_domains']) ? sanitize_text_field($_POST['ae_seo_ro_defer_deny_domains']) : '';
         update_option('ae_seo_ro_defer_deny_domains', $deny_domains);
+
+        $respect = isset($_POST['ae_seo_ro_defer_respect_in_footer']) ? '1' : '0';
+        update_option('ae_seo_ro_defer_respect_in_footer', $respect);
 
         $preserve = isset($_POST['ae_seo_ro_defer_preserve_jquery']) ? '1' : '0';
         update_option('ae_seo_ro_defer_preserve_jquery', $preserve);
@@ -3042,6 +3058,17 @@ class Gm2_SEO_Admin {
         check_admin_referer('gm2_purge_critical_css');
         delete_option('ae_seo_ro_critical_css_map');
         wp_redirect(admin_url('admin.php?page=gm2-seo&tab=performance&critical_css_purged=1'));
+        exit;
+    }
+
+    public function handle_purge_js_map() {
+        if (!current_user_can('manage_options')) {
+            wp_die( esc_html__( 'Permission denied', 'gm2-wordpress-suite' ) );
+        }
+        check_admin_referer('gm2_purge_js_map');
+        delete_transient('gm2_defer_js_map');
+        delete_transient('gm2_defer_js_dependencies');
+        wp_redirect(admin_url('admin.php?page=gm2-seo&tab=performance&js_map_purged=1'));
         exit;
     }
 

--- a/admin/views/settings-render-optimizer.php
+++ b/admin/views/settings-render-optimizer.php
@@ -8,8 +8,12 @@ $strategy   = get_option('ae_seo_ro_critical_strategy', 'per_home_archive_single
 $async      = get_option('ae_seo_ro_async_css_method', 'preload_onload');
 $css_map    = get_option('ae_seo_ro_critical_css_map', []);
 $exclusions = get_option('ae_seo_ro_critical_css_exclusions', '');
+$enable_defer_js = get_option('ae_seo_ro_enable_defer_js', get_option('ae_seo_defer_js', '0'));
+$allow_handles = get_option('gm2_defer_js_allowlist', '');
+$deny_handles  = get_option('gm2_defer_js_denylist', '');
 $allow_domains = get_option('ae_seo_ro_defer_allow_domains', '');
 $deny_domains  = get_option('ae_seo_ro_defer_deny_domains', '');
+$respect_footer = get_option('ae_seo_ro_defer_respect_in_footer', '0');
 $preserve_jquery = get_option('ae_seo_ro_defer_preserve_jquery', '1');
 $post_types = get_post_types(['public' => true], 'objects');
 
@@ -44,9 +48,17 @@ foreach ($post_types as $type) {
 
 echo '<tr><th scope="row">' . esc_html__( 'Excluded Handles', 'gm2-wordpress-suite' ) . '</th><td><input type="text" name="ae_seo_ro_critical_css_exclusions" value="' . esc_attr($exclusions) . '" class="regular-text" /><p class="description">' . esc_html__( 'Comma-separated style handles to skip.', 'gm2-wordpress-suite' ) . '</p></td></tr>';
 
+echo '<tr><th scope="row">' . esc_html__( 'Enable Defer JS', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_seo_ro_enable_defer_js" value="1" ' . checked($enable_defer_js, '1', false) . ' /></td></tr>';
+
+echo '<tr><th scope="row">' . esc_html__( 'Handle Allowlist', 'gm2-wordpress-suite' ) . '</th><td><input type="text" name="gm2_defer_js_allowlist" value="' . esc_attr($allow_handles) . '" class="regular-text" /><p class="description">' . esc_html__( 'Comma-separated script handles to always defer.', 'gm2-wordpress-suite' ) . '</p></td></tr>';
+
+echo '<tr><th scope="row">' . esc_html__( 'Handle Denylist', 'gm2-wordpress-suite' ) . '</th><td><input type="text" name="gm2_defer_js_denylist" value="' . esc_attr($deny_handles) . '" class="regular-text" /><p class="description">' . esc_html__( 'Comma-separated script handles to exclude.', 'gm2-wordpress-suite' ) . '</p></td></tr>';
+
 echo '<tr><th scope="row">' . esc_html__( 'Allow Domains', 'gm2-wordpress-suite' ) . '</th><td><input type="text" name="ae_seo_ro_defer_allow_domains" value="' . esc_attr($allow_domains) . '" class="regular-text" /><p class="description">' . esc_html__( 'Comma-separated hostnames to always async/defer.', 'gm2-wordpress-suite' ) . '</p></td></tr>';
 
 echo '<tr><th scope="row">' . esc_html__( 'Deny Domains', 'gm2-wordpress-suite' ) . '</th><td><input type="text" name="ae_seo_ro_defer_deny_domains" value="' . esc_attr($deny_domains) . '" class="regular-text" /><p class="description">' . esc_html__( 'Comma-separated hostnames to exclude from defer.', 'gm2-wordpress-suite' ) . '</p></td></tr>';
+
+echo '<tr><th scope="row">' . esc_html__( 'Respect in footer', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_seo_ro_defer_respect_in_footer" value="1" ' . checked($respect_footer, '1', false) . ' /><p class="description">' . esc_html__( 'Skip moving footer scripts earlier unless allowlisted.', 'gm2-wordpress-suite' ) . '</p></td></tr>';
 
 echo '<tr><th scope="row">' . esc_html__( 'Preserve jQuery', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_seo_ro_defer_preserve_jquery" value="1" ' . checked($preserve_jquery, '1', false) . ' /><p class="description">' . esc_html__( 'Detect early inline jQuery usage and keep jQuery blocking.', 'gm2-wordpress-suite' ) . '</p></td></tr>';
 
@@ -61,4 +73,10 @@ echo '<form method="post" action="' . esc_url(admin_url('admin-post.php')) . '">
 wp_nonce_field('gm2_purge_critical_css');
 echo '<input type="hidden" name="action" value="gm2_purge_critical_css" />';
 submit_button(esc_html__( 'Purge & Rebuild Critical CSS', 'gm2-wordpress-suite' ), 'delete');
+echo '</form>';
+
+echo '<form method="post" action="' . esc_url(admin_url('admin-post.php')) . '">';
+wp_nonce_field('gm2_purge_js_map');
+echo '<input type="hidden" name="action" value="gm2_purge_js_map" />';
+submit_button(esc_html__( 'Purge & Rebuild JS Map', 'gm2-wordpress-suite' ), 'delete');
 echo '</form>';

--- a/includes/render-optimizer/class-ae-seo-render-optimizer.php
+++ b/includes/render-optimizer/class-ae-seo-render-optimizer.php
@@ -26,8 +26,10 @@ class AE_SEO_Render_Optimizer {
         AE_SEO_Critical_CSS::OPTION_CSS_MAP      => [],
         AE_SEO_Critical_CSS::OPTION_ASYNC_METHOD => 'preload_onload',
         AE_SEO_Critical_CSS::OPTION_EXCLUSIONS   => [],
+        'ae_seo_ro_enable_defer_js'              => '0',
         'ae_seo_ro_defer_allow_domains'          => '',
         'ae_seo_ro_defer_deny_domains'           => '',
+        'ae_seo_ro_defer_respect_in_footer'      => '0',
         'ae_seo_ro_defer_preserve_jquery'        => '1',
     ];
     /**
@@ -160,7 +162,7 @@ class AE_SEO_Render_Optimizer {
     private function disable_features() {
         $options = [
             AE_SEO_Critical_CSS::OPTION_ENABLE,
-            'ae_seo_defer_js',
+            'ae_seo_ro_enable_defer_js',
             'ae_seo_diff_serving',
             'ae_seo_combine_minify',
         ];
@@ -205,7 +207,7 @@ class AE_SEO_Render_Optimizer {
             new AE_SEO_Critical_CSS();
         }
 
-        if (get_option('ae_seo_defer_js', '0') === '1') {
+        if (get_option('ae_seo_ro_enable_defer_js', '0') === '1') {
             require_once __DIR__ . '/class-ae-seo-defer-js.php';
             new AE_SEO_Defer_JS();
         }


### PR DESCRIPTION
## Summary
- Add settings fields for enabling JS defer, handle/domain lists, and footer/jQuery options.
- Save new render optimizer options and provide JS map purge handler.
- Register defaults and hook Defer JS feature to new option name.

## Testing
- `npm test` *(fails: jest not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5cc664af8832781849b01cc05b0de