### PR TITLE
feat: add on-demand analytics loaders

### DIFF
--- a/assets/src/modules/fbq.js
+++ b/assets/src/modules/fbq.js
@@ -1,11 +1,25 @@
-export default function(id){
-  if(!id||window.fbq){return;}
-  var n=window.fbq=function(){n.callMethod? n.callMethod.apply(n,arguments):n.queue.push(arguments);};
-  if(!window._fbq){window._fbq=n;}
-  n.push=n; n.loaded=!0; n.version='2.0'; n.queue=[];
-  var s=document.createElement('script');
-  s.async=true;
-  s.src='https://connect.facebook.net/en_US/fbevents.js';
-  document.head.appendChild(s);
-  n('init',id); n('track','PageView');
+export default function fbq(id) {
+  if (!id || window.fbq) {
+    return;
+  }
+  const n = function() {
+    n.callMethod ? n.callMethod.apply(n, arguments) : n.queue.push(arguments);
+  };
+  window.fbq = n;
+  if (!window._fbq) {
+    window._fbq = n;
+  }
+  n.push = n;
+  n.loaded = true;
+  n.version = '2.0';
+  n.queue = [];
+
+  const script = document.createElement('script');
+  script.async = true;
+  script.id = 'ae-fbq';
+  script.src = 'https://connect.facebook.net/en_US/fbevents.js';
+  document.head.appendChild(script);
+
+  n('init', id);
+  n('track', 'PageView');
 }

--- a/assets/src/modules/gtag.js
+++ b/assets/src/modules/gtag.js
@@ -1,11 +1,16 @@
-export default function(id){
-  if(!id){return;}
-  var s=document.createElement('script');
-  s.async=true;
-  s.src='https://www.googletagmanager.com/gtag/js?id='+encodeURIComponent(id);
-  document.head.appendChild(s);
-  window.dataLayer=window.dataLayer||[];
-  function gtag(){dataLayer.push(arguments);} window.gtag=gtag;
-  gtag('js',new Date());
-  gtag('config',id);
+export default function gtag(id, config = {}) {
+  if (!id || window.gtag || document.getElementById('ae-gtag')) {
+    return;
+  }
+  const script = document.createElement('script');
+  script.async = true;
+  script.id = 'ae-gtag';
+  script.src = 'https://www.googletagmanager.com/gtag/js?id=' +
+    encodeURIComponent(id);
+  document.head.appendChild(script);
+  window.dataLayer = window.dataLayer || [];
+  function gtagFn() { window.dataLayer.push(arguments); }
+  window.gtag = gtagFn;
+  gtagFn('js', new Date());
+  gtagFn('config', id, config);
 }

--- a/assets/src/modules/gtm.js
+++ b/assets/src/modules/gtm.js
@@ -1,9 +1,13 @@
-export default function(id){
-  if(!id){return;}
-  window.dataLayer=window.dataLayer||[];
-  window.dataLayer.push({'gtm.start':new Date().getTime(),event:'gtm.js'});
-  var s=document.createElement('script');
-  s.async=true;
-  s.src='https://www.googletagmanager.com/gtm.js?id='+encodeURIComponent(id);
-  document.head.appendChild(s);
+export default function gtm(id) {
+  if (!id || document.getElementById('ae-gtm')) {
+    return;
+  }
+  window.dataLayer = window.dataLayer || [];
+  window.dataLayer.push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+  const script = document.createElement('script');
+  script.async = true;
+  script.id = 'ae-gtm';
+  script.src = 'https://www.googletagmanager.com/gtm.js?id=' +
+    encodeURIComponent(id);
+  document.head.appendChild(script);
 }

--- a/assets/src/modules/recaptcha.js
+++ b/assets/src/modules/recaptcha.js
@@ -1,9 +1,10 @@
-export default function(siteKey){
-  if(document.getElementById('ae-recaptcha')){return;}
-  var s=document.createElement('script');
-  s.id='ae-recaptcha';
-  var src='https://www.google.com/recaptcha/api.js';
-  if(siteKey){src+='?render='+encodeURIComponent(siteKey);}
-  s.src=src;
-  document.head.appendChild(s);
+export default function recaptcha(siteKey) {
+  if (!siteKey || document.getElementById('ae-recaptcha')) {
+    return;
+  }
+  const script = document.createElement('script');
+  script.id = 'ae-recaptcha';
+  script.src = 'https://www.google.com/recaptcha/api.js?render=' +
+    encodeURIComponent(siteKey);
+  document.head.appendChild(script);
 }


### PR DESCRIPTION
## Summary
- add modules to load reCAPTCHA, Google Tag, Google Tag Manager and Facebook Pixel only when invoked
- guard against duplicate injections and accept IDs/config parameters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b83e6626808327a9f29965e667fa5a