### PR TITLE
docs: document jQuery on-demand and replacements

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ Front‑end scripts are bundled with **esbuild** using page‑scoped entry point
 npm run build:assets
 ```
 
-This generates `assets/dist/ae-main.modern.js`, `ae-main.legacy.js`, page‑specific bundles like `contact.js`, and `polyfills.js`. Modern browsers load only the ESM files; older browsers without module support receive the `nomodule` bundle and polyfills when `needPolyfills()` detects missing features. Commit the updated files in `assets/dist` to version control.
+This generates `assets/dist/ae-main.modern.js`, `ae-main.legacy.js`, page‑specific bundles like `contact.js`, `polyfills.js`, and a `vanilla-helpers.js` module. Modern browsers load only the ESM files; older browsers without module support receive the `nomodule` bundle and polyfills when `needPolyfills()` detects missing features. Commit the updated files in `assets/dist` to version control.
 
 ### JavaScript Replacements
 
-When the **Enable Replacements** option is active (`ae_js_replacements`), front‑end scripts execute callbacks on matched elements. Use the `ae_seo/js/replacements` filter to return an associative array where keys are CSS selectors and values are callback names available on `window`. Each callback receives the matched element as its only argument.
+When the **Enable Replacements** option is active (`ae_js_replacements`), front‑end scripts execute callbacks on matched elements. Use the `ae_seo/js/replacements` filter to return an associative array where keys are CSS selectors and values are callback names available on `window`. Each callback receives the matched element as its only argument. The plugin also ships a `vanilla-helpers.js` module with tiny DOM utilities for these callbacks.
 
 ## AI Providers
 
@@ -402,7 +402,7 @@ AE_SEO_JS_Detector builds a transient map of registered scripts and records the 
 
 AE_SEO_JS_Lazy adds user-intent triggers and consent gating so modules load only when needed. New settings let you define scroll or input events that wake dormant modules, gate analytics behind consent or interaction, and toggle each module individually. Analytics stays idle until a visitor grants consent or interacts with the page, while reCAPTCHA loads only when a form field receives focus—typically in under 200&nbsp;ms.
 
-Settings live under **SEO → Performance → JavaScript** to enable the manager, lazy-loading, script replacements, debug logging, handle allow and deny lists and an optional safe-mode query parameter. Per-page auto-dequeue remains in beta—test on staging and use the allowlist, denylist or `?aejs=off` parameter if a handle is removed incorrectly.
+Settings live under **SEO → Performance → JavaScript** to enable the manager, lazy-loading, script replacements, debug logging, handle allow and deny lists and an optional safe-mode query parameter. A **Load jQuery only when required** option removes jQuery when no enqueued scripts depend on it; pages using Elementor or other jQuery‑dependent assets still receive it automatically. Regex patterns in **Always include jQuery on these URLs** let you force jQuery on specific URLs. When **Debug Log** is enabled, script decisions are recorded in `wp-content/ae-seo/logs/js-optimizer.log`. Per-page auto-dequeue remains in beta—test on staging and use the allowlist, denylist or `?aejs=off` parameter if a handle is removed incorrectly.
 
 The **SEO → Script Usage** page lists discovered script handles with counts per template so you can accept or override which templates require each script before relying on auto-dequeue.
 

--- a/readme.txt
+++ b/readme.txt
@@ -31,6 +31,8 @@ Key features include:
 * Script Attributes manager with dependency-aware “Defer all third-party” and “Conservative” presets
 * Render Optimizer for critical CSS, JS deferral with handle/domain allow and deny lists plus inline dependency and jQuery auto-detection, differential serving with page-scoped entry points so modern browsers load only the ESM bundle while legacy browsers get a `nomodule` file and polyfills, and optional asset combination/minification with size limits and purge controls
 * JavaScript Manager powered by AE_SEO_JS_Detector, AE_SEO_JS_Controller and AE_SEO_JS_Lazy for optional per-page auto-dequeue (beta), user-intent triggers, consent gating, per-module toggles, lazy loading, script replacements, handle allow/deny lists, a Script Usage admin page for acceptance scenarios, and performance gains such as idle analytics and sub-200 ms reCAPTCHA on form focus
+* Option to load jQuery only when required with URL-based overrides and debug logging; pages with Elementor or other jQuery-dependent assets still enqueue it
+* DOM replacements via the `ae_seo/js/replacements` filter and bundled `vanilla-helpers.js` helpers
 
 == Installation ==
 1. Upload the plugin files to the `/wp-content/plugins/gm2-wordpress-suite` directory.
@@ -162,6 +164,8 @@ AE_SEO_JS_Detector builds a map of registered scripts and caches the page type, 
 AE_SEO_JS_Lazy introduces user-intent triggers and consent gating so modules activate only when necessary. New per-module toggles let you specify scroll or input events that wake dormant scripts, gate analytics behind consent or interaction, and load reCAPTCHA only when a form field receives focus—usually in under 200 ms.
 
 Open **SEO → Performance → JavaScript** to enable the manager, lazy loading, script replacements, debug logging and an optional safe-mode query parameter. The screen also provides handle allow and deny lists and a per-page auto-dequeue option that is still in beta.
+
+A **Load jQuery only when required** checkbox removes jQuery when no queued handles depend on it; pages with Elementor or other jQuery-based assets still load it automatically. Enter regex patterns in **Always include jQuery on these URLs** to force jQuery on specific pages. When **Debug Log** is enabled, decisions are recorded in `wp-content/ae-seo/logs/js-optimizer.log`. Define DOM replacements through the `ae_seo/js/replacements` filter and leverage helpers from `vanilla-helpers.js` in your callbacks.
 
 Visit **SEO → Script Usage** to review discovered handles and mark which page templates must always enqueue them. Use this page to define acceptance scenarios before enabling auto-dequeue on production—critical scripts can otherwise be removed.
 


### PR DESCRIPTION
## Summary
- describe vanilla-helpers.js and `ae_seo/js/replacements`
- document URL overrides, logging, and jQuery on-demand behavior

## Testing
- `npm test` *(fails: jest not found)*
- `phpunit` *(fails: missing /tmp/wordpress-tests-lib)*

------
https://chatgpt.com/codex/tasks/task_e_68b85979871c83278def96ba80f62a14