### PR TITLE
chore: unify JS lazy option names

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,8 @@ AE_SEO_JS_Detector builds a transient map of registered scripts and records the 
 
 AE_SEO_JS_Lazy adds user-intent triggers and consent gating so modules load only when needed. New settings let you define scroll or input events that wake dormant modules, gate analytics behind consent or interaction, and toggle each module individually. Analytics stays idle until a visitor grants consent or interacts with the page, while reCAPTCHA loads only when a form field receives focus—typically in under 200&nbsp;ms.
 
+IDs for Google Analytics, Tag Manager and Facebook Pixel are stored in the unified options `ae_js_analytics_id`, `ae_js_gtm_id` and `ae_js_fb_id`.
+
 Settings live under **SEO → Performance → JavaScript** to enable the manager, lazy-loading, script replacements, debug logging and handle allow and deny lists. Enable **Respect Safe Mode param** to honour `?aejs=off` and temporarily disable the manager when troubleshooting. A **Load jQuery only when required** option removes jQuery when no enqueued scripts depend on it; pages using Elementor or other jQuery‑dependent assets still receive it automatically. Regex patterns in **Always include jQuery on these URLs** let you force jQuery on specific URLs.
 
 When **Debug Log** is enabled, script decisions are recorded in `wp-content/ae-seo/logs/js-optimizer.log`. Toggle **Log to console in dev** to echo the same messages in DevTools:

--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -33,6 +33,33 @@ class Gm2_SEO_Admin {
     private function infer_brand_name(int $post_id): string {
         return gm2_infer_brand_name($post_id);
     }
+
+    private function migrate_js_option_names(): void {
+        $map = [
+            'ae_gtag_id'        => 'ae_js_analytics_id',
+            'ae_gtm_id'         => 'ae_js_gtm_id',
+            'ae_fbq_id'         => 'ae_js_fb_id',
+            'ae_lazy_recaptcha' => 'ae_js_lazy_recaptcha',
+        ];
+        foreach ($map as $old => $new) {
+            $value = get_option($old, null);
+            if ($value !== null) {
+                update_option($new, $value);
+                delete_option($old);
+            }
+        }
+        $legacy = [
+            get_option('ae_lazy_gtag', null),
+            get_option('ae_lazy_gtm', null),
+            get_option('ae_lazy_fbq', null),
+        ];
+        if (in_array('1', $legacy, true)) {
+            update_option('ae_js_lazy_analytics', '1');
+        }
+        foreach (['ae_lazy_gtag', 'ae_lazy_gtm', 'ae_lazy_fbq'] as $old) {
+            delete_option($old);
+        }
+    }
     public function run() {
         add_option('ae_seo_ro_enable_critical_css', '0');
         add_option('ae_seo_ro_enable_defer_js', '0');
@@ -71,6 +98,8 @@ class Gm2_SEO_Admin {
         add_option('ae_js_dequeue_denylist', []);
         add_option('ae_js_jquery_on_demand', '0');
         add_option('ae_js_jquery_url_allow', '');
+
+        $this->migrate_js_option_names();
 
         add_action('admin_menu', [$this, 'add_settings_pages']);
         add_action('add_meta_boxes', [$this, 'register_meta_boxes']);

--- a/includes/class-ae-seo-js-lazy.php
+++ b/includes/class-ae-seo-js-lazy.php
@@ -30,15 +30,15 @@ class AE_SEO_JS_Lazy {
         ae_seo_register_asset('ae-lazy', 'ae-lazy.js');
         $modules = [
             'recaptcha' => ae_seo_should_lazy('recaptcha'),
-            'gtag'      => ae_seo_should_lazy('gtag'),
-            'gtm'       => ae_seo_should_lazy('gtm'),
-            'fbq'       => ae_seo_should_lazy('fbq'),
+            'gtag'      => ae_seo_should_lazy('analytics'),
+            'gtm'       => ae_seo_should_lazy('analytics'),
+            'fbq'       => ae_seo_should_lazy('analytics'),
         ];
         $ids = [
             'recaptcha' => get_option('ae_recaptcha_site_key', ''),
-            'gtag'      => get_option('ae_gtag_id', ''),
-            'gtm'       => get_option('ae_gtm_id', ''),
-            'fbq'       => get_option('ae_fbq_id', ''),
+            'gtag'      => get_option('ae_js_analytics_id', ''),
+            'gtm'       => get_option('ae_js_gtm_id', ''),
+            'fbq'       => get_option('ae_js_fb_id', ''),
         ];
         $consent = [
             'key'   => 'aeConsent',


### PR DESCRIPTION
## Summary
- align lazy loader with `ae_js_lazy_*` option names and unified analytics IDs
- migrate legacy option names to new equivalents
- document analytics ID option names

## Testing
- `npm test`
- `vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*


------
https://chatgpt.com/codex/tasks/task_e_68b887d4e8488327b28f009e7dc00c65