### PR TITLE
Populate hero image dimensions from metadata

### DIFF
--- a/includes/class-ae-seo-lcp-image.php
+++ b/includes/class-ae-seo-lcp-image.php
@@ -100,6 +100,17 @@ class AE_SEO_LCP_Image {
                 if (!isset($attr['fetchpriority'])) {
                     $attr['fetchpriority'] = 'high';
                 }
+                if (empty($attr['width']) || empty($attr['height'])) {
+                    $meta = wp_get_attachment_metadata($attachment->ID);
+                    if (is_array($meta)) {
+                        if (empty($attr['width']) && ! empty($meta['width'])) {
+                            $attr['width'] = (string) $meta['width'];
+                        }
+                        if (empty($attr['height']) && ! empty($meta['height'])) {
+                            $attr['height'] = (string) $meta['height'];
+                        }
+                    }
+                }
                 self::$done = true;
             }
         }


### PR DESCRIPTION
## Summary
- detect missing hero image dimensions and populate them from `wp_get_attachment_metadata`

## Testing
- `vendor/bin/phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): Failed to open stream)*
- `npm test`

Prompt for Codex: Extend the LCP filter to derive width and height from attachment metadata when the hero image lacks those attributes.


------
https://chatgpt.com/codex/tasks/task_e_68b9bdfcf6e88327a625f82e42bef90e