### PR TITLE
Add LCP picture helper with WebP and AVIF sources

### DIFF
--- a/includes/class-ae-seo-lcp-image.php
+++ b/includes/class-ae-seo-lcp-image.php
@@ -47,6 +47,7 @@ class AE_SEO_LCP_Image {
     public static function init(): void {
         add_filter('wp_lazy_loading_enabled', [ __CLASS__, 'maybe_disable_lazy' ], 10, 3);
         add_filter('wp_get_attachment_image_attributes', [ __CLASS__, 'maybe_adjust_attributes' ], 10, 3);
+        add_filter('wp_get_attachment_image', [ __CLASS__, 'maybe_use_picture' ], 10, 5);
     }
 
     /**
@@ -115,6 +116,101 @@ class AE_SEO_LCP_Image {
             }
         }
         return $attr;
+    }
+
+    /**
+     * Convert the LCP image markup to use a <picture> element when possible.
+     *
+     * @param string       $html          Image markup.
+     * @param int          $attachment_id Attachment ID.
+     * @param string|int[] $size          Requested size.
+     * @param bool         $icon          Whether image is an icon.
+     * @param array|string $attr          Image attributes.
+     * @return string
+     */
+    public static function maybe_use_picture(string $html, $attachment_id, $size, $icon, $attr): string {
+        if (!self::is_lcp_image()) {
+            return $html;
+        }
+
+        if (function_exists('gm2_queue_image_optimization')) {
+            gm2_queue_image_optimization($attachment_id);
+        }
+
+        $srcset = wp_get_attachment_image_srcset($attachment_id, $size);
+        if (!$srcset) {
+            return $html;
+        }
+
+        $src = wp_get_attachment_image_url($attachment_id, $size);
+        if (!$src) {
+            return $html;
+        }
+
+        $ext = pathinfo($src, PATHINFO_EXTENSION);
+        if (!$ext) {
+            return $html;
+        }
+
+        $webp_srcset = self::convert_srcset_extension($srcset, $ext, 'webp');
+        $avif_srcset = self::convert_srcset_extension($srcset, $ext, 'avif');
+
+        if (!self::srcset_files_exist($webp_srcset) || !self::srcset_files_exist($avif_srcset)) {
+            return $html;
+        }
+
+        return sprintf(
+            '<picture><source type="image/avif" srcset="%s" /><source type="image/webp" srcset="%s" />%s</picture>',
+            esc_attr($avif_srcset),
+            esc_attr($webp_srcset),
+            $html
+        );
+    }
+
+    /**
+     * Swap the file extension for each item in a srcset string.
+     *
+     * @param string $srcset    Original srcset.
+     * @param string $from_ext  Extension to replace.
+     * @param string $to_ext    New extension.
+     * @return string
+     */
+    private static function convert_srcset_extension(string $srcset, string $from_ext, string $to_ext): string {
+        $sources   = array_map('trim', explode(',', $srcset));
+        $converted = [];
+        foreach ($sources as $source) {
+            if ($source === '') {
+                continue;
+            }
+            $parts      = preg_split('/\s+/', $source);
+            $url        = $parts[0];
+            $descriptor = $parts[1] ?? '';
+            $url        = preg_replace('/\.' . preg_quote($from_ext, '/') . '$/', '.' . $to_ext, $url);
+            $converted[] = trim($url . ' ' . $descriptor);
+        }
+        return implode(', ', $converted);
+    }
+
+    /**
+     * Verify that at least one file in a srcset exists on disk.
+     *
+     * @param string $srcset Srcset string.
+     * @return bool
+     */
+    private static function srcset_files_exist(string $srcset): bool {
+        $uploads = wp_get_upload_dir();
+        $sources = array_map('trim', explode(',', $srcset));
+        foreach ($sources as $source) {
+            if ($source === '') {
+                continue;
+            }
+            $url  = trim(explode(' ', $source)[0]);
+            $path = str_replace($uploads['baseurl'], $uploads['basedir'], $url);
+            if (file_exists($path)) {
+                return true;
+            }
+        }
+        return false;
     }
 }
 


### PR DESCRIPTION
## Summary
- Wrap the LCP image in a `<picture>` element when WebP and AVIF variants exist
- Queue image optimization for LCP image to ensure alternate formats are generated
- Utility helpers for srcset conversion and verification

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: ERESOLVE could not resolve dependencies)*
- `phpunit` *(fails: Missing /tmp/wordpress-tests-lib)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bf23a41083279c4b92b12ea9068a