### PR TITLE
Skip render optimizer on login and register pages

### DIFF
--- a/includes/render-optimizer/class-ae-seo-render-optimizer.php
+++ b/includes/render-optimizer/class-ae-seo-render-optimizer.php
@@ -150,7 +150,8 @@ class AE_SEO_Render_Optimizer {
             wp_doing_ajax() ||
             wp_doing_cron() ||
             (defined('REST_REQUEST') && REST_REQUEST) ||
-            is_feed()
+            is_feed() ||
+            (isset($GLOBALS['pagenow']) && in_array($GLOBALS['pagenow'], [ 'wp-login.php', 'wp-register.php' ], true))
         ) {
             return true;
         }

--- a/tests/test-render-optimizer-conflicts.php
+++ b/tests/test-render-optimizer-conflicts.php
@@ -27,5 +27,32 @@ class RenderOptimizerConflictsTest extends WP_UnitTestCase {
         rmdir($tempDir . '/wp-admin');
         rmdir($tempDir);
     }
+
+    public function test_login_url_skips_loading_features() {
+        $originalPagenow = $GLOBALS['pagenow'] ?? null;
+        $GLOBALS['pagenow'] = 'wp-login.php';
+
+        AE_SEO_Render_Optimizer::update_option(AE_SEO_Critical_CSS::OPTION_ENABLE, '1');
+
+        $optimizer = new class extends AE_SEO_Render_Optimizer {
+            public $loaded = false;
+            public function __construct() {}
+            protected function load_features() {
+                $this->loaded = true;
+            }
+        };
+
+        $optimizer->maybe_bootstrap();
+
+        $this->assertFalse($optimizer->loaded);
+
+        AE_SEO_Render_Optimizer::delete_option(AE_SEO_Critical_CSS::OPTION_ENABLE);
+
+        if ($originalPagenow === null) {
+            unset($GLOBALS['pagenow']);
+        } else {
+            $GLOBALS['pagenow'] = $originalPagenow;
+        }
+    }
 }
 


### PR DESCRIPTION
## Summary
- Avoid running render optimizer during WordPress login or registration by checking the current page
- Ensure optimizer classes do not load on login URL through a new unit test

## Testing
- `composer install`
- `bash bin/install-wp-tests.sh wordpress_test root '' localhost:/run/mysqld/mysqld.sock latest`
- `vendor/bin/phpunit -- tests/test-render-optimizer-conflicts.php` *(fails: Class test-render-optimizer-conflicts could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b72da6fe6483279d20c9c2599e6fb9