### PR TITLE
Localize WP-CLI messages for translation

### DIFF
--- a/includes/cli/class-ae-seo-critical-cli.php
+++ b/includes/cli/class-ae-seo-critical-cli.php
@@ -46,18 +46,18 @@ class AE_SEO_Critical_CLI extends \WP_CLI_Command {
         set_transient( 'ae_seo_ro_critical_job', $urls, 12 * HOUR_IN_SECONDS );
 
         if ( ! function_exists( 'shell_exec' ) ) {
-            \WP_CLI::error( 'shell_exec is not available.' );
+            \WP_CLI::error( __( 'shell_exec is not available.', 'gm2-wordpress-suite' ) );
         }
         $critical = shell_exec( 'which critical' );
         if ( empty( trim( $critical ) ) ) {
-            \WP_CLI::error( 'critical CLI not found. Install with `npm install -g critical`.' );
+            \WP_CLI::error( __( 'critical CLI not found. Install with `npm install -g critical`.', 'gm2-wordpress-suite' ) );
         }
 
         $css_map = get_option( 'ae_seo_ro_critical_css_map', [] );
         foreach ( $urls as $data ) {
             $url     = $data['url'];
             $context = $data['context'];
-            \WP_CLI::log( 'Processing ' . $url );
+            \WP_CLI::log( sprintf( __( 'Processing %s', 'gm2-wordpress-suite' ), $url ) );
             $cmd = 'critical ' . escapeshellarg( $url ) . ' --inline=false --minify';
             $css = shell_exec( $cmd );
             if ( ! isset( $css_map[ $context ] ) ) {
@@ -66,7 +66,7 @@ class AE_SEO_Critical_CLI extends \WP_CLI_Command {
             $css_map[ $context ][ md5( $url ) ] = $css;
         }
         update_option( 'ae_seo_ro_critical_css_map', $css_map );
-        \WP_CLI::success( 'Critical CSS build complete.' );
+        \WP_CLI::success( __( 'Critical CSS build complete.', 'gm2-wordpress-suite' ) );
     }
 }
 

--- a/includes/cli/class-gm2-cli.php
+++ b/includes/cli/class-gm2-cli.php
@@ -16,14 +16,14 @@ class Gm2_CLI extends \WP_CLI_Command {
     public function sitemap( $args, $assoc_args ) {
         $sub = $args[0] ?? '';
         if ( $sub !== 'generate' ) {
-            \WP_CLI::error( 'Usage: wp gm2 sitemap generate' );
+            \WP_CLI::error( __( 'Usage: wp gm2 sitemap generate', 'gm2-wordpress-suite' ) );
         }
 
         $result = \gm2_generate_sitemap();
         if ( is_wp_error( $result ) ) {
             \WP_CLI::error( $result->get_error_message() );
         }
-        \WP_CLI::success( 'Sitemap generated.' );
+        \WP_CLI::success( __( 'Sitemap generated.', 'gm2-wordpress-suite' ) );
     }
 
     /**
@@ -36,17 +36,17 @@ class Gm2_CLI extends \WP_CLI_Command {
     public function ai( $args, $assoc_args ) {
         $sub = $args[0] ?? '';
         if ( $sub !== 'clear' ) {
-            \WP_CLI::error( 'Usage: wp gm2 ai clear' );
+            \WP_CLI::error( __( 'Usage: wp gm2 ai clear', 'gm2-wordpress-suite' ) );
         }
 
         if ( ! function_exists( '\gm2_ai_clear' ) ) {
-            \WP_CLI::error( 'gm2_ai_clear() function not found.' );
+            \WP_CLI::error( __( 'gm2_ai_clear() function not found.', 'gm2-wordpress-suite' ) );
         }
         $result = \gm2_ai_clear();
         if ( is_wp_error( $result ) ) {
             \WP_CLI::error( $result->get_error_message() );
         }
-        \WP_CLI::success( 'AI data cleared.' );
+        \WP_CLI::success( __( 'AI data cleared.', 'gm2-wordpress-suite' ) );
     }
 
     /**
@@ -63,24 +63,24 @@ class Gm2_CLI extends \WP_CLI_Command {
             $logger = function_exists('wc_get_logger') ? wc_get_logger() : null;
             $ac    = new Gm2_Abandoned_Carts($logger);
             $count = $ac->migrate_recovered_carts();
-            \WP_CLI::success( sprintf( '%d carts migrated.', $count ) );
+            \WP_CLI::success( sprintf( __( '%d carts migrated.', 'gm2-wordpress-suite' ), $count ) );
             return;
         }
 
         if ( $sub === 'process' ) {
             Gm2_Abandoned_Carts::cron_mark_abandoned();
-            \WP_CLI::success( 'Abandoned carts processed.' );
+            \WP_CLI::success( __( 'Abandoned carts processed.', 'gm2-wordpress-suite' ) );
             return;
         }
 
         if ( $sub === 'retry-failed' ) {
             $messaging = new Gm2_Abandoned_Carts_Messaging();
             $count = $messaging->reprocess_failed_messages();
-            \WP_CLI::success( sprintf( '%d failed messages reprocessed.', $count ) );
+            \WP_CLI::success( sprintf( __( '%d failed messages reprocessed.', 'gm2-wordpress-suite' ), $count ) );
             return;
         }
 
-        \WP_CLI::error( 'Usage: wp gm2 ac <migrate|process|retry-failed>' );
+        \WP_CLI::error( __( 'Usage: wp gm2 ac <migrate|process|retry-failed>', 'gm2-wordpress-suite' ) );
     }
 
     /**
@@ -104,7 +104,7 @@ class Gm2_CLI extends \WP_CLI_Command {
                     wp_mkdir_p( dirname( $path ) );
                 }
                 file_put_contents( $path, "{{ gm2_field('example') }}\n" );
-                \WP_CLI::success( 'Twig template created at ' . $path );
+                \WP_CLI::success( sprintf( __( 'Twig template created at %s', 'gm2-wordpress-suite' ), $path ) );
                 break;
             case 'blade':
                 $path = trailingslashit( $theme_dir ) . 'resources/views/' . $slug . '.blade.php';
@@ -112,7 +112,7 @@ class Gm2_CLI extends \WP_CLI_Command {
                     wp_mkdir_p( dirname( $path ) );
                 }
                 file_put_contents( $path, "{{ gm2_field('example') }}\n" );
-                \WP_CLI::success( 'Blade template created at ' . $path );
+                \WP_CLI::success( sprintf( __( 'Blade template created at %s', 'gm2-wordpress-suite' ), $path ) );
                 break;
             case 'theme-json':
             case 'theme':
@@ -120,23 +120,23 @@ class Gm2_CLI extends \WP_CLI_Command {
                 if ( ! file_exists( $path ) ) {
                     $contents = json_encode( [ '$schema' => 'https://schemas.wp.org/wp/6.4/theme.json' ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
                     file_put_contents( $path, $contents );
-                    \WP_CLI::success( 'theme.json created at ' . $path );
+                    \WP_CLI::success( sprintf( __( 'theme.json created at %s', 'gm2-wordpress-suite' ), $path ) );
                 } else {
-                    \WP_CLI::success( 'theme.json already exists at ' . $path );
+                    \WP_CLI::success( sprintf( __( 'theme.json already exists at %s', 'gm2-wordpress-suite' ), $path ) );
                 }
                 $label = ucwords( str_replace( '-', ' ', $slug ) );
                 $sample = [
                     'customTemplates' => [
-                        [ 'name' => 'single-' . $slug, 'title' => 'Single ' . $label ],
-                        [ 'name' => 'archive-' . $slug, 'title' => 'Archive ' . $label ],
+                        [ 'name' => 'single-' . $slug, 'title' => sprintf( __( 'Single %s', 'gm2-wordpress-suite' ), $label ) ],
+                        [ 'name' => 'archive-' . $slug, 'title' => sprintf( __( 'Archive %s', 'gm2-wordpress-suite' ), $label ) ],
                     ],
                     'patterns' => [ 'gm2/' . $slug ],
                 ];
-                \WP_CLI::line( 'Hint: add the following to theme.json to reference custom templates and patterns:' );
+                \WP_CLI::line( __( 'Hint: add the following to theme.json to reference custom templates and patterns:', 'gm2-wordpress-suite' ) );
                 \WP_CLI::line( json_encode( $sample, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
                 break;
             default:
-                \WP_CLI::error( 'Usage: wp gm2 scaffold <twig|blade|theme-json> <slug>' );
+                \WP_CLI::error( __( 'Usage: wp gm2 scaffold <twig|blade|theme-json> <slug>', 'gm2-wordpress-suite' ) );
         }
     }
 }

--- a/includes/cli/class-gm2-migrate.php
+++ b/includes/cli/class-gm2-migrate.php
@@ -14,7 +14,7 @@ class Gm2_Migrate_CLI extends \WP_CLI_Command {
      */
     public function install( $args, $assoc_args ) {
         \gm2_custom_tables_maybe_install();
-        \WP_CLI::success( 'Custom tables are up to date.' );
+        \WP_CLI::success( __( 'Custom tables are up to date.', 'gm2-wordpress-suite' ) );
     }
 
     /**
@@ -22,7 +22,7 @@ class Gm2_Migrate_CLI extends \WP_CLI_Command {
      */
     public function backfill( $args, $assoc_args ) {
         $count = \gm2_custom_tables_backfill();
-        \WP_CLI::success( sprintf( '%d rows backfilled.', $count ) );
+        \WP_CLI::success( sprintf( __( '%d rows backfilled.', 'gm2-wordpress-suite' ), $count ) );
     }
 }
 

--- a/includes/cli/class-gm2-model.php
+++ b/includes/cli/class-gm2-model.php
@@ -26,7 +26,7 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
     public function export( $args, $assoc_args ) {
         $file = $args[0] ?? '';
         if ( empty( $file ) ) {
-            \WP_CLI::error( 'Missing file argument.' );
+            \WP_CLI::error( __( 'Missing file argument.', 'gm2-wordpress-suite' ) );
         }
         $format = $assoc_args['format'] ?? 'json';
         $data   = \gm2_model_export( $format );
@@ -34,7 +34,7 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
             \WP_CLI::error( $data->get_error_message() );
         }
         file_put_contents( $file, $data );
-        \WP_CLI::success( 'Models exported to ' . $file );
+        \WP_CLI::success( sprintf( __( 'Models exported to %s', 'gm2-wordpress-suite' ), $file ) );
     }
 
     /**
@@ -51,7 +51,7 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
     public function import( $args, $assoc_args ) {
         $file = $args[0] ?? '';
         if ( empty( $file ) || ! file_exists( $file ) ) {
-            \WP_CLI::error( 'File not found.' );
+            \WP_CLI::error( __( 'File not found.', 'gm2-wordpress-suite' ) );
         }
         $format = $assoc_args['format'] ?? '';
         if ( ! $format ) {
@@ -62,7 +62,7 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
         if ( is_wp_error( $result ) ) {
             \WP_CLI::error( $result->get_error_message() );
         }
-        \WP_CLI::success( 'Models imported from ' . $file );
+        \WP_CLI::success( sprintf( __( 'Models imported from %s', 'gm2-wordpress-suite' ), $file ) );
     }
 
     /**
@@ -79,7 +79,7 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
     public function generate_plugin( $args, $assoc_args ) {
         $file = $args[0] ?? '';
         if ( empty( $file ) ) {
-            \WP_CLI::error( 'Missing file argument.' );
+            \WP_CLI::error( __( 'Missing file argument.', 'gm2-wordpress-suite' ) );
         }
         $mu   = ! empty( $assoc_args['mu'] );
         $data = \gm2_model_export( 'array' );
@@ -87,7 +87,7 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
         if ( is_wp_error( $zip ) ) {
             \WP_CLI::error( $zip->get_error_message() );
         }
-        \WP_CLI::success( 'Plugin generated at ' . $file );
+        \WP_CLI::success( sprintf( __( 'Plugin generated at %s', 'gm2-wordpress-suite' ), $file ) );
     }
 
     /**
@@ -104,7 +104,7 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
     public function create( $args, $assoc_args ) {
         $type = $args[0] ?? '';
         if ( ! $type ) {
-            \WP_CLI::error( 'Usage: wp gm2 model create <cpt|taxonomy|field> ...' );
+            \WP_CLI::error( __( 'Usage: wp gm2 model create <cpt|taxonomy|field> ...', 'gm2-wordpress-suite' ) );
         }
 
         array_shift( $args );
@@ -121,7 +121,7 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
                 $this->field_create( $args, $assoc_args );
                 break;
             default:
-                \WP_CLI::error( 'Unknown type. Use cpt, taxonomy or field.' );
+                \WP_CLI::error( __( 'Unknown type. Use cpt, taxonomy or field.', 'gm2-wordpress-suite' ) );
         }
     }
 
@@ -139,7 +139,7 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
     public function update( $args, $assoc_args ) {
         $type = $args[0] ?? '';
         if ( ! $type ) {
-            \WP_CLI::error( 'Usage: wp gm2 model update <cpt|taxonomy|field> ...' );
+            \WP_CLI::error( __( 'Usage: wp gm2 model update <cpt|taxonomy|field> ...', 'gm2-wordpress-suite' ) );
         }
 
         array_shift( $args );
@@ -156,7 +156,7 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
                 $this->field_update( $args, $assoc_args );
                 break;
             default:
-                \WP_CLI::error( 'Unknown type. Use cpt, taxonomy or field.' );
+                \WP_CLI::error( __( 'Unknown type. Use cpt, taxonomy or field.', 'gm2-wordpress-suite' ) );
         }
     }
 
@@ -183,7 +183,7 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
     public function delete( $args, $assoc_args ) {
         $type = $args[0] ?? '';
         if ( ! $type ) {
-            \WP_CLI::error( 'Usage: wp gm2 model delete <cpt|taxonomy|field> ...' );
+            \WP_CLI::error( __( 'Usage: wp gm2 model delete <cpt|taxonomy|field> ...', 'gm2-wordpress-suite' ) );
         }
 
         array_shift( $args );
@@ -200,7 +200,7 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
                 $this->field_delete( $args, $assoc_args );
                 break;
             default:
-                \WP_CLI::error( 'Unknown type. Use cpt, taxonomy or field.' );
+                \WP_CLI::error( __( 'Unknown type. Use cpt, taxonomy or field.', 'gm2-wordpress-suite' ) );
         }
     }
 
@@ -218,21 +218,21 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
     public function cpt_create( $args, $assoc_args ) {
         $slug = $args[0] ?? '';
         if ( ! $slug ) {
-            \WP_CLI::error( 'Missing CPT slug.' );
+            \WP_CLI::error( __( 'Missing CPT slug.', 'gm2-wordpress-suite' ) );
         }
 
         $models = get_option( 'gm2_models', [] );
         foreach ( $models as $model ) {
             $pt = $model['slug'] ?? ( $model['post_type'] ?? '' );
             if ( $pt === $slug ) {
-                \WP_CLI::error( 'CPT already exists.' );
+                \WP_CLI::error( __( 'CPT already exists.', 'gm2-wordpress-suite' ) );
             }
         }
 
         $args_json = $assoc_args['args'] ?? '{}';
         $pt_args   = json_decode( $args_json, true );
         if ( ! is_array( $pt_args ) ) {
-            \WP_CLI::error( 'Invalid args JSON.' );
+            \WP_CLI::error( __( 'Invalid args JSON.', 'gm2-wordpress-suite' ) );
         }
 
         $model = [
@@ -247,7 +247,7 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
         $models[] = $model;
         update_option( 'gm2_models', $models );
         $this->run_migrations_for_model( $slug, $model );
-        \WP_CLI::success( 'CPT created.' );
+        \WP_CLI::success( __( 'CPT created.', 'gm2-wordpress-suite' ) );
     }
 
     /**
@@ -267,7 +267,7 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
     public function cpt_update( $args, $assoc_args ) {
         $slug = $args[0] ?? '';
         if ( ! $slug ) {
-            \WP_CLI::error( 'Missing CPT slug.' );
+            \WP_CLI::error( __( 'Missing CPT slug.', 'gm2-wordpress-suite' ) );
         }
 
         $models = get_option( 'gm2_models', [] );
@@ -277,7 +277,7 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
                 if ( isset( $assoc_args['args'] ) ) {
                     $new_args = json_decode( $assoc_args['args'], true );
                     if ( ! is_array( $new_args ) ) {
-                        \WP_CLI::error( 'Invalid args JSON.' );
+                        \WP_CLI::error( __( 'Invalid args JSON.', 'gm2-wordpress-suite' ) );
                     }
                     $model['args'] = array_merge( $model['args'] ?? [], $new_args );
                 }
@@ -286,11 +286,11 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
                 }
                 update_option( 'gm2_models', $models );
                 $this->run_migrations_for_model( $slug, $model );
-                \WP_CLI::success( 'CPT updated.' );
+                \WP_CLI::success( __( 'CPT updated.', 'gm2-wordpress-suite' ) );
                 return;
             }
         }
-        \WP_CLI::error( 'CPT not found.' );
+        \WP_CLI::error( __( 'CPT not found.', 'gm2-wordpress-suite' ) );
     }
 
     /**
@@ -304,7 +304,7 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
     public function cpt_delete( $args, $assoc_args ) {
         $slug = $args[0] ?? '';
         if ( ! $slug ) {
-            \WP_CLI::error( 'Missing CPT slug.' );
+            \WP_CLI::error( __( 'Missing CPT slug.', 'gm2-wordpress-suite' ) );
         }
 
         $models = get_option( 'gm2_models', [] );
@@ -316,11 +316,11 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
                 $versions = get_option( 'gm2_model_versions', [] );
                 unset( $versions[ $slug ] );
                 update_option( 'gm2_model_versions', $versions );
-                \WP_CLI::success( 'CPT deleted.' );
+                \WP_CLI::success( __( 'CPT deleted.', 'gm2-wordpress-suite' ) );
                 return;
             }
         }
-        \WP_CLI::error( 'CPT not found.' );
+        \WP_CLI::error( __( 'CPT not found.', 'gm2-wordpress-suite' ) );
     }
 
     /**
@@ -341,7 +341,7 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
         $cpt = $args[0] ?? '';
         $slug = $args[1] ?? '';
         if ( ! $cpt || ! $slug ) {
-            \WP_CLI::error( 'Usage: wp gm2 model taxonomy create <cpt> <slug> [--args]' );
+            \WP_CLI::error( __( 'Usage: wp gm2 model taxonomy create <cpt> <slug> [--args]', 'gm2-wordpress-suite' ) );
         }
 
         $models = get_option( 'gm2_models', [] );
@@ -352,12 +352,12 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
                 foreach ( $taxes as $tax ) {
                     $tax_slug = $tax['taxonomy'] ?? ( $tax['slug'] ?? '' );
                     if ( $tax_slug === $slug ) {
-                        \WP_CLI::error( 'Taxonomy already exists.' );
+                        \WP_CLI::error( __( 'Taxonomy already exists.', 'gm2-wordpress-suite' ) );
                     }
                 }
                 $tax_args = isset( $assoc_args['args'] ) ? json_decode( $assoc_args['args'], true ) : [];
                 if ( isset( $assoc_args['args'] ) && ! is_array( $tax_args ) ) {
-                    \WP_CLI::error( 'Invalid args JSON.' );
+                    \WP_CLI::error( __( 'Invalid args JSON.', 'gm2-wordpress-suite' ) );
                 }
                 $model['taxonomies'][] = [
                     'slug'        => $slug,
@@ -367,11 +367,11 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
                 ];
                 update_option( 'gm2_models', $models );
                 $this->run_migrations_for_model( $cpt, $model );
-                \WP_CLI::success( 'Taxonomy created.' );
+                \WP_CLI::success( __( 'Taxonomy created.', 'gm2-wordpress-suite' ) );
                 return;
             }
         }
-        \WP_CLI::error( 'CPT not found.' );
+        \WP_CLI::error( __( 'CPT not found.', 'gm2-wordpress-suite' ) );
     }
 
     /**
@@ -381,7 +381,7 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
         $cpt = $args[0] ?? '';
         $slug = $args[1] ?? '';
         if ( ! $cpt || ! $slug ) {
-            \WP_CLI::error( 'Usage: wp gm2 model taxonomy update <cpt> <slug> [--args]' );
+            \WP_CLI::error( __( 'Usage: wp gm2 model taxonomy update <cpt> <slug> [--args]', 'gm2-wordpress-suite' ) );
         }
 
         $models = get_option( 'gm2_models', [] );
@@ -394,20 +394,20 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
                         if ( isset( $assoc_args['args'] ) ) {
                             $new_args = json_decode( $assoc_args['args'], true );
                             if ( ! is_array( $new_args ) ) {
-                                \WP_CLI::error( 'Invalid args JSON.' );
+                                \WP_CLI::error( __( 'Invalid args JSON.', 'gm2-wordpress-suite' ) );
                             }
                             $tax['args'] = array_merge( $tax['args'] ?? [], $new_args );
                         }
                         update_option( 'gm2_models', $models );
                         $this->run_migrations_for_model( $cpt, $model );
-                        \WP_CLI::success( 'Taxonomy updated.' );
+                        \WP_CLI::success( __( 'Taxonomy updated.', 'gm2-wordpress-suite' ) );
                         return;
                     }
                 }
-                \WP_CLI::error( 'Taxonomy not found.' );
+                \WP_CLI::error( __( 'Taxonomy not found.', 'gm2-wordpress-suite' ) );
             }
         }
-        \WP_CLI::error( 'CPT not found.' );
+        \WP_CLI::error( __( 'CPT not found.', 'gm2-wordpress-suite' ) );
     }
 
     /**
@@ -417,7 +417,7 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
         $cpt = $args[0] ?? '';
         $slug = $args[1] ?? '';
         if ( ! $cpt || ! $slug ) {
-            \WP_CLI::error( 'Usage: wp gm2 model taxonomy delete <cpt> <slug>' );
+            \WP_CLI::error( __( 'Usage: wp gm2 model taxonomy delete <cpt> <slug>', 'gm2-wordpress-suite' ) );
         }
 
         $models = get_option( 'gm2_models', [] );
@@ -431,14 +431,14 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
                         $model['taxonomies'] = array_values( $model['taxonomies'] );
                         update_option( 'gm2_models', $models );
                         $this->run_migrations_for_model( $cpt, $model );
-                        \WP_CLI::success( 'Taxonomy deleted.' );
+                        \WP_CLI::success( __( 'Taxonomy deleted.', 'gm2-wordpress-suite' ) );
                         return;
                     }
                 }
-                \WP_CLI::error( 'Taxonomy not found.' );
+                \WP_CLI::error( __( 'Taxonomy not found.', 'gm2-wordpress-suite' ) );
             }
         }
-        \WP_CLI::error( 'CPT not found.' );
+        \WP_CLI::error( __( 'CPT not found.', 'gm2-wordpress-suite' ) );
     }
 
     /**
@@ -459,7 +459,7 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
         $cpt = $args[0] ?? '';
         $key = $args[1] ?? '';
         if ( ! $cpt || ! $key ) {
-            \WP_CLI::error( 'Usage: wp gm2 model field create <cpt> <key> [--args]' );
+            \WP_CLI::error( __( 'Usage: wp gm2 model field create <cpt> <key> [--args]', 'gm2-wordpress-suite' ) );
         }
 
         $models = get_option( 'gm2_models', [] );
@@ -469,12 +469,12 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
                 foreach ( $model['fields'] ?? [] as $field ) {
                     $f_key = $field['key'] ?? ( $field['name'] ?? '' );
                     if ( $f_key === $key ) {
-                        \WP_CLI::error( 'Field already exists.' );
+                        \WP_CLI::error( __( 'Field already exists.', 'gm2-wordpress-suite' ) );
                     }
                 }
                 $field_args = isset( $assoc_args['args'] ) ? json_decode( $assoc_args['args'], true ) : [];
                 if ( isset( $assoc_args['args'] ) && ! is_array( $field_args ) ) {
-                    \WP_CLI::error( 'Invalid args JSON.' );
+                    \WP_CLI::error( __( 'Invalid args JSON.', 'gm2-wordpress-suite' ) );
                 }
                 $model['fields'][] = [
                     'key'  => $key,
@@ -483,11 +483,11 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
                 ];
                 update_option( 'gm2_models', $models );
                 $this->run_migrations_for_model( $cpt, $model );
-                \WP_CLI::success( 'Field created.' );
+                \WP_CLI::success( __( 'Field created.', 'gm2-wordpress-suite' ) );
                 return;
             }
         }
-        \WP_CLI::error( 'CPT not found.' );
+        \WP_CLI::error( __( 'CPT not found.', 'gm2-wordpress-suite' ) );
     }
 
     /**
@@ -497,7 +497,7 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
         $cpt = $args[0] ?? '';
         $key = $args[1] ?? '';
         if ( ! $cpt || ! $key ) {
-            \WP_CLI::error( 'Usage: wp gm2 model field update <cpt> <key> [--args]' );
+            \WP_CLI::error( __( 'Usage: wp gm2 model field update <cpt> <key> [--args]', 'gm2-wordpress-suite' ) );
         }
 
         $models = get_option( 'gm2_models', [] );
@@ -508,22 +508,22 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
                     $f_key = $field['key'] ?? ( $field['name'] ?? '' );
                     if ( $f_key === $key ) {
                         if ( isset( $assoc_args['args'] ) ) {
-                            $new_args = json_decode( $assoc_args['args'], true );
-                            if ( ! is_array( $new_args ) ) {
-                                \WP_CLI::error( 'Invalid args JSON.' );
-                            }
+                                $new_args = json_decode( $assoc_args['args'], true );
+                                if ( ! is_array( $new_args ) ) {
+                                    \WP_CLI::error( __( 'Invalid args JSON.', 'gm2-wordpress-suite' ) );
+                                }
                             $field['args'] = array_merge( $field['args'] ?? [], $new_args );
                         }
                         update_option( 'gm2_models', $models );
                         $this->run_migrations_for_model( $cpt, $model );
-                        \WP_CLI::success( 'Field updated.' );
+                        \WP_CLI::success( __( 'Field updated.', 'gm2-wordpress-suite' ) );
                         return;
                     }
                 }
-                \WP_CLI::error( 'Field not found.' );
+                \WP_CLI::error( __( 'Field not found.', 'gm2-wordpress-suite' ) );
             }
         }
-        \WP_CLI::error( 'CPT not found.' );
+        \WP_CLI::error( __( 'CPT not found.', 'gm2-wordpress-suite' ) );
     }
 
     /**
@@ -533,7 +533,7 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
         $cpt = $args[0] ?? '';
         $key = $args[1] ?? '';
         if ( ! $cpt || ! $key ) {
-            \WP_CLI::error( 'Usage: wp gm2 model field delete <cpt> <key>' );
+            \WP_CLI::error( __( 'Usage: wp gm2 model field delete <cpt> <key>', 'gm2-wordpress-suite' ) );
         }
 
         $models = get_option( 'gm2_models', [] );
@@ -547,14 +547,14 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
                         $model['fields'] = array_values( $model['fields'] );
                         update_option( 'gm2_models', $models );
                         $this->run_migrations_for_model( $cpt, $model );
-                        \WP_CLI::success( 'Field deleted.' );
+                        \WP_CLI::success( __( 'Field deleted.', 'gm2-wordpress-suite' ) );
                         return;
                     }
                 }
-                \WP_CLI::error( 'Field not found.' );
+                \WP_CLI::error( __( 'Field not found.', 'gm2-wordpress-suite' ) );
             }
         }
-        \WP_CLI::error( 'CPT not found.' );
+        \WP_CLI::error( __( 'CPT not found.', 'gm2-wordpress-suite' ) );
     }
 
     /**
@@ -588,7 +588,7 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
         $models     = get_option( 'gm2_models', [] );
 
         if ( empty( $models ) ) {
-            \WP_CLI::warning( 'No models found in the gm2_models option.' );
+        \WP_CLI::warning( __( 'No models found in the gm2_models option.', 'gm2-wordpress-suite' ) );
             return;
         }
 
@@ -634,14 +634,14 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
         $php_code .= "});\n";
 
         if ( ! wp_mkdir_p( dirname( $php_file ) ) ) {
-            \WP_CLI::error( 'Failed to create directory: ' . dirname( $php_file ) );
+            \WP_CLI::error( sprintf( __( 'Failed to create directory: %s', 'gm2-wordpress-suite' ), dirname( $php_file ) ) );
         }
         file_put_contents( $php_file, $php_code );
 
         $json_code = wp_json_encode( $models, JSON_PRETTY_PRINT );
         if ( $json_file ) {
             if ( ! wp_mkdir_p( dirname( $json_file ) ) ) {
-                \WP_CLI::error( 'Failed to create directory: ' . dirname( $json_file ) );
+                \WP_CLI::error( sprintf( __( 'Failed to create directory: %s', 'gm2-wordpress-suite' ), dirname( $json_file ) ) );
             }
             file_put_contents( $json_file, $json_code );
         }
@@ -650,10 +650,10 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
             \WP_CLI::line( gm2_render_open_in_code( $php_code, $json_code ) );
         }
 
-        \WP_CLI::success( $mu ? 'Generated MU plugin code.' : 'Generated plugin code.' );
-        \WP_CLI::line( 'PHP file: ' . $php_file );
+        \WP_CLI::success( $mu ? __( 'Generated MU plugin code.', 'gm2-wordpress-suite' ) : __( 'Generated plugin code.', 'gm2-wordpress-suite' ) );
+        \WP_CLI::line( sprintf( __( 'PHP file: %s', 'gm2-wordpress-suite' ), $php_file ) );
         if ( $json_file ) {
-            \WP_CLI::line( 'JSON file: ' . $json_file );
+            \WP_CLI::line( sprintf( __( 'JSON file: %s', 'gm2-wordpress-suite' ), $json_file ) );
         }
     }
 
@@ -680,9 +680,9 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
         update_option( 'gm2_model_versions', $versions );
 
         if ( $migrated ) {
-            \WP_CLI::success( sprintf( '%d model migrations completed.', $migrated ) );
+            \WP_CLI::success( sprintf( __( '%d model migrations completed.', 'gm2-wordpress-suite' ), $migrated ) );
         } else {
-            \WP_CLI::success( 'Models are up to date.' );
+            \WP_CLI::success( __( 'Models are up to date.', 'gm2-wordpress-suite' ) );
         }
     }
 
@@ -762,7 +762,7 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
             $media_count++;
         }
 
-        \WP_CLI::success( sprintf( 'Seeded %d posts, %d terms and %d media items.', $post_count, $term_count, $media_count ) );
+        \WP_CLI::success( sprintf( __( 'Seeded %d posts, %d terms and %d media items.', 'gm2-wordpress-suite' ), $post_count, $term_count, $media_count ) );
     }
 
     /**
@@ -776,7 +776,7 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
     public function env( $args, $assoc_args ) {
         $env = $args[0] ?? 'dev';
         update_option( 'gm2_model_env', $env );
-        \WP_CLI::success( 'Environment set to ' . $env );
+        \WP_CLI::success( sprintf( __( 'Environment set to %s', 'gm2-wordpress-suite' ), $env ) );
     }
 
     /**
@@ -784,7 +784,7 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
      */
     public function lock( $args, $assoc_args ) {
         update_option( 'gm2_model_locked', 1 );
-        \WP_CLI::success( 'Models locked.' );
+        \WP_CLI::success( __( 'Models locked.', 'gm2-wordpress-suite' ) );
     }
 
     /**
@@ -792,7 +792,7 @@ class Gm2_Model_CLI extends \WP_CLI_Command {
      */
     public function unlock( $args, $assoc_args ) {
         delete_option( 'gm2_model_locked' );
-        \WP_CLI::success( 'Models unlocked.' );
+        \WP_CLI::success( __( 'Models unlocked.', 'gm2-wordpress-suite' ) );
     }
 
     /**

--- a/includes/cli/class-gm2-schema-audit.php
+++ b/includes/cli/class-gm2-schema-audit.php
@@ -25,17 +25,17 @@ class Gm2_Schema_Audit_CLI extends \WP_CLI_Command {
             $missing = $this->get_missing_fields( $id );
             if ( $missing ) {
                 $issues++;
-                \WP_CLI::line( sprintf( 'Product %d: %s', $id, get_permalink( $id ) ) );
+                \WP_CLI::line( sprintf( __( 'Product %1$d: %2$s', 'gm2-wordpress-suite' ), $id, get_permalink( $id ) ) );
                 foreach ( $missing as $field ) {
-                    \WP_CLI::line( sprintf( '  - Missing %s. %s', $field, $this->recommendation( $field ) ) );
+                    \WP_CLI::line( sprintf( __( '  - Missing %s. %s', 'gm2-wordpress-suite' ), $field, $this->recommendation( $field ) ) );
                 }
             }
         }
 
         if ( $issues ) {
-            \WP_CLI::warning( sprintf( '%d products have schema issues.', $issues ) );
+            \WP_CLI::warning( sprintf( __( '%d products have schema issues.', 'gm2-wordpress-suite' ), $issues ) );
         } else {
-            \WP_CLI::success( 'All products have required schema fields.' );
+            \WP_CLI::success( __( 'All products have required schema fields.', 'gm2-wordpress-suite' ) );
         }
     }
 
@@ -85,15 +85,15 @@ class Gm2_Schema_Audit_CLI extends \WP_CLI_Command {
     protected function recommendation( $field ) {
         switch ( $field ) {
             case 'name':
-                return 'Add a product title.';
+                return __( 'Add a product title.', 'gm2-wordpress-suite' );
             case 'price':
-                return 'Set a price in product metadata.';
+                return __( 'Set a price in product metadata.', 'gm2-wordpress-suite' );
             case 'availability':
-                return 'Specify stock status or quantity.';
+                return __( 'Specify stock status or quantity.', 'gm2-wordpress-suite' );
             case 'SKU':
-                return 'Assign a unique SKU.';
+                return __( 'Assign a unique SKU.', 'gm2-wordpress-suite' );
             case 'brand':
-                return 'Provide a brand name.';
+                return __( 'Provide a brand name.', 'gm2-wordpress-suite' );
             default:
                 return '';
         }

--- a/includes/cli/class-gm2-seo-perf-cli.php
+++ b/includes/cli/class-gm2-seo-perf-cli.php
@@ -12,7 +12,7 @@ class Gm2_SEO_Perf_CLI extends \WP_CLI_Command {
     public function audit( $args, $assoc_args ) {
         $prompt = 'Prompt A: Audit this WordPress site for SEO and performance issues. Return JSON recommendations.';
         if ( ! function_exists( '\\gm2_ai_send_prompt' ) ) {
-            \WP_CLI::error( 'AI utilities not available.', 1 );
+            \WP_CLI::error( __( 'AI utilities not available.', 'gm2-wordpress-suite' ), 1 );
         }
         $response = \gm2_ai_send_prompt( $prompt );
         if ( is_wp_error( $response ) ) {
@@ -28,19 +28,19 @@ class Gm2_SEO_Perf_CLI extends \WP_CLI_Command {
         $result = Gm2_Cache_Headers_Apache::maybe_apply();
         switch ( $result['status'] ?? '' ) {
             case 'written':
-                \WP_CLI::success( 'Cache headers written to .htaccess.' );
+                \WP_CLI::success( __( 'Cache headers written to .htaccess.', 'gm2-wordpress-suite' ) );
                 break;
             case 'unsupported':
-                \WP_CLI::error( 'Server does not appear to be Apache or LiteSpeed.', 1 );
+                \WP_CLI::error( __( 'Server does not appear to be Apache or LiteSpeed.', 'gm2-wordpress-suite' ), 1 );
                 break;
             case 'already_handled':
-                \WP_CLI::error( 'CDN already sets cache headers.', 2 );
+                \WP_CLI::error( __( 'CDN already sets cache headers.', 'gm2-wordpress-suite' ), 2 );
                 break;
             case 'not_writable':
-                \WP_CLI::error( 'The .htaccess file or directory is not writable.', 3 );
+                \WP_CLI::error( __( 'The .htaccess file or directory is not writable.', 'gm2-wordpress-suite' ), 3 );
                 break;
             default:
-                \WP_CLI::error( 'Unknown result applying .htaccess rules.', 4 );
+                \WP_CLI::error( __( 'Unknown result applying .htaccess rules.', 'gm2-wordpress-suite' ), 4 );
         }
     }
 
@@ -55,17 +55,17 @@ class Gm2_SEO_Perf_CLI extends \WP_CLI_Command {
                 \WP_CLI::success( $file );
                 break;
             case 'unsupported':
-                \WP_CLI::error( 'Server does not appear to be Nginx.', 1 );
+                \WP_CLI::error( __( 'Server does not appear to be Nginx.', 'gm2-wordpress-suite' ), 1 );
                 break;
             case 'already_handled':
-                \WP_CLI::error( 'CDN already sets cache headers.', 2 );
+                \WP_CLI::error( __( 'CDN already sets cache headers.', 'gm2-wordpress-suite' ), 2 );
                 break;
             case 'not_writable':
                 $file = $result['file'] ?? Gm2_Cache_Headers_Nginx::get_file_path();
-                \WP_CLI::error( 'Directory not writable: ' . dirname( $file ), 3 );
+                \WP_CLI::error( sprintf( __( 'Directory not writable: %s', 'gm2-wordpress-suite' ), dirname( $file ) ), 3 );
                 break;
             default:
-                \WP_CLI::error( 'Unknown result generating Nginx config.', 4 );
+                \WP_CLI::error( __( 'Unknown result generating Nginx config.', 'gm2-wordpress-suite' ), 4 );
         }
     }
 
@@ -76,9 +76,9 @@ class Gm2_SEO_Perf_CLI extends \WP_CLI_Command {
         Gm2_Cache_Headers_Apache::remove_rules();
         $file = Gm2_Cache_Headers_Nginx::get_file_path();
         if ( file_exists( $file ) && ! @unlink( $file ) ) {
-            \WP_CLI::error( 'Could not remove Nginx config file.', 1 );
+            \WP_CLI::error( __( 'Could not remove Nginx config file.', 'gm2-wordpress-suite' ), 1 );
         }
-        \WP_CLI::success( 'Cache header markers cleared.' );
+        \WP_CLI::success( __( 'Cache header markers cleared.', 'gm2-wordpress-suite' ) );
     }
 }
 


### PR DESCRIPTION
## Summary
- wrap WP-CLI error, warning, log and success strings in `__()` with the `gm2-wordpress-suite` text domain
- ensure CLI scaffolding samples and recommendations are translatable

## Testing
- `composer install` *(passed)*
- `./vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b76111e9c883279ce0886245b51d77