### PR TITLE
Add separate combine CSS/JS options

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -39,7 +39,8 @@ class Gm2_SEO_Admin {
         add_option('ae_seo_ro_enable_diff_serving', '1');
         add_option('ae_seo_defer_js', '0');
         add_option('ae_seo_diff_serving', '0');
-        add_option('ae_seo_combine_minify', '0');
+        add_option('ae_seo_ro_enable_combine_css', '0');
+        add_option('ae_seo_ro_enable_combine_js', '0');
         add_option('ae_seo_ro_critical_strategy', 'per_home_archive_single');
         add_option('ae_seo_ro_critical_css_map', []);
         add_option('ae_seo_ro_async_css_method', 'preload_onload');
@@ -2921,6 +2922,12 @@ class Gm2_SEO_Admin {
 
         $preserve = isset($_POST['ae_seo_ro_defer_preserve_jquery']) ? '1' : '0';
         update_option('ae_seo_ro_defer_preserve_jquery', $preserve);
+
+        $combine_css = isset($_POST['ae_seo_ro_enable_combine_css']) ? '1' : '0';
+        update_option('ae_seo_ro_enable_combine_css', $combine_css);
+
+        $combine_js = isset($_POST['ae_seo_ro_enable_combine_js']) ? '1' : '0';
+        update_option('ae_seo_ro_enable_combine_js', $combine_js);
 
         wp_redirect(admin_url('admin.php?page=gm2-seo&tab=performance&subtab=render-optimizer&updated=1'));
         exit;

--- a/admin/views/settings-render-optimizer.php
+++ b/admin/views/settings-render-optimizer.php
@@ -15,6 +15,8 @@ $allow_domains = get_option('ae_seo_ro_defer_allow_domains', '');
 $deny_domains  = get_option('ae_seo_ro_defer_deny_domains', '');
 $respect_footer = get_option('ae_seo_ro_defer_respect_in_footer', '0');
 $preserve_jquery = get_option('ae_seo_ro_defer_preserve_jquery', '1');
+$combine_css = get_option('ae_seo_ro_enable_combine_css', '0');
+$combine_js  = get_option('ae_seo_ro_enable_combine_js', '0');
 $post_types = get_post_types(['public' => true], 'objects');
 
 echo '<form method="post" action="' . esc_url(admin_url('admin-post.php')) . '">';
@@ -61,6 +63,12 @@ echo '<tr><th scope="row">' . esc_html__( 'Deny Domains', 'gm2-wordpress-suite' 
 echo '<tr><th scope="row">' . esc_html__( 'Respect in footer', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_seo_ro_defer_respect_in_footer" value="1" ' . checked($respect_footer, '1', false) . ' /><p class="description">' . esc_html__( 'Skip moving footer scripts earlier unless allowlisted.', 'gm2-wordpress-suite' ) . '</p></td></tr>';
 
 echo '<tr><th scope="row">' . esc_html__( 'Preserve jQuery', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_seo_ro_defer_preserve_jquery" value="1" ' . checked($preserve_jquery, '1', false) . ' /><p class="description">' . esc_html__( 'Detect early inline jQuery usage and keep jQuery blocking.', 'gm2-wordpress-suite' ) . '</p></td></tr>';
+
+echo '<tr><th scope="row">' . esc_html__( 'Combine CSS', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_seo_ro_enable_combine_css" value="1" ' . checked($combine_css, '1', false) . ' /></td></tr>';
+
+echo '<tr><th scope="row">' . esc_html__( 'Combine JS', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_seo_ro_enable_combine_js" value="1" ' . checked($combine_js, '1', false) . ' /></td></tr>';
+
+echo '<tr><td colspan="2"><p class="description">' . esc_html__( 'Combining assets may offer limited benefits and can cause compatibility issues under HTTP/2 or HTTP/3.', 'gm2-wordpress-suite' ) . '</p></td></tr>';
 
 echo '</tbody></table>';
 

--- a/includes/render-optimizer/class-ae-seo-combine-minify.php
+++ b/includes/render-optimizer/class-ae-seo-combine-minify.php
@@ -29,9 +29,12 @@ class AE_SEO_Combine_Minify {
         if (is_admin() || $this->other_optimizers_active()) {
             return;
         }
-
-        add_filter('print_styles_array', [ $this, 'combine_styles' ], 20);
-        add_filter('print_scripts_array', [ $this, 'combine_scripts' ], 20);
+        if (get_option('ae_seo_ro_enable_combine_css', '0') === '1') {
+            add_filter('print_styles_array', [ $this, 'combine_styles' ], 20);
+        }
+        if (get_option('ae_seo_ro_enable_combine_js', '0') === '1') {
+            add_filter('print_scripts_array', [ $this, 'combine_scripts' ], 20);
+        }
     }
 
     private function other_optimizers_active() {

--- a/includes/render-optimizer/class-ae-seo-render-optimizer.php
+++ b/includes/render-optimizer/class-ae-seo-render-optimizer.php
@@ -28,6 +28,8 @@ class AE_SEO_Render_Optimizer {
         AE_SEO_Critical_CSS::OPTION_EXCLUSIONS   => [],
         'ae_seo_ro_enable_diff_serving'          => '1',
         'ae_seo_ro_enable_defer_js'              => '0',
+        'ae_seo_ro_enable_combine_css'          => '0',
+        'ae_seo_ro_enable_combine_js'           => '0',
         'ae_seo_ro_defer_allow_handles'          => '',
         'ae_seo_ro_defer_deny_handles'           => '',
         'ae_seo_ro_defer_allow_domains'          => '',
@@ -122,7 +124,8 @@ class AE_SEO_Render_Optimizer {
             self::get_option(AE_SEO_Critical_CSS::OPTION_ENABLE, '0') !== '1' &&
             get_option('ae_seo_ro_enable_defer_js', '0') !== '1' &&
             get_option('ae_seo_ro_enable_diff_serving', '0') !== '1' &&
-            get_option('ae_seo_combine_minify', '0') !== '1'
+            get_option('ae_seo_ro_enable_combine_css', '0') !== '1' &&
+            get_option('ae_seo_ro_enable_combine_js', '0') !== '1'
         ) {
             return;
         }
@@ -176,7 +179,8 @@ class AE_SEO_Render_Optimizer {
             AE_SEO_Critical_CSS::OPTION_ENABLE,
             'ae_seo_ro_enable_defer_js',
             'ae_seo_ro_enable_diff_serving',
-            'ae_seo_combine_minify',
+            'ae_seo_ro_enable_combine_css',
+            'ae_seo_ro_enable_combine_js',
         ];
 
         foreach ($options as $option) {
@@ -229,7 +233,10 @@ class AE_SEO_Render_Optimizer {
             new AE_SEO_Diff_Serving();
         }
 
-        if (get_option('ae_seo_combine_minify', '0') === '1') {
+        if (
+            get_option('ae_seo_ro_enable_combine_css', '0') === '1' ||
+            get_option('ae_seo_ro_enable_combine_js', '0') === '1'
+        ) {
             require_once __DIR__ . '/class-ae-seo-combine-minify.php';
             new AE_SEO_Combine_Minify();
         }


### PR DESCRIPTION
## Summary
- add separate `ae_seo_ro_enable_combine_css` and `ae_seo_ro_enable_combine_js` options
- expose combine CSS/JS checkboxes in render optimizer settings with HTTP/2/3 notice
- bootstrap combine/minify features based on new options

## Testing
- `npm test`
- `phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_68b6e4870db48327b21b5717ad7d5a14