### PR TITLE
docs: document aePerf.runTask usage

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -10,6 +10,16 @@ The Performance module exposes optional front‑end helpers that can be toggled 
 | `passive_listeners` | `ae_perf_passive_listeners` | Default scroll and touch handlers to passive. |
 | `dom_audit` | `ae_perf_dom_audit` | Log total DOM nodes after paint. |
 
+To offload expensive tasks to a Web Worker, use `aePerf.runTask`:
+
+```js
+if (window.aePerf?.runTask) {
+  const hash = await window.aePerf.runTask('sha1', { text: longString });
+}
+```
+
+Note that disabling the `worker`/`webWorker` flag prevents worker creation, causing the fallback to run on the main thread.
+
 Developers may override any flag:
 
 ```php


### PR DESCRIPTION
## Summary
- add example demonstrating how to offload tasks via `aePerf.runTask`
- note that disabling the worker flag falls back to running on main thread

## Testing
- `npm test`
- `vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*


------
https://chatgpt.com/codex/tasks/task_e_68bb18448da48327b382452660d3e17b