### PR TITLE
Add AESEO LCP optimizer boot loader

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -117,6 +117,7 @@ require_once GM2_PLUGIN_DIR . 'includes/render-optimizer/class-ae-seo-render-opt
 require_once GM2_PLUGIN_DIR . 'includes/Versioning_MTime.php';
 require_once GM2_PLUGIN_DIR . 'admin/class-ae-seo-debug-logs-admin.php';
 require_once GM2_PLUGIN_DIR . 'admin/class-ae-seo-server-hints.php';
+require_once GM2_PLUGIN_DIR . 'includes/class-aeseo-plugin.php';
 
 \Gm2\Gm2_REST_Visibility::init();
 \Gm2\Gm2_REST_Rate_Limiter::init();
@@ -135,6 +136,7 @@ require_once GM2_PLUGIN_DIR . 'admin/class-ae-seo-server-hints.php';
 \Gm2\Versioning_MTime::init();
 (new \Gm2\AE_SEO_Debug_Logs_Admin())->run();
 (new \Gm2\AE_SEO_Server_Hints())->run();
+\Gm2\AESEO_Plugin::init();
 if (get_option('gm2_pretty_versioned_urls', '0') === '1') {
     \Gm2\Gm2_Version_Route_Apache::maybe_apply();
 }

--- a/includes/class-aeseo-plugin.php
+++ b/includes/class-aeseo-plugin.php
@@ -1,0 +1,27 @@
+<?php
+namespace Gm2;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (class_exists(__NAMESPACE__ . '\\AESEO_Plugin')) {
+    return;
+}
+
+/**
+ * Loader for AESEO features.
+ */
+final class AESEO_Plugin {
+    /**
+     * Initialize the plugin components.
+     */
+    public static function init(): void {
+        if (is_admin() || is_feed() || defined('REST_REQUEST')) {
+            return;
+        }
+
+        require_once __DIR__ . '/class-aeseo-lcp-optimizer.php';
+        AESEO_LCP_Optimizer::boot();
+    }
+}


### PR DESCRIPTION
## Summary
- load LCP optimizer when running on the frontend and not in feeds or REST requests
- initialize optimizer via new AESEO_Plugin loader

## Testing
- `vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9c9cca5408327be4c7ae19f22d714