### PR TITLE
Refine version parsing

### DIFF
--- a/includes/MobileDetect.php
+++ b/includes/MobileDetect.php
@@ -1649,7 +1649,6 @@ class MobileDetect
 
     /**
      * Prepare the version number.
-     * @todo Remove the error suppression from str_replace() call.
      *
      * @param string $ver The string version, like "2.6.21.2152";
      * @return float
@@ -1659,8 +1658,18 @@ class MobileDetect
         $ver = str_replace(['_', ' ', '/'], '.', $ver);
         $arrVer = explode('.', $ver, 2);
 
+        if (!is_numeric($arrVer[0])) {
+            return 0.0;
+        }
+
         if (isset($arrVer[1])) {
-            $arrVer[1] = @str_replace('.', '', $arrVer[1]); // @todo: treat strings versions.
+            $arrVer[1] = str_replace('.', '', $arrVer[1]);
+            $arrVer[1] = preg_replace('/[^0-9]/', '', $arrVer[1]);
+            if ($arrVer[1] === '') {
+                return (float) $arrVer[0];
+            }
+        } else {
+            return (float) $arrVer[0];
         }
 
         return (float) implode('.', $arrVer);

--- a/tests/MobileDetectVersionTest.php
+++ b/tests/MobileDetectVersionTest.php
@@ -1,0 +1,30 @@
+<?php
+require_once __DIR__ . '/../includes/Psr/SimpleCache/CacheInterface.php';
+require_once __DIR__ . '/../includes/Psr/SimpleCache/CacheException.php';
+require_once __DIR__ . '/../includes/Psr/SimpleCache/InvalidArgumentException.php';
+require_once __DIR__ . '/../includes/Detection/Cache/Cache.php';
+require_once __DIR__ . '/../includes/Detection/Cache/CacheException.php';
+require_once __DIR__ . '/../includes/Detection/Cache/CacheInvalidArgumentException.php';
+require_once __DIR__ . '/../includes/Detection/Exception/MobileDetectException.php';
+require_once __DIR__ . '/../includes/Detection/Exception/MobileDetectExceptionCode.php';
+require_once __DIR__ . '/../includes/MobileDetect.php';
+
+use Detection\MobileDetect;
+use PHPUnit\Framework\TestCase;
+
+class MobileDetectVersionTest extends TestCase {
+    public function test_prepare_version_strips_non_digit_minor() {
+        $detect = new MobileDetect();
+        $this->assertSame(1.2, $detect->prepareVersionNo('1.2.beta'));
+    }
+
+    public function test_prepare_version_returns_zero_for_invalid() {
+        $detect = new MobileDetect();
+        $this->assertSame(0.0, $detect->prepareVersionNo('beta'));
+    }
+
+    public function test_prepare_version_compacts_three_part_version() {
+        $detect = new MobileDetect();
+        $this->assertSame(1.23, $detect->prepareVersionNo('1.2.3'));
+    }
+}


### PR DESCRIPTION
## Summary
- remove error suppression from MobileDetect version parsing
- validate version strings and handle non-digit segments
- add unit tests for MobileDetect version edge cases

## Testing
- ⚠️ `vendor/bin/phpunit` *(failed: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- ✅ `vendor/bin/phpunit --no-configuration tests/MobileDetectVersionTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b720d603b88327b90d5a22f088c52d