### PR TITLE
Handle GitHub comment retrieval errors

### DIFF
--- a/admin/js/gm2-github-comments.js
+++ b/admin/js/gm2-github-comments.js
@@ -14,10 +14,12 @@
 
     function App() {
         const [comments, setComments] = useState(gm2GithubComments.comments || []);
-        const [notice, setNotice] = useState('');
+        const [notice, setNotice] = useState(gm2GithubComments.error || '');
+        const [noticeIsError, setNoticeIsError] = useState(!!gm2GithubComments.error);
 
         function applyPatch(file, patch) {
             setNotice('');
+            setNoticeIsError(false);
             const body = new URLSearchParams({
                 action: 'gm2_apply_patch',
                 nonce: gm2GithubComments.nonce,
@@ -35,12 +37,13 @@
                     setComments(data.data.comments || []);
                 } else {
                     setNotice(data.data || 'Error');
+                    setNoticeIsError(true);
                 }
             });
         }
 
         return h('div', null, [
-            notice ? h('div', {className: 'gm2-notice'}, notice) : null,
+            notice ? h('div', {className: noticeIsError ? 'gm2-notice gm2-notice-error' : 'gm2-notice'}, notice) : null,
             comments.map(c => h(CommentItem, {key: c.id, comment: c, onApply: applyPatch}))
         ]);
     }

--- a/includes/Gm2_Github_Client.php
+++ b/includes/Gm2_Github_Client.php
@@ -39,8 +39,15 @@ namespace Gm2 {
     }
 
     public function get_comments($repo, $pr_number) {
-        $url = sprintf('https://api.github.com/repos/%s/pulls/%d/comments', $repo, $pr_number);
-        return $this->get($url);
+        $url    = sprintf('https://api.github.com/repos/%s/pulls/%d/comments', $repo, $pr_number);
+        $result = $this->get($url);
+        if (is_wp_error($result)) {
+            return $result;
+        }
+        if (!is_array($result)) {
+            return new \WP_Error('github_invalid_response', __('Invalid response from GitHub', 'gm2-wordpress-suite'));
+        }
+        return $result;
     }
 }
 }
@@ -48,8 +55,7 @@ namespace Gm2 {
 namespace {
     function gm2_get_github_comments($repo, $pr_number) {
         $client = new \Gm2\Gm2_Github_Client();
-        $result = $client->get_comments($repo, $pr_number);
-        return is_wp_error($result) ? [] : $result;
+        return $client->get_comments($repo, $pr_number);
     }
 }
 


### PR DESCRIPTION
## Summary
- Propagate WP_Error failures from GitHub comment retrieval
- Surface GitHub API errors in admin UI
- Show error notices in GitHub comments script

## Testing
- `phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php) not found)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc65a2b0148327a1e164b82c1f9cc3