### PR TITLE
Enqueue page-specific bundles based on page context

### DIFF
--- a/config/script-map.json
+++ b/config/script-map.json
@@ -1,1 +1,5 @@
-{}
+{
+  "contact": "ae-contact",
+  "woo-product": "ae-product",
+  "single-post": "ae-blog"
+}


### PR DESCRIPTION
## Summary
- map page types to their entry script handles
- load only the page-specific script or fall back to main/legacy bundle when needed

## Testing
- `npm test`
- `vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_68b78475cf248327b156b21dbe026026