### PR TITLE
Add JS optimizer auto-dequeue settings

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -56,6 +56,10 @@ class Gm2_SEO_Admin {
         add_option('ae_js_lazy_load', '0');
         add_option('ae_js_replacements', '0');
         add_option('ae_js_debug_log', '0');
+        add_option('ae_js_auto_dequeue', '0');
+        add_option('ae_js_respect_safe_mode', '0');
+        add_option('ae_js_dequeue_allowlist', []);
+        add_option('ae_js_dequeue_denylist', []);
 
         add_action('admin_menu', [$this, 'add_settings_pages']);
         add_action('add_meta_boxes', [$this, 'register_meta_boxes']);
@@ -284,6 +288,20 @@ class Gm2_SEO_Admin {
         $sanitized = [];
         foreach ($value as $key => $css) {
             $sanitized[sanitize_key($key)] = $this->sanitize_css($css);
+        }
+        return $sanitized;
+    }
+
+    public function sanitize_handle_array($value) {
+        if (!is_array($value)) {
+            return [];
+        }
+        $sanitized = [];
+        foreach ($value as $handle) {
+            $handle = sanitize_key($handle);
+            if ($handle !== '') {
+                $sanitized[] = $handle;
+            }
         }
         return $sanitized;
     }
@@ -554,6 +572,18 @@ class Gm2_SEO_Admin {
         ]);
         register_setting('gm2_seo_options', 'ae_js_debug_log', [
             'sanitize_callback' => 'sanitize_text_field',
+        ]);
+        register_setting('gm2_seo_options', 'ae_js_auto_dequeue', [
+            'sanitize_callback' => 'sanitize_text_field',
+        ]);
+        register_setting('gm2_seo_options', 'ae_js_respect_safe_mode', [
+            'sanitize_callback' => 'sanitize_text_field',
+        ]);
+        register_setting('gm2_seo_options', 'ae_js_dequeue_allowlist', [
+            'sanitize_callback' => [ $this, 'sanitize_handle_array' ],
+        ]);
+        register_setting('gm2_seo_options', 'ae_js_dequeue_denylist', [
+            'sanitize_callback' => [ $this, 'sanitize_handle_array' ],
         ]);
         register_setting('gm2_seo_options', 'gm2_tax_desc_prompt', [
             'sanitize_callback' => 'sanitize_textarea_field',
@@ -2978,6 +3008,18 @@ class Gm2_SEO_Admin {
 
         $debug = isset($_POST['ae_js_debug_log']) ? '1' : '0';
         update_option('ae_js_debug_log', $debug);
+
+        $auto = isset($_POST['ae_js_auto_dequeue']) ? '1' : '0';
+        update_option('ae_js_auto_dequeue', $auto);
+
+        $safe = isset($_POST['ae_js_respect_safe_mode']) ? '1' : '0';
+        update_option('ae_js_respect_safe_mode', $safe);
+
+        $allow = isset($_POST['ae_js_dequeue_allowlist']) ? $this->sanitize_handle_array((array) $_POST['ae_js_dequeue_allowlist']) : [];
+        update_option('ae_js_dequeue_allowlist', $allow);
+
+        $deny = isset($_POST['ae_js_dequeue_denylist']) ? $this->sanitize_handle_array((array) $_POST['ae_js_dequeue_denylist']) : [];
+        update_option('ae_js_dequeue_denylist', $deny);
 
         wp_redirect(admin_url('admin.php?page=gm2-seo&tab=performance&subtab=javascript&updated=1'));
         exit;

--- a/admin/views/settings-js-optimizer.php
+++ b/admin/views/settings-js-optimizer.php
@@ -7,6 +7,18 @@ $enable      = get_option('ae_js_enable_manager', '0');
 $lazy        = get_option('ae_js_lazy_load', '0');
 $replace     = get_option('ae_js_replacements', '0');
 $debug       = get_option('ae_js_debug_log', '0');
+$auto        = get_option('ae_js_auto_dequeue', '0');
+$safe_mode   = get_option('ae_js_respect_safe_mode', '0');
+$allow       = get_option('ae_js_dequeue_allowlist', []);
+$deny        = get_option('ae_js_dequeue_denylist', []);
+if (!is_array($allow)) {
+    $allow = [];
+}
+if (!is_array($deny)) {
+    $deny = [];
+}
+$scripts    = wp_scripts();
+$registered = $scripts instanceof \WP_Scripts ? array_keys($scripts->registered) : [];
 
 echo '<form method="post" action="' . esc_url(admin_url('admin-post.php')) . '">';
 wp_nonce_field('gm2_js_optimizer_save', 'gm2_js_optimizer_nonce');
@@ -17,6 +29,18 @@ echo '<tr><th scope="row">' . esc_html__( 'Enable JS Manager', 'gm2-wordpress-su
 echo '<tr><th scope="row">' . esc_html__( 'Lazy Load Scripts', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_js_lazy_load" value="1" ' . checked($lazy, '1', false) . ' /></td></tr>';
 echo '<tr><th scope="row">' . esc_html__( 'Enable Replacements', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_js_replacements" value="1" ' . checked($replace, '1', false) . ' /></td></tr>';
 echo '<tr><th scope="row">' . esc_html__( 'Debug Log', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_js_debug_log" value="1" ' . checked($debug, '1', false) . ' /></td></tr>';
+echo '<tr><th scope="row">' . esc_html__( 'Enable Per-Page Auto-Dequeue (Beta)', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_js_auto_dequeue" value="1" ' . checked($auto, '1', false) . ' /></td></tr>';
+echo '<tr><th scope="row">' . esc_html__( 'Respect Safe Mode param', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_js_respect_safe_mode" value="1" ' . checked($safe_mode, '1', false) . ' /></td></tr>';
+echo '<tr><th scope="row">' . esc_html__( 'Handle Allowlist', 'gm2-wordpress-suite' ) . '</th><td><select name="ae_js_dequeue_allowlist[]" multiple size="10" style="min-width:200px;">';
+foreach ($registered as $handle) {
+    echo '<option value="' . esc_attr($handle) . '" ' . selected(in_array($handle, $allow, true), true, false) . '>' . esc_html($handle) . '</option>';
+}
+echo '</select><p class="description">' . esc_html__( 'Always load selected handles.', 'gm2-wordpress-suite' ) . '</p></td></tr>';
+echo '<tr><th scope="row">' . esc_html__( 'Handle Denylist', 'gm2-wordpress-suite' ) . '</th><td><select name="ae_js_dequeue_denylist[]" multiple size="10" style="min-width:200px;">';
+foreach ($registered as $handle) {
+    echo '<option value="' . esc_attr($handle) . '" ' . selected(in_array($handle, $deny, true), true, false) . '>' . esc_html($handle) . '</option>';
+}
+echo '</select><p class="description">' . esc_html__( 'Never load selected handles.', 'gm2-wordpress-suite' ) . '</p></td></tr>';
 echo '</tbody></table>';
 
 submit_button( esc_html__( 'Save Settings', 'gm2-wordpress-suite' ) );


### PR DESCRIPTION
## Summary
- Add JS optimizer toggles for per-page auto-dequeue and safe mode
- Introduce handle allow/deny lists populated from `wp_scripts()`
- Persist new settings via admin-post handler

## Testing
- `npm test` *(fails: jest not found)*
- `phpunit` *(fails: WordPress test library missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b7734215cc8327a957d4f029b5c956