### PR TITLE
Add lazy JS analytics settings

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -54,6 +54,13 @@ class Gm2_SEO_Admin {
         add_option('ae_seo_ro_defer_preserve_jquery', '1');
         add_option('ae_js_enable_manager', '0');
         add_option('ae_js_lazy_load', '0');
+        add_option('ae_js_lazy_recaptcha', '0');
+        add_option('ae_js_lazy_analytics', '0');
+        add_option('ae_js_analytics_id', '');
+        add_option('ae_js_gtm_id', '');
+        add_option('ae_js_fb_id', '');
+        add_option('ae_js_consent_key', 'aeConsent');
+        add_option('ae_js_consent_value', 'allow_analytics');
         add_option('ae_js_replacements', '0');
         add_option('ae_js_debug_log', '0');
         add_option('ae_js_auto_dequeue', '0');
@@ -566,6 +573,27 @@ class Gm2_SEO_Admin {
             'sanitize_callback' => 'sanitize_text_field',
         ]);
         register_setting('gm2_seo_options', 'ae_js_lazy_load', [
+            'sanitize_callback' => 'sanitize_text_field',
+        ]);
+        register_setting('gm2_seo_options', 'ae_js_lazy_recaptcha', [
+            'sanitize_callback' => 'sanitize_text_field',
+        ]);
+        register_setting('gm2_seo_options', 'ae_js_lazy_analytics', [
+            'sanitize_callback' => 'sanitize_text_field',
+        ]);
+        register_setting('gm2_seo_options', 'ae_js_analytics_id', [
+            'sanitize_callback' => 'sanitize_text_field',
+        ]);
+        register_setting('gm2_seo_options', 'ae_js_gtm_id', [
+            'sanitize_callback' => 'sanitize_text_field',
+        ]);
+        register_setting('gm2_seo_options', 'ae_js_fb_id', [
+            'sanitize_callback' => 'sanitize_text_field',
+        ]);
+        register_setting('gm2_seo_options', 'ae_js_consent_key', [
+            'sanitize_callback' => 'sanitize_text_field',
+        ]);
+        register_setting('gm2_seo_options', 'ae_js_consent_value', [
             'sanitize_callback' => 'sanitize_text_field',
         ]);
         register_setting('gm2_seo_options', 'ae_js_replacements', [
@@ -3003,6 +3031,27 @@ class Gm2_SEO_Admin {
 
         $lazy = isset($_POST['ae_js_lazy_load']) ? '1' : '0';
         update_option('ae_js_lazy_load', $lazy);
+
+        $lazy_recaptcha = isset($_POST['ae_js_lazy_recaptcha']) ? '1' : '0';
+        update_option('ae_js_lazy_recaptcha', $lazy_recaptcha);
+
+        $lazy_analytics = isset($_POST['ae_js_lazy_analytics']) ? '1' : '0';
+        update_option('ae_js_lazy_analytics', $lazy_analytics);
+
+        $analytics_id = isset($_POST['ae_js_analytics_id']) ? sanitize_text_field($_POST['ae_js_analytics_id']) : '';
+        update_option('ae_js_analytics_id', $analytics_id);
+
+        $gtm_id = isset($_POST['ae_js_gtm_id']) ? sanitize_text_field($_POST['ae_js_gtm_id']) : '';
+        update_option('ae_js_gtm_id', $gtm_id);
+
+        $fb_id = isset($_POST['ae_js_fb_id']) ? sanitize_text_field($_POST['ae_js_fb_id']) : '';
+        update_option('ae_js_fb_id', $fb_id);
+
+        $consent_key = isset($_POST['ae_js_consent_key']) ? sanitize_text_field($_POST['ae_js_consent_key']) : 'aeConsent';
+        update_option('ae_js_consent_key', $consent_key);
+
+        $consent_value = isset($_POST['ae_js_consent_value']) ? sanitize_text_field($_POST['ae_js_consent_value']) : 'allow_analytics';
+        update_option('ae_js_consent_value', $consent_value);
 
         $replacements = isset($_POST['ae_js_replacements']) ? '1' : '0';
         update_option('ae_js_replacements', $replacements);

--- a/admin/views/settings-js-optimizer.php
+++ b/admin/views/settings-js-optimizer.php
@@ -3,15 +3,22 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-$enable      = get_option('ae_js_enable_manager', '0');
-$lazy        = get_option('ae_js_lazy_load', '0');
-$replace     = get_option('ae_js_replacements', '0');
-$debug       = get_option('ae_js_debug_log', '0');
-$auto        = get_option('ae_js_auto_dequeue', '0');
-$safe_mode   = get_option('ae_js_respect_safe_mode', '0');
-$nomodule    = get_option('ae_js_nomodule_legacy', '0');
-$allow       = get_option('ae_js_dequeue_allowlist', []);
-$deny        = get_option('ae_js_dequeue_denylist', []);
+$enable        = get_option('ae_js_enable_manager', '0');
+$lazy          = get_option('ae_js_lazy_load', '0');
+$lazy_recaptcha = get_option('ae_js_lazy_recaptcha', '0');
+$lazy_analytics = get_option('ae_js_lazy_analytics', '0');
+$analytics_id   = get_option('ae_js_analytics_id', '');
+$gtm_id         = get_option('ae_js_gtm_id', '');
+$fb_id          = get_option('ae_js_fb_id', '');
+$consent_key    = get_option('ae_js_consent_key', 'aeConsent');
+$consent_value  = get_option('ae_js_consent_value', 'allow_analytics');
+$replace       = get_option('ae_js_replacements', '0');
+$debug         = get_option('ae_js_debug_log', '0');
+$auto          = get_option('ae_js_auto_dequeue', '0');
+$safe_mode     = get_option('ae_js_respect_safe_mode', '0');
+$nomodule      = get_option('ae_js_nomodule_legacy', '0');
+$allow         = get_option('ae_js_dequeue_allowlist', []);
+$deny          = get_option('ae_js_dequeue_denylist', []);
 if (!is_array($allow)) {
     $allow = [];
 }
@@ -28,6 +35,13 @@ echo '<input type="hidden" name="action" value="gm2_js_optimizer_settings" />';
 echo '<table class="form-table"><tbody>';
 echo '<tr><th scope="row">' . esc_html__( 'Enable JS Manager', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_js_enable_manager" value="1" ' . checked($enable, '1', false) . ' /></td></tr>';
 echo '<tr><th scope="row">' . esc_html__( 'Lazy Load Scripts', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_js_lazy_load" value="1" ' . checked($lazy, '1', false) . ' /></td></tr>';
+echo '<tr><th scope="row">' . esc_html__( 'Lazy-load reCAPTCHA', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_js_lazy_recaptcha" value="1" ' . checked($lazy_recaptcha, '1', false) . ' /></td></tr>';
+echo '<tr><th scope="row">' . esc_html__( 'Lazy-load Analytics/Tag Manager', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_js_lazy_analytics" value="1" ' . checked($lazy_analytics, '1', false) . ' /></td></tr>';
+echo '<tr><th scope="row">' . esc_html__( 'Analytics Measurement ID', 'gm2-wordpress-suite' ) . '</th><td><input type="text" name="ae_js_analytics_id" value="' . esc_attr($analytics_id) . '" placeholder="G-XXXX" /></td></tr>';
+echo '<tr><th scope="row">' . esc_html__( 'GTM ID', 'gm2-wordpress-suite' ) . '</th><td><input type="text" name="ae_js_gtm_id" value="' . esc_attr($gtm_id) . '" placeholder="GTM-XXXX" /></td></tr>';
+echo '<tr><th scope="row">' . esc_html__( 'Facebook Pixel ID', 'gm2-wordpress-suite' ) . '</th><td><input type="text" name="ae_js_fb_id" value="' . esc_attr($fb_id) . '" /></td></tr>';
+echo '<tr><th scope="row">' . esc_html__( 'Consent Mode key', 'gm2-wordpress-suite' ) . '</th><td><input type="text" name="ae_js_consent_key" value="' . esc_attr($consent_key) . '" /></td></tr>';
+echo '<tr><th scope="row">' . esc_html__( 'Consent Mode value to watch', 'gm2-wordpress-suite' ) . '</th><td><input type="text" name="ae_js_consent_value" value="' . esc_attr($consent_value) . '" /><p class="description">' . esc_html__( 'Default value is allow_analytics', 'gm2-wordpress-suite' ) . '</p></td></tr>';
 echo '<tr><th scope="row">' . esc_html__( 'Enable Replacements', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_js_replacements" value="1" ' . checked($replace, '1', false) . ' /></td></tr>';
 echo '<tr><th scope="row">' . esc_html__( 'Debug Log', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_js_debug_log" value="1" ' . checked($debug, '1', false) . ' /></td></tr>';
 echo '<tr><th scope="row">' . esc_html__( 'Enable Per-Page Auto-Dequeue (Beta)', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_js_auto_dequeue" value="1" ' . checked($auto, '1', false) . ' /></td></tr>';


### PR DESCRIPTION
## Summary
- add settings to lazy-load reCAPTCHA and analytics tags
- store Analytics Measurement, GTM, Facebook Pixel, and consent mode settings

## Testing
- `vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_68b841152e648327be5e21af7b4016d5