### PR TITLE
Use passive event helper across scripts

### DIFF
--- a/admin/js/gm2-cpt-wizard.js
+++ b/admin/js/gm2-cpt-wizard.js
@@ -3,6 +3,9 @@
     const { render } = wp.element;
     const { Button, TextControl, SelectControl, PanelBody, Panel, NoticeList, SnackbarList } = wp.components;
     const { dispatch, useSelect } = wp.data;
+    const addPassive = !window.AE_PERF_DISABLE_PASSIVE && window.aePerf?.addPassive
+        ? window.aePerf.addPassive
+        : (el, type, handler, options) => el.addEventListener(type, handler, options);
 
     const slugify = (str) => str.toLowerCase().replace(/[^a-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '');
 
@@ -388,7 +391,7 @@
         );
     };
 
-    document.addEventListener('DOMContentLoaded', () => {
+    addPassive(document, 'DOMContentLoaded', () => {
         const root = document.getElementById('gm2-cpt-wizard-root');
         if(root){
             render(el(Wizard), root);

--- a/admin/js/gm2-fg-wizard.js
+++ b/admin/js/gm2-fg-wizard.js
@@ -3,6 +3,9 @@
     const { render } = wp.element;
     const { Button, TextControl, SelectControl, FormTokenField, PanelBody, Panel, Card, CardBody, Sortable } = wp.components;
     const { dispatch } = wp.data;
+    const addPassive = !window.AE_PERF_DISABLE_PASSIVE && window.aePerf?.addPassive
+        ? window.aePerf.addPassive
+        : (el, type, handler, options) => el.addEventListener(type, handler, options);
 
     const StepOne = ({ data, setData, existing, loadGroup, setExisting }) => {
         const options = [ { label: 'New', value: '' } ];
@@ -491,7 +494,7 @@
         );
     };
 
-    document.addEventListener('DOMContentLoaded', () => {
+    addPassive(document, 'DOMContentLoaded', () => {
         const root = document.getElementById('gm2-fg-wizard-root');
         if(root){
             render(el(Wizard), root);

--- a/admin/js/gm2-geospatial.js
+++ b/admin/js/gm2-geospatial.js
@@ -1,4 +1,8 @@
-document.addEventListener('DOMContentLoaded', () => {
+const addPassive = !window.AE_PERF_DISABLE_PASSIVE && window.aePerf?.addPassive
+    ? window.aePerf.addPassive
+    : (el, type, handler, options) => el.addEventListener(type, handler, options);
+
+addPassive(document, 'DOMContentLoaded', () => {
     const fields = document.querySelectorAll('.gm2-geo-field');
     fields.forEach(field => {
         const mapEl = field.querySelector('.gm2-geo-map');

--- a/assets/src/ae-lazy.js
+++ b/assets/src/ae-lazy.js
@@ -5,6 +5,11 @@ if (document.documentElement.hasAttribute('data-aejs-off')) {
   var modules = cfg.modules || {};
   var ids = cfg.ids || {};
   var consent = cfg.consent || { key: 'aeConsent', value: 'allow_analytics' };
+  var addPassive = !window.AE_PERF_DISABLE_PASSIVE && window.aePerf && window.aePerf.addPassive
+    ? window.aePerf.addPassive
+    : function (el, type, handler, options) {
+        el.addEventListener(type, handler, options);
+      };
 
   function cookie(name) {
     var match = document.cookie.match('(^|;) ?' + name + '=([^;]*)(;|$)');
@@ -82,26 +87,26 @@ if (document.documentElement.hasAttribute('data-aejs-off')) {
         var els = document.querySelectorAll('[data-ae-module="' + moduleName + '"]');
         for (var i = 0; i < els.length; i++) {
           var el = els[i];
-          el.addEventListener('mouseenter', load, { once: true });
-          el.addEventListener('focus', load, { once: true });
+          addPassive(el, 'mouseenter', load, { once: true });
+          addPassive(el, 'focus', load, { once: true });
         }
       })(name);
     }
   }
 
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', setupCustomModules);
+    addPassive(document, 'DOMContentLoaded', setupCustomModules);
   } else {
     setupCustomModules();
   }
 
-  window.addEventListener('ae:engaged', function () {
+  addPassive(window, 'ae:engaged', function () {
     loadAnalytics();
     loadRecaptcha();
     loadHCaptcha();
   });
 
-  document.addEventListener('aeConsentChanged', loadAnalytics);
+  addPassive(document, 'aeConsentChanged', loadAnalytics);
 
   var fired = false;
   function go() {
@@ -112,9 +117,9 @@ if (document.documentElement.hasAttribute('data-aejs-off')) {
     window.dispatchEvent(new Event('ae:engaged'));
   }
 
-  window.addEventListener('click', go, { once: true });
-  window.addEventListener('scroll', go, { once: true });
-  window.addEventListener('keydown', go, { once: true });
-  window.addEventListener('pointerdown', go, { once: true, passive: true });
+  addPassive(window, 'click', go, { once: true });
+  addPassive(window, 'scroll', go, { once: true });
+  addPassive(window, 'keydown', go, { once: true });
+  addPassive(window, 'pointerdown', go, { once: true });
   setTimeout(go, 3000);
 }

--- a/assets/src/vanilla-helpers.js
+++ b/assets/src/vanilla-helpers.js
@@ -1,5 +1,11 @@
-export function on(el, evt, fn) {
-  el.addEventListener(evt, fn);
+const addPassive = !window.AE_PERF_DISABLE_PASSIVE && window.aePerf && window.aePerf.addPassive
+  ? window.aePerf.addPassive
+  : function (el, type, handler, options) {
+      el.addEventListener(type, handler, options);
+    };
+
+export function on(el, evt, fn, options) {
+  addPassive(el, evt, fn, options);
 }
 
 export function closest(el, selector) {

--- a/public/js/gm2-ac-activity.js
+++ b/public/js/gm2-ac-activity.js
@@ -2,6 +2,9 @@
     const dom = window.aePerf?.dom;
     const measure = dom ? dom.measure.bind(dom) : (fn) => fn();
     const mutate = dom ? dom.mutate.bind(dom) : (fn) => fn();
+    const addPassive = !window.AE_PERF_DISABLE_PASSIVE && window.aePerf?.addPassive
+        ? window.aePerf.addPassive
+        : (el, type, handler, options) => el.addEventListener(type, handler, options);
 
     const KEY = 'gm2AcTabCount';
     const ENTRY_KEY = 'gm2_entry_url';
@@ -209,11 +212,11 @@
     }
 
     mutate(() => {
-        document.body.addEventListener('added_to_cart', () => {
+        addPassive(document.body, 'added_to_cart', () => {
             resetInactivityTimer();
         });
 
-        document.addEventListener('click', (e) => {
+        addPassive(document, 'click', (e) => {
             resetInactivityTimer();
             let anchor;
             measure(() => {
@@ -236,10 +239,10 @@
         });
 
         ['mousemove', 'keydown', 'scroll', 'touchstart'].forEach((ev) => {
-            document.addEventListener(ev, resetInactivityTimer, { passive: true });
+            addPassive(document, ev, resetInactivityTimer);
         });
 
-        document.addEventListener('visibilitychange', () => {
+        addPassive(document, 'visibilitychange', () => {
             let state;
             measure(() => {
                 state = document.visibilityState;
@@ -249,7 +252,7 @@
                 resetInactivityTimer(false);
             }
         });
-        window.addEventListener('beforeunload', () => {
+        addPassive(window, 'beforeunload', () => {
             if (decrementTabs()) {
                 if (typeof pendingTargetUrl === 'undefined') {
                     send('gm2_ac_mark_abandoned');
@@ -257,7 +260,7 @@
                 }
             }
         });
-        window.addEventListener('pagehide', () => {
+        addPassive(window, 'pagehide', () => {
             if (decrementTabs()) {
                 if (typeof pendingTargetUrl === 'undefined') {
                     send('gm2_ac_mark_abandoned');

--- a/public/js/gm2-analytics-tracker.js
+++ b/public/js/gm2-analytics-tracker.js
@@ -2,9 +2,12 @@
     const dom = window.aePerf?.dom;
     const measure = dom ? dom.measure.bind(dom) : (fn) => fn();
     const mutate = dom ? dom.mutate.bind(dom) : (fn) => fn();
+    const addPassive = !window.AE_PERF_DISABLE_PASSIVE && window.aePerf?.addPassive
+        ? window.aePerf.addPassive
+        : (el, type, handler, options) => el.addEventListener(type, handler, options);
 
     mutate(() => {
-        document.addEventListener('DOMContentLoaded', function(){
+        addPassive(document, 'DOMContentLoaded', function(){
             if (typeof gm2Analytics === 'undefined' || !gm2Analytics.ajax_url) {
                 return;
             }
@@ -53,12 +56,12 @@
             }
 
             mutate(() => {
-                document.addEventListener('visibilitychange', handleVisibility);
-                window.addEventListener('pagehide', handleVisibility);
+                addPassive(document, 'visibilitychange', handleVisibility);
+                addPassive(window, 'pagehide', handleVisibility);
             });
 
             mutate(() => {
-                document.addEventListener('click', function(e){
+                addPassive(document, 'click', function(e){
                     var el;
                     measure(() => {
                         el = e.target;
@@ -74,7 +77,7 @@
                         identifier = el.getAttribute('href') || el.getAttribute('id') || el.getAttribute('class') || '';
                     });
                     send({ event_type: 'click', element: identifier });
-                }, true);
+                }, { capture: true });
             });
         });
     });

--- a/public/js/gm2-login-widget.js
+++ b/public/js/gm2-login-widget.js
@@ -2,6 +2,9 @@ jQuery(function($){
   const dom = window.aePerf?.dom;
   const measure = dom ? dom.measure.bind(dom) : (fn) => fn();
   const mutate = dom ? dom.mutate.bind(dom) : (fn) => fn();
+  const addPassive = !window.AE_PERF_DISABLE_PASSIVE && window.aePerf?.addPassive
+    ? window.aePerf.addPassive
+    : (el, type, handler, options) => el.addEventListener(type, handler, options);
 
   mutate(() => {
     jQuery(window).on('elementor/frontend/init', function() {
@@ -75,7 +78,7 @@ jQuery(function($){
             return;
           }
           mutate(() => {
-            form.addEventListener('submit', function() {
+            addPassive(form, 'submit', function() {
               var contact;
               var emailHidden;
               measure(() => {


### PR DESCRIPTION
## Summary
- use window.aePerf.addPassive for events in frontend and admin scripts
- expose addPassive through vanilla helpers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb5e9410e88327ab48fc5e33ba9c0c