### PR TITLE
docs: add testing steps for consent and recaptcha

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,8 @@
+# Testing
+
+To validate script loading and consent workflow:
+
+- In Lighthouse, confirm JS execution time decreases and analytics scripts stay absent on idle load.
+- Focus a `data-recaptcha` form and verify reCAPTCHA loads within ~200 ms.
+- Change `aeConsent` value and dispatch `aeConsentChanged` to ensure analytics imports after consent.
+


### PR DESCRIPTION
## Summary
- document QA steps for recaptcha and analytics consent verification

## Testing
- `npm test`
- `vendor/bin/phpunit` *(fails: missing WordPress test library)*

------
https://chatgpt.com/codex/tasks/task_e_68b84ed537f08327b8a0df005e41970f