### PR TITLE
refactor: use longTasks flag and expose summary accessor

### DIFF
--- a/assets/js/perf/index.js
+++ b/assets/js/perf/index.js
@@ -50,9 +50,9 @@ window.aePerf = {
 if (flags.longTasks === true) {
     imports.push(import('./yield.js').then((m) => { window.aePerf.yield = m; }));
     imports.push(
-        import('./longtask.js').then((m) => {
-            m.init();
-            window.aePerf.getSummary = m.getSummary;
+        import('./longtask.js').then(async (m) => {
+            await m.init();
+            window.aePerf.getLongTaskSummary = m.getSummary;
         })
     );
 }

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -10,7 +10,7 @@ The Performance module exposes optional front‑end helpers that can be toggled 
 | `passive_listeners` | `ae_perf_passive_listeners` | Default scroll and touch handlers to passive. |
 | `dom_audit` | `ae_perf_dom_audit` | Log total DOM nodes after paint. |
 
-Enabling `longTasks` logs per‑second summaries of `longtask` entries. Lifetime totals are available via `aePerf.getSummary()`. If `AE_PERF_FLAGS.longTaskBudgetMs` is defined, a warning is emitted when the last 10 s of long tasks exceed this budget.
+Enabling `longTasks` logs per‑second summaries of `longtask` entries. Lifetime totals are available via `aePerf.getLongTaskSummary()`. If `AE_PERF_FLAGS.longTaskBudgetMs` is defined, a warning is emitted when the last 10 s of long tasks exceed this budget.
 
 To offload expensive tasks to a Web Worker, use `aePerf.runTask`:
 

--- a/includes/Perf/Manager.php
+++ b/includes/Perf/Manager.php
@@ -41,7 +41,7 @@ class Manager {
         $map = [
             'webWorker'        => 'ae_perf_worker',
             'worker'           => 'ae_perf_worker', // Legacy key for compatibility.
-            'long_tasks'       => 'ae_perf_long_tasks',
+            'longTasks'        => 'ae_perf_long_tasks',
             'noThrash'         => 'ae_perf_no_thrash',
             'passive_listeners' => 'ae_perf_passive_listeners',
             'dom_audit'        => 'ae_perf_dom_audit',


### PR DESCRIPTION
## Summary
- camelCase long task flag and hook up longtask observer import
- expose `aePerf.getLongTaskSummary` after long task module initializes
- document new accessor and update flag mapping

## Testing
- `npm test`
- `vendor/bin/phpunit` *(fails: missing /tmp/wordpress-tests-lib)*

------
https://chatgpt.com/codex/tasks/task_e_68bb70f61f44832783ca6520144d69d7