### PR TITLE
Document hashed build pipeline and server hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ npm run build:assets
 
 This generates `assets/dist/ae-main.modern.js`, `ae-main.legacy.js`, page‑specific bundles like `contact.js`, `polyfills.js`, and a `vanilla-helpers.js` module. Modern browsers load only the ESM files; older browsers without module support receive the `nomodule` bundle and polyfills when `needPolyfills()` detects missing features. Commit the updated files in `assets/dist` to version control.
 
+### Hashed Asset Pipeline and Sourcemaps
+
+The build step appends a content hash to each filename so browsers can cache assets indefinitely. Enqueue files with `ae_seo_register_asset()` which resolves the current hash and registers the correct path. When `SCRIPT_DEBUG` is enabled the pipeline also emits sourcemaps to aid debugging.
+
+**Acceptance check:** hashed files must be minified, served compressed and return long‑cache headers such as `Cache-Control: public, max-age=31536000`.
+
 ### JavaScript Replacements
 
 When the **Enable Replacements** option is active (`ae_js_replacements`), front‑end scripts execute callbacks on matched elements. Use the `ae_seo/js/replacements` filter to return an associative array where keys are CSS selectors and values are callback names available on `window`. Each callback receives the matched element as its only argument. The plugin also ships a `vanilla-helpers.js` module with tiny DOM utilities for these callbacks.
@@ -461,6 +467,11 @@ site.
 
 WP-CLI prints an error message and exits with the code above. Review the
 message to resolve permission or server issues before retrying.
+
+
+## Server Hints and Diagnostics
+
+Open **Tools → Server Hints** to validate caching behaviour. The page lists hashed assets, reports whether they are minified and compressed and shows their cache headers. A one-click button writes caching rules into `.htaccess` on Apache or LiteSpeed. The same details are available from the `wp-json/ae-seo/v1/server-hints` diagnostic REST endpoint for automated tests.
 
 
 

--- a/readme.txt
+++ b/readme.txt
@@ -33,6 +33,8 @@ Key features include:
 * JavaScript Manager powered by AE_SEO_JS_Detector, AE_SEO_JS_Controller and AE_SEO_JS_Lazy for optional per-page auto-dequeue (beta), user-intent triggers, consent gating, per-module toggles, lazy loading, script replacements, handle allow/deny lists, a Script Usage admin page for acceptance scenarios, and performance gains such as idle analytics and sub-200 ms reCAPTCHA on form focus
 * Option to load jQuery only when required with URL-based overrides and debug logging; pages with Elementor or other jQuery-dependent assets still enqueue it
 * DOM replacements via the `ae_seo/js/replacements` filter and bundled `vanilla-helpers.js` helpers
+* Hashed build pipeline with `ae_seo_register_asset` helper and debug sourcemaps
+* Tools → Server Hints page with one-click `.htaccess` writer and diagnostic REST endpoint
 
 == Installation ==
 1. Upload the plugin files to the `/wp-content/plugins/gm2-wordpress-suite` directory.
@@ -65,7 +67,7 @@ archive with `bash bin/build-plugin.sh`. This command packages the plugin with
 all dependencies into `gm2-wordpress-suite.zip` for installation via the
 **Plugins → Add New** screen.
 
-Front‑end scripts are built with **esbuild** using page‑scoped entry points. Run `npm run build:assets` to produce modern ESM and optional legacy bundles alongside a `polyfills.js` loader that only runs when `needPolyfills()` detects missing browser features.
+Front‑end scripts are built with **esbuild** using page‑scoped entry points and a hashed build pipeline. Run `npm run build:assets` to produce modern ESM and optional legacy bundles with hash-mapped filenames alongside a `polyfills.js` loader. Enqueue the generated files with `ae_seo_register_asset` which reads the latest hash. When `SCRIPT_DEBUG` is enabled the build emits sourcemaps for easier debugging.
 == Setup Wizard ==
 After activation the **Gm2 Setup Wizard** (`index.php?page=gm2-setup-wizard`) opens once to walk through entering your AI provider API key, Google OAuth credentials, sitemap settings and which modules to enable. The wizard is optional and can be launched again from the **Gm2 Suite** dashboard at any time.
 
@@ -101,6 +103,11 @@ curl -I https://example.com/wp-includes/js/jquery/jquery.min.js
 
 Verify the `Cache-Control` header and, for repeat-view testing, keep **Disable cache**
 unchecked in DevTools, hard reload the page and confirm the file loads from disk cache.
+
+== Server Hints ==
+Open **Tools → Server Hints** to inspect how static assets are delivered. The page lists hashed files with their minification, compression and cache headers. A one-click button writes caching rules into `.htaccess` on Apache or LiteSpeed, and the same data is exposed via the `wp-json/ae-seo/v1/server-hints` diagnostic REST endpoint.
+
+**Acceptance check:** hashed files should be minified, compressed and return long-cache headers.
 
 == Render Optimizer ==
 Enable performance modules from **SEO → Performance → Render Optimizer**. Available options include:


### PR DESCRIPTION
## Summary
- document hashed asset pipeline and `ae_seo_register_asset` helper along with debug sourcemaps and long-cache acceptance check
- explain Tools → Server Hints page, one-click `.htaccess` writer, and diagnostic REST endpoint

## Testing
- `npm test`
- `vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_68b86bada47c83279555b481ccc8f863