### PR TITLE
Implement diff-based patch application

### DIFF
--- a/includes/gm2-apply-patch.php
+++ b/includes/gm2-apply-patch.php
@@ -3,33 +3,107 @@
  * Apply a patch to a plugin file.
  *
  * This function uses the WordPress filesystem abstraction to modify
- * files within the plugin directory. The patch string is simply appended
- * to the existing file contents. The change is logged via error_log.
+ * files within the plugin directory. The patch string must be a unified
+ * diff which will be parsed and applied to the file. Success and failure
+ * are logged via error_log.
  *
  * @param string $file  Relative path to the plugin file.
- * @param string $patch Patch contents to append.
+ * @param string $patch Patch contents in unified diff format.
  * @return true|\WP_Error True on success, WP_Error on failure.
  */
 function gm2_apply_patch($file, $patch) {
     if (!function_exists('WP_Filesystem')) {
         require_once ABSPATH . 'wp-admin/includes/file.php';
     }
+
     global $wp_filesystem;
     if (!WP_Filesystem()) {
-        return new \WP_Error('fs_init_failed', __('Unable to initialize filesystem', 'gm2-wordpress-suite'));
+        $error = new \WP_Error('fs_init_failed', __('Unable to initialize filesystem', 'gm2-wordpress-suite'));
+        error_log('gm2_apply_patch: ' . $error->get_error_message());
+        return $error;
     }
+
     $path = realpath(GM2_PLUGIN_DIR . ltrim($file, '/'));
     if ($path === false || strpos($path, realpath(GM2_PLUGIN_DIR)) !== 0) {
-        return new \WP_Error('invalid_file', __('Invalid file path', 'gm2-wordpress-suite'));
+        $error = new \WP_Error('invalid_file', __('Invalid file path', 'gm2-wordpress-suite'));
+        error_log('gm2_apply_patch: ' . $error->get_error_message());
+        return $error;
     }
+
     $current = $wp_filesystem->get_contents($path);
     if ($current === false) {
-        return new \WP_Error('read_error', __('Unable to read file', 'gm2-wordpress-suite'));
+        $error = new \WP_Error('read_error', __('Unable to read file', 'gm2-wordpress-suite'));
+        error_log('gm2_apply_patch: ' . $error->get_error_message());
+        return $error;
     }
-    $new = $current . "\n" . $patch . "\n";
+
+    $new = gm2_apply_unified_diff($current, $patch);
+    if (is_wp_error($new)) {
+        error_log('gm2_apply_patch: ' . $new->get_error_message());
+        return $new;
+    }
+
     if (!$wp_filesystem->put_contents($path, $new, FS_CHMOD_FILE)) {
-        return new \WP_Error('write_error', __('Unable to write file', 'gm2-wordpress-suite'));
+        $error = new \WP_Error('write_error', __('Unable to write file', 'gm2-wordpress-suite'));
+        error_log('gm2_apply_patch: ' . $error->get_error_message());
+        return $error;
     }
-    error_log(sprintf('gm2_apply_patch: %s modified', $path));
+
+    error_log(sprintf('gm2_apply_patch: %s patched successfully', $path));
     return true;
+}
+
+/**
+ * Apply a unified diff to a string.
+ *
+ * @param string $original Original file contents.
+ * @param string $patch    Unified diff.
+ * @return string|\WP_Error Patched contents or WP_Error on failure.
+ */
+function gm2_apply_unified_diff($original, $patch) {
+    $lines        = preg_split('/\r?\n/', $original);
+    $patch_lines  = preg_split('/\r?\n/', $patch);
+    $i            = 0;
+    $offset       = 0;
+
+    while ($i < count($patch_lines)) {
+        $line = $patch_lines[$i];
+
+        if (preg_match('/^@@\s+-(\d+)(?:,(\d+))?\s+\+(\d+)(?:,(\d+))?\s+@@/', $line, $m)) {
+            $old_start = (int) $m[1];
+            $i++;
+            $hunk = [];
+            while ($i < count($patch_lines) && (isset($patch_lines[$i][0]) && $patch_lines[$i][0] !== '@')) {
+                $hunk[] = $patch_lines[$i];
+                $i++;
+            }
+
+            $expected    = [];
+            $replacement = [];
+            foreach ($hunk as $hunk_line) {
+                if ($hunk_line === '' || $hunk_line[0] === '\\') {
+                    continue;
+                }
+                if ($hunk_line[0] === ' ' || $hunk_line[0] === '-') {
+                    $expected[] = substr($hunk_line, 1);
+                }
+                if ($hunk_line[0] === ' ' || $hunk_line[0] === '+') {
+                    $replacement[] = substr($hunk_line, 1);
+                }
+            }
+
+            $index = $old_start - 1 + $offset;
+            $slice = array_slice($lines, $index, count($expected));
+            if ($slice !== $expected) {
+                return new \WP_Error('patch_mismatch', __('Patch does not apply cleanly', 'gm2-wordpress-suite'));
+            }
+            array_splice($lines, $index, count($expected), $replacement);
+            $offset += count($replacement) - count($expected);
+        } else {
+            // Skip non-hunk lines such as file headers.
+            $i++;
+        }
+    }
+
+    return implode("\n", $lines);
 }

--- a/tests/test-apply-patch.php
+++ b/tests/test-apply-patch.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Tests for gm2_apply_patch.
+ */
+class ApplyPatchTest extends WP_UnitTestCase {
+    /**
+     * Ensure a valid unified diff is applied.
+     */
+    public function test_apply_patch_success() {
+        global $wp_filesystem;
+        WP_Filesystem();
+        $dir = GM2_PLUGIN_DIR . 'tests/tmp';
+        if (!is_dir($dir)) {
+            mkdir($dir, 0777, true);
+        }
+        $file = $dir . '/sample.txt';
+        file_put_contents($file, "line1\nline2\nline3\n");
+        $rel  = str_replace(GM2_PLUGIN_DIR, '', $file);
+        $patch = "--- a/sample.txt\n+++ b/sample.txt\n@@ -1,3 +1,3 @@\n line1\n-line2\n+LINE2\n line3\n";
+        $result = gm2_apply_patch($rel, $patch);
+        $this->assertTrue($result);
+        $this->assertStringEqualsFile($file, "line1\nLINE2\nline3\n");
+    }
+
+    /**
+     * A patch that does not match should return WP_Error.
+     */
+    public function test_apply_patch_failure() {
+        global $wp_filesystem;
+        WP_Filesystem();
+        $dir = GM2_PLUGIN_DIR . 'tests/tmp';
+        if (!is_dir($dir)) {
+            mkdir($dir, 0777, true);
+        }
+        $file = $dir . '/sample.txt';
+        file_put_contents($file, "line1\nline2\nline3\n");
+        $rel  = str_replace(GM2_PLUGIN_DIR, '', $file);
+        $patch = "--- a/sample.txt\n+++ b/sample.txt\n@@ -1,3 +1,3 @@\n line1\n-lineX\n+LINE2\n line3\n";
+        $result = gm2_apply_patch($rel, $patch);
+        $this->assertInstanceOf('WP_Error', $result);
+    }
+}


### PR DESCRIPTION
## Summary
- Parse unified diff patches and apply them to target files
- Validate patches, returning WP_Error and logging on failure
- Log success of patch application and add coverage tests

## Testing
- `composer install`
- `vendor/bin/phpunit tests/test-apply-patch.php` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): Failed to open stream)*

------
https://chatgpt.com/codex/tasks/task_e_68bc672efea48327b81c97a9946d4c39