### PR TITLE
Expand Palm user-agent detection

### DIFF
--- a/includes/MobileDetect.php
+++ b/includes/MobileDetect.php
@@ -448,8 +448,7 @@ class MobileDetect
         // http://www.micromaxinfo.com/mobiles/smartphones
         // Added because the codes might conflict with Acer Tablets.
         'Micromax'  => 'Micromax.*\b(A210|A92|A88|A72|A111|A110Q|A115|A116|A110|A90S|A26|A51|A35|A54|A25|A27|A89|A68|A65|A57|A90)\b',
-        // @todo Complete the regex.
-        'Palm'  => 'PalmSource|Palm', // avantgo|blazer|elaine|hiptop|plucker|xiino ;
+        'Palm'  => 'PalmSource|PalmOS|Palm|PalmOne|webOS|AvantGo|Blazer|Elaine|Hiptop|Plucker|Xiino|Treo|Pre|Pixi|Centro|Tungsten',
         // Just for fun ;)
         'Vertu' => 'Vertu|Vertu.*Ltd|Vertu.*Ascent|Vertu.*Ayxta|Vertu.*Constellation(F|Quest)?|Vertu.*Monika|Vertu.*Signature',
         // http://www.pantech.co.kr/en/prod/prodList.do?gbrand=VEGA (PANTECH)


### PR DESCRIPTION
## Summary
- broaden Palm device regex to match PalmOS, webOS, AvantGo, Blazer, Treo, Pre, Pixi, Centro, Tungsten and more
- remove obsolete TODO

## Testing
- `npm test`
- `./vendor/bin/phpunit` (fails: Warning: require_once(/tmp/wordpress-tests-lib/includes/functions.php): Failed to open stream)
- `make test` (fails: Makefile:21: *** missing separator (did you mean TAB instead of 8 spaces?).  Stop.)

------
https://chatgpt.com/codex/tasks/task_e_68b7163b9b70832788d3b36e0067ba57