### PR TITLE
Track JS timing metrics in Server-Timing header

### DIFF
--- a/includes/class-ae-seo-diff-serving.php
+++ b/includes/class-ae-seo-diff-serving.php
@@ -9,6 +9,8 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+use Gm2\AE_SEO_JS_Manager;
+
 /**
  * Handle loading of modern/legacy bundles and polyfills.
  */
@@ -40,6 +42,7 @@ class AE_SEO_Main_Diff_Serving {
         if (ae_seo_needs_polyfills()) {
             ae_seo_register_asset('ae-polyfills', 'polyfills.js');
             wp_enqueue_script('ae-polyfills');
+            AE_SEO_JS_Manager::$polyfills++;
         }
 
         // Enqueue main scripts.

--- a/includes/class-ae-seo-js-controller.php
+++ b/includes/class-ae-seo-js-controller.php
@@ -51,6 +51,7 @@ class AE_SEO_JS_Controller {
                     continue;
                 }
                 wp_dequeue_script($handle);
+                AE_SEO_JS_Manager::$dequeued++;
                 $reason = in_array($handle, $context_scripts, true) ? 'filter' : 'context';
                 ae_seo_js_log('dequeue ' . $handle . ' (' . $reason . ') ' . $url);
             }
@@ -117,6 +118,7 @@ class AE_SEO_JS_Controller {
         if (!$needs_jquery) {
             wp_dequeue_script('jquery');
             wp_dequeue_script('jquery-migrate');
+            AE_SEO_JS_Manager::$jquery++;
             ae_seo_js_log('dequeue jquery (no-deps) ' . $url);
         }
     }


### PR DESCRIPTION
## Summary
- add static counters on `AE_SEO_JS_Manager` for dequeues, lazy loads, polyfills, and jQuery removal
- increment counters in script control, lazy load handling, polyfill gate, and jQuery removal
- emit `Server-Timing` header summarizing these counts

## Testing
- `npm test`
- `vendor/bin/phpunit` *(fails: requires wordpress tests library)*

------
https://chatgpt.com/codex/tasks/task_e_68b8758ead5c8327ba8ee3d5083dc762