### PR TITLE
Document critical CSS CLI builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,22 @@ Inline above-the-fold styles and load remaining CSS asynchronously.
 
 Provide handles or patterns to skip. Editor, dashicons, admin-bar and WooCommerce inline styles are ignored automatically.
 
+### Critical CSS CLI Build
+
+Generate and refresh critical CSS from the command line:
+
+```bash
+wp ae-seo critical:build
+```
+
+The command queues home, archive and recent single URLs in the `ae_seo_ro_critical_job` transient and invokes the Node `critical` package via `shell_exec`. Install the dependency globally with:
+
+```bash
+npm i -g critical
+```
+
+Each run populates the `ae_seo_ro_critical_css_map` option and never executes during front‑end requests. If snippets become outdated, clear the transient or delete the map—using the **Purge Critical CSS** button or WP‑CLI—to force a rebuild.
+
 ### JavaScript Deferral
 
 Toggle script deferral on or off and maintain allow and deny lists for specific handles and hostnames. List analytics domains like `www.googletagmanager.com` or `www.google.com/recaptcha` to always load asynchronously. The **Respect in footer** option keeps footer scripts at the bottom unless allowlisted. Inline blocks are parsed to detect dependencies automatically and jQuery remains blocking when early inline usage is detected.

--- a/readme.txt
+++ b/readme.txt
@@ -114,7 +114,16 @@ Inline above-the-fold styles and load full stylesheets asynchronously.
 * Async methods:
   * `preload_onload` – outputs a `<link rel="preload">` tag that swaps to `rel="stylesheet"` with a `<noscript>` fallback.
   * `media_print` – starts with `media="print"` and switches to `all` on load.
-  * Exclusions – provide handles to skip; editor, dashicons, admin-bar and WooCommerce inline styles are ignored automatically.
+* Exclusions – provide handles to skip; editor, dashicons, admin-bar and WooCommerce inline styles are ignored automatically.
+
+=== Critical CSS CLI ===
+Generate critical CSS from the command line:
+
+`wp ae-seo critical:build`
+
+The command queues home, archive and recent single URLs in the `ae_seo_ro_critical_job` transient and invokes the Node `critical` package via `shell_exec`. Install it globally with `npm i -g critical`.
+
+Each run populates the `ae_seo_ro_critical_css_map` option and runs only from the CLI, never during front-end requests. If results become stale, clear the transient or delete the map—using **Purge Critical CSS** or WP-CLI—to rebuild.
 
 === JavaScript Deferral ===
 Toggle script deferral on or off and maintain allow and deny lists for specific handles and hostnames. Example analytics domains include `www.googletagmanager.com` and `www.google.com/recaptcha`. The **Respect in footer** setting keeps footer scripts in place unless allowlisted. Inline blocks are scanned to detect dependencies automatically and jQuery stays blocking when early inline usage is detected.


### PR DESCRIPTION
## Summary
- document `wp ae-seo critical:build` usage for generating critical CSS
- note transient queue, Node `critical` dependency, and CLI-only execution
- advise clearing the transient or CSS map when results are stale

## Testing
- `CI=true npm test`
- `vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_68b72a3b02b4832787f07051236c504e