### PR TITLE
Add admin page to view AE SEO debug logs

### DIFF
--- a/admin/class-ae-seo-debug-logs-admin.php
+++ b/admin/class-ae-seo-debug-logs-admin.php
@@ -1,0 +1,39 @@
+<?php
+namespace Gm2;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class AE_SEO_Debug_Logs_Admin {
+    public function run(): void {
+        add_action('admin_menu', [ $this, 'add_page' ]);
+    }
+
+    public function add_page(): void {
+        add_management_page(
+            __('AE Debug Logs', 'gm2-wordpress-suite'),
+            __('AE Debug Logs', 'gm2-wordpress-suite'),
+            'manage_options',
+            'ae-seo-debug-logs',
+            [ $this, 'render_page' ]
+        );
+    }
+
+    public function render_page(): void {
+        $file = WP_CONTENT_DIR . '/ae-seo/logs/js-optimizer.log';
+        echo '<div class="wrap">';
+        echo '<h1>' . esc_html__( 'AE Debug Logs', 'gm2-wordpress-suite' ) . '</h1>';
+        if (is_readable($file)) {
+            $contents = file_get_contents($file);
+            if ($contents !== false) {
+                echo '<pre>' . esc_html($contents) . '</pre>';
+            } else {
+                echo '<p>' . esc_html__( 'Unable to read log file.', 'gm2-wordpress-suite' ) . '</p>';
+            }
+        } else {
+            echo '<p>' . esc_html__( 'Log file not found.', 'gm2-wordpress-suite' ) . '</p>';
+        }
+        echo '</div>';
+    }
+}

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -109,6 +109,7 @@ require_once GM2_PLUGIN_DIR . 'includes/class-ae-seo-js-manager.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_Search_Console.php';
 require_once GM2_PLUGIN_DIR . 'includes/render-optimizer/class-ae-seo-render-optimizer.php';
 require_once GM2_PLUGIN_DIR . 'includes/Versioning_MTime.php';
+require_once GM2_PLUGIN_DIR . 'admin/class-ae-seo-debug-logs-admin.php';
 
 \Gm2\Gm2_REST_Visibility::init();
 \Gm2\Gm2_REST_Rate_Limiter::init();
@@ -121,6 +122,7 @@ require_once GM2_PLUGIN_DIR . 'includes/Versioning_MTime.php';
 \Gm2\Gm2_Search_Console::init();
 \Gm2\AE_SEO_JS_Manager::init();
 \Gm2\Versioning_MTime::init();
+(new \Gm2\AE_SEO_Debug_Logs_Admin())->run();
 if (get_option('gm2_pretty_versioned_urls', '0') === '1') {
     \Gm2\Gm2_Version_Route_Apache::maybe_apply();
 }


### PR DESCRIPTION
## Summary
- add `AE_SEO_Debug_Logs_Admin` class to expose AE Debug Logs under Tools
- display contents of js-optimizer log or a not-found notice
- load and run the new admin class from the plugin bootstrap

## Testing
- `./vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b76cc1e664832789e4e9f235a14eb2