### PR TITLE
docs: clarify differential JS serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ The Render Optimizer groups several front-end performance features behind **SEO 
 
 * Inline critical CSS and preload full stylesheets.
 * Defer or async scripts with an enable toggle plus handle and domain allow/deny lists.
-* Serve modern and legacy JavaScript bundles using `type="module"`/`nomodule`.
+* Serve modern and legacy JavaScript bundles using `<script type="module" crossorigin="anonymous">` and `<script nomodule crossorigin="anonymous">`. Differential serving is enabled by default (`ae_seo_ro_enable_diff_serving`), and module scripts remain blocking even when JS deferral is active.
 * Combine and minify local CSS and JS assets.
 
 ### Critical CSS
@@ -180,6 +180,8 @@ Toggle script deferral on or off and maintain allow and deny lists for specific 
 **Purge workflow**
 
 Use the **Purge Critical CSS** and **Purge JS Map** buttons on the Render Optimizer screen to rebuild caches after changing themes or script settings. After purging, clear any page, opcode or CDN caches and acceptance-test the site: load key pages, check the browser console and verify forms, logins and checkout flows work as expected.
+
+To confirm differential serving, open the site in a modern browser and ensure only the `optimizer-modern.js` module bundle executes. Test again in an older or emulated legacy browser and verify only `optimizer-legacy.js` runs.
 
 The optimizer automatically disables its features when popular optimization plugins like WP&nbsp;Rocket, Autoptimize or Perfmatters are active. Only one optimization plugin should run at a time.
 

--- a/readme.txt
+++ b/readme.txt
@@ -102,7 +102,7 @@ Enable performance modules from **SEO → Performance → Render Optimizer**. Av
 
 * Critical CSS with allow/deny lists and optional manual overrides.
 * JavaScript deferral with an enable toggle, handle and domain allow/deny lists, a "Respect in footer" option, and automatic inline dependency and jQuery detection.
-* Differential serving of modern and legacy JavaScript bundles.
+* Differential serving of modern and legacy JavaScript bundles using `<script type="module" crossorigin="anonymous">` and `<script nomodule crossorigin="anonymous">`. This feature is enabled by default via `ae_seo_ro_enable_diff_serving`, and module scripts stay blocking when deferral is active.
 * Combination and minification of local CSS and JS assets.
 
 === Critical CSS ===
@@ -121,6 +121,8 @@ Toggle script deferral on or off and maintain allow and deny lists for specific 
 
 === Purge and acceptance testing ===
 Use **Purge Critical CSS** and **Purge JS Map** on the Render Optimizer screen after changing themes or deferral settings. Clear any page, server or CDN caches and acceptance-test the site: load key pages, check the browser console and verify forms, logins and checkout flows work.
+
+For differential serving, open the site in a modern browser and confirm only `optimizer-modern.js` runs. Repeat in an older or emulated legacy browser to ensure just `optimizer-legacy.js` executes.
 
 If WP Rocket, Autoptimize, Perfmatters or other optimizer plugins are active, the subsystem automatically disables its features and displays a warning. Only one optimization plugin should run at a time.
 


### PR DESCRIPTION
## Summary
- document that differential JS bundles use module/nomodule tags with `crossorigin="anonymous"` and that differential serving is enabled by default
- note that module scripts remain blocking when JS deferral is enabled
- add acceptance test steps to verify only one bundle executes per browser

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e918f430832783db57180f80f0fc