### PR TITLE
Add JS controller for context-based dequeue

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -107,6 +107,7 @@ require_once GM2_PLUGIN_DIR . 'includes/Gm2_Cache_Audit.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_Script_Attributes.php';
 require_once GM2_PLUGIN_DIR . 'includes/class-ae-seo-js-detector.php';
 require_once GM2_PLUGIN_DIR . 'includes/class-ae-seo-js-manager.php';
+require_once GM2_PLUGIN_DIR . 'includes/class-ae-seo-js-controller.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_Search_Console.php';
 require_once GM2_PLUGIN_DIR . 'includes/render-optimizer/class-ae-seo-render-optimizer.php';
 require_once GM2_PLUGIN_DIR . 'includes/Versioning_MTime.php';
@@ -123,6 +124,7 @@ require_once GM2_PLUGIN_DIR . 'admin/class-ae-seo-debug-logs-admin.php';
 \Gm2\Gm2_Search_Console::init();
 \Gm2\AE_SEO_JS_Detector::init();
 \Gm2\AE_SEO_JS_Manager::init();
+\Gm2\AE_SEO_JS_Controller::init();
 \Gm2\Versioning_MTime::init();
 (new \Gm2\AE_SEO_Debug_Logs_Admin())->run();
 if (get_option('gm2_pretty_versioned_urls', '0') === '1') {

--- a/includes/class-ae-seo-js-controller.php
+++ b/includes/class-ae-seo-js-controller.php
@@ -1,0 +1,88 @@
+<?php
+namespace Gm2;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (class_exists(__NAMESPACE__ . '\\AE_SEO_JS_Controller')) {
+    return;
+}
+
+/**
+ * Control JavaScript loading based on detector context.
+ */
+class AE_SEO_JS_Controller {
+    /**
+     * Bootstrap the controller.
+     */
+    public static function init(): void {
+        add_action('wp_enqueue_scripts', [ __CLASS__, 'control_scripts' ], 999);
+    }
+
+    /**
+     * Dequeue scripts not allowed for current context.
+     */
+    public static function control_scripts(): void {
+        $scripts = wp_scripts();
+        if (!$scripts) {
+            return;
+        }
+        $context = AE_SEO_JS_Detector::get_current_context();
+        $context_scripts = $context['scripts'] ?? [];
+        $has_blocks = false;
+        foreach ($context['widgets'] ?? [] as $widget) {
+            if (strpos($widget, '/') !== false) {
+                $has_blocks = true;
+                break;
+            }
+        }
+        $url = self::current_url();
+        foreach ($scripts->queue as $handle) {
+            $allow = in_array($handle, $context_scripts, true);
+            $allow = apply_filters('ae_seo/js/enqueue_decision', $allow, $handle, $context);
+            if (!$allow) {
+                if ($has_blocks && self::is_core_block_handle($handle)) {
+                    continue;
+                }
+                wp_dequeue_script($handle);
+                $reason = in_array($handle, $context_scripts, true) ? 'filter' : 'context';
+                ae_seo_js_log('dequeue ' . $handle . ' (' . $reason . ') ' . $url);
+            }
+        }
+    }
+
+    /**
+     * Determine whether handle is core block editor script.
+     */
+    private static function is_core_block_handle(string $handle): bool {
+        $core = [
+            'wp-block-library',
+            'wp-blocks',
+            'wp-dom-ready',
+            'wp-element',
+            'wp-components',
+            'wp-editor',
+            'wp-edit-post',
+            'wp-block-editor',
+            'wp-data',
+            'wp-i18n',
+            'wp-compose',
+            'wp-hooks',
+            'wp-plugins',
+            'wp-polyfill',
+        ];
+        return in_array($handle, $core, true);
+    }
+
+    /**
+     * Build current URL.
+     */
+    private static function current_url(): string {
+        $scheme = is_ssl() ? 'https' : 'http';
+        $host   = $_SERVER['HTTP_HOST'] ?? '';
+        $uri    = $_SERVER['REQUEST_URI'] ?? '';
+        return $scheme . '://' . $host . $uri;
+    }
+}
+

--- a/includes/class-ae-seo-js-manager.php
+++ b/includes/class-ae-seo-js-manager.php
@@ -103,7 +103,9 @@ class AE_SEO_JS_Manager {
             if ($src === '') {
                 continue;
             }
-            $allow = apply_filters('ae_seo/js/enqueue_decision', true, $handle, $src);
+            $ctx = AE_SEO_JS_Detector::get_current_context();
+            $ctx['src'] = $src;
+            $allow = apply_filters('ae_seo/js/enqueue_decision', true, $handle, $ctx);
             if (!$allow) {
                 ae_seo_js_log('skip ' . $handle);
                 continue;


### PR DESCRIPTION
## Summary
- control front-end scripts using detector context
- log dequeue decisions and respect block editor assets

## Testing
- `vendor/bin/phpunit` *(fails: WordPress test suite missing)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b77228d5888327b6db82c35458edc8