### PR TITLE
Document render optimizer filters and diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,21 @@ Use the **Purge Critical CSS** and **Purge JS Map** buttons on the Render Optimi
 
 To confirm differential serving, open the site in a modern browser and ensure only the `optimizer-modern.js` module bundle executes. Test again in an older or emulated legacy browser and verify only `optimizer-legacy.js` runs.
 
+### Runtime Filters
+
+The Render Optimizer can be toggled at runtime with two filters:
+
+* `ae_seo_ro_enable_for_logged_in` &mdash; return `true` to process optimizer features for logged-in users instead of skipping them. This allows administrators to see the front end exactly as visitors do.
+* `ae_seo_ro_skip_url` &mdash; receives the current URL and lets you bypass optimization on matching paths, such as preview pages.
+
+### AJAX Purge Buttons
+
+Four buttons on the Render Optimizer screen issue AJAX requests to clear caches: **Purge & Rebuild Critical CSS**, **Purge & Rebuild JS Map**, **Purge Combined Assets**, and **Clear Diagnostics**. Each action verifies the caller has the `manage_options` capability and returns an escaped confirmation message. Purging Critical CSS also resets the JS map and combined asset cache, while purging the JS map clears its dependencies. Purging combined assets flushes generated bundles and related maps, and clearing diagnostics removes any logged entries.
+
+### Optimizer Diagnostics Panel
+
+The diagnostic table lists request-level logs for optimizer decisions with columns for type, handle, bundle and reason. Use it to determine why a script or style was bundled, deferred or skipped. All output is escaped for safety, and the **Clear Diagnostics** button (also requiring `manage_options`) resets the log so a fresh page load repopulates it.
+
 The optimizer automatically disables its features when popular optimization plugins like WP&nbsp;Rocket, Autoptimize or Perfmatters are active. If WordPress's `is_plugin_active()` helper isn't available, the conflict check is skipped to avoid errors. Only one optimization plugin should run at a time.
 
 After adjusting the source files in `assets/src/optimizer`, rebuild the distributed scripts as noted in [Rebuilding Optimizer assets](#rebuilding-optimizer-assets).

--- a/readme.txt
+++ b/readme.txt
@@ -127,6 +127,18 @@ Use **Purge Critical CSS** and **Purge JS Map** on the Render Optimizer screen a
 
 For differential serving, open the site in a modern browser and confirm only `optimizer-modern.js` runs. Repeat in an older or emulated legacy browser to ensure just `optimizer-legacy.js` executes.
 
+=== Runtime Filters ===
+The optimizer behavior can be customized with two filters:
+
+* `ae_seo_ro_enable_for_logged_in` – return `true` to run optimizer features for logged-in users instead of skipping them.
+* `ae_seo_ro_skip_url` – receives the current URL and allows bypassing optimization for matching paths.
+
+=== AJAX Purge Buttons ===
+**Purge & Rebuild Critical CSS**, **Purge & Rebuild JS Map**, **Purge Combined Assets**, and **Clear Diagnostics** buttons send AJAX requests to clear related caches. Each action requires the `manage_options` capability and replies with an escaped confirmation. Purging Critical CSS also resets the JS map and combined asset cache, purging the JS map clears its dependencies, purging combined assets flushes generated bundles and maps, and clearing diagnostics removes logged entries.
+
+=== Optimizer Diagnostics ===
+The diagnostics table lists optimizer decisions with columns for type, handle, bundle and reason. Use it to understand why assets were bundled, deferred or skipped. Output is escaped, and the **Clear Diagnostics** button—also restricted to `manage_options`—wipes the log so a fresh page load repopulates it.
+
 If WP Rocket, Autoptimize, Perfmatters or other optimizer plugins are active, the subsystem automatically disables its features and displays a warning. Only one optimization plugin should run at a time.
 
 == SEO Performance CLI ==


### PR DESCRIPTION
## Summary
- document render optimizer filters `ae_seo_ro_enable_for_logged_in` and `ae_seo_ro_skip_url`
- describe AJAX-based purge buttons and diagnostic panel with capability checks and escaping

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b72246572883279113df510a53a1a9