### PR TITLE
Build JS map on wp_enqueue_scripts

### DIFF
--- a/includes/class-ae-seo-js-detector.php
+++ b/includes/class-ae-seo-js-detector.php
@@ -17,7 +17,7 @@ class AE_SEO_JS_Detector {
      * Bootstrap the detector.
      */
     public static function init(): void {
-        add_action('init', [ __CLASS__, 'build_map' ]);
+        add_action('wp_enqueue_scripts', [ __CLASS__, 'build_map' ], PHP_INT_MAX);
         add_action('shutdown', [ __CLASS__, 'store_context' ]);
     }
 


### PR DESCRIPTION
## Summary
- build JavaScript dependency map during `wp_enqueue_scripts` instead of `init`

## Testing
- `vendor/bin/phpunit` *(fails: require_once /tmp/wordpress-tests-lib/includes/functions.php: No such file or directory)*
- `npx --yes jest` *(fails: Cannot find module 'jquery' from tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bdaac55fac83279294c560a5e1f9a4