### PR TITLE
Add GitHub PR dropdown and multi-PR comment fetching

### DIFF
--- a/admin/class-gm2-github-comments-admin.php
+++ b/admin/class-gm2-github-comments-admin.php
@@ -52,13 +52,47 @@ class Gm2_Github_Comments_Admin {
 
     private function get_comments() {
         $repo       = isset($_GET['repo']) ? sanitize_text_field(wp_unslash($_GET['repo'])) : get_option('gm2_last_repo', '');
-        $pr         = isset($_GET['pr']) ? absint($_GET['pr']) : 0;
+        $pr         = isset($_GET['pr']) ? sanitize_text_field(wp_unslash($_GET['pr'])) : '';
         $this->error = '';
         if ($repo !== '') {
             update_option('gm2_last_repo', $repo);
         }
-        if ($repo !== '' && $pr > 0) {
-            $comments = gm2_get_github_comments($repo, $pr);
+        if ($repo === '') {
+            return [];
+        }
+        $client = new Gm2_Github_Client();
+        if ($pr === '' || $pr === '0') {
+            $numbers = $client->list_open_pr_numbers($repo);
+            if (is_wp_error($numbers)) {
+                $this->error = $numbers->get_error_message();
+                return [];
+            }
+            if (empty($numbers)) {
+                return [];
+            }
+            $pr = (string) $numbers[0];
+            $_GET['pr'] = $pr;
+        }
+        if ($pr === 'all') {
+            $numbers = $client->list_open_pr_numbers($repo);
+            if (is_wp_error($numbers)) {
+                $this->error = $numbers->get_error_message();
+                return [];
+            }
+            $comments = [];
+            foreach ($numbers as $number) {
+                $pr_comments = gm2_get_github_comments($repo, $number);
+                if (is_wp_error($pr_comments)) {
+                    $this->error = $pr_comments->get_error_message();
+                    return [];
+                }
+                $comments = array_merge($comments, $pr_comments);
+            }
+            return $comments;
+        }
+        $pr_number = absint($pr);
+        if ($pr_number > 0) {
+            $comments = gm2_get_github_comments($repo, $pr_number);
             if (is_wp_error($comments)) {
                 $this->error = $comments->get_error_message();
                 return [];
@@ -72,14 +106,27 @@ class Gm2_Github_Comments_Admin {
         if (!current_user_can('manage_options')) {
             return;
         }
-        $repo = isset($_GET['repo']) ? sanitize_text_field(wp_unslash($_GET['repo'])) : get_option('gm2_last_repo', '');
-        $pr   = isset($_GET['pr']) ? absint($_GET['pr']) : 0;
+        $repo        = isset($_GET['repo']) ? sanitize_text_field(wp_unslash($_GET['repo'])) : get_option('gm2_last_repo', '');
+        $pr          = isset($_GET['pr']) ? sanitize_text_field(wp_unslash($_GET['pr'])) : '';
+        $client      = new Gm2_Github_Client();
+        $pr_numbers  = $repo !== '' ? $client->list_open_pr_numbers($repo) : [];
+        if (is_wp_error($pr_numbers)) {
+            $pr_numbers = [];
+        }
+        if ($pr === '' && !empty($pr_numbers)) {
+            $pr = (string) $pr_numbers[0];
+        }
         echo '<div class="wrap"><h1>' . esc_html__('PR Reviews', 'gm2-wordpress-suite') . '</h1>';
         echo '<form method="get"><input type="hidden" name="page" value="gm2-github-comments" />';
         echo '<p><label>' . esc_html__('Repository (owner/repo)', 'gm2-wordpress-suite') . ' <input type="text" name="repo" value="' . esc_attr($repo) . '" /></label></p>';
-        echo '<p><label>' . esc_html__('PR Number', 'gm2-wordpress-suite') . ' <input type="number" name="pr" value="' . ($pr > 0 ? esc_attr($pr) : '') . '" /></label></p>';
+        echo '<p><label>' . esc_html__('PR Number', 'gm2-wordpress-suite') . ' <select name="pr">';
+        echo '<option value="all"' . selected($pr === 'all', true, false) . '>' . esc_html__('All', 'gm2-wordpress-suite') . '</option>';
+        foreach ($pr_numbers as $number) {
+            echo '<option value="' . esc_attr($number) . '"' . selected($pr == $number, true, false) . '>' . esc_html($number) . '</option>';
+        }
+        echo '</select></label></p>';
         echo '<p><input type="submit" class="button button-primary" value="' . esc_attr__('Load', 'gm2-wordpress-suite') . '" /></p></form>';
-        if ($repo === '' || $pr <= 0) {
+        if ($repo === '' || $pr === '') {
             echo '<p>' . esc_html__('No PR selected', 'gm2-wordpress-suite') . '</p>';
         }
         echo '<div id="gm2-github-comments-root"></div></div>';

--- a/includes/Gm2_Github_Client.php
+++ b/includes/Gm2_Github_Client.php
@@ -38,6 +38,18 @@ namespace Gm2 {
         return $body === '' ? [] : json_decode($body, true);
     }
 
+    public function list_open_pr_numbers($repo) {
+        $url    = sprintf('https://api.github.com/repos/%s/pulls?state=open', $repo);
+        $result = $this->get($url);
+        if (is_wp_error($result)) {
+            return $result;
+        }
+        if (!is_array($result)) {
+            return new \WP_Error('github_invalid_response', __('Invalid response from GitHub', 'gm2-wordpress-suite'));
+        }
+        return array_map('intval', array_column($result, 'number'));
+    }
+
     public function get_comments($repo, $pr_number) {
         $url    = sprintf('https://api.github.com/repos/%s/pulls/%d/comments', $repo, $pr_number);
         $result = $this->get($url);


### PR DESCRIPTION
## Summary
- Add `list_open_pr_numbers()` to GitHub client for querying open PR numbers
- Provide PR number dropdown with "All" option on admin page and default to first PR
- Fetch comments from multiple PRs when "All" is selected

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6ac947b083278de0eb4bec65b4d2