### PR TITLE
Add PR dropdown and support loading comments from all PRs

### DIFF
--- a/admin/class-gm2-github-comments-admin.php
+++ b/admin/class-gm2-github-comments-admin.php
@@ -112,7 +112,6 @@ class Gm2_Github_Comments_Admin {
             return;
         }
         $repo   = get_option('gm2_last_repo', '');
-        $pr     = '';
         $client = new Gm2_Github_Client();
         $this->token_result = $client->validate_token();
         echo '<div class="wrap"><h1>' . esc_html__('PR Reviews', 'gm2-wordpress-suite') . '</h1>';
@@ -125,7 +124,23 @@ class Gm2_Github_Comments_Admin {
             }
         }
         echo '<p><label>' . esc_html__('Repository (owner/repo)', 'gm2-wordpress-suite') . ' <input type="text" id="gm2-repo" value="' . esc_attr($repo) . '" /></label></p>';
-        echo '<p><label>' . esc_html__('PR Number', 'gm2-wordpress-suite') . ' <input type="text" id="gm2-pr" value="' . esc_attr($pr) . '" /></label></p>';
+
+        $numbers = [];
+        if ($repo !== '' && !is_wp_error($this->token_result)) {
+            $numbers = $client->list_open_pr_numbers($repo);
+            if (is_wp_error($numbers)) {
+                echo '<div class="notice notice-error"><p>' . esc_html($numbers->get_error_message()) . '</p></div>';
+                $numbers = [];
+            }
+        }
+
+        echo '<p><label>' . esc_html__('PR Number', 'gm2-wordpress-suite') . ' <select id="gm2-pr">';
+        echo '<option value="all">' . esc_html__('All PRs', 'gm2-wordpress-suite') . '</option>';
+        foreach ($numbers as $number) {
+            echo '<option value="' . esc_attr($number) . '">' . esc_html($number) . '</option>';
+        }
+        echo '</select></label></p>';
+
         echo '<p><button type="button" class="button button-primary" id="gm2-load-comments">' . esc_html__('Load', 'gm2-wordpress-suite') . '</button></p>';
         echo '<div id="gm2-github-comments-root"></div></div>';
     }

--- a/admin/js/gm2-github-comments.js
+++ b/admin/js/gm2-github-comments.js
@@ -196,16 +196,16 @@
         if (btn) {
             btn.addEventListener('click', function(){
                 const repoInput = document.getElementById('gm2-repo');
-                const prInput = document.getElementById('gm2-pr');
+                const prSelect = document.getElementById('gm2-pr');
                 const repo = repoInput ? repoInput.value.trim() : '';
-                const pr = prInput ? prInput.value.trim() : '';
+                const pr = prSelect ? prSelect.options[prSelect.selectedIndex].value : '';
                 gm2GithubComments.currentRepo = repo;
                 gm2GithubComments.currentPr = pr;
                 const body = new URLSearchParams({
                     action: 'gm2_get_github_comments',
                     nonce: gm2GithubComments.commentsNonce,
                     repo: repo,
-                    pr: pr
+                    pr: pr === 'all' ? 'all' : pr
                 });
                 document.dispatchEvent(new CustomEvent('gm2CommentsLoading'));
                 fetch(gm2GithubComments.ajax_url, {


### PR DESCRIPTION
## Summary
- add PR selection dropdown with 'All PRs' option in admin comments screen
- send selected PR (including `all`) in AJAX request
- handle `pr=all` by iterating over all open PR numbers

## Testing
- `npm test`
- `vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*


------
https://chatgpt.com/codex/tasks/task_e_68bda209828483279ec7a92f39a58a3f