### PR TITLE
Use build manifest to register hashed assets

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -105,6 +105,7 @@ require_once GM2_PLUGIN_DIR . 'includes/Gm2_Audit_Log.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_Ajax_Upload.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_Cache_Audit.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_Script_Attributes.php';
+require_once GM2_PLUGIN_DIR . 'includes/functions-assets.php';
 require_once GM2_PLUGIN_DIR . 'includes/class-ae-seo-js-detector.php';
 require_once GM2_PLUGIN_DIR . 'includes/class-ae-seo-js-manager.php';
 require_once GM2_PLUGIN_DIR . 'includes/class-ae-seo-js-controller.php';

--- a/includes/class-ae-seo-diff-serving.php
+++ b/includes/class-ae-seo-diff-serving.php
@@ -27,20 +27,19 @@ class AE_SEO_Main_Diff_Serving {
      * @return void
      */
     public function setup() {
-        $base = GM2_PLUGIN_URL . 'assets/dist/';
-        $ver  = defined('GM2_VERSION') ? GM2_VERSION : false;
+        $load_legacy = get_option('ae_js_nomodule_legacy', '0') === '1';
 
         // Register scripts.
-        wp_register_script('ae-main-modern', $base . 'ae-main.modern.js', [], $ver, true);
+        ae_seo_register_asset('ae-main-modern', 'ae-main.modern.js');
 
-        $load_legacy = get_option('ae_js_nomodule_legacy', '0') === '1';
         if ($load_legacy) {
-            wp_register_script('ae-main-legacy', $base . 'ae-main.legacy.js', [], $ver, true);
+            ae_seo_register_asset('ae-main-legacy', 'ae-main.legacy.js');
         }
 
         // Conditionally enqueue polyfills.
         if (ae_seo_needs_polyfills()) {
-            wp_enqueue_script('ae-polyfills', $base . 'polyfills.js', [], $ver, true);
+            ae_seo_register_asset('ae-polyfills', 'polyfills.js');
+            wp_enqueue_script('ae-polyfills');
         }
 
         // Enqueue main scripts.

--- a/includes/class-ae-seo-js-lazy.php
+++ b/includes/class-ae-seo-js-lazy.php
@@ -24,9 +24,7 @@ class AE_SEO_JS_Lazy {
      * Register and enqueue script with configuration.
      */
     public static function enqueue(): void {
-        $base = GM2_PLUGIN_URL . 'assets/dist/';
-        $ver  = defined('GM2_VERSION') ? GM2_VERSION : false;
-        wp_register_script('ae-lazy', $base . 'ae-lazy.js', [], $ver, true);
+        ae_seo_register_asset('ae-lazy', 'ae-lazy.js');
         $modules = [
             'recaptcha' => get_option('ae_lazy_recaptcha', '0') === '1',
             'gtag'      => get_option('ae_lazy_gtag', '0') === '1',

--- a/includes/class-ae-seo-js-manager.php
+++ b/includes/class-ae-seo-js-manager.php
@@ -124,9 +124,6 @@ class AE_SEO_JS_Manager {
         $page_type = $ctx['page_type'] ?? '';
         $handle    = $page_type !== '' && isset($this->map[$page_type]) ? (string) $this->map[$page_type] : '';
 
-        $base = GM2_PLUGIN_URL . 'assets/dist/';
-        $ver  = defined('GM2_VERSION') ? GM2_VERSION : false;
-
         if ($handle !== '') {
             $allow = apply_filters('ae_seo/js/enqueue_decision', true, $handle, $ctx);
             if (!$allow) {
@@ -134,7 +131,8 @@ class AE_SEO_JS_Manager {
                 return;
             }
             $file = str_replace('ae-', '', $handle) . '.js';
-            wp_enqueue_script($handle, $base . $file, [], $ver, true);
+            ae_seo_register_asset($handle, $file);
+            wp_enqueue_script($handle);
             wp_script_add_data($handle, 'type', 'module');
             $this->ae_seo_localize_replacements($handle);
             ae_seo_js_log('enqueue ' . $handle);
@@ -148,12 +146,14 @@ class AE_SEO_JS_Manager {
             return;
         }
 
-        wp_enqueue_script('ae-main-modern', $base . 'ae-main.modern.js', [], $ver, true);
+        ae_seo_register_asset('ae-main-modern', 'ae-main.modern.js');
+        wp_enqueue_script('ae-main-modern');
         wp_script_add_data('ae-main-modern', 'type', 'module');
         $this->ae_seo_localize_replacements('ae-main-modern');
 
         if (get_option('ae_js_nomodule_legacy', '0') === '1') {
-            wp_enqueue_script('ae-main-legacy', $base . 'ae-main.legacy.js', [], $ver, true);
+            ae_seo_register_asset('ae-main-legacy', 'ae-main.legacy.js');
+            wp_enqueue_script('ae-main-legacy');
             wp_script_add_data('ae-main-legacy', 'nomodule', true);
             $this->ae_seo_localize_replacements('ae-main-legacy');
         }

--- a/includes/functions-assets.php
+++ b/includes/functions-assets.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Helper for registering built assets using the manifest.
+ *
+ * @package Gm2
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!function_exists('ae_seo_register_asset')) {
+    /**
+     * Register a script or style from the compiled assets.
+     *
+     * @param string $handle       Asset handle.
+     * @param string $logical_path Logical path in the manifest.
+     * @return void
+     */
+    function ae_seo_register_asset(string $handle, string $logical_path): void {
+        static $manifest = null;
+
+        if ($manifest === null) {
+            $manifest_file = GM2_PLUGIN_DIR . 'assets/build/manifest.json';
+            if (file_exists($manifest_file)) {
+                $json = file_get_contents($manifest_file);
+                $manifest = json_decode($json, true);
+                if (!is_array($manifest)) {
+                    $manifest = [];
+                }
+            } else {
+                $manifest = [];
+            }
+        }
+
+        $file = $manifest[$logical_path] ?? $logical_path;
+
+        $version = null;
+        if (preg_match('/\.([a-f0-9]{8})\.(?:js|css)$/', $file, $m)) {
+            $version = $m[1];
+        }
+
+        $src = GM2_PLUGIN_URL . 'assets/dist/' . $file;
+
+        if (str_ends_with($file, '.js')) {
+            wp_register_script($handle, $src, [], $version, true);
+        } elseif (str_ends_with($file, '.css')) {
+            wp_register_style($handle, $src, [], $version);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `ae_seo_register_asset()` helper that reads the build manifest and registers scripts/styles with version hashes
- switch JS loaders to use the helper for modern, legacy, lazy and page-specific bundles
- load new helper during plugin bootstrap

## Testing
- `php -l includes/functions-assets.php`
- `php -l includes/class-ae-seo-diff-serving.php`
- `php -l includes/class-ae-seo-js-lazy.php`
- `php -l includes/class-ae-seo-js-manager.php`
- `vendor/bin/phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b85eb519a08327ab93b5831783286e