### PR TITLE
Improve LCP candidate detection and caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ When the **Enable Replacements** option is active (`ae_js_replacements`), front�
 
 Improve Largest Contentful Paint by enabling targeted tweaks in **SEO → Performance → LCP Optimization**. The module runs entirely on the front end and is compatible with PHP 7.4+ and WordPress 5.8+.
 
-LCP candidates are detected by preferring the featured image on singular pages, falling back to the first image in rendered content and supporting WooCommerce product images. Results are cached briefly to avoid repeated parsing.
+LCP candidates are detected by preferring the featured image on singular pages, falling back to the first image in rendered content and supporting WooCommerce product images. Detection runs automatically when `get_lcp_candidate()` is called and results are cached for a minute to avoid repeated parsing.
 
 Configuration options include:
 

--- a/readme.txt
+++ b/readme.txt
@@ -42,7 +42,7 @@ Key features include:
 == LCP Optimization ==
 Improve Largest Contentful Paint with targeted tweaks under **SEO → Performance → LCP Optimization**. The module operates solely on the front end and supports PHP 7.4+ and WordPress 5.8+.
 
-LCP candidates are detected by preferring the featured image on singular pages, falling back to the first image in content and handling WooCommerce product images. Results are cached briefly to avoid repeated parsing.
+LCP candidates are detected by preferring the featured image on singular pages, falling back to the first image in content and handling WooCommerce product images. The lookup runs automatically when `get_lcp_candidate()` is used and results are cached for sixty seconds to avoid repeated parsing.
 
 Configuration options:
 


### PR DESCRIPTION
## Summary
- Enhance LCP candidate lookup to auto-prime from cache, featured image, or parsed content on demand
- Fill missing dimensions for detected images from attachment metadata
- Document automatic LCP detection and caching in readme files

## Testing
- `~/.local/share/mise/installs/php/8.4.12/.composer/vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9cfbe522083279388894271d63bdb