### PR TITLE
Document asset combination settings and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ The Render Optimizer groups several front-end performance features behind **SEO 
 * Inline critical CSS and preload full stylesheets.
 * Defer or async scripts with an enable toggle plus handle and domain allow/deny lists.
 * Serve modern and legacy JavaScript bundles using `<script type="module" crossorigin="anonymous">` and `<script nomodule crossorigin="anonymous">`. Differential serving is enabled by default (`ae_seo_ro_enable_diff_serving`), and module scripts remain blocking even when JS deferral is active.
-* Combine and minify local CSS and JS assets.
+* Combine and minify local CSS and JS assets with per-type toggles, size caps and exclusion lists.
 
 ### Critical CSS
 
@@ -176,6 +176,10 @@ Provide handles or patterns to skip. Editor, dashicons, admin-bar and WooCommerc
 ### JavaScript Deferral
 
 Toggle script deferral on or off and maintain allow and deny lists for specific handles and hostnames. List analytics domains like `www.googletagmanager.com` or `www.google.com/recaptcha` to always load asynchronously. The **Respect in footer** option keeps footer scripts at the bottom unless allowlisted. Inline blocks are parsed to detect dependencies automatically and jQuery remains blocking when early inline usage is detected.
+
+### Combination and Minification
+
+Toggle CSS and JS combination independently. Local files under the per‑file size limit are merged until a bundle cap is reached, and handles, hostnames or regex patterns in the exclusion lists remain separate. Generated bundles are stored in `wp-content/uploads/ae-seo/optimizer/`, and a **Purge Combined Files** button removes them. Combining assets may cause compatibility issues and offers little benefit on HTTP/2 or HTTP/3 servers.
 
 **Purge workflow**
 

--- a/readme.txt
+++ b/readme.txt
@@ -29,7 +29,7 @@ Key features include:
 * Automatically writes long-lived cache headers to `.htaccess` on Apache and LiteSpeed
 * Remote mirror for vendor scripts like Facebook Pixel and gtag with SRI hashes and a daily refresh
 * Script Attributes manager with dependency-aware “Defer all third-party” and “Conservative” presets
-* Render Optimizer for critical CSS, JS deferral with handle/domain allow and deny lists plus inline dependency and jQuery auto-detection, differential serving, and asset combination/minification
+* Render Optimizer for critical CSS, JS deferral with handle/domain allow and deny lists plus inline dependency and jQuery auto-detection, differential serving, and optional asset combination/minification with size limits and purge controls
 
 == Installation ==
 1. Upload the plugin files to the `/wp-content/plugins/gm2-wordpress-suite` directory.
@@ -103,7 +103,7 @@ Enable performance modules from **SEO → Performance → Render Optimizer**. Av
 * Critical CSS with allow/deny lists and optional manual overrides.
 * JavaScript deferral with an enable toggle, handle and domain allow/deny lists, a "Respect in footer" option, and automatic inline dependency and jQuery detection.
 * Differential serving of modern and legacy JavaScript bundles using `<script type="module" crossorigin="anonymous">` and `<script nomodule crossorigin="anonymous">`. This feature is enabled by default via `ae_seo_ro_enable_diff_serving`, and module scripts stay blocking when deferral is active.
-* Combination and minification of local CSS and JS assets.
+* Combination and minification of local CSS and JS assets with per-type toggles, size caps and exclusion lists.
 
 === Critical CSS ===
 Inline above-the-fold styles and load full stylesheets asynchronously.
@@ -118,6 +118,9 @@ Inline above-the-fold styles and load full stylesheets asynchronously.
 
 === JavaScript Deferral ===
 Toggle script deferral on or off and maintain allow and deny lists for specific handles and hostnames. Example analytics domains include `www.googletagmanager.com` and `www.google.com/recaptcha`. The **Respect in footer** setting keeps footer scripts in place unless allowlisted. Inline blocks are scanned to detect dependencies automatically and jQuery stays blocking when early inline usage is detected.
+
+=== Combination and Minification ===
+Toggle CSS and JS combination separately. Local files under the per-file limit are merged until a bundle size cap is reached. Provide handle and domain exclusion lists or regex patterns to keep assets separate. Generated bundles live in `wp-content/uploads/ae-seo/optimizer/`, and a **Purge Combined Files** button deletes them. Combining assets can break scripts and yields little benefit on HTTP/2 or HTTP/3 servers.
 
 === Purge and acceptance testing ===
 Use **Purge Critical CSS** and **Purge JS Map** on the Render Optimizer screen after changing themes or deferral settings. Clear any page, server or CDN caches and acceptance-test the site: load key pages, check the browser console and verify forms, logins and checkout flows work.

