### PR TITLE
Use chunk helper for longtask observer

### DIFF
--- a/assets/js/perf/longtask.js
+++ b/assets/js/perf/longtask.js
@@ -3,16 +3,18 @@
  *
  * @return {void}
  */
+import { chunk } from './yield.js';
 export function init() {
     if (typeof PerformanceObserver === 'undefined') {
         return;
     }
     try {
         const observer = new PerformanceObserver((list) => {
-            for (const entry of list.getEntries()) {
+            const entries = list.getEntries();
+            chunk(entries, 50, (entry) => {
                 // eslint-disable-next-line no-console
                 console.log('Long task:', entry);
-            }
+            });
         });
         observer.observe({ type: 'longtask', buffered: true });
     } catch (e) {


### PR DESCRIPTION
## Summary
- import chunk helper in longtask performance script
- use chunk to process long task entries in batches

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb1bd8af908327a504fd12b6cd1fd0