### PR TITLE
Add performance settings administration

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -141,6 +141,7 @@ require_once GM2_PLUGIN_DIR . 'includes/class-aeseo-settings.php';
 (new \Gm2\AE_SEO_Server_Hints())->run();
 \Gm2\AESEO_Plugin::init();
 \Gm2\AESEO_Settings::register();
+\Gm2\Perf\Settings::init();
 \Gm2\AE_SEO_Font_Manager::init();
 if (get_option('gm2_pretty_versioned_urls', '0') === '1') {
     \Gm2\Gm2_Version_Route_Apache::maybe_apply();

--- a/includes/Perf/Manager.php
+++ b/includes/Perf/Manager.php
@@ -39,12 +39,12 @@ class Manager {
      */
     private static function get_flags(): array {
         $map = [
-            'webWorker'        => 'ae_perf_worker',
-            'worker'           => 'ae_perf_worker', // Legacy key for compatibility.
-            'longTasks'        => 'ae_perf_long_tasks',
-            'noThrash'         => 'ae_perf_no_thrash',
-            'passive_listeners' => 'ae_perf_passive_listeners',
-            'dom_audit'        => 'ae_perf_dom_audit',
+            'webWorker'         => 'ae_perf_webworker',
+            'worker'            => 'ae_perf_webworker', // Legacy key for compatibility.
+            'longTasks'         => 'ae_perf_longtasks',
+            'noThrash'          => 'ae_perf_nothrash',
+            'passive_listeners' => 'ae_perf_passive',
+            'dom_audit'         => 'ae_perf_domaudit',
         ];
         $flags = [];
         foreach ($map as $feature => $option) {
@@ -65,7 +65,8 @@ class Manager {
          *
          * @param bool $allow_patch Whether the passive listeners patch is allowed.
          */
-        $flags['passivePatch'] = $flags['passive_listeners'] && apply_filters('ae/perf/passive_allow_patch', true);
+        $allow_patch           = get_option('ae_perf_passive_patch', '0') === '1';
+        $flags['passivePatch'] = $flags['passive_listeners'] && $allow_patch && apply_filters('ae/perf/passive_allow_patch', true);
 
         return $flags;
     }

--- a/includes/Perf/Settings.php
+++ b/includes/Perf/Settings.php
@@ -1,0 +1,128 @@
+<?php
+namespace Gm2\Perf;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Register performance settings.
+ */
+class Settings {
+    /**
+     * Bootstrap hooks.
+     */
+    public static function init(): void {
+        add_action('admin_init', [ __CLASS__, 'register' ]);
+        add_action('admin_menu', [ __CLASS__, 'menu' ], 99);
+    }
+
+    /**
+     * Register options and fields.
+     */
+    public static function register(): void {
+        $options = [
+            'ae_perf_webworker'     => __( 'Enable Web Worker offloading', 'gm2-wordpress-suite' ),
+            'ae_perf_longtasks'     => __( 'Break up long tasks', 'gm2-wordpress-suite' ),
+            'ae_perf_nothrash'      => __( 'Batch DOM reads & writes', 'gm2-wordpress-suite' ),
+            'ae_perf_passive'       => __( 'Passive scroll/touch listeners', 'gm2-wordpress-suite' ),
+            'ae_perf_passive_patch' => __( 'Allow passive listeners patch', 'gm2-wordpress-suite' ),
+            'ae_perf_domaudit'      => __( 'DOM size audit', 'gm2-wordpress-suite' ),
+        ];
+
+        foreach ($options as $option => $label) {
+            add_option($option, '0');
+            register_setting('gm2_performance', $option, [
+                'type'              => 'string',
+                'sanitize_callback' => [ __CLASS__, 'sanitize_checkbox' ],
+                'default'           => '0',
+            ]);
+        }
+
+        add_settings_section(
+            'gm2_performance_main',
+            __( 'Performance', 'gm2-wordpress-suite' ),
+            '__return_false',
+            'gm2-perf'
+        );
+
+        foreach ($options as $option => $label) {
+            add_settings_field(
+                $option,
+                $label,
+                [ __CLASS__, 'render_checkbox' ],
+                'gm2-perf',
+                'gm2_performance_main',
+                [ 'option' => $option ]
+            );
+        }
+    }
+
+    /**
+     * Add a menu page or attach to existing settings page.
+     */
+    public static function menu(): void {
+        $parent = 'gm2-seo';
+        if (self::menu_exists($parent)) {
+            add_submenu_page(
+                $parent,
+                __( 'Performance', 'gm2-wordpress-suite' ),
+                __( 'Performance', 'gm2-wordpress-suite' ),
+                'manage_options',
+                'gm2-perf',
+                [ __CLASS__, 'render' ]
+            );
+        } else {
+            add_options_page(
+                __( 'Performance', 'gm2-wordpress-suite' ),
+                __( 'Performance', 'gm2-wordpress-suite' ),
+                'manage_options',
+                'gm2-perf',
+                [ __CLASS__, 'render' ]
+            );
+        }
+    }
+
+    /**
+     * Check if a menu slug exists.
+     */
+    private static function menu_exists(string $slug): bool {
+        global $menu;
+        foreach ((array) $menu as $item) {
+            if ($item[2] === $slug) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Render checkbox input.
+     */
+    public static function render_checkbox(array $args): void {
+        $option = $args['option'];
+        $value  = get_option($option, '0');
+        echo '<input type="checkbox" name="' . esc_attr($option) . '" value="1" ' . checked($value, '1', false) . ' />';
+    }
+
+    /**
+     * Sanitize checkbox value.
+     */
+    public static function sanitize_checkbox($value): string {
+        return $value === '1' ? '1' : '0';
+    }
+
+    /**
+     * Render settings page.
+     */
+    public static function render(): void {
+        echo '<div class="wrap">';
+        echo '<h1>' . esc_html__( 'Performance', 'gm2-wordpress-suite' ) . '</h1>';
+        echo '<form method="post" action="options.php">';
+        settings_fields('gm2_performance');
+        do_settings_sections('gm2-perf');
+        submit_button();
+        echo '</form>';
+        echo '</div>';
+    }
+}


### PR DESCRIPTION
## Summary
- add Gm2\Perf\Settings to expose performance toggles in admin
- update performance flag manager to new option names and patch toggle
- bootstrap performance settings on plugin load

## Testing
- `./vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `bash bin/install-wp-tests.sh wordpress_test root '' localhost latest` *(fails: mysqladmin command not found)*
- `apt-get install -y default-mysql-client` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2c0ae8ac8327b3d25101e0789d20