### PR TITLE
Enhance MeeGo and Maemo detection

### DIFF
--- a/includes/MobileDetect.php
+++ b/includes/MobileDetect.php
@@ -880,11 +880,9 @@ class MobileDetect
         // https://sailfishos.org/
         'SailfishOS'        => 'Sailfish',
         // http://en.wikipedia.org/wiki/MeeGo
-        // @todo: research MeeGo in UAs
-        'MeeGoOS'           => 'MeeGo',
+        'MeeGoOS'           => 'MeeGo|NokiaN9',
         // http://en.wikipedia.org/wiki/Maemo
-        // @todo: research Maemo in UAs
-        'MaemoOS'           => 'Maemo',
+        'MaemoOS'           => 'Maemo|NokiaN900',
         'JavaOS'            => 'J2ME/|\bMIDP\b|\bCLDC\b', // '|Java/' produces bug #135
         'webOS'             => 'webOS|hpwOS',
         'badaOS'            => '\bBada\b',

--- a/tests/MobileDetectOsTest.php
+++ b/tests/MobileDetectOsTest.php
@@ -1,0 +1,29 @@
+<?php
+require_once __DIR__ . '/../includes/Psr/SimpleCache/CacheInterface.php';
+require_once __DIR__ . '/../includes/Psr/SimpleCache/CacheException.php';
+require_once __DIR__ . '/../includes/Psr/SimpleCache/InvalidArgumentException.php';
+require_once __DIR__ . '/../includes/Detection/Cache/Cache.php';
+require_once __DIR__ . '/../includes/Detection/Cache/CacheException.php';
+require_once __DIR__ . '/../includes/Detection/Cache/CacheInvalidArgumentException.php';
+require_once __DIR__ . '/../includes/Detection/Exception/MobileDetectException.php';
+require_once __DIR__ . '/../includes/Detection/Exception/MobileDetectExceptionCode.php';
+require_once __DIR__ . '/../includes/MobileDetect.php';
+
+use Detection\MobileDetect;
+use PHPUnit\Framework\TestCase;
+
+class MobileDetectOsTest extends TestCase {
+    public function test_detects_meego() {
+        $ua = 'Mozilla/5.0 (MeeGo; NokiaN9) AppleWebKit/534.13 (KHTML, like Gecko) NokiaBrowser/8.5.0 Mobile Safari/534.13';
+        $detect = new MobileDetect(null, ['autoInitOfHttpHeaders' => false]);
+        $detect->setUserAgent($ua);
+        $this->assertTrue($detect->isMeeGoOS());
+    }
+
+    public function test_detects_maemo() {
+        $ua = 'Opera/9.80 (Linux armv7l; Maemo; Opera Mobi/14; U; en) Presto/2.9.201 Version/11.50';
+        $detect = new MobileDetect(null, ['autoInitOfHttpHeaders' => false]);
+        $detect->setUserAgent($ua);
+        $this->assertTrue($detect->isMaemoOS());
+    }
+}


### PR DESCRIPTION
## Summary
- Expand MeeGo and Maemo OS regexes and drop outdated TODO notes
- Add PHPUnit tests for MeeGo and Maemo user agents

## Testing
- `vendor/bin/phpunit --no-configuration --testdox tests/MobileDetectVersionTest.php`
- `vendor/bin/phpunit --no-configuration --testdox tests/MobileDetectOsTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7222e40488327ac8b26caf7a91b37