### PR TITLE
feat: add per-page JS auto-dequeue controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This repository contains the development version of the Gm2 WordPress Suite plug
 
 The suite includes an optional **Pretty Versioned URLs** feature that rewrites `file.css?ver=123` to `file.v123.css` and supplies matching Apache and Nginx rules.
 
+## JavaScript Management
+
+The plugin ships with a JavaScript Manager that can lazy-load scripts, replace sources via a JSON map, and automatically dequeue unneeded assets on a per-page basis. The detector records script usage and page context, while a controller removes unnecessary handles with an optional `?aejs=off` safe-mode override. Administrators can review usage stats under **Performance → Script Usage** and configure per-handle allow/deny lists or template-specific allowances.
+
 ## Building the Plugin
 
 Generate a production-ready ZIP package with all dependencies using:

--- a/admin/views/performance-script-usage.php
+++ b/admin/views/performance-script-usage.php
@@ -1,0 +1,38 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$usage = get_option('ae_js_script_usage', []);
+if (!is_array($usage) || empty($usage)) {
+    echo '<p>' . esc_html__( 'No script usage data recorded yet.', 'gm2-wordpress-suite' ) . '</p>';
+    return;
+}
+arsort($usage);
+$templates = [
+    'front_page' => esc_html__( 'Front Page', 'gm2-wordpress-suite' ),
+    'singular'   => esc_html__( 'Singular', 'gm2-wordpress-suite' ),
+    'product'    => esc_html__( 'Product', 'gm2-wordpress-suite' ),
+];
+$allow = get_option('ae_js_template_allow', []);
+
+echo '<form method="post" action="' . esc_url(admin_url('admin-post.php')) . '">';
+wp_nonce_field('gm2_js_usage_save', 'gm2_js_usage_nonce');
+echo '<input type="hidden" name="action" value="gm2_js_usage_settings" />';
+
+echo '<table class="widefat"><thead><tr><th>' . esc_html__( 'Handle', 'gm2-wordpress-suite' ) . '</th><th>' . esc_html__( 'Count', 'gm2-wordpress-suite' ) . '</th>';
+foreach ($templates as $key => $label) {
+    echo '<th>' . esc_html($label) . '</th>';
+}
+echo '</tr></thead><tbody>';
+foreach ($usage as $handle => $count) {
+    echo '<tr><td>' . esc_html($handle) . '</td><td>' . intval($count) . '</td>';
+    foreach ($templates as $key => $label) {
+        $checked = isset($allow[$handle]) && in_array($key, $allow[$handle], true) ? 'checked' : '';
+        echo '<td><input type="checkbox" name="ae_js_template_allow[' . esc_attr($handle) . '][]" value="' . esc_attr($key) . '" ' . $checked . ' /></td>';
+    }
+    echo '</tr>';
+}
+echo '</tbody></table>';
+submit_button( esc_html__( 'Save Settings', 'gm2-wordpress-suite' ) );
+echo '</form>';

--- a/admin/views/settings-js-optimizer.php
+++ b/admin/views/settings-js-optimizer.php
@@ -7,6 +7,12 @@ $enable      = get_option('ae_js_enable_manager', '0');
 $lazy        = get_option('ae_js_lazy_load', '0');
 $replace     = get_option('ae_js_replacements', '0');
 $debug       = get_option('ae_js_debug_log', '0');
+$auto        = get_option('ae_js_auto_dequeue', '0');
+$respect     = get_option('ae_js_respect_safe_mode', '1');
+$allow_list  = get_option('ae_js_allow_list', []);
+$deny_list   = get_option('ae_js_deny_list', []);
+$map         = get_transient('ae_js_dependency_map');
+$handles     = is_array($map) ? array_keys($map) : [];
 
 echo '<form method="post" action="' . esc_url(admin_url('admin-post.php')) . '">';
 wp_nonce_field('gm2_js_optimizer_save', 'gm2_js_optimizer_nonce');
