### PR TITLE
feat: preload hero background images

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ When the **Enable Replacements** option is active (`ae_js_replacements`), front�
 
 Improve Largest Contentful Paint by enabling targeted tweaks in **SEO → Performance → LCP Optimization**. The module runs entirely on the front end and is compatible with PHP 7.4+ and WordPress 5.8+.
 
-LCP candidates are detected by preferring the featured image on singular pages, falling back to the first image in rendered content and supporting WooCommerce product images. Detection runs automatically when `get_lcp_candidate()` is called and results are cached for a minute to avoid repeated parsing.
+LCP candidates are detected by preferring the featured image on singular pages, falling back to the first image in rendered content and supporting WooCommerce product images. If no `<img>` candidate exists, enqueued styles are scanned for `background-image` rules on common hero selectors (e.g. `.hero`, `.site-hero`, `.elementor-hero`, `.wp-block-cover`, `.slider`) and the first large image is preloaded. Detection runs automatically when `get_lcp_candidate()` is called and results are cached for a minute to avoid repeated parsing.
 
 When a candidate lacks dimension metadata, the optimizer fetches its intrinsic width and height—falling back to PHP's `getimagesize()`—and injects the attributes to prevent Cumulative Layout Shift.
 

--- a/readme.txt
+++ b/readme.txt
@@ -60,7 +60,7 @@ window.aeLazy.modules.hcaptcha = true;
 == LCP Optimization ==
 Improve Largest Contentful Paint with targeted tweaks under **SEO → Performance → LCP Optimization**. The module operates solely on the front end and supports PHP 7.4+ and WordPress 5.8+.
 
-LCP candidates are detected by preferring the featured image on singular pages, falling back to the first image in content and handling WooCommerce product images. The lookup runs automatically when `get_lcp_candidate()` is used and results are cached for sixty seconds to avoid repeated parsing.
+LCP candidates are detected by preferring the featured image on singular pages, falling back to the first image in content and handling WooCommerce product images. If no `<img>` candidate is found, enqueued styles are scanned for `background-image` rules on common hero selectors such as `.hero`, `.site-hero`, `.elementor-hero`, `.wp-block-cover` or `.slider` and the first large match is preloaded. The lookup runs automatically when `get_lcp_candidate()` is used and results are cached for sixty seconds to avoid repeated parsing.
 
 If a candidate is missing dimension metadata, the optimizer retrieves intrinsic width and height—using PHP's `getimagesize()` as a fallback—and injects the attributes to prevent Cumulative Layout Shift.
 


### PR DESCRIPTION
## Summary
- detect CSS hero background images and preload first large background if no `<img>` LCP candidate
- document background hero preload behaviour in readmes

## Testing
- `npm test` *(fails: jest not found)*
- `composer install`
- `vendor/bin/phpunit` *(fails: missing WordPress tests library)*

------
https://chatgpt.com/codex/tasks/task_e_68bafa79a4e88327a66aee876883ce7d