### PR TITLE
Add link to configure GitHub token for comments admin

### DIFF
--- a/admin/class-gm2-github-comments-admin.php
+++ b/admin/class-gm2-github-comments-admin.php
@@ -117,7 +117,12 @@ class Gm2_Github_Comments_Admin {
         $this->token_result = $client->validate_token();
         echo '<div class="wrap"><h1>' . esc_html__('PR Reviews', 'gm2-wordpress-suite') . '</h1>';
         if (is_wp_error($this->token_result)) {
-            echo '<div class="notice notice-error"><p>' . esc_html($this->token_result->get_error_message()) . '</p></div>';
+            echo '<div class="notice notice-error"><p>' . esc_html($this->token_result->get_error_message());
+            if ($this->token_result->get_error_code() === 'github_no_token') {
+                $settings_url = esc_url(admin_url('admin.php?page=gm2-github-settings'));
+                echo ' <a href="' . $settings_url . '">' . esc_html__('Configure your token on the GitHub settings page', 'gm2-wordpress-suite') . '</a>';
+            }
+            echo '</p></div>';
         } else {
             $login = isset($this->token_result['login']) ? $this->token_result['login'] : '';
             if ($login !== '') {


### PR DESCRIPTION
## Summary
- show configuration link when GitHub token is missing in PR Reviews admin page

## Testing
- `./vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd9fbcd1f883279e8adb4b8b37b99f