### PR TITLE
Add GitHub token settings page

### DIFF
--- a/admin/class-gm2-github-settings.php
+++ b/admin/class-gm2-github-settings.php
@@ -1,0 +1,77 @@
+<?php
+namespace Gm2;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Gm2_Github_Settings {
+    public function run() {
+        add_action('admin_menu', [ $this, 'add_menu' ]);
+        add_action('admin_init', [ $this, 'register_settings' ]);
+    }
+
+    public function add_menu() {
+        add_options_page(
+            __('GitHub Settings', 'gm2-wordpress-suite'),
+            __('GitHub', 'gm2-wordpress-suite'),
+            'manage_options',
+            'gm2-github-settings',
+            [ $this, 'render_page' ]
+        );
+    }
+
+    public function register_settings() {
+        register_setting(
+            'gm2_github',
+            'gm2_github_token',
+            [
+                'type'              => 'string',
+                'sanitize_callback' => [ $this, 'sanitize_token' ],
+                'default'           => '',
+                'capability'        => 'manage_options',
+            ]
+        );
+
+        add_settings_section(
+            'gm2_github_section',
+            __('GitHub', 'gm2-wordpress-suite'),
+            '__return_false',
+            'gm2-github-settings'
+        );
+
+        add_settings_field(
+            'gm2_github_token',
+            __('Token', 'gm2-wordpress-suite'),
+            [ $this, 'token_field' ],
+            'gm2-github-settings',
+            'gm2_github_section'
+        );
+    }
+
+    public function sanitize_token($token) {
+        return sanitize_text_field($token);
+    }
+
+    public function token_field() {
+        $token = get_option('gm2_github_token', '');
+        printf(
+            '<input type="password" name="gm2_github_token" value="%s" class="regular-text" />',
+            esc_attr($token)
+        );
+    }
+
+    public function render_page() {
+        if (!current_user_can('manage_options')) {
+            return;
+        }
+        echo '<div class="wrap">';
+        echo '<h1>' . esc_html__( 'GitHub Settings', 'gm2-wordpress-suite' ) . '</h1>';
+        echo '<form action="options.php" method="post">';
+        settings_fields('gm2_github');
+        do_settings_sections('gm2-github-settings');
+        submit_button();
+        echo '</form>';
+        echo '</div>';
+    }
+}

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -92,6 +92,7 @@ require_once GM2_PLUGIN_DIR . 'admin/Gm2_Recovered_Carts_Admin.php';
 require_once GM2_PLUGIN_DIR . 'admin/class-gm2-ac-table.php';
 require_once GM2_PLUGIN_DIR . 'admin/class-gm2-bulk-ai-list-table.php';
 require_once GM2_PLUGIN_DIR . 'admin/class-gm2-bulk-ai-tax-list-table.php';
+require_once GM2_PLUGIN_DIR . 'admin/class-gm2-github-settings.php';
 require_once GM2_PLUGIN_DIR . 'admin/Gm2_Model_Export_Admin.php';
 require_once GM2_PLUGIN_DIR . 'admin/gm2-config-history.php';
 require_once GM2_PLUGIN_DIR . 'public/Gm2_Abandoned_Carts_Public.php';

--- a/includes/Gm2_Loader.php
+++ b/includes/Gm2_Loader.php
@@ -32,6 +32,9 @@ class Gm2_Loader {
 
             $links = new Gm2_Link_Counts();
             $links->run();
+
+            $github = new Gm2_Github_Settings();
+            $github->run();
         }
 
         $enable_seo       = get_option('gm2_enable_seo', '1') === '1';


### PR DESCRIPTION
## Summary
- add GitHub settings page with secure token option
- bootstrap settings page via loader and main plugin

## Testing
- `vendor/bin/phpunit` *(fails: failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5b1cd20c8327886a7fcc211168d3