### PR TITLE
docs: document intrinsic dimension handling in LCP optimizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,13 @@ Improve Largest Contentful Paint by enabling targeted tweaks in **SEO → Perfor
 
 LCP candidates are detected by preferring the featured image on singular pages, falling back to the first image in rendered content and supporting WooCommerce product images. Detection runs automatically when `get_lcp_candidate()` is called and results are cached for a minute to avoid repeated parsing.
 
+When a candidate lacks dimension metadata, the optimizer fetches its intrinsic width and height—falling back to PHP's `getimagesize()`—and injects the attributes to prevent Cumulative Layout Shift.
+
 Configuration options include:
 
 - `remove_lazy_on_lcp` – strips lazy‑loading from the element identified as the LCP candidate.
 - `add_fetchpriority_high` – adds `fetchpriority="high"` to the LCP resource so browsers request it sooner. Existing `the_content` and block output is scanned to insert the attribute when missing.
-- `force_width_height` – injects missing width and height attributes to avoid layout shifts.
+- `force_width_height` – fetches intrinsic dimensions (using `getimagesize()` if metadata is absent) and injects width and height attributes to avoid layout shifts.
 - `responsive_picture_nextgen` – converts `<img>` tags to responsive `<picture>` markup with modern formats when possible.
 - `add_preconnect` – outputs `preconnect` hints for the LCP host.
 - `add_preload` – preloads the LCP image or font so it starts downloading immediately.

--- a/readme.txt
+++ b/readme.txt
@@ -44,11 +44,13 @@ Improve Largest Contentful Paint with targeted tweaks under **SEO → Performanc
 
 LCP candidates are detected by preferring the featured image on singular pages, falling back to the first image in content and handling WooCommerce product images. The lookup runs automatically when `get_lcp_candidate()` is used and results are cached for sixty seconds to avoid repeated parsing.
 
+If a candidate is missing dimension metadata, the optimizer retrieves intrinsic width and height—using PHP's `getimagesize()` as a fallback—and injects the attributes to prevent Cumulative Layout Shift.
+
 Configuration options:
 
 * `remove_lazy_on_lcp` – remove lazy-loading from the element identified as the LCP candidate.
 * `add_fetchpriority_high` – add `fetchpriority="high"` so the browser requests the LCP resource sooner. Existing markup in `the_content` or block output is scanned to ensure the attribute is present.
-* `force_width_height` – inject missing width and height attributes to prevent layout shifts.
+* `force_width_height` – fetch intrinsic dimensions (using `getimagesize()` if metadata is absent) and inject width and height attributes to prevent layout shifts.
 * `responsive_picture_nextgen` – convert images to responsive `<picture>` markup with next‑generation formats when possible.
 * `add_preconnect` – output `preconnect` hints for the LCP host.
 * `add_preload` – preload the LCP image or font for immediate fetching.
@@ -587,6 +589,7 @@ the last 100 missing URLs to help you create new redirects.
 == Changelog ==
 = 1.6.24 =
 * Added `fetchpriority="high"` to the detected LCP image in rendered content and WooCommerce markup.
+* `force_width_height` now fetches intrinsic image dimensions (using `getimagesize()` when metadata is absent) and injects `width`/`height` attributes to prevent CLS.
 = 1.6.23 =
 * Exempted the LCP image from lazy-loading via `data-aeseo-lcp="1"` and added a `wp_img_tag_add_loading_attr` safeguard for WooCommerce compatibility.
 = 1.6.22 =


### PR DESCRIPTION
## Summary
- clarify that LCP optimizer fetches intrinsic image dimensions, falling back to `getimagesize()`
- note width/height injection to avoid CLS and add changelog entry

## Testing
- `npm test`
- `./vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*


------
https://chatgpt.com/codex/tasks/task_e_68b9f7c266988327aebd8ae6d89b8a1c