### PR TITLE
Add GitHub comments client for PR comment retrieval

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -83,6 +83,7 @@ require_once GM2_PLUGIN_DIR . 'includes/gm2-field-renderers.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-schema-tooltips.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-editorial-comments.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-model-export.php';
+require_once GM2_PLUGIN_DIR . 'includes/Gm2_Github_Client.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-config-versions.php';
 // Temporarily disable Recovery Email Queue.
 // require_once GM2_PLUGIN_DIR . 'includes/Gm2_Abandoned_Carts_Messaging.php';

--- a/includes/Gm2_Github_Client.php
+++ b/includes/Gm2_Github_Client.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Gm2 {
+    if (!defined('ABSPATH')) {
+        exit;
+    }
+
+    class Gm2_Github_Client {
+        private $token;
+
+        public function __construct() {
+            $this->token = (string) get_option('gm2_github_token', '');
+        }
+
+    private function get($url) {
+        $args = [
+            'timeout' => 20,
+            'headers' => [
+                'Accept'     => 'application/vnd.github+json',
+                'User-Agent' => 'Gm2-WordPress-Suite',
+            ],
+        ];
+        if ($this->token !== '') {
+            $args['headers']['Authorization'] = 'Bearer ' . $this->token;
+        }
+        $response = wp_safe_remote_get($url, $args);
+        if (is_wp_error($response)) {
+            return $response;
+        }
+        $code = wp_remote_retrieve_response_code($response);
+        if ($code < 200 || $code >= 300) {
+            return new \WP_Error('github_api_error', "HTTP $code response", [
+                'code' => $code,
+                'body' => wp_remote_retrieve_body($response),
+            ]);
+        }
+        $body = wp_remote_retrieve_body($response);
+        return $body === '' ? [] : json_decode($body, true);
+    }
+
+    public function get_comments($repo, $pr_number) {
+        $url = sprintf('https://api.github.com/repos/%s/pulls/%d/comments', $repo, $pr_number);
+        return $this->get($url);
+    }
+}
+}
+
+namespace {
+    function gm2_get_github_comments($repo, $pr_number) {
+        $client = new \Gm2\Gm2_Github_Client();
+        $result = $client->get_comments($repo, $pr_number);
+        return is_wp_error($result) ? [] : $result;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `Gm2_Github_Client` to fetch PR comments via GitHub API
- expose `gm2_get_github_comments()` helper
- load client in main plugin bootstrap

## Testing
- `composer install`
- `npm test` *(fails: jest not found)*
- `vendor/bin/phpunit` *(fails: missing WordPress test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5a0697e88327a06e1ab27f581eab