### PR TITLE
Add responsive picture markup with AVIF/WebP for LCP image

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Configuration options include:
 - `remove_lazy_on_lcp` – strips lazy‑loading from the element identified as the LCP candidate.
 - `add_fetchpriority_high` – adds `fetchpriority="high"` to the LCP resource so browsers request it sooner. Existing `the_content` and block output is scanned to insert the attribute when missing.
 - `force_width_height` – fetches intrinsic dimensions (using `getimagesize()` if metadata is absent) and injects width and height attributes to avoid layout shifts.
-- `responsive_picture_nextgen` – converts `<img>` tags to responsive `<picture>` markup with modern formats when possible.
+- `responsive_picture_nextgen` – converts the LCP image to a responsive `<picture>` with AVIF/WebP sources and full `srcset`/`sizes` when supported.
 - `add_preconnect` – outputs `preconnect` hints for the LCP host.
 - `add_preload` – preloads the LCP image or font so it starts downloading immediately.
 

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Gm2 WordPress Suite
  * Description:       A powerful suite of tools and features for WordPress, by Gm2.
- * Version:           1.6.24
+ * Version:           1.6.25
  * Author:            Your Name or Team Gm2
  * Author URI:        https://yourwebsite.com
  * License:           GPL-2.0+
@@ -15,7 +15,7 @@
 defined('ABSPATH') or die('No script kiddies please!');
 
 // Define constants
