### PR TITLE
Add AJAX-based optimizer cache purging

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -87,6 +87,10 @@ class Gm2_SEO_Admin {
         add_action('admin_post_gm2_import_settings', [$this, 'handle_import_settings']);
         add_action('admin_post_gm2_render_optimizer_settings', [$this, 'handle_render_optimizer_form']);
 
+        add_action('wp_ajax_gm2_purge_critical_css', [$this, 'ajax_purge_critical_css']);
+        add_action('wp_ajax_gm2_purge_js_map', [$this, 'ajax_purge_js_map']);
+        add_action('wp_ajax_gm2_purge_optimizer_cache', [$this, 'ajax_purge_optimizer_cache']);
+
         add_action('wp_ajax_gm2_check_rules', [$this, 'ajax_check_rules']);
         add_action('wp_ajax_gm2_keyword_ideas', [$this, 'ajax_keyword_ideas']);
         add_action('wp_ajax_gm2_research_content_rules', [$this, 'ajax_research_content_rules']);
@@ -3090,6 +3094,46 @@ class Gm2_SEO_Admin {
         }
         wp_redirect(admin_url('admin.php?page=gm2-seo&tab=performance&optimizer_cache_purged=1'));
         exit;
+    }
+
+    public function ajax_purge_critical_css() {
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(['message' => esc_html__( 'Permission denied', 'gm2-wordpress-suite' )], 403);
+        }
+        check_ajax_referer('gm2_purge_critical_css', 'nonce');
+        delete_option('ae_seo_ro_critical_css_map');
+        delete_transient('gm2_defer_js_map');
+        delete_transient('gm2_defer_js_dependencies');
+        if (class_exists('\\AE_SEO_Combine_Minify')) {
+            \AE_SEO_Combine_Minify::purge_cache();
+        }
+        wp_send_json_success(['message' => esc_html__( 'Critical CSS purged.', 'gm2-wordpress-suite' )]);
+    }
+
+    public function ajax_purge_js_map() {
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(['message' => esc_html__( 'Permission denied', 'gm2-wordpress-suite' )], 403);
+        }
+        check_ajax_referer('gm2_purge_js_map', 'nonce');
+        delete_transient('gm2_defer_js_map');
+        delete_transient('gm2_defer_js_dependencies');
+        if (class_exists('\\AE_SEO_Combine_Minify')) {
+            \AE_SEO_Combine_Minify::purge_cache();
+        }
+        wp_send_json_success(['message' => esc_html__( 'JS map purged.', 'gm2-wordpress-suite' )]);
+    }
+
+    public function ajax_purge_optimizer_cache() {
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(['message' => esc_html__( 'Permission denied', 'gm2-wordpress-suite' )], 403);
+        }
+        check_ajax_referer('gm2_purge_optimizer_cache', 'nonce');
+        delete_transient('gm2_defer_js_map');
+        delete_transient('gm2_defer_js_dependencies');
+        if (class_exists('\\AE_SEO_Combine_Minify')) {
+            \AE_SEO_Combine_Minify::purge_cache();
+        }
+        wp_send_json_success(['message' => esc_html__( 'Optimizer cache purged.', 'gm2-wordpress-suite' )]);
     }
 
     public function handle_insert_cache_rules() {

--- a/admin/js/gm2-seo.js
+++ b/admin/js/gm2-seo.js
@@ -71,8 +71,8 @@ jQuery(function($){
         a.href = url;
         return a.hostname && a.hostname !== window.location.hostname;
     }
-    if(typeof wpLink !== 'undefined'){
-        var $relField = $('<p class="gm2-link-rel"><label>Rel <select id="gm2-link-rel"><option value="">None</option><option value="nofollow">nofollow</option><option value="sponsored">sponsored</option><option value="nofollow sponsored">nofollow &amp; sponsored</option></select></label></p>');
+        if(typeof wpLink !== 'undefined'){
+            var $relField = $('<p class="gm2-link-rel"><label>Rel <select id="gm2-link-rel"><option value="">None</option><option value="nofollow">nofollow</option><option value="sponsored">sponsored</option><option value="nofollow sponsored">nofollow &amp; sponsored</option></select></label></p>');
         $('#wp-link .link-target').after($relField);
         var openOrig = wpLink.open;
         wpLink.open = function(editorId){
@@ -100,4 +100,33 @@ jQuery(function($){
             updateOrig.call(wpLink);
         };
     }
+
+    function gm2ShowNotice(message, type){
+        var $notice = $('<div class="notice notice-'+type+' is-dismissible gm2-optimizer-notice"><p>'+message+'</p></div>');
+        $('.gm2-optimizer-notice').remove();
+        $('.wrap').first().prepend($notice);
+    }
+
+    function gm2HandlePurge(selector, action){
+        $(document).on('click', selector, function(e){
+            e.preventDefault();
+            var $btn = $(this);
+            wp.ajax.post(action, { nonce: $btn.data('nonce') })
+                .done(function(response){
+                    var msg = response && response.data && response.data.message ? response.data.message : 'Done.';
+                    gm2ShowNotice(msg, 'success');
+                })
+                .fail(function(response){
+                    var msg = 'Error';
+                    if(response && response.responseJSON && response.responseJSON.data && response.responseJSON.data.message){
+                        msg = response.responseJSON.data.message;
+                    }
+                    gm2ShowNotice(msg, 'error');
+                });
+        });
+    }
+
+    gm2HandlePurge('.gm2-purge-critical-css', 'gm2_purge_critical_css');
+    gm2HandlePurge('.gm2-purge-js-map', 'gm2_purge_js_map');
+    gm2HandlePurge('.gm2-purge-optimizer-cache', 'gm2_purge_optimizer_cache');
 });

--- a/admin/views/settings-render-optimizer.php
+++ b/admin/views/settings-render-optimizer.php
@@ -77,14 +77,10 @@ echo '<p class="description"><a href="#">' . esc_html__( 'Learn how to auto-gene
 submit_button( esc_html__( 'Save Settings', 'gm2-wordpress-suite' ) );
 echo '</form>';
 
-echo '<form method="post" action="' . esc_url(admin_url('admin-post.php')) . '">';
-wp_nonce_field('gm2_purge_critical_css');
-echo '<input type="hidden" name="action" value="gm2_purge_critical_css" />';
-submit_button(esc_html__( 'Purge & Rebuild Critical CSS', 'gm2-wordpress-suite' ), 'delete');
-echo '</form>';
+$critical_nonce = wp_create_nonce('gm2_purge_critical_css');
+$js_nonce       = wp_create_nonce('gm2_purge_js_map');
+$cache_nonce    = wp_create_nonce('gm2_purge_optimizer_cache');
 
-echo '<form method="post" action="' . esc_url(admin_url('admin-post.php')) . '">';
-wp_nonce_field('gm2_purge_js_map');
-echo '<input type="hidden" name="action" value="gm2_purge_js_map" />';
-submit_button(esc_html__( 'Purge & Rebuild JS Map', 'gm2-wordpress-suite' ), 'delete');
-echo '</form>';
+echo '<p><button type="button" class="button gm2-purge-critical-css" data-nonce="' . esc_attr($critical_nonce) . '">' . esc_html__( 'Purge & Rebuild Critical CSS', 'gm2-wordpress-suite' ) . '</button></p>';
+echo '<p><button type="button" class="button gm2-purge-js-map" data-nonce="' . esc_attr($js_nonce) . '">' . esc_html__( 'Purge & Rebuild JS Map', 'gm2-wordpress-suite' ) . '</button></p>';
+echo '<p><button type="button" class="button gm2-purge-optimizer-cache" data-nonce="' . esc_attr($cache_nonce) . '">' . esc_html__( 'Purge Combined Assets', 'gm2-wordpress-suite' ) . '</button></p>';


### PR DESCRIPTION
## Summary
- add wp_ajax handlers to purge optimizer cache, JS map, and critical CSS with nonce and capability checks
- switch optimizer settings form buttons to AJAX calls
- show admin notices after async purges

## Testing
- `vendor/bin/phpunit` *(fails: Missing WordPress test suite/MySQL)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7165222e883278e006a5ef6d7fd4f