### PR TITLE
feat: add worker pool for perf tasks

### DIFF
--- a/assets/js/perf/worker.js
+++ b/assets/js/perf/worker.js
@@ -1,18 +1,1 @@
-/**
- * Offload work to a Web Worker.
- *
- * Placeholder implementation that spins up a no-op worker.
- *
- * @return {void}
- */
-export function init() {
-    if (typeof Worker === 'undefined') {
-        return;
-    }
-    const blob = new Blob(['self.onmessage=e=>{self.postMessage(e.data)}'], { type: 'text/javascript' });
-    const worker = new Worker(URL.createObjectURL(blob));
-    worker.postMessage('');
-    worker.onmessage = () => {
-        worker.terminate();
-    };
-}
+export { init, runTask } from './worker/index.js';

--- a/assets/js/perf/worker/ae-worker.js
+++ b/assets/js/perf/worker/ae-worker.js
@@ -1,0 +1,61 @@
+/**
+ * AE Web Worker tasks.
+ *
+ * Accepts messages of the form { id, name, payload } and posts back
+ * { id, result } or { id, error }.
+ */
+
+export async function sha1(text) {
+    const data = new TextEncoder().encode(text);
+    const digest = await crypto.subtle.digest('SHA-1', data);
+    const bytes = new Uint8Array(digest);
+    return Array.from(bytes).map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+export function calcHistogram(arr) {
+    const hist = new Array(256).fill(0);
+    if (arr instanceof Uint8Array) {
+        for (let i = 0; i < arr.length; i += 1) {
+            hist[arr[i]] += 1;
+        }
+    }
+    return hist;
+}
+
+export function compressStats(arr) {
+    if (!arr || arr.length === 0) {
+        return [];
+    }
+    const out = [];
+    let prev = arr[0];
+    let count = 1;
+    for (let i = 1; i < arr.length; i += 1) {
+        const val = arr[i];
+        if (val === prev) {
+            count += 1;
+        } else {
+            out.push([prev, count]);
+            prev = val;
+            count = 1;
+        }
+    }
+    out.push([prev, count]);
+    return out;
+}
+
+const tasks = { sha1, calcHistogram, compressStats };
+
+self.onmessage = async (e) => {
+    const { id, name, payload } = e.data || {};
+    const fn = tasks[name];
+    if (!fn) {
+        self.postMessage({ id, error: 'Unknown task' });
+        return;
+    }
+    try {
+        const result = await fn(payload);
+        self.postMessage({ id, result });
+    } catch (err) {
+        self.postMessage({ id, error: err && err.message ? err.message : String(err) });
+    }
+};

--- a/assets/js/perf/worker/index.js
+++ b/assets/js/perf/worker/index.js
@@ -1,0 +1,57 @@
+/**
+ * Worker pool facade.
+ */
+
+import { WorkerPool } from './pool.js';
+import { sha1, calcHistogram, compressStats } from './ae-worker.js';
+
+let pool;
+let warned = false;
+
+export function init(size) {
+    if (typeof Worker === 'undefined') {
+        if (!warned) {
+            // eslint-disable-next-line no-console
+            console.warn('Web Workers are not supported');
+            warned = true;
+        }
+        pool = null;
+        return;
+    }
+    if (!pool) {
+        pool = new WorkerPool(size);
+    }
+}
+
+const fallbackTasks = { sha1, calcHistogram, compressStats };
+
+export function runTask(name, payload) {
+    if (pool) {
+        return pool.runTask(name, payload);
+    }
+    if (typeof Worker !== 'undefined') {
+        init();
+        if (pool) {
+            return pool.runTask(name, payload);
+        }
+    }
+    if (!warned) {
+        // eslint-disable-next-line no-console
+        console.warn('Web Workers are not supported');
+        warned = true;
+    }
+    return new Promise((resolve, reject) => {
+        queueMicrotask(async () => {
+            try {
+                const fn = fallbackTasks[name];
+                if (!fn) {
+                    throw new Error('Unknown task');
+                }
+                const result = await fn(payload);
+                resolve(result);
+            } catch (err) {
+                reject(err);
+            }
+        });
+    });
+}

--- a/assets/js/perf/worker/pool.js
+++ b/assets/js/perf/worker/pool.js
@@ -1,0 +1,75 @@
+/**
+ * Simple worker pool for AE tasks.
+ */
+
+const DEFAULT_SIZE = 2;
+const TASK_TIMEOUT = 10000;
+
+export class WorkerPool {
+    constructor(size = DEFAULT_SIZE) {
+        const limit = Math.min(4, typeof navigator !== 'undefined' && navigator.hardwareConcurrency ? navigator.hardwareConcurrency : DEFAULT_SIZE);
+        this.size = Math.min(size, limit);
+        this.workers = [];
+        this.nextWorker = 0;
+        this.taskId = 0;
+        for (let i = 0; i < this.size; i += 1) {
+            this.workers[i] = this._spawnWorker(i);
+        }
+    }
+
+    _spawnWorker(index) {
+        const worker = new Worker(new URL('./ae-worker.js', import.meta.url), { type: 'module' });
+        const tasks = new Map();
+
+        const handleMessage = (e) => {
+            const { id, result, error } = e.data || {};
+            const task = tasks.get(id);
+            if (!task) {
+                return;
+            }
+            clearTimeout(task.timer);
+            tasks.delete(id);
+            if (error) {
+                task.reject(new Error(error));
+            } else {
+                task.resolve(result);
+            }
+        };
+
+        const handleError = (err) => {
+            tasks.forEach((t) => {
+                clearTimeout(t.timer);
+                t.reject(err instanceof Error ? err : new Error('Worker error'));
+            });
+            tasks.clear();
+            worker.terminate();
+            this.workers[index] = this._spawnWorker(index);
+        };
+
+        worker.addEventListener('message', handleMessage);
+        worker.addEventListener('error', handleError);
+        worker.addEventListener('messageerror', handleError);
+
+        return { worker, tasks };
+    }
+
+    runTask(name, payload) {
+        const id = ++this.taskId;
+        const workerObj = this.workers[this.nextWorker];
+        this.nextWorker = (this.nextWorker + 1) % this.workers.length;
+        return new Promise((resolve, reject) => {
+            const timer = setTimeout(() => {
+                workerObj.tasks.delete(id);
+                reject(new Error('Task timed out'));
+            }, TASK_TIMEOUT);
+            workerObj.tasks.set(id, { resolve, reject, timer });
+            try {
+                workerObj.worker.postMessage({ id, name, payload });
+            } catch (err) {
+                clearTimeout(timer);
+                workerObj.tasks.delete(id);
+                reject(err);
+            }
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add ae-worker with sha1, histogram, and stat compression tasks
- implement worker pool with restart and timeout handling
- expose runTask/init with main-thread fallback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb14a9eaa48327b1ab3fccfdae9e91