### PR TITLE
Handle missing is_plugin_active in render optimizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Use the **Purge Critical CSS** and **Purge JS Map** buttons on the Render Optimi
 
 To confirm differential serving, open the site in a modern browser and ensure only the `optimizer-modern.js` module bundle executes. Test again in an older or emulated legacy browser and verify only `optimizer-legacy.js` runs.
 
-The optimizer automatically disables its features when popular optimization plugins like WP&nbsp;Rocket, Autoptimize or Perfmatters are active. Only one optimization plugin should run at a time.
+The optimizer automatically disables its features when popular optimization plugins like WP&nbsp;Rocket, Autoptimize or Perfmatters are active. If WordPress's `is_plugin_active()` helper isn't available, the conflict check is skipped to avoid errors. Only one optimization plugin should run at a time.
 
 After adjusting the source files in `assets/src/optimizer`, rebuild the distributed scripts as noted in [Rebuilding Optimizer assets](#rebuilding-optimizer-assets).
 

--- a/includes/render-optimizer/class-ae-seo-render-optimizer.php
+++ b/includes/render-optimizer/class-ae-seo-render-optimizer.php
@@ -161,10 +161,17 @@ class AE_SEO_Render_Optimizer {
     /**
      * Check for conflicting optimization plugins.
      *
+     * Gracefully returns false if the core `is_plugin_active()` helper is
+     * unavailable to avoid calling an undefined function.
+     *
      * @return bool
      */
     private function has_conflicts() {
         include_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+        if (!function_exists('is_plugin_active')) {
+            return false;
+        }
 
         $plugins = [
             'wp-rocket/wp-rocket.php'       => 'WP Rocket',

--- a/tests/test-render-optimizer-conflicts.php
+++ b/tests/test-render-optimizer-conflicts.php
@@ -1,0 +1,31 @@
+<?php
+class RenderOptimizerConflictsTest extends WP_UnitTestCase {
+    public function test_missing_is_plugin_active_returns_false() {
+        $classFile = realpath(dirname(__DIR__) . '/includes/render-optimizer/class-ae-seo-render-optimizer.php');
+
+        $tempDir = sys_get_temp_dir() . '/gm2_fake_wp_' . uniqid();
+        mkdir($tempDir . '/wp-admin/includes', 0777, true);
+        file_put_contents($tempDir . '/wp-admin/includes/plugin.php', "<?php\n");
+
+        $script = <<<'PHP'
+        define('ABSPATH', '%s/');
+        require '%s';
+        class Test_RO extends AE_SEO_Render_Optimizer {
+            public function __construct() {}
+            public function run() { return $this->has_conflicts(); }
+        }
+        $t = new Test_RO();
+        var_export($t->run());
+        PHP;
+        $script = sprintf($script, $tempDir, $classFile);
+
+        $output = trim(shell_exec('php -r ' . escapeshellarg($script)));
+        $this->assertSame('false', $output);
+
+        unlink($tempDir . '/wp-admin/includes/plugin.php');
+        rmdir($tempDir . '/wp-admin/includes');
+        rmdir($tempDir . '/wp-admin');
+        rmdir($tempDir);
+    }
+}
+


### PR DESCRIPTION
## Summary
- Avoid fatal errors when `is_plugin_active()` is unavailable
- Document conflict check behaviour
- Add regression test for missing `is_plugin_active`

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: database connection could not be established)*

------
https://chatgpt.com/codex/tasks/task_e_68b720bd303c8327a882dc15cdda7cc1