### PR TITLE
Display error when cache audit data missing

### DIFF
--- a/admin/js/gm2-cache-audit.js
+++ b/admin/js/gm2-cache-audit.js
@@ -1,6 +1,13 @@
 jQuery(function($){
     if (typeof gm2CacheAudit === 'undefined') {
+        var msg = 'Cache audit data is missing. Please reload the page.';
         console.warn('gm2CacheAudit is undefined; cache audit script aborted.');
+        var $notice = $('<div class="notice notice-error inline"><p></p></div>');
+        $notice.find('p').text(msg);
+        $('#gm2-cache-audit').prepend($notice);
+        if (typeof wp !== 'undefined' && wp.a11y && wp.a11y.speak) {
+            wp.a11y.speak(msg);
+        }
         return;
     }
 


### PR DESCRIPTION
## Summary
- Add inline notice when `gm2CacheAudit` data is missing
- Announce missing cache audit data to screen readers via `wp.a11y.speak`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5df352a80832783e76e59e956f6bc