### PR TITLE
Add LCP optimization settings page

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -504,6 +504,15 @@ class Gm2_SEO_Admin {
         );
 
         add_submenu_page(
+            'gm2-seo',
+            esc_html__( 'LCP Optimization', 'gm2-wordpress-suite' ),
+            esc_html__( 'LCP Optimization', 'gm2-wordpress-suite' ),
+            'manage_options',
+            'gm2-lcp-optimization',
+            [ $this, 'display_lcp_settings_page' ]
+        );
+
+        add_submenu_page(
             'gm2-ai',
             esc_html__( 'Bulk AI Review', 'gm2-wordpress-suite' ),
             esc_html__( 'Bulk AI Review', 'gm2-wordpress-suite' ),
@@ -6935,6 +6944,10 @@ class Gm2_SEO_Admin {
 
     public function display_script_audit_page() {
         require GM2_PLUGIN_DIR . 'admin/views/third-party-audit.php';
+    }
+
+    public function display_lcp_settings_page() {
+        require GM2_PLUGIN_DIR . 'admin/views/settings-lcp.php';
     }
 
     public function cron_process_ai_tax_queue() {

--- a/admin/views/settings-lcp.php
+++ b/admin/views/settings-lcp.php
@@ -1,0 +1,50 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$settings = get_option('aeseo_lcp_settings', []);
+if (!is_array($settings)) {
+    $settings = [];
+}
+
+$defaults = [
+    'remove_lazy_on_lcp'       => '0',
+    'add_fetchpriority_high'   => '0',
+    'force_width_height'       => '0',
+    'responsive_picture_nextgen' => '0',
+    'add_preconnect'           => '0',
+    'add_preload'              => '0',
+];
+$settings = array_merge($defaults, $settings);
+
+echo '<div class="wrap">';
+echo '<h1>' . esc_html__('LCP Optimization', 'gm2-wordpress-suite') . '</h1>';
+if (isset($_GET['settings-updated'])) {
+    echo '<div id="message" class="updated notice is-dismissible"><p>' . esc_html__('Settings saved.', 'gm2-wordpress-suite') . '</p></div>';
+}
+echo '<form method="post" action="' . esc_url(admin_url('admin-post.php')) . '">';
+wp_nonce_field('gm2_lcp_settings');
+echo '<input type="hidden" name="action" value="gm2_lcp_settings" />';
+
+echo '<table class="form-table"><tbody>';
+
+$fields = [
+    'remove_lazy_on_lcp'       => esc_html__('Remove lazy-loading on LCP image', 'gm2-wordpress-suite'),
+    'add_fetchpriority_high'   => esc_html__('Add fetchpriority="high" to LCP image', 'gm2-wordpress-suite'),
+    'force_width_height'       => esc_html__('Force width/height attributes', 'gm2-wordpress-suite'),
+    'responsive_picture_nextgen' => esc_html__('Serve responsive <picture> with next-gen formats', 'gm2-wordpress-suite'),
+    'add_preconnect'           => esc_html__('Preconnect to LCP origin', 'gm2-wordpress-suite'),
+    'add_preload'              => esc_html__('Preload LCP image', 'gm2-wordpress-suite'),
+];
+
+foreach ($fields as $key => $label) {
+    $checked = $settings[$key] === '1' ? 'checked="checked"' : '';
+    echo '<tr><th scope="row">' . $label . '</th><td><input type="checkbox" name="aeseo_lcp_settings[' . esc_attr($key) . ']" value="1" ' . $checked . ' /></td></tr>';
+}
+
+echo '</tbody></table>';
+
+submit_button(esc_html__('Save Settings', 'gm2-wordpress-suite'));
+echo '</form>';
+echo '</div>';

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -119,6 +119,7 @@ require_once GM2_PLUGIN_DIR . 'includes/Versioning_MTime.php';
 require_once GM2_PLUGIN_DIR . 'admin/class-ae-seo-debug-logs-admin.php';
 require_once GM2_PLUGIN_DIR . 'admin/class-ae-seo-server-hints.php';
 require_once GM2_PLUGIN_DIR . 'includes/class-aeseo-plugin.php';
+require_once GM2_PLUGIN_DIR . 'includes/class-aeseo-settings.php';
 
 \Gm2\Gm2_REST_Visibility::init();
 \Gm2\Gm2_REST_Rate_Limiter::init();
@@ -138,6 +139,7 @@ require_once GM2_PLUGIN_DIR . 'includes/class-aeseo-plugin.php';
 (new \Gm2\AE_SEO_Debug_Logs_Admin())->run();
 (new \Gm2\AE_SEO_Server_Hints())->run();
 \Gm2\AESEO_Plugin::init();
+\Gm2\AESEO_Settings::register();
 \Gm2\AE_SEO_Font_Manager::init();
 if (get_option('gm2_pretty_versioned_urls', '0') === '1') {
     \Gm2\Gm2_Version_Route_Apache::maybe_apply();

--- a/includes/class-aeseo-settings.php
+++ b/includes/class-aeseo-settings.php
@@ -1,0 +1,42 @@
+<?php
+namespace Gm2;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class AESEO_Settings {
+    public static function register(): void {
+        add_action('admin_post_gm2_lcp_settings', [__CLASS__, 'save_lcp_settings']);
+    }
+
+    public static function save_lcp_settings(): void {
+        check_admin_referer('gm2_lcp_settings');
+
+        $defaults = [
+            'remove_lazy_on_lcp'       => '0',
+            'add_fetchpriority_high'   => '0',
+            'force_width_height'       => '0',
+            'responsive_picture_nextgen' => '0',
+            'add_preconnect'           => '0',
+            'add_preload'              => '0',
+        ];
+
+        $submitted = isset($_POST['aeseo_lcp_settings']) && is_array($_POST['aeseo_lcp_settings']) ? $_POST['aeseo_lcp_settings'] : [];
+        $sanitized = [];
+        foreach ($defaults as $key => $value) {
+            $sanitized[$key] = isset($submitted[$key]) && $submitted[$key] === '1' ? '1' : '0';
+        }
+
+        $settings = array_merge($defaults, $sanitized);
+        update_option('aeseo_lcp_settings', $settings);
+
+        $redirect = wp_get_referer();
+        if (!$redirect) {
+            $redirect = admin_url('admin.php?page=gm2-lcp-optimization');
+        }
+        $redirect = add_query_arg('settings-updated', 'true', $redirect);
+        wp_safe_redirect($redirect);
+        exit;
+    }
+}


### PR DESCRIPTION
## Summary
- add LCP Optimization admin view and persistence handler
- register new submenu under SEO for LCP settings
- wire up settings class and option storage

## Testing
- ❌ `npm test` *(jest: not found)*
- ⚠️ `vendor/bin/phpunit` *(missing WordPress test library)*

------
https://chatgpt.com/codex/tasks/task_e_68bb07db70ec8327ad7d4e7c9589b4fd