### PR TITLE
Add differential JS loader with polyfill detection

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -108,6 +108,7 @@ require_once GM2_PLUGIN_DIR . 'includes/Gm2_Script_Attributes.php';
 require_once GM2_PLUGIN_DIR . 'includes/class-ae-seo-js-detector.php';
 require_once GM2_PLUGIN_DIR . 'includes/class-ae-seo-js-manager.php';
 require_once GM2_PLUGIN_DIR . 'includes/class-ae-seo-js-controller.php';
+require_once GM2_PLUGIN_DIR . 'includes/class-ae-seo-diff-serving.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_Search_Console.php';
 require_once GM2_PLUGIN_DIR . 'includes/render-optimizer/class-ae-seo-render-optimizer.php';
 require_once GM2_PLUGIN_DIR . 'includes/Versioning_MTime.php';

--- a/includes/class-ae-seo-diff-serving.php
+++ b/includes/class-ae-seo-diff-serving.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Differential serving for main front-end script.
+ *
+ * @package Gm2
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Handle loading of modern/legacy bundles and polyfills.
+ */
+class AE_SEO_Main_Diff_Serving {
+    /**
+     * Constructor.
+     */
+    public function __construct() {
+        add_action('wp_enqueue_scripts', [ $this, 'setup' ], 5);
+        add_filter('script_loader_tag', [ $this, 'script_loader_tag' ], 20, 3);
+    }
+
+    /**
+     * Register and enqueue scripts.
+     *
+     * @return void
+     */
+    public function setup() {
+        $base = GM2_PLUGIN_URL . 'assets/dist/';
+        $ver  = defined('GM2_VERSION') ? GM2_VERSION : false;
+
+        // Register scripts.
+        wp_register_script('ae-main-modern', $base . 'ae-main.modern.js', [], $ver, true);
+
+        $load_legacy = get_option('ae_js_nomodule_legacy', '1') === '1';
+        if ($load_legacy) {
+            wp_register_script('ae-main-legacy', $base . 'ae-main.legacy.js', [], $ver, true);
+        }
+
+        // Conditionally enqueue polyfills.
+        if (ae_seo_needs_polyfills()) {
+            wp_enqueue_script('ae-polyfills', $base . 'polyfills.js', [], $ver, true);
+        }
+
+        // Enqueue main scripts.
+        wp_enqueue_script('ae-main-modern');
+        if ($load_legacy) {
+            wp_enqueue_script('ae-main-legacy');
+        }
+    }
+
+    /**
+     * Add module/nomodule attributes.
+     *
+     * @param string $tag    Script tag.
+     * @param string $handle Script handle.
+     * @param string $src    Script source.
+     * @return string
+     */
+    public function script_loader_tag($tag, $handle, $src) {
+        if ($handle === 'ae-main-modern') {
+            return str_replace('<script ', '<script type="module" ', $tag);
+        }
+        if ($handle === 'ae-main-legacy') {
+            return str_replace('<script ', '<script nomodule ', $tag);
+        }
+        return $tag;
+    }
+}
+
+if (!function_exists('ae_seo_needs_polyfills')) {
+    /**
+     * Determine if polyfills are required for the current browser.
+     *
+     * Uses a cookie set via feature detection to avoid repeated checks.
+     *
+     * @return bool
+     */
+    function ae_seo_needs_polyfills(): bool {
+        if (isset($_COOKIE['ae_js_polyfills'])) {
+            return $_COOKIE['ae_js_polyfills'] === '1';
+        }
+
+        $inline = "(function(){var n=!('IntersectionObserver' in window)||!('fetch' in window)||!('Promise' in window)||!('classList' in document.createElement('div'));document.cookie='ae_js_polyfills='+(n?1:0)+';path=/';})();";
+        wp_add_inline_script('ae-main-modern', $inline, 'before');
+        return true;
+    }
+}
+
+// Bootstrap.
+new AE_SEO_Main_Diff_Serving();

--- a/tests/test-main-diff-serving.php
+++ b/tests/test-main-diff-serving.php
@@ -1,0 +1,72 @@
+<?php
+require_once __DIR__ . '/../includes/class-ae-seo-diff-serving.php';
+
+class MainDiffServingTest extends WP_UnitTestCase {
+    protected function tearDown(): void {
+        wp_dequeue_script('ae-main-modern');
+        wp_deregister_script('ae-main-modern');
+        wp_dequeue_script('ae-main-legacy');
+        wp_deregister_script('ae-main-legacy');
+        wp_dequeue_script('ae-polyfills');
+        wp_deregister_script('ae-polyfills');
+        wp_scripts()->done = [];
+        unset($_COOKIE['ae_js_polyfills']);
+        delete_option('ae_js_nomodule_legacy');
+        parent::tearDown();
+    }
+
+    private function get_output(string $handle): string {
+        ob_start();
+        wp_print_scripts($handle);
+        return ob_get_clean();
+    }
+
+    private function extract_tag(string $html, string $handle): string {
+        preg_match("/\<script[^>]*id='" . preg_quote($handle, '/') . "-js'[^>]*>\<\/script>/", $html, $m);
+        return $m[0] ?? '';
+    }
+
+    public function test_module_and_nomodule_when_enabled() {
+        update_option('ae_js_nomodule_legacy', '1');
+        new AE_SEO_Main_Diff_Serving();
+        do_action('wp_enqueue_scripts');
+
+        $html      = $this->get_output('ae-main-legacy');
+        $modernTag = $this->extract_tag($html, 'ae-main-modern');
+        $legacyTag = $this->extract_tag($html, 'ae-main-legacy');
+
+        $this->assertNotEmpty($modernTag);
+        $this->assertNotEmpty($legacyTag);
+        $this->assertStringContainsString('type="module"', $modernTag);
+        $this->assertStringContainsString('nomodule', $legacyTag);
+    }
+
+    public function test_legacy_skipped_when_disabled() {
+        update_option('ae_js_nomodule_legacy', '0');
+        new AE_SEO_Main_Diff_Serving();
+        do_action('wp_enqueue_scripts');
+
+        $html      = $this->get_output('ae-main-modern');
+        $modernTag = $this->extract_tag($html, 'ae-main-modern');
+        $legacyTag = $this->extract_tag($html, 'ae-main-legacy');
+
+        $this->assertNotEmpty($modernTag);
+        $this->assertEmpty($legacyTag);
+    }
+
+    public function test_polyfills_enqueued_when_cookie_set() {
+        $_COOKIE['ae_js_polyfills'] = '1';
+        new AE_SEO_Main_Diff_Serving();
+        do_action('wp_enqueue_scripts');
+        $html = $this->get_output('ae-polyfills');
+        $tag  = $this->extract_tag($html, 'ae-polyfills');
+        $this->assertNotEmpty($tag);
+    }
+
+    public function test_polyfills_skipped_when_cookie_zero() {
+        $_COOKIE['ae_js_polyfills'] = '0';
+        new AE_SEO_Main_Diff_Serving();
+        do_action('wp_enqueue_scripts');
+        $this->assertFalse(wp_script_is('ae-polyfills', 'enqueued'));
+    }
+}


### PR DESCRIPTION
## Summary
- load `ae-main.modern.js` and optional legacy bundle with module/nomodule attributes
- enqueue `polyfills.js` only when feature-detection cookie indicates it's needed
- add tests for module/nomodule handling and polyfill cookie

## Testing
- `vendor/bin/phpunit` *(fails: Error establishing a database connection)*

------
https://chatgpt.com/codex/tasks/task_e_68b781dbe40883278a991a2518ff106b