### PR TITLE
docs: document LCP lazy-load exemption

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Configuration options include:
 
 Each option can be toggled individually to tailor optimization for specific themes and content.
 
+The detected LCP image bypasses WordPress's lazy-loading and is flagged with `data-aeseo-lcp="1"`. A `wp_img_tag_add_loading_attr` safeguard preserves WooCommerce compatibility when altering the `loading` attribute.
+
 ## AI Providers
 
 The suite can generate content using multiple AI services. Select **ChatGPT**, **Gemma**, or **Llama** from the **Gm2 → AI Settings** page and enter the corresponding API key and optional endpoint. The chosen provider is used throughout the plugin for AI-powered features.

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Gm2 WordPress Suite
  * Description:       A powerful suite of tools and features for WordPress, by Gm2.
- * Version:           1.6.22
+ * Version:           1.6.23
  * Author:            Your Name or Team Gm2
  * Author URI:        https://yourwebsite.com
  * License:           GPL-2.0+
@@ -15,7 +15,7 @@
 defined('ABSPATH') or die('No script kiddies please!');
 
 // Define constants
-define('GM2_VERSION', '1.6.22');
+define('GM2_VERSION', '1.6.23');
 define('GM2_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('GM2_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('GM2_CHATGPT_LOG_FILE', GM2_PLUGIN_DIR . 'chatgpt.log');

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: gm2team
 Tags: admin, tools, suite, performance
 Requires at least: 6.0
 Tested up to: 6.5
-Stable tag: 1.6.22
+Stable tag: 1.6.23
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -54,6 +54,8 @@ Configuration options:
 * `add_preload` – preload the LCP image or font for immediate fetching.
 
 Each option can be enabled independently to match theme requirements.
+
+The identified LCP image bypasses lazy-loading and carries a `data-aeseo-lcp="1"` marker. A `wp_img_tag_add_loading_attr` safeguard maintains compatibility with WooCommerce when modifying the `loading` attribute.
 
 == Installation ==
 1. Upload the plugin files to the `/wp-content/plugins/gm2-wordpress-suite` directory.
@@ -583,6 +585,8 @@ the last 100 missing URLs to help you create new redirects.
 * **Real-time character counts** – display running totals in the SEO meta box.
 
 == Changelog ==
+= 1.6.23 =
+* Exempted the LCP image from lazy-loading via `data-aeseo-lcp="1"` and added a `wp_img_tag_add_loading_attr` safeguard for WooCommerce compatibility.
 = 1.6.22 =
 * Improved LCP candidate detection for featured images, first content images and WooCommerce products with short-term caching.
 = 1.6.21 =


### PR DESCRIPTION
## Summary
- document that the LCP image skips lazy-loading via `data-aeseo-lcp="1"`
- note WooCommerce compatibility with `wp_img_tag_add_loading_attr`
- bump to version 1.6.23 and add changelog entry

## Testing
- `npm test` *(fails: jest not found)*
- `phpunit` *(fails: command not found)*
- `make test` *(fails: missing separator)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e72b9ecc8327bd286e414a048b41