### PR TITLE
Add script usage admin page with per-template overrides

### DIFF
--- a/admin/Gm2_JS_Usage_Admin.php
+++ b/admin/Gm2_JS_Usage_Admin.php
@@ -1,0 +1,109 @@
+<?php
+namespace Gm2;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Gm2_JS_Usage_Admin {
+    public function run() {
+        add_action('admin_menu', [ $this, 'add_menu' ]);
+        add_action('admin_post_gm2_js_usage_save', [ $this, 'save_overrides' ]);
+    }
+
+    public function add_menu() {
+        add_submenu_page(
+            'gm2-seo',
+            __('Script Usage', 'gm2-wordpress-suite'),
+            __('Script Usage', 'gm2-wordpress-suite'),
+            'manage_options',
+            'gm2-js-usage',
+            [ $this, 'display_page' ]
+        );
+    }
+
+    private function get_script_stats(): array {
+        global $wpdb;
+        $prefix = $wpdb->esc_like('_transient_aejs_ctx:') . '%';
+        $sql    = $wpdb->prepare("SELECT option_value FROM {$wpdb->options} WHERE option_name LIKE %s", $prefix);
+        $rows   = $wpdb->get_col($sql);
+        $counts = [];
+        $templates = [];
+        foreach ($rows as $value) {
+            $ctx = maybe_unserialize($value);
+            if (!is_array($ctx)) {
+                continue;
+            }
+            $page = $ctx['page_type'] ?? '';
+            if ($page !== '') {
+                $templates[$page] = true;
+            }
+            foreach ($ctx['scripts'] ?? [] as $handle) {
+                if (!is_string($handle)) {
+                    continue;
+                }
+                if (!isset($counts[$handle])) {
+                    $counts[$handle] = 0;
+                }
+                $counts[$handle]++;
+            }
+        }
+        arsort($counts);
+        return [ $counts, array_keys($templates) ];
+    }
+
+    public function display_page() {
+        [ $counts, $templates ] = $this->get_script_stats();
+        $overrides = get_option('ae_js_overrides', []);
+        echo '<div class="wrap"><h1>' . esc_html__( 'Script Usage', 'gm2-wordpress-suite' ) . '</h1>';
+        echo '<form method="post" action="' . esc_url(admin_url('admin-post.php')) . '">';
+        echo '<input type="hidden" name="action" value="gm2_js_usage_save" />';
+        wp_nonce_field('gm2_js_usage_save');
+        echo '<table class="widefat fixed"><thead><tr><th>' . esc_html__( 'Handle', 'gm2-wordpress-suite' ) . '</th><th>' . esc_html__( 'Count', 'gm2-wordpress-suite' ) . '</th>';
+        foreach ($templates as $template) {
+            echo '<th>' . esc_html($template) . '</th>';
+        }
+        echo '</tr></thead><tbody>';
+        foreach ($counts as $handle => $count) {
+            echo '<tr><td>' . esc_html($handle) . '</td><td>' . (int) $count . '</td>';
+            foreach ($templates as $template) {
+                $checked = (isset($overrides[$handle]) && in_array($template, $overrides[$handle], true)) ? 'checked' : '';
+                echo '<td><input type="checkbox" name="overrides[' . esc_attr($handle) . '][]" value="' . esc_attr($template) . '" ' . $checked . ' /></td>';
+            }
+            echo '</tr>';
+        }
+        echo '</tbody></table>';
+        submit_button(__('Save Changes', 'gm2-wordpress-suite'));
+        echo '</form></div>';
+    }
+
+    public function save_overrides() {
+        if (!current_user_can('manage_options')) {
+            wp_die(__('Access denied.', 'gm2-wordpress-suite'));
+        }
+        check_admin_referer('gm2_js_usage_save');
+        $raw = $_POST['overrides'] ?? [];
+        $overrides = [];
+        if (is_array($raw)) {
+            foreach ($raw as $handle => $templates) {
+                $handle = sanitize_key($handle);
+                if (!is_array($templates)) {
+                    continue;
+                }
+                $clean = [];
+                foreach ($templates as $t) {
+                    $t = sanitize_key($t);
+                    if ($t !== '') {
+                        $clean[] = $t;
+                    }
+                }
+                if ($clean) {
+                    $overrides[$handle] = array_values(array_unique($clean));
+                }
+            }
+        }
+        update_option('ae_js_overrides', $overrides);
+        wp_redirect(add_query_arg('updated', '1', admin_url('admin.php?page=gm2-js-usage')));
+        exit;
+    }
+}

--- a/includes/Gm2_Loader.php
+++ b/includes/Gm2_Loader.php
@@ -59,6 +59,8 @@ class Gm2_Loader {
             if (is_admin()) {
                 $cache_admin = new Gm2_Cache_Audit_Admin();
                 $cache_admin->run();
+                $js_usage_admin = new Gm2_JS_Usage_Admin();
+                $js_usage_admin->run();
             }
         }
 

--- a/includes/class-ae-seo-js-controller.php
+++ b/includes/class-ae-seo-js-controller.php
@@ -18,6 +18,7 @@ class AE_SEO_JS_Controller {
      */
     public static function init(): void {
         add_action('wp_enqueue_scripts', [ __CLASS__, 'control_scripts' ], 999);
+        add_filter('ae_seo/js/enqueue_decision', [ __CLASS__, 'allow_override' ], 5, 3);
     }
 
     /**
@@ -50,6 +51,29 @@ class AE_SEO_JS_Controller {
                 ae_seo_js_log('dequeue ' . $handle . ' (' . $reason . ') ' . $url);
             }
         }
+    }
+
+    /**
+     * Always allow scripts based on saved overrides.
+     *
+     * @param bool   $allow   Current allow decision.
+     * @param string $handle  Script handle.
+     * @param array  $context Context data.
+     * @return bool
+     */
+    public static function allow_override(bool $allow, string $handle, array $context): bool {
+        if ($allow) {
+            return true;
+        }
+        $overrides = get_option('ae_js_overrides', []);
+        if (!isset($overrides[$handle]) || !is_array($overrides[$handle])) {
+            return $allow;
+        }
+        $page = $context['page_type'] ?? '';
+        if ($page !== '' && in_array($page, $overrides[$handle], true)) {
+            return true;
+        }
+        return $allow;
     }
 
     /**


### PR DESCRIPTION
## Summary
- Add admin page under Performance to list script usage frequencies and allow per-template overrides
- Instantiate new admin tool in loader and allow JS controller to honor saved overrides

## Testing
- `npm test` *(fails: jest: not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b775afd9a8832795a69bfce1ee61ef