### PR TITLE
perf: add yield module for long tasks

### DIFF
--- a/assets/js/perf/index.js
+++ b/assets/js/perf/index.js
@@ -47,6 +47,10 @@ window.aePerf = {
     runTask: fallbackRunTask,
 };
 
+if (flags.longTasks === true) {
+    imports.push(import('./yield.js').then((m) => { window.aePerf.yield = m; }));
+}
+
 if (flags.webWorker && typeof Worker !== 'undefined') {
     imports.push(
         import('./worker/index.js').then((m) => {


### PR DESCRIPTION
## Summary
- load optional yield module when `AE_PERF_FLAGS.longTasks` is true

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb1af3314c83279f34b0e0bc985b13