### PR TITLE
Add helper to centralize lazy-load checks

### DIFF
--- a/includes/class-ae-seo-js-lazy.php
+++ b/includes/class-ae-seo-js-lazy.php
@@ -29,10 +29,10 @@ class AE_SEO_JS_Lazy {
         }
         ae_seo_register_asset('ae-lazy', 'ae-lazy.js');
         $modules = [
-            'recaptcha' => get_option('ae_lazy_recaptcha', '0') === '1',
-            'gtag'      => get_option('ae_lazy_gtag', '0') === '1',
-            'gtm'       => get_option('ae_lazy_gtm', '0') === '1',
-            'fbq'       => get_option('ae_lazy_fbq', '0') === '1',
+            'recaptcha' => ae_seo_should_lazy('recaptcha'),
+            'gtag'      => ae_seo_should_lazy('gtag'),
+            'gtm'       => ae_seo_should_lazy('gtm'),
+            'fbq'       => ae_seo_should_lazy('fbq'),
         ];
         $ids = [
             'recaptcha' => get_option('ae_recaptcha_site_key', ''),

--- a/includes/functions-assets.php
+++ b/includes/functions-assets.php
@@ -61,6 +61,30 @@ if (!function_exists('ae_seo_js_safe_mode')) {
     }
 }
 
+if (!function_exists('ae_seo_should_lazy')) {
+    /**
+     * Determine if a module should be lazy loaded.
+     *
+     * @param string $what Module identifier.
+     * @return bool
+     */
+    function ae_seo_should_lazy(string $what): bool {
+        if (ae_seo_js_safe_mode()) {
+            return false;
+        }
+
+        $lazy = get_option('ae_js_lazy_' . $what, '1') === '1';
+        /**
+         * Filter whether a module should be lazy loaded.
+         *
+         * @param bool   $lazy Whether the module should lazy load.
+         * @param string $what Module identifier.
+         */
+        $lazy = apply_filters('ae_seo/js/should_lazy_load', $lazy, $what, '');
+        return (bool) $lazy;
+    }
+}
+
 if (!function_exists('ae_seo_script_loader_tag')) {
     /**
      * Add module or nomodule attributes to AE scripts.


### PR DESCRIPTION
## Summary
- add `ae_seo_should_lazy()` helper that respects safe mode and filter
- use helper in `AE_SEO_JS_Lazy` when configuring module lazy-loading

## Testing
- `npm test`
- `vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*


------
https://chatgpt.com/codex/tasks/task_e_68b883c8d7008327a7b4a50352ebe5f4