### PR TITLE
Classify Dell Streak as phone

### DIFF
--- a/includes/MobileDetect.php
+++ b/includes/MobileDetect.php
@@ -364,8 +364,7 @@ class MobileDetect
             'ADR6400L|ADR6425|001HT|Inspire 4G|Android.*\bEVO\b|T-Mobile G1|Z520m|Android [0-9.]+; Pixel'
         ],
         'Nexus'         => 'Nexus One|Nexus S|Galaxy.*Nexus|Android.*Nexus.*Mobile|Nexus 4|Nexus 5|Nexus 5X|Nexus 6',
-        // @todo: Is 'Dell Streak' a tablet or a phone? ;)
-        'Dell'          => 'Dell[;]? (Streak|Aero|Venue|Venue Pro|Flash|Smoke|Mini 3iX)|XCD28|XCD35|\b001DL\b|\b101DL\b|\bGS01\b',
+        'Dell'          => 'Dell[;]? (Streak(?!\\s?(?:7|10))|Aero|Venue|Venue Pro|Flash|Smoke|Mini 3iX)|XCD28|XCD35|\\b001DL\\b|\\b101DL\\b|\\bGS01\\b',
         'Motorola'      => [
             'Motorola|DROIDX|DROID BIONIC|\bDroid\b.*Build|Android.*Xoom|HRI39|MOT-|A1260|A1680|A555|A853|A855|A953|A955',
             'A956|Motorola.*ELECTRIFY|Motorola.*i1|i867|i940|MB200|MB300|MB501|MB502|MB508|MB511|MB520|MB525|MB526|MB611',


### PR DESCRIPTION
## Summary
- treat Dell Streak as a phone by refining the detection regex
- remove todo comment about Dell Streak classification

## Testing
- `npm test`
- `./vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*


------
https://chatgpt.com/codex/tasks/task_e_68b70f9d19f08327805cd4a4c156f63c