### PR TITLE
Handle partial cache fixes

### DIFF
--- a/admin/js/gm2-cache-audit.js
+++ b/admin/js/gm2-cache-audit.js
@@ -55,7 +55,6 @@ jQuery(function($){
             var $row = $btn.closest('tr');
             if (resp && resp.success && resp.data) {
                 $row.find('.gm2-cache-status').text(resp.data.status);
-                $row.find('.gm2-cache-fix').text(resp.data.fix);
                 if (typeof resp.data.ttl !== 'undefined') {
                     $row.find('td').eq(3).text(resp.data.ttl);
                 }
@@ -64,8 +63,11 @@ jQuery(function($){
                     if ($checkbox.length) {
                         $checkbox.prop('checked', true);
                     }
+                    // Show remaining suggested fix for manual resolution.
+                    $row.find('.gm2-cache-fix').text(resp.data.fix);
                     $btn.prop('disabled', false);
                 } else {
+                    $row.find('.gm2-cache-fix').text(resp.data.fix);
                     $checkbox.remove();
                     $btn.remove();
                     $('#gm2-cache-select-all').prop('checked', false);
@@ -120,13 +122,14 @@ jQuery(function($){
             $.post(gm2CacheAudit.fix_url, data).done(function(resp){
                 if (resp && resp.success && resp.data) {
                     item.$row.find('.gm2-cache-status').text(resp.data.status);
-                    item.$row.find('.gm2-cache-fix').text(resp.data.fix);
                     if (typeof resp.data.ttl !== 'undefined') {
                         item.$row.find('td').eq(3).text(resp.data.ttl);
                     }
                     if (resp.data.needs_attention) {
+                        item.$row.find('.gm2-cache-fix').text(resp.data.fix);
                         item.$checkbox.prop('checked', true);
                     } else {
+                        item.$row.find('.gm2-cache-fix').text(resp.data.fix);
                         item.$row.find('.gm2-cache-fix-now').remove();
                         item.$checkbox.remove();
                     }

--- a/includes/Gm2_Cache_Audit.php
+++ b/includes/Gm2_Cache_Audit.php
@@ -295,18 +295,11 @@ class Gm2_Cache_Audit {
             $updated['ttl']           = $ttl;
 
             if ($ttl === null || $ttl < 604800) {
-                $updated['needs_attention'] = !empty($updated['issues']);
+                // TTL remains too short; keep existing issues and flag for manual attention.
+                $updated['needs_attention'] = true;
                 $results['assets'][$index]  = $updated;
                 static::save_results($results);
-                return new \WP_Error(
-                    'ttl_unverified',
-                    __('Cache headers unchanged; verify server rules.', 'gm2-wordpress-suite'),
-                    [
-                        'ttl'          => $ttl,
-                        'cache_control'=> $cache_control,
-                        'expires'      => $expires,
-                    ]
-                );
+                return $updated;
             }
 
             // Only clear related issues if the TTL verifies at a week or longer.
@@ -416,18 +409,11 @@ class Gm2_Cache_Audit {
                 $updated['ttl']           = $ttl;
 
                 if ($ttl === null || $ttl < 604800) {
-                    $updated['needs_attention'] = !empty($updated['issues']);
+                    // TTL remains too short; keep existing issues and flag for manual attention.
+                    $updated['needs_attention'] = true;
                     $results['assets'][$index]  = $updated;
                     static::save_results($results);
-                    return new \WP_Error(
-                        'ttl_unverified',
-                        __('Cache headers unchanged; verify server rules.', 'gm2-wordpress-suite'),
-                        [
-                            'ttl'           => $ttl,
-                            'cache_control' => $cache_control,
-                            'expires'       => $expires,
-                        ]
-                    );
+                    return $updated;
                 }
 
                 $updated['issues'] = array_diff($updated['issues'], ['short_max_age', 'missing_cache_control']);


### PR DESCRIPTION
## Summary
- Return partial asset object when cache headers remain unverified and keep issues flagged
- Preserve manual-fix selection in cache audit UI when attention is still needed

## Testing
- `php -l includes/Gm2_Cache_Audit.php`
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5da4ec61c83278eed33db2c7275bb