### PR TITLE
Add default JS compatibility allowlist with overrides

### DIFF
--- a/config/compat-defaults.php
+++ b/config/compat-defaults.php
@@ -1,0 +1,16 @@
+<?php
+return [
+    'elementor' => [
+        'elementor-frontend',
+    ],
+    'woocommerce' => [
+        'woocommerce',
+    ],
+    'contact-form-7' => [
+        'contact-form-7',
+    ],
+    'seo-by-rank-math' => [
+        'rank-math',
+        'rank-math-editor',
+    ],
+];


### PR DESCRIPTION
## Summary
- add config mapping plugin slugs to fragile script handles
- merge compatibility handles into AE_SEO_JS_Controller allowlist and honor ae_js_compat_overrides opt-outs

## Testing
- `npm test`
- `vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*


------
https://chatgpt.com/codex/tasks/task_e_68b899d48d8c832794f2be0e2cc6317b