### PR TITLE
Add diff serving option and refine script enqueue logic

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -36,6 +36,7 @@ class Gm2_SEO_Admin {
     public function run() {
         add_option('ae_seo_ro_enable_critical_css', '0');
         add_option('ae_seo_ro_enable_defer_js', '0');
+        add_option('ae_seo_ro_enable_diff_serving', '1');
         add_option('ae_seo_defer_js', '0');
         add_option('ae_seo_diff_serving', '0');
         add_option('ae_seo_combine_minify', '0');

--- a/includes/render-optimizer/class-ae-seo-diff-serving.php
+++ b/includes/render-optimizer/class-ae-seo-diff-serving.php
@@ -32,8 +32,12 @@ class AE_SEO_Diff_Serving {
         $legacy = GM2_PLUGIN_URL . 'assets/dist/optimizer-legacy.js';
         $ver    = defined('GM2_VERSION') ? GM2_VERSION : false;
 
-        wp_enqueue_script('ae-seo-optimizer-modern', $modern, [], $ver, true);
-        wp_enqueue_script('ae-seo-optimizer-legacy', $legacy, [], $ver, true);
+        if (get_option('ae_seo_ro_enable_diff_serving', '1') === '1') {
+            wp_enqueue_script('ae-seo-optimizer-modern', $modern, [], $ver, true);
+            wp_enqueue_script('ae-seo-optimizer-legacy', $legacy, [], $ver, true);
+        } else {
+            wp_enqueue_script('ae-seo-optimizer-legacy', $legacy, [], $ver, true);
+        }
     }
 
     /**
@@ -46,10 +50,20 @@ class AE_SEO_Diff_Serving {
      * @return string
      */
     public function script_loader_tag($tag, $handle, $src) {
+        $enabled = get_option('ae_seo_ro_enable_diff_serving', '1') === '1';
+
         if ($handle === 'ae-seo-optimizer-modern') {
-            $tag = str_replace('<script ', '<script type="module" ', $tag);
+            if ($enabled) {
+                $tag = str_replace('<script ', '<script type="module" crossorigin="anonymous" ', $tag);
+            } else {
+                $tag = str_replace('<script ', '<script crossorigin="anonymous" ', $tag);
+            }
         } elseif ($handle === 'ae-seo-optimizer-legacy') {
-            $tag = str_replace('<script ', '<script nomodule ', $tag);
+            if ($enabled) {
+                $tag = str_replace('<script ', '<script nomodule crossorigin="anonymous" ', $tag);
+            } else {
+                $tag = str_replace('<script ', '<script crossorigin="anonymous" ', $tag);
+            }
         }
         return $tag;
     }

--- a/includes/render-optimizer/class-ae-seo-render-optimizer.php
+++ b/includes/render-optimizer/class-ae-seo-render-optimizer.php
@@ -26,6 +26,7 @@ class AE_SEO_Render_Optimizer {
         AE_SEO_Critical_CSS::OPTION_CSS_MAP      => [],
         AE_SEO_Critical_CSS::OPTION_ASYNC_METHOD => 'preload_onload',
         AE_SEO_Critical_CSS::OPTION_EXCLUSIONS   => [],
+        'ae_seo_ro_enable_diff_serving'          => '1',
         'ae_seo_ro_enable_defer_js'              => '0',
         'ae_seo_ro_defer_allow_handles'          => '',
         'ae_seo_ro_defer_deny_handles'           => '',


### PR DESCRIPTION
## Summary
- add `ae_seo_ro_enable_diff_serving` option with default enabled
- only enqueue legacy optimizer bundle when differential serving is disabled
- add `crossorigin="anonymous"` to optimizer script tags

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5df43a72883278e6c2417b9585fb8