-define('GM2_VERSION', '1.6.24');
+define('GM2_VERSION', '1.6.25');
 define('GM2_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('GM2_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('GM2_CHATGPT_LOG_FILE', GM2_PLUGIN_DIR . 'chatgpt.log');

--- a/includes/class-ae-seo-lcp-image.php
+++ b/includes/class-ae-seo-lcp-image.php
@@ -186,6 +186,10 @@ class AE_SEO_LCP_Image {
             return $html;
         }
 
+        if (stripos($html, '<source') !== false && (stripos($html, 'image/avif') !== false || stripos($html, 'image/webp') !== false)) {
+            return $html;
+        }
+
         if (function_exists('gm2_queue_image_optimization')) {
             gm2_queue_image_optimization($attachment_id);
         }
@@ -205,19 +209,49 @@ class AE_SEO_LCP_Image {
             return $html;
         }
 
-        $webp_srcset = self::convert_srcset_extension($srcset, $ext, 'webp');
-        $avif_srcset = self::convert_srcset_extension($srcset, $ext, 'avif');
-
-        if (!self::srcset_files_exist($webp_srcset) || !self::srcset_files_exist($avif_srcset)) {
-            return $html;
+        $sizes_attr = wp_get_attachment_image_sizes($attachment_id, $size);
+        if (!$sizes_attr) {
+            $sizes_attr = '(max-width: 768px) 100vw, 1200px';
         }
 
-        return sprintf(
-            '<picture><source type="image/avif" srcset="%s" /><source type="image/webp" srcset="%s" />%s</picture>',
-            esc_attr($avif_srcset),
-            esc_attr($webp_srcset),
-            $html
-        );
+        $img_tag = $html;
+        if (preg_match('/<img[^>]*>/i', $html, $m)) {
+            $img_tag = $m[0];
+            if (strpos($img_tag, ' srcset=') !== false) {
+                $img_tag = preg_replace('/srcset="[^"]*"/', 'srcset="' . esc_attr($srcset) . '"', $img_tag);
+            } else {
+                $img_tag = preg_replace('/<img/', '<img srcset="' . esc_attr($srcset) . '"', $img_tag, 1);
+            }
+            if (strpos($img_tag, ' sizes=') !== false) {
+                $img_tag = preg_replace('/sizes="[^"]*"/', 'sizes="' . esc_attr($sizes_attr) . '"', $img_tag);
+            } else {
+                $img_tag = preg_replace('/<img/', '<img sizes="' . esc_attr($sizes_attr) . '"', $img_tag, 1);
+            }
+        }
+
+        $sources = '';
+
+        if (wp_image_editor_supports(['mime_type' => 'image/avif'])) {
+            self::maybe_generate_nextgen_files($attachment_id, 'avif');
+            $avif_srcset = self::convert_srcset_extension($srcset, $ext, 'avif');
+            if (self::srcset_files_exist($avif_srcset)) {
+                $sources .= sprintf('<source type="image/avif" srcset="%s" sizes="%s" />', esc_attr($avif_srcset), esc_attr($sizes_attr));
+            }
+        }
+
+        if (wp_image_editor_supports(['mime_type' => 'image/webp'])) {
+            self::maybe_generate_nextgen_files($attachment_id, 'webp');
+            $webp_srcset = self::convert_srcset_extension($srcset, $ext, 'webp');
+            if (self::srcset_files_exist($webp_srcset)) {
+                $sources .= sprintf('<source type="image/webp" srcset="%s" sizes="%s" />', esc_attr($webp_srcset), esc_attr($sizes_attr));
+            }
+        }
+
+        if ($sources === '') {
+            return $img_tag;
+        }
+
+        return '<picture>' . $sources . $img_tag . '</picture>';
     }
 
     /**
@@ -264,6 +298,54 @@ class AE_SEO_LCP_Image {
             }
         }
         return false;
+    }
+
+    /**
+     * Generate next-gen images for the attachment if missing.
+     *
+     * @param int    $attachment_id Attachment ID.
+     * @param string $ext           Extension to generate.
+     */
+    private static function maybe_generate_nextgen_files(int $attachment_id, string $ext): void {
+        if (!in_array($ext, [ 'webp', 'avif' ], true)) {
+            return;
+        }
+
+        $mime = 'image/' . $ext;
+        if (!wp_image_editor_supports([ 'mime_type' => $mime ])) {
+            return;
+        }
+
+        $meta = wp_get_attachment_metadata($attachment_id);
+        if (!is_array($meta) || empty($meta['file'])) {
+            return;
+        }
+
+        $uploads = wp_get_upload_dir();
+        $base    = trailingslashit($uploads['basedir']) . trailingslashit(dirname($meta['file']));
+        $files   = [ $meta['file'] ];
+        if (!empty($meta['sizes']) && is_array($meta['sizes'])) {
+            foreach ($meta['sizes'] as $data) {
+                if (!empty($data['file'])) {
+                    $files[] = $data['file'];
+                }
+            }
+        }
+
+        foreach ($files as $file) {
+            $src_file  = $base . $file;
+            $dest_file = preg_replace('/\.[^.]+$/', '.' . $ext, $src_file);
+            if (!file_exists($src_file) || file_exists($dest_file)) {
+                continue;
+            }
+
+            $editor = wp_get_image_editor($src_file);
+            if (is_wp_error($editor)) {
+                continue;
+            }
+
+            $editor->save($dest_file, $mime);
+        }
     }
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: gm2team
 Tags: admin, tools, suite, performance
 Requires at least: 6.0
 Tested up to: 6.5
-Stable tag: 1.6.24
+Stable tag: 1.6.25
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -51,7 +51,7 @@ Configuration options:
 * `remove_lazy_on_lcp` – remove lazy-loading from the element identified as the LCP candidate.
 * `add_fetchpriority_high` – add `fetchpriority="high"` so the browser requests the LCP resource sooner. Existing markup in `the_content` or block output is scanned to ensure the attribute is present.
 * `force_width_height` – fetch intrinsic dimensions (using `getimagesize()` if metadata is absent) and inject width and height attributes to prevent layout shifts.
-* `responsive_picture_nextgen` – convert images to responsive `<picture>` markup with next‑generation formats when possible.
+* `responsive_picture_nextgen` – convert the LCP image to a responsive `<picture>` with AVIF/WebP sources and full `srcset`/`sizes` when supported.
 * `add_preconnect` – output `preconnect` hints for the LCP host.
 * `add_preload` – preload the LCP image or font for immediate fetching.
 
@@ -587,6 +587,8 @@ the last 100 missing URLs to help you create new redirects.
 * **Real-time character counts** – display running totals in the SEO meta box.
 
 == Changelog ==
+= 1.6.25 =
+* LCP Optimization now generates AVIF/WebP sources with responsive `srcset`/`sizes` for the LCP image and skips themes that already output next-gen `<picture>` markup.
 = 1.6.24 =
 * Added `fetchpriority="high"` to the detected LCP image in rendered content and WooCommerce markup.
 * `force_width_height` now fetches intrinsic image dimensions (using `getimagesize()` when metadata is absent) and injects `width`/`height` attributes to prevent CLS.


### PR DESCRIPTION
## Summary
- Generate AVIF and WebP versions of the LCP image and build a responsive `<picture>` with srcset/sizes
- Skip conversion when themes already provide next-gen sources and preserve original image attributes
- Document new LCP optimization capability and bump plugin version

## Testing
- `npm test` *(fails: jest: not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f8f8f1a4832782cd86edbf5be4cb