### PR TITLE
docs: add jQuery verification steps

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -6,3 +6,8 @@ To validate script loading and consent workflow:
 - Focus a `data-recaptcha` form and verify reCAPTCHA loads within ~200 ms.
 - Change `aeConsent` value and dispatch `aeConsentChanged` to ensure analytics imports after consent.
 
+To verify jQuery handling:
+
+- Visit a page with no scripts depending on jQuery; confirm `jquery.js` and `jquery-migrate.js` are absent and `js-optimizer.log` records their removal.
+- Visit a page using Elementor or another jQuery-dependent plugin or theme; confirm both jQuery files remain loaded.
+


### PR DESCRIPTION
## Summary
- document how to verify jQuery removal and retention in testing

## Testing
- `npm test`
- `./vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*


------
https://chatgpt.com/codex/tasks/task_e_68b85aa8727c8327a68ccc5309d6c063