### PR TITLE
Add branch filtering for GitHub PR comments

### DIFF
--- a/admin/js/gm2-github-comments.js
+++ b/admin/js/gm2-github-comments.js
@@ -44,7 +44,8 @@
                 file: file,
                 patch: patch,
                 repo: gm2GithubComments.currentRepo || '',
-                pr: gm2GithubComments.currentPr || ''
+                pr: gm2GithubComments.currentPr || '',
+                branch: gm2GithubComments.currentBranch || ''
             });
             fetch(gm2GithubComments.ajax_url, {
                 method: 'POST',
@@ -85,7 +86,8 @@
                 nonce: gm2GithubComments.nonce,
                 patches: JSON.stringify(patches),
                 repo: gm2GithubComments.currentRepo || '',
-                pr: gm2GithubComments.currentPr || ''
+                pr: gm2GithubComments.currentPr || '',
+                branch: gm2GithubComments.currentBranch || ''
             });
             fetch(gm2GithubComments.ajax_url, {
                 method: 'POST',
@@ -197,15 +199,19 @@
             btn.addEventListener('click', function(){
                 const repoInput = document.getElementById('gm2-repo');
                 const prSelect = document.getElementById('gm2-pr');
+                const branchSelect = document.getElementById('gm2-branch');
                 const repo = repoInput ? repoInput.value.trim() : '';
                 const pr = prSelect ? prSelect.options[prSelect.selectedIndex].value : '';
+                const branch = branchSelect ? branchSelect.options[branchSelect.selectedIndex].value : '';
                 gm2GithubComments.currentRepo = repo;
                 gm2GithubComments.currentPr = pr;
+                gm2GithubComments.currentBranch = branch;
                 const body = new URLSearchParams({
                     action: 'gm2_get_github_comments',
                     nonce: gm2GithubComments.commentsNonce,
                     repo: repo,
-                    pr: pr === 'all' ? 'all' : pr
+                    pr: pr === 'all' ? 'all' : pr,
+                    branch: branch
                 });
                 document.dispatchEvent(new CustomEvent('gm2CommentsLoading'));
                 fetch(gm2GithubComments.ajax_url, {

--- a/includes/Gm2_Github_Client.php
+++ b/includes/Gm2_Github_Client.php
@@ -52,8 +52,25 @@ namespace Gm2 {
         return $user;
     }
 
-    public function list_open_pr_numbers($repo) {
-        $url    = sprintf('https://api.github.com/repos/%s/pulls?state=open', $repo);
+    public function list_branches($repo) {
+        $url    = sprintf('https://api.github.com/repos/%s/branches', $repo);
+        $result = $this->get($url);
+        if (is_wp_error($result)) {
+            return $result;
+        }
+        if (!is_array($result)) {
+            return new \WP_Error('github_invalid_response', __('Invalid response from GitHub', 'gm2-wordpress-suite'));
+        }
+        return array_values(array_filter(array_map(function ($b) {
+            return isset($b['name']) ? (string) $b['name'] : '';
+        }, $result)));
+    }
+
+    public function list_open_pr_numbers($repo, $branch = '') {
+        $url = sprintf('https://api.github.com/repos/%s/pulls?state=open', $repo);
+        if ($branch !== '') {
+            $url .= '&base=' . rawurlencode($branch);
+        }
         $result = $this->get($url);
         if (is_wp_error($result)) {
             return $result;


### PR DESCRIPTION
## Summary
- allow selecting branches when listing PRs and fetching comments
- send selected branch to backend and GitHub API

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*


------
https://chatgpt.com/codex/tasks/task_e_68bda331cfc88327ac4f0f8020bd03e1