### PR TITLE
Add vanilla JS helpers and drop jQuery in AC popup

### DIFF
--- a/assets/build/build.mjs
+++ b/assets/build/build.mjs
@@ -51,6 +51,14 @@ await build({
   ...shared
 });
 
+await build({
+  entryPoints: ['assets/src/vanilla-helpers.js'],
+  outfile: 'assets/dist/vanilla-helpers.js',
+  format: 'esm',
+  target: ['es2020'],
+  ...shared
+});
+
 const modules = await readdir('assets/src/modules');
 for (const file of modules) {
   if (!file.endsWith('.js')) {

--- a/assets/dist/vanilla-helpers.js
+++ b/assets/dist/vanilla-helpers.js
@@ -1,0 +1,1 @@
+function o(t,e,n){t.addEventListener(e,n)}function s(t,e){return t.closest(e)}function r(t,e={}){return fetch(t,e)}function c(t){t.classList.toggle("is-open")}export{r as ajax,s as closest,o as on,c as slideToggle};

--- a/assets/src/vanilla-helpers.js
+++ b/assets/src/vanilla-helpers.js
@@ -1,0 +1,15 @@
+export function on(el, evt, fn) {
+  el.addEventListener(evt, fn);
+}
+
+export function closest(el, selector) {
+  return el.closest(selector);
+}
+
+export function ajax(url, options = {}) {
+  return fetch(url, options);
+}
+
+export function slideToggle(el) {
+  el.classList.toggle('is-open');
+}

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "directories": {
     "test": "tests"
   },
-    "scripts": {
+  "scripts": {
     "test": "jest",
     "prebuild:optimizer": "rm -f assets/dist/optimizer-legacy.js assets/dist/optimizer-modern.js assets/dist/optimizer.css",
     "build:optimizer": "rollup -c rollup.config.mjs",
-    "prebuild:assets": "rm -f assets/dist/ae-main.modern.js assets/dist/ae-main.legacy.js assets/dist/contact.js assets/dist/product.js assets/dist/blog.js assets/dist/polyfills.js assets/dist/ae-lazy.js && rm -rf assets/dist/modules",
+    "prebuild:assets": "rm -f assets/dist/ae-main.modern.js assets/dist/ae-main.legacy.js assets/dist/contact.js assets/dist/product.js assets/dist/blog.js assets/dist/polyfills.js assets/dist/ae-lazy.js assets/dist/vanilla-helpers.js && rm -rf assets/dist/modules",
     "build:assets": "node assets/build/build.mjs",
     "build": "npm run build:optimizer && npm run build:assets"
   },
@@ -19,20 +19,20 @@
   "license": "ISC",
   "type": "commonjs",
   "devDependencies": {
+    "@babel/core": "^7.23.9",
+    "@babel/preset-env": "^7.23.9",
+    "@rollup/plugin-babel": "^6.0.4",
+    "@rollup/plugin-commonjs": "^28.0.6",
+    "@rollup/plugin-node-resolve": "^15.2.1",
+    "classlist-polyfill": "^1.2.0",
+    "esbuild": "^0.20.2",
+    "intersection-observer": "^0.12.2",
     "jest": "^30.0.4",
     "jquery": "^3.7.1",
     "jsdom": "^26.1.0",
-    "rollup": "^4.13.0",
-    "@rollup/plugin-node-resolve": "^15.2.1",
-    "@rollup/plugin-commonjs": "^28.0.6",
-    "@rollup/plugin-babel": "^6.0.4",
-    "rollup-plugin-terser": "^7.0.2",
-    "@babel/core": "^7.23.9",
-    "@babel/preset-env": "^7.23.9",
-    "esbuild": "^0.20.2",
-    "intersection-observer": "^0.12.2",
-    "whatwg-fetch": "^3.6.20",
     "promise-polyfill": "^8.2.3",
-    "classlist-polyfill": "^1.2.0"
+    "rollup": "^4.13.0",
+    "rollup-plugin-terser": "^7.0.2",
+    "whatwg-fetch": "^3.6.20"
   }
 }

--- a/public/js/gm2-ac-popup.js
+++ b/public/js/gm2-ac-popup.js
@@ -1,37 +1,45 @@
-jQuery(function($){
-    if (typeof gm2AcPopup === 'undefined' || !gm2AcPopup.popup_id) {
-        return;
-    }
+import { on, closest, ajax } from '../../assets/dist/vanilla-helpers.js';
 
-    function openPopup() {
-        if (window.elementorProFrontend && elementorProFrontend.modules && elementorProFrontend.modules.popup) {
-            try {
-                elementorProFrontend.modules.popup.showPopup({ id: gm2AcPopup.popup_id });
-            } catch (e) {
-                console.error('GM2 AC Popup: failed to open popup', e);
-            }
-        }
-    }
+on(document, 'DOMContentLoaded', () => {
+  if (typeof gm2AcPopup === 'undefined' || !gm2AcPopup.popup_id) {
+    return;
+  }
 
+  function openPopup() {
     if (window.elementorProFrontend && elementorProFrontend.modules && elementorProFrontend.modules.popup) {
-        openPopup();
-    } else {
-        $(window).on('elementor/frontend/init', openPopup);
+      try {
+        elementorProFrontend.modules.popup.showPopup({ id: gm2AcPopup.popup_id });
+      } catch (e) {
+        console.error('GM2 AC Popup: failed to open popup', e);
+      }
     }
+  }
 
-    $(document).on('submit', '.elementor-form', function(){
-        var $form = $(this);
-        var email = $form.find('input[type="email"]').val();
-        var phone = $form.find('input[type="tel"]').val();
-        if (!email && !phone) {
-            return;
-        }
-        $.post(gm2AcPopup.ajax_url, {
-            action: 'gm2_ac_contact_capture',
-            nonce: gm2AcPopup.nonce,
-            email: email,
-            phone: phone,
-            url: window.location.href
-        });
+  if (window.elementorProFrontend && elementorProFrontend.modules && elementorProFrontend.modules.popup) {
+    openPopup();
+  } else {
+    on(window, 'elementor/frontend/init', openPopup);
+  }
+
+  on(document, 'submit', (e) => {
+    const form = closest(e.target, '.elementor-form');
+    if (!form) {
+      return;
+    }
+    const email = form.querySelector('input[type="email"]').value;
+    const phone = form.querySelector('input[type="tel"]').value;
+    if (!email && !phone) {
+      return;
+    }
+    ajax(gm2AcPopup.ajax_url, {
+      method: 'POST',
+      body: new URLSearchParams({
+        action: 'gm2_ac_contact_capture',
+        nonce: gm2AcPopup.nonce,
+        email,
+        phone,
+        url: window.location.href
+      })
     });
+  });
 });


### PR DESCRIPTION
## Summary
- add reusable `on`, `closest`, `ajax`, and `slideToggle` utilities
- bundle helpers via esbuild and clean them during prebuild
- refactor AC popup script to use vanilla helpers instead of jQuery

## Testing
- `npm run build:assets`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b852724268832797208db37e2b9566