### PR TITLE
docs: document block script mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,7 +404,18 @@ reload, and confirm the file loads from disk cache.
 
 ## JavaScript Manager and Auto-Dequeue (Beta)
 
-AE_SEO_JS_Detector builds a transient map of registered scripts and records the page type, widgets and enqueued handles for each front-end request. AE_SEO_JS_Controller reads that context and dequeues scripts not seen for the current URL.
+AE_SEO_JS_Detector builds a transient map of registered scripts and records the page type, widgets and enqueued handles for each front-end request. When a post contains blocks, the detector walks the parsed structure, extracts block names and providers and maps them to related script handles. AE_SEO_JS_Controller reads that context and dequeues scripts not seen for the current URL.
+
+The block–to–script map is filterable via `ae_seo/js/block_scripts`, allowing custom modules to stay whitelisted. Return an array where the key is the block name (optionally suffixed with `/provider`) and the value is a list of handles to keep.
+
+Example: whitelist only the core `wp-embed` script and the plugin’s YouTube helper for the `core/embed` block:
+
+```php
+add_filter('ae_seo/js/block_scripts', function (array $map): array {
+    $map['core/embed/youtube'] = [ 'wp-embed', 'ae-youtube' ];
+    return $map;
+});
+```
 
 AE_SEO_JS_Lazy adds user-intent triggers and consent gating so modules load only when needed. New settings let you define scroll or input events that wake dormant modules, gate analytics behind consent or interaction, and toggle each module individually. Analytics stays idle until a visitor grants consent or interacts with the page, while reCAPTCHA loads only when a form field receives focus—typically in under 200&nbsp;ms.
 

--- a/readme.txt
+++ b/readme.txt
@@ -184,6 +184,17 @@ If WP Rocket, Autoptimize, Perfmatters or other optimizer plugins are active, th
 
 AE_SEO_JS_Detector builds a map of registered scripts and caches the page type, widgets and handles used on each request. AE_SEO_JS_Controller consults that context to dequeue handles that were not previously seen for the current URL.
 
+When blocks exist in the post content the detector parses them, detects providers for embeds and looks up related script handles from a block‑to‑script map. Developers can customize this map with the `ae_seo/js/block_scripts` filter. Return an array where keys are block names (optionally suffixed with `/provider`) and values are arrays of script handles to keep whitelisted.
+
+Example: only keep the core `wp-embed` script and the plugin’s YouTube helper for the `core/embed` block:
+
+```
+add_filter('ae_seo/js/block_scripts', function ( $map ) {
+    $map['core/embed/youtube'] = [ 'wp-embed', 'ae-youtube' ];
+    return $map;
+});
+```
+
 AE_SEO_JS_Lazy introduces user-intent triggers and consent gating so modules activate only when necessary. New per-module toggles let you specify scroll or input events that wake dormant scripts, gate analytics behind consent or interaction, and load reCAPTCHA only when a form field receives focus—usually in under 200 ms.
 
 Open **SEO → Performance → JavaScript** to enable the manager, lazy loading, script replacements, debug logging and an optional safe-mode query parameter. The screen also provides handle allow and deny lists and a per-page auto-dequeue option that is still in beta.


### PR DESCRIPTION
## Summary
- Document how AE_SEO_JS_Detector scans blocks and maps them to script handles
- Note the `ae_seo/js/block_scripts` filter for custom block-to-script mappings
- Provide `core/embed` YouTube example whitelisting `wp-embed` and provider scripts

## Testing
- `npm test`
- `vendor/bin/phpunit` *(fails: required WordPress test suite missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b8975a36188327bffeabf2378cc836