### PR TITLE
Add passive listeners patch flag

### DIFF
--- a/includes/Perf/Manager.php
+++ b/includes/Perf/Manager.php
@@ -60,6 +60,13 @@ class Manager {
         // Include flag indicating whether a user is logged in.
         $flags['isAdmin'] = (bool) is_user_logged_in();
 
+        /**
+         * Filter whether the passive listeners patch is allowed.
+         *
+         * @param bool $allow_patch Whether the passive listeners patch is allowed.
+         */
+        $flags['passivePatch'] = $flags['passive_listeners'] && apply_filters('ae/perf/passive_allow_patch', true);
+
         return $flags;
     }
 }


### PR DESCRIPTION
## Summary
- support optional passive listener polyfill via `ae/perf/passive_allow_patch`

## Testing
- `./vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb5dc033688327869d8bc2bb5f718c