### PR TITLE
Surface cache header details when fixes fail

### DIFF
--- a/admin/js/gm2-cache-audit.js
+++ b/admin/js/gm2-cache-audit.js
@@ -3,7 +3,22 @@ jQuery(function($){
         return;
     }
 
-    function showError($row, msg){
+    function showError($row, msg, data){
+        var details = [];
+        if (data) {
+            if (typeof data.ttl !== 'undefined') {
+                details.push('TTL: ' + data.ttl);
+            }
+            if (data.cache_control) {
+                details.push('Cache-Control: ' + data.cache_control);
+            }
+            if (data.expires) {
+                details.push('Expires: ' + data.expires);
+            }
+        }
+        if (details.length) {
+            msg += ' (' + details.join(', ') + ')';
+        }
         if (typeof wp !== 'undefined' && wp.a11y && wp.a11y.speak) {
             wp.a11y.speak(msg);
         }
@@ -57,7 +72,7 @@ jQuery(function($){
                 }
             } else {
                 var msg = resp && resp.data && resp.data.message ? resp.data.message : gm2CacheAudit.generic_error;
-                showError($row, msg);
+                showError($row, msg, resp && resp.data);
                 $btn.prop('disabled', false);
             }
         }).fail(function(resp){
@@ -117,7 +132,7 @@ jQuery(function($){
                     }
                 } else {
                     var msg = resp && resp.data && resp.data.message ? resp.data.message : gm2CacheAudit.generic_error;
-                    showError(item.$row, msg);
+                    showError(item.$row, msg, resp && resp.data);
                     if (typeof wp !== 'undefined' && wp.a11y && wp.a11y.speak) {
                         wp.a11y.speak(gm2CacheAudit.bulk_halted.replace('%s', msg));
                     }

--- a/includes/Gm2_Cache_Audit.php
+++ b/includes/Gm2_Cache_Audit.php
@@ -298,7 +298,15 @@ class Gm2_Cache_Audit {
                 $updated['needs_attention'] = !empty($updated['issues']);
                 $results['assets'][$index]  = $updated;
                 static::save_results($results);
-                return new \WP_Error('ttl_unverified', __('Cache headers unchanged; verify server rules.', 'gm2-wordpress-suite'));
+                return new \WP_Error(
+                    'ttl_unverified',
+                    __('Cache headers unchanged; verify server rules.', 'gm2-wordpress-suite'),
+                    [
+                        'ttl'          => $ttl,
+                        'cache_control'=> $cache_control,
+                        'expires'      => $expires,
+                    ]
+                );
             }
 
             // Only clear related issues if the TTL verifies at a week or longer.
@@ -411,7 +419,15 @@ class Gm2_Cache_Audit {
                     $updated['needs_attention'] = !empty($updated['issues']);
                     $results['assets'][$index]  = $updated;
                     static::save_results($results);
-                    return new \WP_Error('ttl_unverified', __('Cache headers unchanged; verify server rules.', 'gm2-wordpress-suite'));
+                    return new \WP_Error(
+                        'ttl_unverified',
+                        __('Cache headers unchanged; verify server rules.', 'gm2-wordpress-suite'),
+                        [
+                            'ttl'           => $ttl,
+                            'cache_control' => $cache_control,
+                            'expires'       => $expires,
+                        ]
+                    );
                 }
 
                 $updated['issues'] = array_diff($updated['issues'], ['short_max_age', 'missing_cache_control']);


### PR DESCRIPTION
## Summary
- include measured TTL, Cache-Control, and Expires values in `ttl_unverified` errors so responses share diagnostic info
- show TTL, Cache-Control, and Expires from failed cache-fix responses in admin inline notices

## Testing
- `npm test`
- `phpunit tests/test-cache-audit.php` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d8b3c2f0832781cb290e23ce2839