### PR TITLE
Add isAdmin flag to performance manager

### DIFF
--- a/includes/Perf/Manager.php
+++ b/includes/Perf/Manager.php
@@ -35,7 +35,7 @@ class Manager {
     /**
      * Retrieve flags.
      *
-     * @return array
+     * @return array<string,bool> Performance flags keyed by feature.
      */
     private static function get_flags(): array {
         $map = [
@@ -57,6 +57,9 @@ class Manager {
              */
             $flags[$feature] = (bool) apply_filters('ae/perf/flag', $enabled, $feature);
         }
+        // Include flag indicating whether a user is logged in.
+        $flags['isAdmin'] = (bool) is_user_logged_in();
+
         return $flags;
     }
 }


### PR DESCRIPTION
## Summary
- expose login state to frontend by adding `isAdmin` flag in performance manager
- document flag return types and add login flag to performance output

## Testing
- `php -l includes/Perf/Manager.php`
- `vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*


------
https://chatgpt.com/codex/tasks/task_e_68bb591a2ae08327ae1ddb7023b25312