### PR TITLE
Add optimizer diagnostics logging and admin viewer

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -90,6 +90,7 @@ class Gm2_SEO_Admin {
         add_action('wp_ajax_gm2_purge_critical_css', [$this, 'ajax_purge_critical_css']);
         add_action('wp_ajax_gm2_purge_js_map', [$this, 'ajax_purge_js_map']);
         add_action('wp_ajax_gm2_purge_optimizer_cache', [$this, 'ajax_purge_optimizer_cache']);
+        add_action('wp_ajax_gm2_clear_optimizer_diagnostics', [$this, 'ajax_clear_optimizer_diagnostics']);
 
         add_action('wp_ajax_gm2_check_rules', [$this, 'ajax_check_rules']);
         add_action('wp_ajax_gm2_keyword_ideas', [$this, 'ajax_keyword_ideas']);
@@ -3134,6 +3135,17 @@ class Gm2_SEO_Admin {
             \AE_SEO_Combine_Minify::purge_cache();
         }
         wp_send_json_success(['message' => esc_html__( 'Optimizer cache purged.', 'gm2-wordpress-suite' )]);
+    }
+
+    public function ajax_clear_optimizer_diagnostics() {
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(['message' => esc_html__( 'Permission denied', 'gm2-wordpress-suite' )], 403);
+        }
+        check_ajax_referer('gm2_clear_optimizer_diagnostics', 'nonce');
+        if (class_exists('\\AE_SEO_Optimizer_Diagnostics')) {
+            \AE_SEO_Optimizer_Diagnostics::clear();
+        }
+        wp_send_json_success(['message' => esc_html__( 'Diagnostics cleared.', 'gm2-wordpress-suite' )]);
     }
 
     public function handle_insert_cache_rules() {

--- a/admin/js/gm2-seo.js
+++ b/admin/js/gm2-seo.js
@@ -129,4 +129,5 @@ jQuery(function($){
     gm2HandlePurge('.gm2-purge-critical-css', 'gm2_purge_critical_css');
     gm2HandlePurge('.gm2-purge-js-map', 'gm2_purge_js_map');
     gm2HandlePurge('.gm2-purge-optimizer-cache', 'gm2_purge_optimizer_cache');
+    gm2HandlePurge('.gm2-clear-optimizer-diagnostics', 'gm2_clear_optimizer_diagnostics');
 });

--- a/admin/views/settings-render-optimizer.php
+++ b/admin/views/settings-render-optimizer.php
@@ -84,3 +84,22 @@ $cache_nonce    = wp_create_nonce('gm2_purge_optimizer_cache');
 echo '<p><button type="button" class="button gm2-purge-critical-css" data-nonce="' . esc_attr($critical_nonce) . '">' . esc_html__( 'Purge & Rebuild Critical CSS', 'gm2-wordpress-suite' ) . '</button></p>';
 echo '<p><button type="button" class="button gm2-purge-js-map" data-nonce="' . esc_attr($js_nonce) . '">' . esc_html__( 'Purge & Rebuild JS Map', 'gm2-wordpress-suite' ) . '</button></p>';
 echo '<p><button type="button" class="button gm2-purge-optimizer-cache" data-nonce="' . esc_attr($cache_nonce) . '">' . esc_html__( 'Purge Combined Assets', 'gm2-wordpress-suite' ) . '</button></p>';
+
+$diag_nonce = wp_create_nonce('gm2_clear_optimizer_diagnostics');
+$logs = class_exists('AE_SEO_Optimizer_Diagnostics') ? AE_SEO_Optimizer_Diagnostics::get() : [];
+echo '<h2>' . esc_html__( 'Optimizer Diagnostics', 'gm2-wordpress-suite' ) . '</h2>';
+echo '<table class="widefat"><thead><tr><th>' . esc_html__( 'Type', 'gm2-wordpress-suite' ) . '</th><th>' . esc_html__( 'Handle', 'gm2-wordpress-suite' ) . '</th><th>' . esc_html__( 'Bundle', 'gm2-wordpress-suite' ) . '</th><th>' . esc_html__( 'Reason', 'gm2-wordpress-suite' ) . '</th></tr></thead><tbody>';
+if (!empty($logs)) {
+    foreach ($logs as $type => $entries) {
+        foreach ($entries as $entry) {
+            $handle = esc_html($entry['handle'] ?? '');
+            $bundle = esc_html($entry['bundle'] ?? '');
+            $reason = esc_html($entry['reason'] ?? '');
+            echo '<tr><td>' . esc_html($type) . '</td><td>' . $handle . '</td><td>' . $bundle . '</td><td>' . $reason . '</td></tr>';
+        }
+    }
+} else {
+    echo '<tr><td colspan="4">' . esc_html__( 'No diagnostics logged.', 'gm2-wordpress-suite' ) . '</td></tr>';
+}
+echo '</tbody></table>';
+echo '<p><button type="button" class="button gm2-clear-optimizer-diagnostics" data-nonce="' . esc_attr($diag_nonce) . '">' . esc_html__( 'Clear Diagnostics', 'gm2-wordpress-suite' ) . '</button></p>';

--- a/includes/render-optimizer/class-ae-seo-combine-minify.php
+++ b/includes/render-optimizer/class-ae-seo-combine-minify.php
@@ -73,39 +73,105 @@ class AE_SEO_Combine_Minify {
         foreach ($handles as $h) {
             $obj = $wp_styles->registered[$h] ?? null;
             if (!$obj) {
+                AE_SEO_Optimizer_Diagnostics::add('combine_css', [
+                    'handle' => $h,
+                    'bundle' => '',
+                    'reason' => 'not_registered',
+                ]);
                 continue;
             }
             if ($this->is_excluded($h, $obj->src)) {
+                AE_SEO_Optimizer_Diagnostics::add('combine_css', [
+                    'handle' => $h,
+                    'bundle' => '',
+                    'reason' => 'excluded',
+                ]);
                 continue;
             }
             if (!empty($obj->extra['integrity']) || !empty($obj->extra['crossorigin'])) {
+                AE_SEO_Optimizer_Diagnostics::add('combine_css', [
+                    'handle' => $h,
+                    'bundle' => '',
+                    'reason' => 'integrity',
+                ]);
                 continue;
             }
             if ($this->is_local($obj->src)) {
                 $path = $this->local_path($obj->src);
                 if (!file_exists($path)) {
+                    AE_SEO_Optimizer_Diagnostics::add('combine_css', [
+                        'handle' => $h,
+                        'bundle' => '',
+                        'reason' => 'missing',
+                    ]);
                     continue;
                 }
                 $size = filesize($path);
-                if ($size === false || $size > $file_limit) {
+                if ($size === false) {
+                    AE_SEO_Optimizer_Diagnostics::add('combine_css', [
+                        'handle' => $h,
+                        'bundle' => '',
+                        'reason' => 'filesize',
+                    ]);
+                    continue;
+                }
+                if ($size > $file_limit) {
+                    AE_SEO_Optimizer_Diagnostics::add('combine_css', [
+                        'handle' => $h,
+                        'bundle' => '',
+                        'reason' => 'file_limit',
+                    ]);
                     continue;
                 }
                 if ($total + $size > $bundle_cap) {
+                    AE_SEO_Optimizer_Diagnostics::add('combine_css', [
+                        'handle' => $h,
+                        'bundle' => '',
+                        'reason' => 'bundle_cap',
+                    ]);
                     continue;
                 }
                 $total   += $size;
                 $local[] = $h;
                 $media[] = $obj->args ? $obj->args : 'all';
+            } else {
+                AE_SEO_Optimizer_Diagnostics::add('combine_css', [
+                    'handle' => $h,
+                    'bundle' => '',
+                    'reason' => 'external',
+                ]);
             }
         }
 
         if (count($local) < 2) {
+            foreach ($local as $h) {
+                AE_SEO_Optimizer_Diagnostics::add('combine_css', [
+                    'handle' => $h,
+                    'bundle' => '',
+                    'reason' => 'not_enough_files',
+                ]);
+            }
             return $handles;
         }
 
         $src = $this->build_combined_file($local, 'css');
         if (!$src) {
+            foreach ($local as $h) {
+                AE_SEO_Optimizer_Diagnostics::add('combine_css', [
+                    'handle' => $h,
+                    'bundle' => '',
+                    'reason' => 'build_failed',
+                ]);
+            }
             return $handles;
+        }
+
+        foreach ($local as $h) {
+            AE_SEO_Optimizer_Diagnostics::add('combine_css', [
+                'handle' => $h,
+                'bundle' => $src,
+                'reason' => 'combined',
+            ]);
         }
 
         $unique_media = array_unique(array_map(function ($m) {
@@ -153,9 +219,19 @@ class AE_SEO_Combine_Minify {
         foreach ($handles as $h) {
             $obj = $wp_scripts->registered[$h] ?? null;
             if (!$obj) {
+                AE_SEO_Optimizer_Diagnostics::add('combine_js', [
+                    'handle' => $h,
+                    'bundle' => '',
+                    'reason' => 'not_registered',
+                ]);
                 continue;
             }
             if ($this->is_excluded($h, $obj->src)) {
+                AE_SEO_Optimizer_Diagnostics::add('combine_js', [
+                    'handle' => $h,
+                    'bundle' => '',
+                    'reason' => 'excluded',
+                ]);
                 continue;
             }
             $current_group = $wp_scripts->groups[$h] ?? 0;
@@ -163,32 +239,88 @@ class AE_SEO_Combine_Minify {
                 $group = $current_group;
             }
             if ($current_group !== $group) {
+                AE_SEO_Optimizer_Diagnostics::add('combine_js', [
+                    'handle' => $h,
+                    'bundle' => '',
+                    'reason' => 'group_mismatch',
+                ]);
                 continue;
             }
             if ($this->is_local($obj->src)) {
                 $path = $this->local_path($obj->src);
                 if (!file_exists($path)) {
+                    AE_SEO_Optimizer_Diagnostics::add('combine_js', [
+                        'handle' => $h,
+                        'bundle' => '',
+                        'reason' => 'missing',
+                    ]);
                     continue;
                 }
                 $size = filesize($path);
-                if ($size === false || $size > $file_limit) {
+                if ($size === false) {
+                    AE_SEO_Optimizer_Diagnostics::add('combine_js', [
+                        'handle' => $h,
+                        'bundle' => '',
+                        'reason' => 'filesize',
+                    ]);
+                    continue;
+                }
+                if ($size > $file_limit) {
+                    AE_SEO_Optimizer_Diagnostics::add('combine_js', [
+                        'handle' => $h,
+                        'bundle' => '',
+                        'reason' => 'file_limit',
+                    ]);
                     continue;
                 }
                 if ($total + $size > $bundle_cap) {
+                    AE_SEO_Optimizer_Diagnostics::add('combine_js', [
+                        'handle' => $h,
+                        'bundle' => '',
+                        'reason' => 'bundle_cap',
+                    ]);
                     continue;
                 }
                 $total   += $size;
                 $local[] = $h;
+            } else {
+                AE_SEO_Optimizer_Diagnostics::add('combine_js', [
+                    'handle' => $h,
+                    'bundle' => '',
+                    'reason' => 'external',
+                ]);
             }
         }
 
         if (count($local) < 2) {
+            foreach ($local as $h) {
+                AE_SEO_Optimizer_Diagnostics::add('combine_js', [
+                    'handle' => $h,
+                    'bundle' => '',
+                    'reason' => 'not_enough_files',
+                ]);
+            }
             return $handles;
         }
 
         $src = $this->build_combined_file($local, 'js');
         if (!$src) {
+            foreach ($local as $h) {
+                AE_SEO_Optimizer_Diagnostics::add('combine_js', [
+                    'handle' => $h,
+                    'bundle' => '',
+                    'reason' => 'build_failed',
+                ]);
+            }
             return $handles;
+        }
+
+        foreach ($local as $h) {
+            AE_SEO_Optimizer_Diagnostics::add('combine_js', [
+                'handle' => $h,
+                'bundle' => $src,
+                'reason' => 'combined',
+            ]);
         }
 
         $handle   = 'ae-seo-combined-js';

--- a/includes/render-optimizer/class-ae-seo-critical-css.php
+++ b/includes/render-optimizer/class-ae-seo-critical-css.php
@@ -35,6 +35,11 @@ class AE_SEO_Critical_CSS {
      */
     public function setup() {
         if ($this->is_excluded()) {
+            AE_SEO_Optimizer_Diagnostics::add('critical_css', [
+                'handle' => '',
+                'bundle' => '',
+                'reason' => 'request_excluded',
+            ]);
             return;
         }
 
@@ -91,6 +96,11 @@ class AE_SEO_Critical_CSS {
      */
     public function filter_style_tag($html, $handle, $href, $media) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- WordPress filter signature.
         if (is_feed() || is_404()) {
+            AE_SEO_Optimizer_Diagnostics::add('critical_css', [
+                'handle' => $handle,
+                'bundle' => '',
+                'reason' => 'feed_or_404',
+            ]);
             return $html;
         }
 
@@ -100,20 +110,40 @@ class AE_SEO_Critical_CSS {
         $patterns = ['editor', 'dashicons', 'admin-bar', 'woocommerce-inline'];
         foreach ($patterns as $pattern) {
             if (strpos($handle, $pattern) !== false) {
+                AE_SEO_Optimizer_Diagnostics::add('critical_css', [
+                    'handle' => $handle,
+                    'bundle' => '',
+                    'reason' => 'pattern',
+                ]);
                 return $html;
             }
         }
 
         if (in_array($handle, $deny, true)) {
+            AE_SEO_Optimizer_Diagnostics::add('critical_css', [
+                'handle' => $handle,
+                'bundle' => '',
+                'reason' => 'denylist',
+            ]);
             return $html;
         }
 
         if (strpos($html, 'rel="preload"') !== false || strpos($html, "rel='preload'") !== false || strpos($html, 'data-no-async') !== false) {
+            AE_SEO_Optimizer_Diagnostics::add('critical_css', [
+                'handle' => $handle,
+                'bundle' => '',
+                'reason' => 'preload_or_noasync',
+            ]);
             return $html;
         }
 
         $store = AE_SEO_Render_Optimizer::get_option(self::OPTION_CSS_MAP, []);
         if (empty($store[$handle])) {
+            AE_SEO_Optimizer_Diagnostics::add('critical_css', [
+                'handle' => $handle,
+                'bundle' => '',
+                'reason' => 'no_map',
+            ]);
             return $html;
         }
 
@@ -134,6 +164,11 @@ class AE_SEO_Critical_CSS {
             );
         }
 
+        AE_SEO_Optimizer_Diagnostics::add('critical_css', [
+            'handle' => $handle,
+            'bundle' => $href,
+            'reason' => 'processed',
+        ]);
         return $style . $async;
     }
 

--- a/includes/render-optimizer/class-ae-seo-defer-js.php
+++ b/includes/render-optimizer/class-ae-seo-defer-js.php
@@ -66,6 +66,11 @@ class AE_SEO_Defer_JS {
      */
     public function setup() {
         if (get_option('gm2_defer_js_enabled', '1') !== '1') {
+            AE_SEO_Optimizer_Diagnostics::add('defer_js', [
+                'handle' => '',
+                'bundle' => '',
+                'reason' => 'feature_disabled',
+            ]);
             return;
         }
 
@@ -82,6 +87,11 @@ class AE_SEO_Defer_JS {
      */
     public function filter($tag, $handle, $src) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- WordPress filter signature.
         if ($this->is_module_handle($handle, $tag)) {
+            AE_SEO_Optimizer_Diagnostics::add('defer_js', [
+                'handle' => $handle,
+                'bundle' => $src,
+                'reason' => 'module',
+            ]);
             return $tag;
         }
 
@@ -102,6 +112,11 @@ class AE_SEO_Defer_JS {
         ];
 
         if ($host && in_array($host, $deny_domains, true)) {
+            AE_SEO_Optimizer_Diagnostics::add('defer_js', [
+                'handle' => $handle,
+                'bundle' => $src,
+                'reason' => 'deny_domain',
+            ]);
             return $tag;
         }
 
@@ -113,6 +128,11 @@ class AE_SEO_Defer_JS {
 
         if ($host && (in_array($host, $allow_domains, true) || $is_analytics)) {
             $tag = $this->remove_attr($tag);
+            AE_SEO_Optimizer_Diagnostics::add('defer_js', [
+                'handle' => $handle,
+                'bundle' => $src,
+                'reason' => 'allow_domain',
+            ]);
             return str_replace('<script ', '<script async defer ', $tag);
         }
 
@@ -123,21 +143,41 @@ class AE_SEO_Defer_JS {
             }
             $group = $wp_scripts->get_data($handle, 'group');
             if ((int) $group === 1 && !in_array($handle, $allow, true)) {
+                AE_SEO_Optimizer_Diagnostics::add('defer_js', [
+                    'handle' => $handle,
+                    'bundle' => $src,
+                    'reason' => 'respect_footer',
+                ]);
                 return $tag;
             }
         }
 
         if (!empty($allow) && !in_array($handle, $allow, true)) {
+            AE_SEO_Optimizer_Diagnostics::add('defer_js', [
+                'handle' => $handle,
+                'bundle' => $src,
+                'reason' => 'not_allowlisted',
+            ]);
             return $this->remove_attr($tag);
         }
 
         if (in_array($handle, $deny, true)) {
+            AE_SEO_Optimizer_Diagnostics::add('defer_js', [
+                'handle' => $handle,
+                'bundle' => $src,
+                'reason' => 'denylist',
+            ]);
             return $this->remove_attr($tag);
         }
 
         $this->existing  = get_option('gm2_script_attributes', []);
         if (isset($this->existing[$handle])) {
             // Already handled by gm2_script_attributes.
+            AE_SEO_Optimizer_Diagnostics::add('defer_js', [
+                'handle' => $handle,
+                'bundle' => $src,
+                'reason' => 'existing_attribute',
+            ]);
             return $tag;
         }
 
@@ -151,6 +191,11 @@ class AE_SEO_Defer_JS {
         $this->resolved  = [];
 
         $attr = $this->determine_attribute($handle);
+        AE_SEO_Optimizer_Diagnostics::add('defer_js', [
+            'handle' => $handle,
+            'bundle' => $src,
+            'reason' => $attr,
+        ]);
 
         if ($attr === 'async' || $attr === 'defer') {
             $tag = $this->remove_attr($tag);

--- a/includes/render-optimizer/class-ae-seo-optimizer-diagnostics.php
+++ b/includes/render-optimizer/class-ae-seo-optimizer-diagnostics.php
@@ -1,0 +1,56 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Simple request-level diagnostics logger for optimizer classes.
+ */
+class AE_SEO_Optimizer_Diagnostics {
+    /**
+     * Stored logs grouped by optimizer type.
+     *
+     * @var array
+     */
+    private static $logs = [];
+
+    /**
+     * Add a diagnostic entry.
+     *
+     * @param string $type  Optimizer type.
+     * @param array  $entry Data with handle, bundle and reason.
+     * @return void
+     */
+    public static function add(string $type, array $entry): void {
+        $logs = self::get();
+        if (!isset($logs[$type])) {
+            $logs[$type] = [];
+        }
+        $logs[$type][] = $entry;
+        self::$logs = $logs;
+        set_transient('ae_seo_optimizer_diagnostics', $logs, 0);
+    }
+
+    /**
+     * Retrieve all logs for the current request.
+     *
+     * @return array
+     */
+    public static function get(): array {
+        if (empty(self::$logs)) {
+            $stored = get_transient('ae_seo_optimizer_diagnostics');
+            self::$logs = is_array($stored) ? $stored : [];
+        }
+        return self::$logs;
+    }
+
+    /**
+     * Clear stored logs.
+     *
+     * @return void
+     */
+    public static function clear(): void {
+        self::$logs = [];
+        delete_transient('ae_seo_optimizer_diagnostics');
+    }
+}

--- a/includes/render-optimizer/class-ae-seo-render-optimizer.php
+++ b/includes/render-optimizer/class-ae-seo-render-optimizer.php
@@ -10,6 +10,7 @@ if (!defined('ABSPATH')) {
 }
 
 require_once __DIR__ . '/class-ae-seo-critical-css.php';
+require_once __DIR__ . '/class-ae-seo-optimizer-diagnostics.php';
 
 /**
  * Bootstraps render optimization features.


### PR DESCRIPTION
## Summary
- Collect diagnostics from Critical CSS, Defer JS, and asset combining with reasons and bundle paths
- Display optimizer diagnostics and clear button in admin settings
- Support AJAX clearing of logged diagnostics

## Testing
- `vendor/bin/phpunit tests/test-critical-css.php tests/test-defer-js.php tests/test-combine-minify.php tests/test-combine-css.php` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_68b7194bb6a88327ba532b92812101d6