### PR TITLE
Add shared JS safe mode helper

### DIFF
--- a/includes/class-ae-seo-js-controller.php
+++ b/includes/class-ae-seo-js-controller.php
@@ -17,6 +17,9 @@ class AE_SEO_JS_Controller {
      * Bootstrap the controller.
      */
     public static function init(): void {
+        if (ae_seo_js_safe_mode()) {
+            return;
+        }
         add_action('wp_enqueue_scripts', [ __CLASS__, 'control_scripts' ], 999);
         add_action('wp_enqueue_scripts', [ __CLASS__, 'maybe_remove_jquery' ], 1000);
         add_filter('ae_seo/js/enqueue_decision', [ __CLASS__, 'allow_override' ], 5, 3);
@@ -81,6 +84,9 @@ class AE_SEO_JS_Controller {
      * Remove jQuery when no scripts depend on it.
      */
     public static function maybe_remove_jquery(): void {
+        if (ae_seo_js_safe_mode()) {
+            return;
+        }
         if (get_option('ae_js_jquery_on_demand', '0') !== '1') {
             return;
         }

--- a/includes/class-ae-seo-js-lazy.php
+++ b/includes/class-ae-seo-js-lazy.php
@@ -24,6 +24,9 @@ class AE_SEO_JS_Lazy {
      * Register and enqueue script with configuration.
      */
     public static function enqueue(): void {
+        if (ae_seo_js_safe_mode()) {
+            return;
+        }
         ae_seo_register_asset('ae-lazy', 'ae-lazy.js');
         $modules = [
             'recaptcha' => get_option('ae_lazy_recaptcha', '0') === '1',

--- a/includes/class-ae-seo-js-manager.php
+++ b/includes/class-ae-seo-js-manager.php
@@ -31,8 +31,9 @@ class AE_SEO_JS_Manager {
      * Bootstrap the manager.
      */
     public static function init(): void {
-        if (isset($_GET['aejs']) && $_GET['aejs'] === 'off') {
+        if (ae_seo_js_safe_mode()) {
             self::$disabled = true;
+            return;
         }
         (new self())->run();
     }

--- a/includes/functions-assets.php
+++ b/includes/functions-assets.php
@@ -49,3 +49,14 @@ if (!function_exists('ae_seo_register_asset')) {
         }
     }
 }
+
+if (!function_exists('ae_seo_js_safe_mode')) {
+    /**
+     * Determine if safe mode is enabled for JavaScript features.
+     *
+     * @return bool
+     */
+    function ae_seo_js_safe_mode(): bool {
+        return get_option('ae_js_respect_safe_mode') === '1' && (($_GET['aejs'] ?? '') === 'off');
+    }
+}


### PR DESCRIPTION
## Summary
- add `ae_seo_js_safe_mode()` helper for shared safe mode logic
- bail JS manager, controller, jQuery removal, and lazy loader when safe mode is active

## Testing
- `vendor/bin/phpunit` *(fails: missing WordPress test library)*
- `npm test` *(fails: jest not installed due to dependency resolution)*

------
https://chatgpt.com/codex/tasks/task_e_68b873f5670083278b31b7908a924e74