### PR TITLE
refactor: expose addPassive via aePerf

### DIFF
--- a/assets/js/perf/index.js
+++ b/assets/js/perf/index.js
@@ -73,7 +73,11 @@ if (flags.noThrash === true) {
     );
 }
 if (flags.passive_listeners) {
-    imports.push(import('./passive.js'));
+    imports.push(
+        import('./passive.js').then((m) => {
+            window.aePerf.addPassive = m.addPassive;
+        })
+    );
 }
 if (flags.dom_audit) {
     imports.push(import('./dom-audit.js').then((m) => m.init()));


### PR DESCRIPTION
## Summary
- import passive listener helpers dynamically and expose `addPassive` on `window.aePerf`
- maintain conditional import of passive module

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb5cef967c8327a457971711c1888a