### PR TITLE
Replace layout_thrash flag with noThrash and document AE Performance API

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -103,7 +103,6 @@ class Gm2_SEO_Admin {
         add_option('ae_js_compat_overrides', []);
         add_option('ae_perf_worker', '0');
         add_option('ae_perf_long_tasks', '0');
-        add_option('ae_perf_layout_thrash', '0');
         add_option('ae_perf_no_thrash', '0');
         add_option('ae_perf_passive_listeners', '0');
         add_option('ae_perf_dom_audit', '0');
@@ -1190,7 +1189,6 @@ class Gm2_SEO_Admin {
                 $ps_scores = get_option('gm2_pagespeed_scores', []);
                 $perf_worker = get_option('ae_perf_worker', '0');
                 $perf_long   = get_option('ae_perf_long_tasks', '0');
-                $perf_layout = get_option('ae_perf_layout_thrash', '0');
                 $perf_no_thrash = get_option('ae_perf_no_thrash', '0');
                 $perf_passive = get_option('ae_perf_passive_listeners', '0');
                 $perf_dom = get_option('ae_perf_dom_audit', '0');
@@ -1299,7 +1297,6 @@ class Gm2_SEO_Admin {
                 echo '<tr><th colspan="2"><h2>' . esc_html__( 'Performance', 'gm2-wordpress-suite' ) . '</h2></th></tr>';
                 echo '<tr><th scope="row">' . esc_html__( 'Enable Web Worker offloading', 'gm2-wordpress-suite' ) . '</th><td><label><input type="checkbox" name="ae_perf_worker" value="1" ' . checked($perf_worker, '1', false) . '></label></td></tr>';
                 echo '<tr><th scope="row">' . esc_html__( 'Break up long tasks', 'gm2-wordpress-suite' ) . '</th><td><label><input type="checkbox" name="ae_perf_long_tasks" value="1" ' . checked($perf_long, '1', false) . '></label></td></tr>';
-                echo '<tr><th scope="row">' . esc_html__( 'Prevent layout thrash', 'gm2-wordpress-suite' ) . '</th><td><label><input type="checkbox" name="ae_perf_layout_thrash" value="1" ' . checked($perf_layout, '1', false) . '></label></td></tr>';
                 echo '<tr><th scope="row">' . esc_html__( 'Batch DOM reads & writes', 'gm2-wordpress-suite' ) . '</th><td><label><input type="checkbox" name="ae_perf_no_thrash" value="1" ' . checked($perf_no_thrash, '1', false) . '></label></td></tr>';
                 echo '<tr><th scope="row">' . esc_html__( 'Passive scroll/touch listeners', 'gm2-wordpress-suite' ) . '</th><td><label><input type="checkbox" name="ae_perf_passive_listeners" value="1" ' . checked($perf_passive, '1', false) . '></label></td></tr>';
                 echo '<tr><th scope="row">' . esc_html__( 'DOM size audit', 'gm2-wordpress-suite' ) . '</th><td><label><input type="checkbox" name="ae_perf_dom_audit" value="1" ' . checked($perf_dom, '1', false) . '></label></td></tr>';
@@ -3311,8 +3308,6 @@ class Gm2_SEO_Admin {
         update_option('ae_perf_worker', $perf_worker);
         $perf_long = isset($_POST['ae_perf_long_tasks']) ? '1' : '0';
         update_option('ae_perf_long_tasks', $perf_long);
-        $perf_layout = isset($_POST['ae_perf_layout_thrash']) ? '1' : '0';
-        update_option('ae_perf_layout_thrash', $perf_layout);
         $perf_no_thrash = isset($_POST['ae_perf_no_thrash']) ? '1' : '0';
         update_option('ae_perf_no_thrash', $perf_no_thrash);
         $perf_passive = isset($_POST['ae_perf_passive_listeners']) ? '1' : '0';

--- a/assets/js/perf/fastdom-lite.js
+++ b/assets/js/perf/fastdom-lite.js
@@ -120,7 +120,7 @@ function runMeasure(fn) {
         observer.disconnect();
         if (mutated) {
             // eslint-disable-next-line no-console
-            console.warn('aePerf.measure callback mutated the DOM');
+            console.warn('aePerf.dom.measure callback mutated the DOM');
         }
     }
     return result;
@@ -165,7 +165,7 @@ function runMutate(fn) {
         Object.defineProperty(HTMLElement.prototype, 'offsetHeight', ohDesc);
         if (accessed) {
             // eslint-disable-next-line no-console
-            console.warn('aePerf.mutate callback performed a layout read');
+            console.warn('aePerf.dom.mutate callback performed a layout read');
         }
     }
     return result;

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -6,8 +6,7 @@ The Performance module exposes optional front‑end helpers that can be toggled 
 | --- | --- | --- |
 | `worker` | `ae_perf_worker` | Enable Web Worker offloading. |
 | `long_tasks` | `ae_perf_long_tasks` | Observe and log `longtask` entries. |
-| `layout_thrash` | `ae_perf_layout_thrash` | Batch DOM reads and writes via `aePerf.measure` and `aePerf.mutate`. |
-| `noThrash` | `ae_perf_no_thrash` | Batch DOM reads and writes via `fastdom-lite`. |
+| `noThrash` | `ae_perf_no_thrash` | Batch DOM reads and writes via `aePerf.dom.measure` and `aePerf.dom.mutate`. |
 | `passive_listeners` | `ae_perf_passive_listeners` | Default scroll and touch handlers to passive. |
 | `dom_audit` | `ae_perf_dom_audit` | Log total DOM nodes after paint. |
 
@@ -20,6 +19,17 @@ if (window.aePerf?.runTask) {
 ```
 
 Note that disabling the `worker`/`webWorker` flag prevents worker creation, causing the fallback to run on the main thread.
+
+Batch DOM reads and writes:
+
+```js
+if (window.aePerf?.dom) {
+  const height = await aePerf.dom.measure(() => el.offsetHeight);
+  await aePerf.dom.mutate(() => { el.style.height = `${height}px`; });
+}
+```
+
+Both methods return Promises, so `await` can be used. Append `?aePerfDebug=1` to the URL to log if a measure callback mutates or a mutate callback performs layout reads.
 
 Developers may override any flag:
 

--- a/includes/Perf/Manager.php
+++ b/includes/Perf/Manager.php
@@ -42,7 +42,6 @@ class Manager {
             'webWorker'        => 'ae_perf_worker',
             'worker'           => 'ae_perf_worker', // Legacy key for compatibility.
             'long_tasks'       => 'ae_perf_long_tasks',
-            'layout_thrash'    => 'ae_perf_layout_thrash',
             'noThrash'         => 'ae_perf_no_thrash',
             'passive_listeners' => 'ae_perf_passive_listeners',
             'dom_audit'        => 'ae_perf_dom_audit',


### PR DESCRIPTION
## Summary
- remove legacy `layout_thrash` flag in favor of `noThrash` (`ae_perf_no_thrash`)
- switch examples and debug messages to `aePerf.dom.measure`/`aePerf.dom.mutate`
- document `aePerfDebug` query param and promise-based DOM batching API

## Testing
- `npm test` *(fails: npm not installed)*
- `vendor/bin/phpunit` *(fails: missing WordPress test library)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2eb85e6c8327ba902af9fa970aee