### PR TITLE
Add test for cache audit fix with hyphenated handles

### DIFF
--- a/tests/test-cache-fix-handles.php
+++ b/tests/test-cache-fix-handles.php
@@ -1,0 +1,26 @@
+<?php
+use Gm2\Gm2_Cache_Audit;
+
+class CacheFixHandlesTest extends WP_UnitTestCase {
+    protected function tearDown(): void {
+        delete_option('gm2_cache_audit_results');
+        delete_option('gm2_script_attributes');
+        parent::tearDown();
+    }
+
+    public function test_apply_fix_preserves_hyphenated_handle() {
+        $asset = [
+            'url'    => 'https://cdn.example.com/foo.js',
+            'type'   => 'script',
+            'handle' => 'foo-bar',
+            'issues' => [],
+        ];
+        update_option('gm2_cache_audit_results', [ 'assets' => [ $asset ] ]);
+
+        $result = Gm2_Cache_Audit::apply_fix($asset);
+        $this->assertNotInstanceOf(\WP_Error::class, $result);
+
+        $attrs = get_option('gm2_script_attributes', []);
+        $this->assertSame('defer', $attrs['foo-bar'] ?? null);
+    }
+}


### PR DESCRIPTION
## Summary
- add PHPUnit test ensuring `Gm2_Cache_Audit::apply_fix` records script attributes for handles containing hyphens

## Testing
- `phpunit --filter CacheFixHandlesTest tests/test-cache-fix-handles.php` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `./bin/install-wp-tests.sh wordpress_test root '' localhost latest` *(fails: mysqladmin command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e5213bf48327acbd1f81031d822a