### PR TITLE
Add LCP preconnect and preload hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Configuration options include:
 - `add_fetchpriority_high` – adds `fetchpriority="high"` to the LCP resource so browsers request it sooner. Existing `the_content` and block output is scanned to insert the attribute when missing.
 - `force_width_height` – fetches intrinsic dimensions (using `getimagesize()` if metadata is absent) and injects width and height attributes to avoid layout shifts.
 - `responsive_picture_nextgen` – converts the LCP image to a responsive `<picture>` with AVIF/WebP sources and full `srcset`/`sizes` when supported.
-- `add_preconnect` – outputs `preconnect` hints for the LCP host.
-- `add_preload` – preloads the LCP image or font so it starts downloading immediately.
+- `add_preconnect` – adds a `wp_resource_hints` preconnect for the LCP image's origin.
+- `add_preload` – preloads the LCP image via `<link rel="preload" as="image">` with `fetchpriority="high"` and passes through `imagesrcset`/`imagesizes` when available.
 
 Each option can be toggled individually to tailor optimization for specific themes and content.
 

--- a/readme.txt
+++ b/readme.txt
@@ -70,8 +70,8 @@ Configuration options:
 * `add_fetchpriority_high` – add `fetchpriority="high"` so the browser requests the LCP resource sooner. Existing markup in `the_content` or block output is scanned to ensure the attribute is present.
 * `force_width_height` – fetch intrinsic dimensions (using `getimagesize()` if metadata is absent) and inject width and height attributes to prevent layout shifts.
 * `responsive_picture_nextgen` – convert the LCP image to a responsive `<picture>` with AVIF/WebP sources and full `srcset`/`sizes` when supported.
-* `add_preconnect` – output `preconnect` hints for the LCP host.
-* `add_preload` – preload the LCP image or font for immediate fetching.
+* `add_preconnect` – add a `wp_resource_hints` preconnect for the LCP image's origin.
+* `add_preload` – preload the LCP image with `<link rel="preload" as="image" fetchpriority="high">` and include `imagesrcset`/`imagesizes` when available.
 
 Each option can be enabled independently to match theme requirements.
 

--- a/tests/LcpOptimizerIntegrationTest.php
+++ b/tests/LcpOptimizerIntegrationTest.php
@@ -46,11 +46,13 @@ class LcpOptimizerIntegrationTest extends WP_UnitTestCase {
         $class = AESEO_LCP_Optimizer::class;
         $reflect = new ReflectionClass($class);
         $props = [
-            'settings'      => $settings === null ? $defaults : $settings,
-            'candidate'     => [],
-            'current_image' => [],
-            'done'          => false,
-            'optimized'     => [],
+            'settings'        => $settings === null ? $defaults : $settings,
+            'candidate'       => [],
+            'current_image'   => [],
+            'done'            => false,
+            'optimized'       => [],
+            'preconnect_added' => false,
+            'preload_printed'  => false,
         ];
         foreach ($props as $name => $value) {
             $prop = $reflect->getProperty($name);
@@ -84,7 +86,8 @@ class LcpOptimizerIntegrationTest extends WP_UnitTestCase {
         remove_filter('wp_lazy_loading_enabled', [ AESEO_LCP_Optimizer::class, 'maybe_disable_lazy' ], 10);
         remove_filter('wp_get_attachment_image_attributes', [ AESEO_LCP_Optimizer::class, 'maybe_adjust_attributes' ], 10);
         remove_filter('wp_get_attachment_image', [ AESEO_LCP_Optimizer::class, 'maybe_use_picture' ], 10);
-        remove_action('wp_head', [ AESEO_LCP_Optimizer::class, 'maybe_print_links' ], 5);
+        remove_action('wp_head', [ AESEO_LCP_Optimizer::class, 'maybe_print_preload' ], 5);
+        remove_filter('wp_resource_hints', [ AESEO_LCP_Optimizer::class, 'maybe_add_preconnect' ], 10);
     }
 
     /**


### PR DESCRIPTION
## Summary
- add `wp_resource_hints` filter to preconnect LCP image origin
- preload LCP image with srcset/sizes and fetchpriority high
- document LCP preconnect/preload improvements

## Testing
- `npm test` *(fails: jest not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68baf8c5b108832789d32e6a8cf981dd