### PR TITLE
Add script audit admin page and third-party script control

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -493,6 +493,15 @@ class Gm2_SEO_Admin {
         );
 
         add_submenu_page(
+            'gm2-seo',
+            esc_html__( 'Script Audit', 'gm2-wordpress-suite' ),
+            esc_html__( 'Script Audit', 'gm2-wordpress-suite' ),
+            'manage_options',
+            'gm2-script-audit',
+            [ $this, 'display_script_audit_page' ]
+        );
+
+        add_submenu_page(
             'gm2-ai',
             esc_html__( 'Bulk AI Review', 'gm2-wordpress-suite' ),
             esc_html__( 'Bulk AI Review', 'gm2-wordpress-suite' ),
@@ -6908,6 +6917,10 @@ class Gm2_SEO_Admin {
         echo '</tbody></table>';
         submit_button();
         echo '</form></div>';
+    }
+
+    public function display_script_audit_page() {
+        require GM2_PLUGIN_DIR . 'admin/views/third-party-audit.php';
     }
 
     public function cron_process_ai_tax_queue() {

--- a/admin/views/third-party-audit.php
+++ b/admin/views/third-party-audit.php
@@ -1,0 +1,79 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$scripts = wp_scripts();
+$handles = $scripts ? $scripts->queue : [];
+$disabled = get_option('gm2_third_party_disabled', []);
+if (!is_array($disabled)) {
+    $disabled = [];
+}
+
+if (isset($_POST['gm2_tpa_nonce']) && wp_verify_nonce($_POST['gm2_tpa_nonce'], 'gm2_tpa_save')) {
+    $new_disabled = [];
+    foreach ($handles as $h) {
+        if (!isset($_POST['allowed'][$h])) {
+            $new_disabled[] = $h;
+        }
+    }
+    update_option('gm2_third_party_disabled', $new_disabled);
+    $disabled = $new_disabled;
+    echo '<div class="updated notice"><p>' . esc_html__( 'Settings saved.', 'gm2-wordpress-suite' ) . '</p></div>';
+}
+
+echo '<div class="wrap"><h1>' . esc_html__( 'Script Audit', 'gm2-wordpress-suite' ) . '</h1>';
+
+if ($handles) {
+    echo '<form method="post">';
+    wp_nonce_field('gm2_tpa_save', 'gm2_tpa_nonce');
+    echo '<table class="widefat fixed"><thead><tr>';
+    echo '<th>' . esc_html__( 'Handle', 'gm2-wordpress-suite' ) . '</th>';
+    echo '<th>' . esc_html__( 'Domain', 'gm2-wordpress-suite' ) . '</th>';
+    echo '<th>' . esc_html__( 'Size (KB)', 'gm2-wordpress-suite' ) . '</th>';
+    echo '<th>' . esc_html__( 'Enabled', 'gm2-wordpress-suite' ) . '</th>';
+    echo '</tr></thead><tbody>';
+    foreach ($handles as $handle) {
+        $reg = $scripts->registered[$handle] ?? null;
+        if (!$reg) {
+            continue;
+        }
+        $src = $reg->src;
+        if ($src && !preg_match('#^https?://#', $src)) {
+            $src = site_url($src);
+        }
+        $domain = $src ? (parse_url($src, PHP_URL_HOST) ?: '') : '';
+        $size = 0;
+        if ($src) {
+            $url = $src;
+            if (strpos($url, home_url()) === 0) {
+                $path = ABSPATH . ltrim(parse_url($url, PHP_URL_PATH), '/');
+                if (file_exists($path)) {
+                    $size = filesize($path);
+                }
+            } else {
+                $response = wp_remote_head($url);
+                if (!is_wp_error($response)) {
+                    $len = wp_remote_retrieve_header($response, 'content-length');
+                    if ($len) {
+                        $size = (int) $len;
+                    }
+                }
+            }
+        }
+        $size = $size > 0 ? round($size / 1024, 1) : '';
+        echo '<tr>';
+        echo '<td>' . esc_html($handle) . '</td>';
+        echo '<td>' . esc_html($domain) . '</td>';
+        echo '<td>' . esc_html($size) . '</td>';
+        echo '<td><input type="checkbox" name="allowed[' . esc_attr($handle) . ']" value="1"' . checked(!in_array($handle, $disabled, true), true, false) . '></td>';
+        echo '</tr>';
+    }
+    echo '</tbody></table>';
+    submit_button();
+    echo '</form>';
+} else {
+    echo '<p>' . esc_html__( 'No scripts detected.', 'gm2-wordpress-suite' ) . '</p>';
+}
+
+echo '</div>';

--- a/tests/test-third-party-filter.php
+++ b/tests/test-third-party-filter.php
@@ -1,0 +1,20 @@
+<?php
+require_once __DIR__ . '/../includes/class-ae-seo-js-manager.php';
+
+class ThirdPartyFilterTest extends WP_UnitTestCase {
+    protected function tearDown(): void {
+        wp_dequeue_script('gm2-foo');
+        wp_deregister_script('gm2-foo');
+        delete_option('gm2_third_party_disabled');
+        parent::tearDown();
+    }
+
+    public function test_disabled_handle_is_dequeued() {
+        update_option('gm2_third_party_disabled', ['gm2-foo']);
+        add_filter('gm2_third_party_allowed', ['\\Gm2\\AE_SEO_JS_Manager', 'filter_disabled'], 10, 2);
+        wp_register_script('gm2-foo', 'https://example.com/foo.js', [], null);
+        wp_enqueue_script('gm2-foo');
+        \Gm2\AE_SEO_JS_Manager::audit_third_party();
+        $this->assertFalse(wp_script_is('gm2-foo', 'enqueued'));
+    }
+}


### PR DESCRIPTION
## Summary
- Add Script Audit admin page listing enqueued scripts with domain, size, and enable toggles
- Register Script Audit submenu in Gm2_SEO_Admin
- Enforce third-party script allowlist via `gm2_third_party_allowed` filter and audit logic

## Testing
- `npm test`
- `vendor/bin/phpunit` *(fails: Connection refused – database server not running)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fb3af10c8327b2dabc242e3c0efd