### PR TITLE
feat: add console logging for JS optimizer

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -63,6 +63,7 @@ class Gm2_SEO_Admin {
         add_option('ae_js_consent_value', 'allow_analytics');
         add_option('ae_js_replacements', '0');
         add_option('ae_js_debug_log', '0');
+        add_option('ae_js_console_log', '0');
         add_option('ae_js_auto_dequeue', '0');
         add_option('ae_js_respect_safe_mode', '0');
         add_option('ae_js_nomodule_legacy', '0');
@@ -602,6 +603,9 @@ class Gm2_SEO_Admin {
             'sanitize_callback' => 'sanitize_text_field',
         ]);
         register_setting('gm2_seo_options', 'ae_js_debug_log', [
+            'sanitize_callback' => 'sanitize_text_field',
+        ]);
+        register_setting('gm2_seo_options', 'ae_js_console_log', [
             'sanitize_callback' => 'sanitize_text_field',
         ]);
         register_setting('gm2_seo_options', 'ae_js_auto_dequeue', [
@@ -3066,6 +3070,9 @@ class Gm2_SEO_Admin {
 
         $debug = isset($_POST['ae_js_debug_log']) ? '1' : '0';
         update_option('ae_js_debug_log', $debug);
+
+        $console = isset($_POST['ae_js_console_log']) ? '1' : '0';
+        update_option('ae_js_console_log', $console);
 
         $auto = isset($_POST['ae_js_auto_dequeue']) ? '1' : '0';
         update_option('ae_js_auto_dequeue', $auto);

--- a/admin/views/settings-js-optimizer.php
+++ b/admin/views/settings-js-optimizer.php
@@ -14,6 +14,7 @@ $consent_key    = get_option('ae_js_consent_key', 'aeConsent');
 $consent_value  = get_option('ae_js_consent_value', 'allow_analytics');
 $replace       = get_option('ae_js_replacements', '0');
 $debug         = get_option('ae_js_debug_log', '0');
+$console       = get_option('ae_js_console_log', '0');
 $auto          = get_option('ae_js_auto_dequeue', '0');
 $safe_mode     = get_option('ae_js_respect_safe_mode', '0');
 $nomodule      = get_option('ae_js_nomodule_legacy', '0');
@@ -46,6 +47,7 @@ echo '<tr><th scope="row">' . esc_html__( 'Consent Mode key', 'gm2-wordpress-sui
 echo '<tr><th scope="row">' . esc_html__( 'Consent Mode value to watch', 'gm2-wordpress-suite' ) . '</th><td><input type="text" name="ae_js_consent_value" value="' . esc_attr($consent_value) . '" /><p class="description">' . esc_html__( 'Default value is allow_analytics', 'gm2-wordpress-suite' ) . '</p></td></tr>';
 echo '<tr><th scope="row">' . esc_html__( 'Enable Replacements', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_js_replacements" value="1" ' . checked($replace, '1', false) . ' /></td></tr>';
 echo '<tr><th scope="row">' . esc_html__( 'Debug Log', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_js_debug_log" value="1" ' . checked($debug, '1', false) . ' /></td></tr>';
+echo '<tr><th scope="row">' . esc_html__( 'Log to console in dev', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_js_console_log" value="1" ' . checked($console, '1', false) . ' /></td></tr>';
 echo '<tr><th scope="row">' . esc_html__( 'Enable Per-Page Auto-Dequeue (Beta)', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_js_auto_dequeue" value="1" ' . checked($auto, '1', false) . ' /></td></tr>';
 echo '<tr><th scope="row">' . esc_html__( 'Respect Safe Mode param', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_js_respect_safe_mode" value="1" ' . checked($safe_mode, '1', false) . ' /></td></tr>';
 echo '<tr><th scope="row">' . esc_html__( 'Send Legacy (nomodule) Bundle', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="ae_js_nomodule_legacy" value="1" ' . checked($nomodule, '1', false) . ' /><p class="description">' . esc_html__( 'Include an ES5 bundle for older browsers.', 'gm2-wordpress-suite' ) . '</p></td></tr>';

--- a/includes/class-ae-seo-js-manager.php
+++ b/includes/class-ae-seo-js-manager.php
@@ -193,6 +193,25 @@ class AE_SEO_JS_Manager {
  * @param string $message Log message.
  */
 function ae_seo_js_log(string $message): void {
+    static $messages = [];
+    static $hooked   = false;
+
+    if (get_option('ae_js_console_log', '0') === '1') {
+        $messages[] = $message;
+        if (!$hooked) {
+            add_action(
+                'wp_footer',
+                function () use (&$messages) {
+                    if (empty($messages)) {
+                        return;
+                    }
+                    echo '<script>(function(){var msgs=' . wp_json_encode($messages) . ';msgs.forEach(function(msg){console.info("[AE-SEO]", msg);});})();</script>';
+                }
+            );
+            $hooked = true;
+        }
+    }
+
     if (AE_SEO_JS_Manager::is_disabled() || get_option('ae_js_debug_log', '0') !== '1') {
         return;
     }


### PR DESCRIPTION
## Summary
- add `ae_js_console_log` option and admin UI for JS optimizer
- capture JS optimizer logs and optionally print to browser console

## Testing
- `npm test` *(fails: jest: not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b874c1d4fc83278f20cebea6e6cc6d