### PR TITLE
Add capability checks for patch application

### DIFF
--- a/admin/class-gm2-github-comments-admin.php
+++ b/admin/class-gm2-github-comments-admin.php
@@ -87,6 +87,9 @@ class Gm2_Github_Comments_Admin {
 
     public function ajax_apply_patch() {
         check_ajax_referer('gm2_apply_patch', 'nonce');
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(__('You do not have permission to apply patches.', 'gm2-wordpress-suite'));
+        }
         $file  = isset($_POST['file']) ? sanitize_text_field(wp_unslash($_POST['file'])) : '';
         $patch = isset($_POST['patch']) ? wp_unslash($_POST['patch']) : '';
         $result = gm2_apply_patch($file, $patch);

--- a/includes/gm2-apply-patch.php
+++ b/includes/gm2-apply-patch.php
@@ -12,6 +12,11 @@
  * @return true|\WP_Error True on success, WP_Error on failure.
  */
 function gm2_apply_patch($file, $patch) {
+    if (!current_user_can('manage_options')) {
+        $error = new \WP_Error('permission', __('You do not have permission to apply patches.', 'gm2-wordpress-suite'));
+        error_log('gm2_apply_patch: ' . $error->get_error_message());
+        return $error;
+    }
     if (!function_exists('WP_Filesystem')) {
         require_once ABSPATH . 'wp-admin/includes/file.php';
     }

--- a/tests/test-apply-patch.php
+++ b/tests/test-apply-patch.php
@@ -7,6 +7,8 @@ class ApplyPatchTest extends WP_UnitTestCase {
      * Ensure a valid unified diff is applied.
      */
     public function test_apply_patch_success() {
+        $admin_id = self::factory()->user->create(['role' => 'administrator']);
+        wp_set_current_user($admin_id);
         global $wp_filesystem;
         WP_Filesystem();
         $dir = GM2_PLUGIN_DIR . 'tests/tmp';
@@ -26,6 +28,8 @@ class ApplyPatchTest extends WP_UnitTestCase {
      * A patch that does not match should return WP_Error.
      */
     public function test_apply_patch_failure() {
+        $admin_id = self::factory()->user->create(['role' => 'administrator']);
+        wp_set_current_user($admin_id);
         global $wp_filesystem;
         WP_Filesystem();
         $dir = GM2_PLUGIN_DIR . 'tests/tmp';
@@ -36,6 +40,26 @@ class ApplyPatchTest extends WP_UnitTestCase {
         file_put_contents($file, "line1\nline2\nline3\n");
         $rel  = str_replace(GM2_PLUGIN_DIR, '', $file);
         $patch = "--- a/sample.txt\n+++ b/sample.txt\n@@ -1,3 +1,3 @@\n line1\n-lineX\n+LINE2\n line3\n";
+        $result = gm2_apply_patch($rel, $patch);
+        $this->assertInstanceOf('WP_Error', $result);
+    }
+
+    /**
+     * Applying a patch without required capability should fail.
+     */
+    public function test_apply_patch_without_permission() {
+        $user_id = self::factory()->user->create(['role' => 'subscriber']);
+        wp_set_current_user($user_id);
+        global $wp_filesystem;
+        WP_Filesystem();
+        $dir = GM2_PLUGIN_DIR . 'tests/tmp';
+        if (!is_dir($dir)) {
+            mkdir($dir, 0777, true);
+        }
+        $file = $dir . '/sample.txt';
+        file_put_contents($file, "line1\nline2\nline3\n");
+        $rel  = str_replace(GM2_PLUGIN_DIR, '', $file);
+        $patch = "--- a/sample.txt\n+++ b/sample.txt\n@@ -1,3 +1,3 @@\n line1\n-line2\n+LINE2\n line3\n";
         $result = gm2_apply_patch($rel, $patch);
         $this->assertInstanceOf('WP_Error', $result);
     }


### PR DESCRIPTION
## Summary
- Restrict patch application via AJAX to users with `manage_options`
- Harden `gm2_apply_patch` with a capability check
- Update and extend patch tests for permission handling

## Testing
- `vendor/bin/phpunit tests/test-apply-patch.php` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): Failed to open stream)*
- `bin/install-wp-tests.sh wordpress_test root '' localhost latest` *(fails: mysqladmin command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc67f5c6d48327b3a042bde8bccd7b