### PR TITLE
Add CLI command to build Critical CSS

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -736,5 +736,6 @@ if (defined('WP_CLI') && WP_CLI) {
     require_once GM2_PLUGIN_DIR . 'includes/cli/class-gm2-migrate.php';
     require_once GM2_PLUGIN_DIR . 'includes/cli/class-gm2-model.php';
     require_once GM2_PLUGIN_DIR . 'includes/cli/class-gm2-schema-audit.php';
+    require_once GM2_PLUGIN_DIR . 'includes/cli/class-ae-seo-critical-cli.php';
 }
 

--- a/includes/cli/class-ae-seo-critical-cli.php
+++ b/includes/cli/class-ae-seo-critical-cli.php
@@ -1,0 +1,73 @@
+<?php
+namespace AE_SEO;
+
+if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+    return;
+}
+
+class AE_SEO_Critical_CLI extends \WP_CLI_Command {
+    /**
+     * Build Critical CSS for important pages.
+     */
+    public function build() {
+        $urls = [];
+        $urls[] = [
+            'context' => 'home',
+            'url'     => home_url( '/' ),
+        ];
+
+        $post_types = get_post_types( [ 'public' => true ], 'objects' );
+        foreach ( $post_types as $type ) {
+            if ( ! empty( $type->has_archive ) && ( $link = get_post_type_archive_link( $type->name ) ) ) {
+                $urls[] = [
+                    'context' => 'archive-' . $type->name,
+                    'url'     => $link,
+                ];
+            }
+        }
+
+        $query = new \WP_Query( [
+            'post_type'           => array_keys( get_post_types( [ 'public' => true ] ) ),
+            'posts_per_page'      => 20,
+            'post_status'         => 'publish',
+            'orderby'             => 'date',
+            'order'               => 'DESC',
+            'ignore_sticky_posts' => true,
+            'no_found_rows'       => true,
+        ] );
+        foreach ( $query->posts as $post ) {
+            $urls[] = [
+                'context' => 'single-' . $post->post_type,
+                'url'     => get_permalink( $post ),
+            ];
+        }
+        wp_reset_postdata();
+
+        set_transient( 'ae_seo_ro_critical_job', $urls, 12 * HOUR_IN_SECONDS );
+
+        if ( ! function_exists( 'shell_exec' ) ) {
+            \WP_CLI::error( 'shell_exec is not available.' );
+        }
+        $critical = shell_exec( 'which critical' );
+        if ( empty( trim( $critical ) ) ) {
+            \WP_CLI::error( 'critical CLI not found. Install with `npm install -g critical`.' );
+        }
+
+        $css_map = get_option( 'ae_seo_ro_critical_css_map', [] );
+        foreach ( $urls as $data ) {
+            $url     = $data['url'];
+            $context = $data['context'];
+            \WP_CLI::log( 'Processing ' . $url );
+            $cmd = 'critical ' . escapeshellarg( $url ) . ' --inline=false --minify';
+            $css = shell_exec( $cmd );
+            if ( ! isset( $css_map[ $context ] ) ) {
+                $css_map[ $context ] = [];
+            }
+            $css_map[ $context ][ md5( $url ) ] = $css;
+        }
+        update_option( 'ae_seo_ro_critical_css_map', $css_map );
+        \WP_CLI::success( 'Critical CSS build complete.' );
+    }
+}
+
+\WP_CLI::add_command( 'ae-seo critical', 'AE_SEO\\AE_SEO_Critical_CLI' );


### PR DESCRIPTION
## Summary
- add `ae-seo critical` WP-CLI command to build and store Critical CSS for key URLs
- load the new CLI when running under WP-CLI

## Testing
- `composer install`
- `bin/install-wp-tests.sh wordpress_test root '' localhost latest` (fails: Can't connect to MySQL server)
- `vendor/bin/phpunit` (fails: database connection error)


------
https://chatgpt.com/codex/tasks/task_e_68b7245e585c8327b50d76587e0dcd88