### PR TITLE
Respect render optimizer logged-in filter

### DIFF
--- a/includes/render-optimizer/class-ae-seo-critical-css.php
+++ b/includes/render-optimizer/class-ae-seo-critical-css.php
@@ -165,7 +165,15 @@ class AE_SEO_Critical_CSS {
      * @return bool
      */
     private function is_excluded() {
-        if (is_admin() || is_user_logged_in() || is_admin_bar_showing() || is_feed() || is_preview() || wp_doing_cron()) {
+        $enable_for_logged_in = apply_filters('ae_seo_ro_enable_for_logged_in', false);
+        if (
+            is_admin() ||
+            (is_user_logged_in() && !$enable_for_logged_in) ||
+            (is_admin_bar_showing() && !$enable_for_logged_in) ||
+            is_feed() ||
+            is_preview() ||
+            wp_doing_cron()
+        ) {
             return true;
         }
 


### PR DESCRIPTION
## Summary
- allow critical CSS to load for logged-in users when `ae_seo_ro_enable_for_logged_in` filter enables it
- align admin bar check with the same logged-in filter

## Testing
- `vendor/bin/phpunit` *(fails: WordPress test suite missing)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7456687348327a5e7e024c2fd9e22