### PR TITLE
feat: add long task summaries

### DIFF
--- a/assets/js/perf/index.js
+++ b/assets/js/perf/index.js
@@ -49,6 +49,12 @@ window.aePerf = {
 
 if (flags.longTasks === true) {
     imports.push(import('./yield.js').then((m) => { window.aePerf.yield = m; }));
+    imports.push(
+        import('./longtask.js').then((m) => {
+            m.init();
+            window.aePerf.getSummary = m.getSummary;
+        })
+    );
 }
 
 if (flags.webWorker && typeof Worker !== 'undefined') {
@@ -58,9 +64,6 @@ if (flags.webWorker && typeof Worker !== 'undefined') {
             window.aePerf.runTask = m.runTask;
         })
     );
-}
-if (flags.long_tasks) {
-    imports.push(import('./longtask.js').then((m) => m.init()));
 }
 if (flags.noThrash === true) {
     imports.push(

--- a/assets/js/perf/longtask.js
+++ b/assets/js/perf/longtask.js
@@ -1,24 +1,147 @@
 /**
  * Report long tasks via PerformanceObserver.
  *
+ * Buckets entries and logs per-second summaries.
+ *
  * @return {void}
  */
 import { chunk } from './yield.js';
-export function init() {
-    if (typeof PerformanceObserver === 'undefined') {
+
+/* global AE_PERF_FLAGS */
+
+const summary = { events: 0, max: 0, total: 0, buckets: {} };
+const recent = [];
+const budgetWindow = [];
+let budgetLimit;
+let budgetExceeded = false;
+
+function getKey(a = {}) {
+    let key = a.name || 'unknown';
+    if (a.containerType) {
+        key += `:${a.containerType}`;
+        if (a.containerId) {
+            key += `#${a.containerId}`;
+        } else if (a.containerSrc) {
+            key += `@${a.containerSrc}`;
+        }
+    }
+    return key;
+}
+
+function getInfo(a = {}) {
+    const info = {};
+    if (a.name) {
+        info.name = a.name;
+    }
+    if (a.containerType) {
+        info.containerType = a.containerType;
+        if (a.containerId) {
+            info.containerId = a.containerId;
+        } else if (a.containerSrc) {
+            info.containerSrc = a.containerSrc;
+        }
+    }
+    return info;
+}
+
+function prune(queue, now, limitMs) {
+    while (queue.length && now - queue[0].time > limitMs) {
+        queue.shift();
+    }
+}
+
+function handleEntry(entry) {
+    const now = performance.now();
+    recent.push({ time: now, duration: entry.duration });
+    prune(recent, now, 1000);
+
+    const attrib = entry.attribution && entry.attribution[0];
+    const key = getKey(attrib);
+    const bucket = (summary.buckets[key] = summary.buckets[key] || {
+        events: 0,
+        max: 0,
+        total: 0,
+        attribution: getInfo(attrib),
+    });
+    bucket.events++;
+    bucket.total += entry.duration;
+    if (entry.duration > bucket.max) {
+        bucket.max = entry.duration;
+    }
+
+    summary.events++;
+    summary.total += entry.duration;
+    if (entry.duration > summary.max) {
+        summary.max = entry.duration;
+    }
+
+    if (budgetLimit) {
+        budgetWindow.push({ time: now, duration: entry.duration });
+        prune(budgetWindow, now, 10000);
+        const total = budgetWindow.reduce((t, e) => t + e.duration, 0);
+        if (total > budgetLimit && !budgetExceeded) {
+            // eslint-disable-next-line no-console
+            console.warn('Long task budget exceeded', { total, budget: budgetLimit });
+            budgetExceeded = true;
+        } else if (total <= budgetLimit) {
+            budgetExceeded = false;
+        }
+    }
+}
+
+function logRecent() {
+    const now = performance.now();
+    prune(recent, now, 1000);
+    if (!recent.length) {
         return;
     }
+    let total = 0;
+    let max = 0;
+    for (const e of recent) {
+        total += e.duration;
+        if (e.duration > max) {
+            max = e.duration;
+        }
+    }
+    // eslint-disable-next-line no-console
+    console.log('Long tasks (last 1s)', {
+        events: recent.length,
+        max,
+        total,
+    });
+}
+
+/**
+ * Start observing long tasks.
+ *
+ * @return {void}
+ */
+export function init() {
+    const flags = window.AE_PERF_FLAGS || {};
+    if (flags.longTasks !== true || typeof PerformanceObserver === 'undefined') {
+        return;
+    }
+    budgetLimit = flags.longTaskBudgetMs;
     try {
         const observer = new PerformanceObserver((list) => {
             const entries = list.getEntries();
-            chunk(entries, 50, (entry) => {
-                // eslint-disable-next-line no-console
-                console.log('Long task:', entry);
-            });
+            chunk(entries, 50, handleEntry);
         });
         observer.observe({ type: 'longtask', buffered: true });
+        setInterval(logRecent, 1000);
     } catch (e) {
         // eslint-disable-next-line no-console
         console.debug('Longtask observer unsupported', e);
     }
 }
+
+/**
+ * Retrieve lifetime long task totals.
+ *
+ * @return {Object}
+ */
+export function getLongTaskSummary() {
+    return summary;
+}
+
+export const getSummary = getLongTaskSummary;

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -5,10 +5,12 @@ The Performance module exposes optional front‑end helpers that can be toggled 
 | Flag | Option | Description |
 | --- | --- | --- |
 | `worker` | `ae_perf_worker` | Enable Web Worker offloading. |
-| `long_tasks` | `ae_perf_long_tasks` | Observe and log `longtask` entries. |
+| `longTasks` | `ae_perf_long_tasks` | Observe and log `longtask` entries. |
 | `noThrash` | `ae_perf_no_thrash` | Batch DOM reads and writes via `aePerf.dom.measure` and `aePerf.dom.mutate`. |
 | `passive_listeners` | `ae_perf_passive_listeners` | Default scroll and touch handlers to passive. |
 | `dom_audit` | `ae_perf_dom_audit` | Log total DOM nodes after paint. |
+
+Enabling `longTasks` logs per‑second summaries of `longtask` entries. Lifetime totals are available via `aePerf.getSummary()`. If `AE_PERF_FLAGS.longTaskBudgetMs` is defined, a warning is emitted when the last 10 s of long tasks exceed this budget.
 
 To offload expensive tasks to a Web Worker, use `aePerf.runTask`:
 


### PR DESCRIPTION
## Summary
- track long tasks with per-second logging and lifetime summaries
- expose `aePerf.getSummary` for long task totals
- document `longTasks` flag and optional budget warning

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb66384654832791dceea45ef1d70b