### PR TITLE
Add option to toggle legacy nomodule bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ The Render Optimizer groups several front-end performance features behind **SEO 
 
 * Inline critical CSS and preload full stylesheets.
 * Defer or async scripts with an enable toggle plus handle and domain allow/deny lists.
-* Serve modern and legacy JavaScript bundles using `<script type="module" crossorigin="anonymous">` and `<script nomodule crossorigin="anonymous">`. Differential serving is enabled by default (`ae_seo_ro_enable_diff_serving`), and module scripts remain blocking even when JS deferral is active.
+* Serve modern and legacy JavaScript bundles using `<script type="module" crossorigin="anonymous">` and `<script nomodule crossorigin="anonymous">`. Differential serving is enabled by default (`ae_seo_ro_enable_diff_serving`), and module scripts remain blocking even when JS deferral is active. The legacy ES5 bundle can be toggled via the "Send Legacy (nomodule) Bundle" setting (`ae_js_nomodule_legacy`).
 * Combine and minify local CSS and JS assets with per-type toggles, size caps and exclusion lists.
 
 ### Critical CSS

--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -58,6 +58,7 @@ class Gm2_SEO_Admin {
         add_option('ae_js_debug_log', '0');
         add_option('ae_js_auto_dequeue', '0');
         add_option('ae_js_respect_safe_mode', '0');
+        add_option('ae_js_nomodule_legacy', '0');
         add_option('ae_js_dequeue_allowlist', []);
         add_option('ae_js_dequeue_denylist', []);
 
@@ -3014,6 +3015,9 @@ class Gm2_SEO_Admin {
 
         $safe = isset($_POST['ae_js_respect_safe_mode']) ? '1' : '0';
         update_option('ae_js_respect_safe_mode', $safe);
+
+        $nomodule = isset($_POST['ae_js_nomodule_legacy']) ? '1' : '0';
+        update_option('ae_js_nomodule_legacy', $nomodule);
 
         $allow = isset($_POST['ae_js_dequeue_allowlist']) ? $this->sanitize_handle_array((array) $_POST['ae_js_dequeue_allowlist']) : [];
         update_option('ae_js_dequeue_allowlist', $allow);

--- a/admin/views/settings-js-optimizer.php
+++ b/admin/views/settings-js-optimizer.php
@@ -9,6 +9,7 @@ $replace     = get_option('ae_js_replacements', '0');
 $debug       = get_option('ae_js_debug_log', '0');
 $auto        = get_option('ae_js_auto_dequeue', '0');
 $safe_mode   = get_option('ae_js_respect_safe_mode', '0');
+$nomodule    = get_option('ae_js_nomodule_legacy', '0');
 $allow       = get_option('ae_js_dequeue_allowlist', []);
 $deny        = get_option('ae_js_dequeue_denylist', []);
 if (!is_array($allow)) {
@@ -31,6 +32,7 @@ echo '<tr><th scope="row">' . esc_html__( 'Enable Replacements', 'gm2-wordpress-
 echo '<tr><th scope="row">' . esc_html__( 'Debug Log', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_js_debug_log" value="1" ' . checked($debug, '1', false) . ' /></td></tr>';
 echo '<tr><th scope="row">' . esc_html__( 'Enable Per-Page Auto-Dequeue (Beta)', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_js_auto_dequeue" value="1" ' . checked($auto, '1', false) . ' /></td></tr>';
 echo '<tr><th scope="row">' . esc_html__( 'Respect Safe Mode param', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_js_respect_safe_mode" value="1" ' . checked($safe_mode, '1', false) . ' /></td></tr>';
+echo '<tr><th scope="row">' . esc_html__( 'Send Legacy (nomodule) Bundle', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_js_nomodule_legacy" value="1" ' . checked($nomodule, '1', false) . ' /><p class="description">' . esc_html__( 'Include an ES5 bundle for older browsers.', 'gm2-wordpress-suite' ) . '</p></td></tr>';
 echo '<tr><th scope="row">' . esc_html__( 'Handle Allowlist', 'gm2-wordpress-suite' ) . '</th><td><select name="ae_js_dequeue_allowlist[]" multiple size="10" style="min-width:200px;">';
 foreach ($registered as $handle) {
     echo '<option value="' . esc_attr($handle) . '" ' . selected(in_array($handle, $allow, true), true, false) . '>' . esc_html($handle) . '</option>';

--- a/assets/build/README.md
+++ b/assets/build/README.md
@@ -11,6 +11,6 @@ npm run build:assets
 The build step generates the following files in `assets/dist/`:
 
 - `ae-main.modern.js` – ES module targeting modern browsers (`es2020`).
-- `ae-main.legacy.js` – ES5 IIFE build. Enqueue only when the `ae_js_nomodule_legacy` option is enabled.
+- `ae-main.legacy.js` – ES5 IIFE build. Enqueue only when the "Send Legacy (nomodule) Bundle" option (`ae_js_nomodule_legacy`) is enabled.
 - `contact.js`, `product.js`, `blog.js` – page‑specific bundles.
 - `polyfills.js` – loaded at runtime only when `needPolyfills()` detects missing browser features.

--- a/includes/class-ae-seo-diff-serving.php
+++ b/includes/class-ae-seo-diff-serving.php
@@ -33,7 +33,7 @@ class AE_SEO_Main_Diff_Serving {
         // Register scripts.
         wp_register_script('ae-main-modern', $base . 'ae-main.modern.js', [], $ver, true);
 
-        $load_legacy = get_option('ae_js_nomodule_legacy', '1') === '1';
+        $load_legacy = get_option('ae_js_nomodule_legacy', '0') === '1';
         if ($load_legacy) {
             wp_register_script('ae-main-legacy', $base . 'ae-main.legacy.js', [], $ver, true);
         }

--- a/readme.txt
+++ b/readme.txt
@@ -103,7 +103,7 @@ Enable performance modules from **SEO → Performance → Render Optimizer**. Av
 
 * Critical CSS with allow/deny lists and optional manual overrides.
 * JavaScript deferral with an enable toggle, handle and domain allow/deny lists, a "Respect in footer" option, and automatic inline dependency and jQuery detection.
-* Differential serving of modern and legacy JavaScript bundles using `<script type="module" crossorigin="anonymous">` and `<script nomodule crossorigin="anonymous">`. This feature is enabled by default via `ae_seo_ro_enable_diff_serving`, and module scripts stay blocking when deferral is active.
+* Differential serving of modern and legacy JavaScript bundles using `<script type="module" crossorigin="anonymous">` and `<script nomodule crossorigin="anonymous">`. This feature is enabled by default via `ae_seo_ro_enable_diff_serving`, and module scripts stay blocking when deferral is active. The legacy bundle can be toggled via the "Send Legacy (nomodule) Bundle" setting (`ae_js_nomodule_legacy`).
 * Combination and minification of local CSS and JS assets with per-type toggles, size caps and exclusion lists.
 
 === Critical CSS ===


### PR DESCRIPTION
## Summary
- add "Send Legacy (nomodule) Bundle" checkbox to JS optimizer settings
- persist `ae_js_nomodule_legacy` option with default off and update diff serving logic
- document optional legacy bundle in README files

## Testing
- `npm test`
- `vendor/bin/phpunit` *(fails: Missing WordPress test library)*

------
https://chatgpt.com/codex/tasks/task_e_68b78336e7048327a3f69c9694019ff1