@@ -17,6 +23,23 @@ echo '<tr><th scope="row">' . esc_html__( 'Enable JS Manager', 'gm2-wordpress-su
 echo '<tr><th scope="row">' . esc_html__( 'Lazy Load Scripts', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_js_lazy_load" value="1" ' . checked($lazy, '1', false) . ' /></td></tr>';
 echo '<tr><th scope="row">' . esc_html__( 'Enable Replacements', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_js_replacements" value="1" ' . checked($replace, '1', false) . ' /></td></tr>';
 echo '<tr><th scope="row">' . esc_html__( 'Debug Log', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_js_debug_log" value="1" ' . checked($debug, '1', false) . ' /></td></tr>';
+echo '<tr><th scope="row">' . esc_html__( 'Enable Per-Page Auto-Dequeue (Beta)', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_js_auto_dequeue" value="1" ' . checked($auto, '1', false) . ' /></td></tr>';
+echo '<tr><th scope="row">' . esc_html__( 'Respect Safe Mode param', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_js_respect_safe_mode" value="1" ' . checked($respect, '1', false) . ' /></td></tr>';
+if (!empty($handles)) {
+    sort($handles);
+    echo '<tr><th scope="row">' . esc_html__( 'Allow List', 'gm2-wordpress-suite' ) . '</th><td><select multiple size="10" name="ae_js_allow_list[]">';
+    foreach ($handles as $h) {
+        echo '<option value="' . esc_attr($h) . '" ' . selected(is_array($allow_list) && in_array($h, $allow_list, true), true, false) . '>' . esc_html($h) . '</option>';
+    }
+    echo '</select></td></tr>';
+    echo '<tr><th scope="row">' . esc_html__( 'Deny List', 'gm2-wordpress-suite' ) . '</th><td><select multiple size="10" name="ae_js_deny_list[]">';
+    foreach ($handles as $h) {
+        echo '<option value="' . esc_attr($h) . '" ' . selected(is_array($deny_list) && in_array($h, $deny_list, true), true, false) . '>' . esc_html($h) . '</option>';
+    }
+    echo '</select></td></tr>';
+} else {
+    echo '<tr><th scope="row">' . esc_html__( 'Allow/Deny Lists', 'gm2-wordpress-suite' ) . '</th><td>' . esc_html__( 'No scripts detected yet.', 'gm2-wordpress-suite' ) . '</td></tr>';
+}
 echo '</tbody></table>';
 
 submit_button( esc_html__( 'Save Settings', 'gm2-wordpress-suite' ) );

--- a/includes/class-ae-seo-js-controller.php
+++ b/includes/class-ae-seo-js-controller.php
@@ -1,0 +1,81 @@
+<?php
+namespace Gm2;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (class_exists(__NAMESPACE__ . '\\AE_SEO_JS_Controller')) {
+    return;
+}
+
+/**
+ * Control enqueued scripts based on detected context.
+ */
+class AE_SEO_JS_Controller {
+    /**
+     * Bootstrap the controller.
+     */
+    public static function init(): void {
+        add_action('wp_enqueue_scripts', [ new self(), 'control' ], 999);
+    }
+
+    /**
+     * Conditionally dequeue scripts.
+     */
+    public function control(): void {
+        if (get_option('ae_js_auto_dequeue', '0') !== '1') {
+            return;
+        }
+        if (get_option('ae_js_respect_safe_mode', '1') === '1' && isset($_GET['aejs']) && $_GET['aejs'] === 'off') {
+            return;
+        }
+
+        $url     = home_url(add_query_arg([], $_SERVER['REQUEST_URI']));
+        $context = get_transient('aejs_ctx:' . md5($url));
+        if (!is_array($context)) {
+            return;
+        }
+
+        $allow_list     = get_option('ae_js_allow_list', []);
+        $deny_list      = get_option('ae_js_deny_list', []);
+        $template_allow = get_option('ae_js_template_allow', []);
+        $wp_scripts     = wp_scripts();
+        foreach ($wp_scripts->queue as $handle) {
+            if (is_array($allow_list) && in_array($handle, $allow_list, true)) {
+                continue;
+            }
+            if (is_array($deny_list) && in_array($handle, $deny_list, true)) {
+                wp_dequeue_script($handle);
+                ae_seo_js_log('deny ' . $handle . ' ' . $url);
+                continue;
+            }
+
+            $keep = is_array($context['scripts']) && in_array($handle, $context['scripts'], true);
+
+            if (!$keep && isset($template_allow[$handle])) {
+                $tpls = $template_allow[$handle];
+                if (is_front_page() && in_array('front_page', $tpls, true)) {
+                    $keep = true;
+                } elseif (is_singular() && in_array('singular', $tpls, true)) {
+                    $keep = true;
+                } elseif (function_exists('is_product') && is_product() && in_array('product', $tpls, true)) {
+                    $keep = true;
+                }
+            }
+
+            if (!$keep && !empty($context['blocks'])) {
+                $core_block_handles = ['wp-block-library', 'wp-block-library-theme', 'wp-editor', 'wp-dom-ready', 'wp-element', 'wp-embed'];
+                if (in_array($handle, $core_block_handles, true)) {
+                    $keep = true;
+                }
+            }
+
+            $keep = apply_filters('ae_seo/js/enqueue_decision', $keep, $handle, $context);
+            if (!$keep) {
+                wp_dequeue_script($handle);
+                ae_seo_js_log('dequeue ' . $handle . ' ' . $url);
+            }
+        }
+    }
+}

--- a/includes/class-ae-seo-js-detector.php
+++ b/includes/class-ae-seo-js-detector.php
@@ -1,0 +1,162 @@
+<?php
+namespace Gm2;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (class_exists(__NAMESPACE__ . '\\AE_SEO_JS_Detector')) {
+    return;
+}
+
+/**
+ * Detect page context and required scripts.
+ */
+class AE_SEO_JS_Detector {
+    /**
+     * Bootstrap the detector.
+     */
+    public static function init(): void {
+        add_action('wp', [ new self(), 'run' ], 0);
+    }
+
+    /**
+     * Build dependency map and store context for current URL.
+     */
+    public function run(): void {
+        if (get_option('ae_js_respect_safe_mode', '1') === '1' && isset($_GET['aejs']) && $_GET['aejs'] === 'off') {
+            return;
+        }
+
+        $map = get_transient('ae_js_dependency_map');
+        if (!is_array($map)) {
+            $map = $this->build_map();
+            set_transient('ae_js_dependency_map', $map, 30 * MINUTE_IN_SECONDS);
+        }
+
+        $context = $this->detect_context($map);
+        $url     = home_url(add_query_arg([], $_SERVER['REQUEST_URI']));
+        set_transient('aejs_ctx:' . md5($url), $context, 30 * MINUTE_IN_SECONDS);
+
+        $usage = get_option('ae_js_script_usage', []);
+        if (!is_array($usage)) {
+            $usage = [];
+        }
+        foreach ($context['scripts'] as $handle) {
+            $usage[$handle] = ($usage[$handle] ?? 0) + 1;
+        }
+        update_option('ae_js_script_usage', $usage);
+    }
+
+    /**
+     * Build dependency map from registered scripts.
+     *
+     * @return array
+     */
+    private function build_map(): array {
+        $wp_scripts = wp_scripts();
+        $map        = [];
+        foreach ($wp_scripts->registered as $handle => $obj) {
+            $map[$handle] = [
+                'src'       => $obj->src,
+                'deps'      => $obj->deps,
+                'in_footer' => !empty($obj->extra['group']),
+            ];
+        }
+        return $map;
+    }
+
+    /**
+     * Detect page context and needed scripts.
+     *
+     * @param array $map Dependency map.
+     * @return array
+     */
+    private function detect_context(array $map): array {
+        $needed    = [];
+        $widgets   = [];
+        $shortcodes = [];
+        $blocks    = [];
+        $recaptcha = false;
+        $elementor = false;
+        $woo       = false;
+
+        $page_type = 'other';
+        if (is_front_page()) {
+            $page_type = 'front_page';
+        } elseif (is_singular()) {
+            $page_type = 'singular_' . get_post_type();
+        } elseif (is_archive()) {
+            $page_type = 'archive';
+        }
+
+        if (function_exists('is_woocommerce') && (is_woocommerce() || (function_exists('is_cart') && is_cart()) || (function_exists('is_checkout') && is_checkout()) || (function_exists('is_account_page') && is_account_page()))) {
+            $woo     = true;
+            $widgets[] = 'woocommerce';
+            foreach ($map as $handle => $data) {
+                if (strpos($handle, 'wc-') === 0 || strpos($handle, 'woocommerce') !== false) {
+                    $needed[] = $handle;
+                }
+            }
+        }
+
+        $post = null;
+        if (is_singular()) {
+            $post = get_post();
+        }
+        if ($post) {
+            $elementor = (bool) get_post_meta($post->ID, '_elementor_edit_mode', true);
+            $content   = $post->post_content;
+            if (preg_match_all('/\[(\w+)[^\]]*\]/', $content, $m)) {
+                $shortcodes = array_unique($m[1]);
+            }
+            if (function_exists('has_blocks') && has_blocks($post)) {
+                $parsed = parse_blocks($content);
+                foreach ($parsed as $block) {
+                    if (!empty($block['blockName'])) {
+                        $blocks[] = $block['blockName'];
+                    }
+                }
+            }
+            if (strpos($content, 'g-recaptcha') !== false || strpos($content, 'data-sitekey') !== false) {
+                $recaptcha = true;
+                $widgets[] = 'recaptcha';
+            }
+        }
+
+        if (!$elementor && class_exists('\\Elementor\\Plugin')) {
+            $elementor = true;
+        }
+        if ($elementor) {
+            $widgets[] = 'elementor';
+            foreach ($map as $handle => $data) {
+                if (strpos($handle, 'elementor') !== false) {
+                    $needed[] = $handle;
+                }
+            }
+        }
+
+        if (!empty($blocks)) {
+            foreach (['wp-block-library', 'wp-block-library-theme', 'wp-editor', 'wp-dom-ready', 'wp-element', 'wp-embed'] as $bh) {
+                if (isset($map[$bh])) {
+                    $needed[] = $bh;
+                }
+            }
+        }
+        if ($recaptcha) {
+            foreach ($map as $handle => $data) {
+                if (strpos($handle, 'recaptcha') !== false) {
+                    $needed[] = $handle;
+                }
+            }
+        }
+
+        return [
+            'page_type'  => $page_type,
+            'widgets'    => $widgets,
+            'shortcodes' => $shortcodes,
+            'blocks'     => $blocks,
+            'scripts'    => array_values(array_unique($needed)),
+        ];
+    }
+}

--- a/includes/class-ae-seo-js-manager.php
+++ b/includes/class-ae-seo-js-manager.php
@@ -5,6 +5,9 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+require_once __DIR__ . '/class-ae-seo-js-detector.php';
+require_once __DIR__ . '/class-ae-seo-js-controller.php';
+
 if (class_exists(__NAMESPACE__ . '\\AE_SEO_JS_Manager')) {
     return;
 }
@@ -24,7 +27,10 @@ class AE_SEO_JS_Manager {
      * Bootstrap the manager.
      */
     public static function init(): void {
-        if (isset($_GET['aejs']) && $_GET['aejs'] === 'off') {
+        if (get_option('ae_js_enable_manager', '0') !== '1') {
+            return;
+        }
+        if (get_option('ae_js_respect_safe_mode', '1') === '1' && isset($_GET['aejs']) && $_GET['aejs'] === 'off') {
             return;
         }
         (new self())->run();
@@ -35,8 +41,16 @@ class AE_SEO_JS_Manager {
      */
     public function run(): void {
         $this->map = $this->ae_seo_load_map();
-        add_action('wp_enqueue_scripts', [ $this, 'ae_seo_enqueue_scripts' ], 0);
-        add_filter('script_loader_tag', [ $this, 'ae_seo_script_loader_tag' ], 10, 3);
+        if (get_option('ae_js_replacements', '0') === '1') {
+            add_action('wp_enqueue_scripts', [ $this, 'ae_seo_enqueue_scripts' ], 0);
+        }
+        if (get_option('ae_js_lazy_load', '0') === '1') {
+            add_filter('script_loader_tag', [ $this, 'ae_seo_script_loader_tag' ], 10, 3);
+        }
+        if (get_option('ae_js_auto_dequeue', '0') === '1') {
+            AE_SEO_JS_Detector::init();
+            AE_SEO_JS_Controller::init();
+        }
     }
 
     /**

--- a/readme.txt
+++ b/readme.txt
@@ -30,6 +30,7 @@ Key features include:
 * Remote mirror for vendor scripts like Facebook Pixel and gtag with SRI hashes and a daily refresh
 * Script Attributes manager with dependency-aware “Defer all third-party” and “Conservative” presets
 * Render Optimizer for critical CSS, JS deferral with handle/domain allow and deny lists plus inline dependency and jQuery auto-detection, differential serving, and optional asset combination/minification with size limits and purge controls
+* JavaScript Manager for lazy-loading, source replacements, per-page auto-dequeue with safe-mode override, and usage reports with per-handle allow/deny lists
 
 == Installation ==
 1. Upload the plugin files to the `/wp-content/plugins/gm2-wordpress-suite` directory.


### PR DESCRIPTION
## Summary
- add AE_SEO_JS_Detector and AE_SEO_JS_Controller for per-page script dequeuing
- expose allow/deny lists and script usage UI in Performance settings
- document JavaScript Manager in plugin readme files

## Testing
- `npm test`
- `vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_68b76572ddc88327bf00e4b3c8ffd5d2