### PR TITLE
feat(perf): add noThrash fastdom loader

### DIFF
--- a/assets/js/perf/index.js
+++ b/assets/js/perf/index.js
@@ -62,11 +62,13 @@ if (flags.webWorker && typeof Worker !== 'undefined') {
 if (flags.long_tasks) {
     imports.push(import('./longtask.js').then((m) => m.init()));
 }
-if (flags.layout_thrash) {
+if (flags.noThrash === true) {
     imports.push(
         import('./fastdom-lite.js').then((m) => {
-            window.aePerf.measure = m.measure;
-            window.aePerf.mutate = m.mutate;
+            window.aePerf.dom = {
+                measure: m.measure,
+                mutate: m.mutate,
+            };
         })
     );
 }


### PR DESCRIPTION
## Summary
- swap `layout_thrash` flag for `noThrash`
- lazy-load `fastdom-lite` and expose API as `aePerf.dom.measure`/`mutate`

## Testing
- `npm test`
- `./vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*


------
https://chatgpt.com/codex/tasks/task_e_68bb278969208327a562653e4028f96a