--- a/tests/test-combine-minify.php
+++ b/tests/test-combine-minify.php
@@ -1,0 +1,106 @@
+<?php
+
+class CombineMinifyTest extends WP_UnitTestCase {
+    private $files = [];
+
+    protected function tearDown(): void {
+        foreach ($this->files as $file) {
+            @unlink($file);
+        }
+        $handles = ['a','b','c','remote','ae-seo-combined-js'];
+        foreach ($handles as $h) {
+            wp_dequeue_script($h);
+            wp_deregister_script($h);
+        }
+        remove_all_filters('print_scripts_array');
+        delete_option('ae_seo_ro_enable_combine_js');
+        delete_option('ae_seo_ro_combine_js_kb');
+        delete_option('ae_seo_ro_combine_exclude_handles');
+        delete_option('ae_seo_ro_combine_exclude_domains');
+        AE_SEO_Combine_Minify::purge_cache();
+        parent::tearDown();
+    }
+
+    private function make_script(string $handle, string $filename, ?string $domain = null): void {
+        if ($domain) {
+            $url = $domain . '/' . $filename;
+            wp_register_script($handle, $url, [], null, false);
+        } else {
+            $path = WP_CONTENT_DIR . '/' . $filename;
+            file_put_contents($path, str_repeat('a', 100));
+            $this->files[] = $path;
+            $url = content_url($filename);
+            wp_register_script($handle, $url, [], null, false);
+        }
+        wp_enqueue_script($handle);
+    }
+
+    public function test_combines_only_when_enabled_and_within_limits(): void {
+        $this->make_script('b', 'b.js');
+        $this->make_script('c', 'c.js');
+        $handles = ['b','c'];
+
+        update_option('ae_seo_ro_enable_combine_js', '0');
+        $combiner = new AE_SEO_Combine_Minify();
+        $combiner->setup();
+        $result = apply_filters('print_scripts_array', $handles);
+        $this->assertSame($handles, $result, 'Scripts should remain separate when disabled');
+
+        remove_all_filters('print_scripts_array');
+        update_option('ae_seo_ro_enable_combine_js', '1');
+        update_option('ae_seo_ro_combine_js_kb', 1000);
+        $combiner = new AE_SEO_Combine_Minify();
+        $combiner->setup();
+        $result = apply_filters('print_scripts_array', $handles);
+        $this->assertContains('ae-seo-combined-js', $result);
+        $this->assertNotContains('b', $result);
+        $this->assertNotContains('c', $result);
+
+        remove_all_filters('print_scripts_array');
+        update_option('ae_seo_ro_combine_js_kb', 0);
+        $combiner = new AE_SEO_Combine_Minify();
+        $combiner->setup();
+        $result = apply_filters('print_scripts_array', $handles);
+        $this->assertNotContains('ae-seo-combined-js', $result);
+    }
+
+    public function test_excluded_handles_and_domains_remain_separate(): void {
+        $this->make_script('a', 'a.js');
+        $this->make_script('b', 'b.js');
+        $this->make_script('c', 'c.js');
+        $this->make_script('remote', 'remote.js', 'https://cdn.example.com');
+        $handles = ['a','b','c','remote'];
+
+        update_option('ae_seo_ro_enable_combine_js', '1');
+        update_option('ae_seo_ro_combine_js_kb', 1000);
+        update_option('ae_seo_ro_combine_exclude_handles', 'a');
+        update_option('ae_seo_ro_combine_exclude_domains', 'cdn.example.com');
+        $combiner = new AE_SEO_Combine_Minify();
+        $combiner->setup();
+        $result = apply_filters('print_scripts_array', $handles);
+        $this->assertContains('ae-seo-combined-js', $result);
+        $this->assertContains('a', $result);
+        $this->assertContains('remote', $result);
+        $this->assertNotContains('b', $result);
+        $this->assertNotContains('c', $result);
+    }
+
+    public function test_purge_action_removes_generated_files(): void {
+        $this->make_script('b', 'b.js');
+        $this->make_script('c', 'c.js');
+        $handles = ['b','c'];
+        update_option('ae_seo_ro_enable_combine_js', '1');
+        update_option('ae_seo_ro_combine_js_kb', 1000);
+        $combiner = new AE_SEO_Combine_Minify();
+        $combiner->setup();
+        $result = apply_filters('print_scripts_array', $handles);
+        $this->assertContains('ae-seo-combined-js', $result);
+        global $wp_scripts;
+        $src = $wp_scripts->registered['ae-seo-combined-js']->src;
+        $upload = wp_upload_dir();
+        $path = str_replace($upload['baseurl'], $upload['basedir'], $src);
+        $this->assertFileExists($path);
+        AE_SEO_Combine_Minify::purge_cache();
+        $this->assertFileDoesNotExist($path);
+    }
+}


### PR DESCRIPTION
## Summary
- document CSS and JS combination options, storage path and HTTP/2/3 caveats in readmes
- add tests covering combine/minify toggles, exclusions and purge handling

## Testing
- `vendor/bin/phpunit tests/test-combine-minify.php` *(fails: Error establishing a database connection)*
- `bash bin/install-wp-tests.sh wordpress_test root '' localhost latest` *(fails: Can't connect to MySQL server)*

------
https://chatgpt.com/codex/tasks/task_e_68b70c20da40832798dc57497a9fcc52