### PR TITLE
Merge JS map entries and add rebuild CLI command

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -781,5 +781,6 @@ if (defined('WP_CLI') && WP_CLI) {
     require_once GM2_PLUGIN_DIR . 'includes/cli/class-gm2-schema-audit.php';
     require_once GM2_PLUGIN_DIR . 'includes/cli/class-ae-seo-critical-cli.php';
     require_once GM2_PLUGIN_DIR . 'includes/cli/class-ae-seo-js-smoketest.php';
+    require_once GM2_PLUGIN_DIR . 'includes/cli/class-ae-seo-js-map.php';
 }
 

--- a/includes/class-ae-seo-js-detector.php
+++ b/includes/class-ae-seo-js-detector.php
@@ -25,21 +25,25 @@ class AE_SEO_JS_Detector {
      * Build and cache script dependency map.
      */
     public static function build_map(): void {
-        if (get_transient('aejs_map') !== false) {
-            return;
-        }
+        $existing = get_transient('aejs_map');
+        $map      = is_array($existing) ? $existing : [];
+
         $scripts = wp_scripts();
         if (!$scripts) {
             return;
         }
-        $map = [];
+
         foreach ($scripts->registered as $handle => $script) {
+            if (isset($map[$handle])) {
+                continue;
+            }
             $map[$handle] = [
                 'src'       => $script->src,
                 'deps'      => $script->deps,
                 'in_footer' => !empty($script->extra['group']) && (int) $script->extra['group'] === 1,
             ];
         }
+
         set_transient('aejs_map', $map, 30 * MINUTE_IN_SECONDS);
     }
 

--- a/includes/cli/class-ae-seo-js-map.php
+++ b/includes/cli/class-ae-seo-js-map.php
@@ -1,0 +1,28 @@
+<?php
+namespace AE_SEO;
+
+if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+    return;
+}
+
+/**
+ * Rebuild the cached JavaScript map.
+ */
+class AE_SEO_JS_Map extends \WP_CLI_Command {
+    /**
+     * Rebuild the JavaScript dependency map.
+     *
+     * ## EXAMPLES
+     *
+     *     wp ae-seo js:map
+     *
+     * @when after_wp_load
+     */
+    public function __invoke( $args, $assoc_args ) {
+        delete_transient( 'aejs_map' );
+        \Gm2\AE_SEO_JS_Detector::build_map();
+        \WP_CLI::success( 'JavaScript map rebuilt.' );
+    }
+}
+
+\WP_CLI::add_command( 'ae-seo js:map', __NAMESPACE__ . '\\AE_SEO_JS_Map' );


### PR DESCRIPTION
## Summary
- Merge existing `aejs_map` transient entries with newly registered scripts when building the map
- Add `ae-seo js:map` WP-CLI command to flush and rebuild the cached JS map

## Testing
- `php -l includes/class-ae-seo-js-detector.php && php -l includes/cli/class-ae-seo-js-map.php && php -l gm2-wordpress-suite.php`
- `vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_68beeb3514f08327a6b3ac73287be97c