### PR TITLE
Add guard for empty branch dropdown

### DIFF
--- a/admin/js/gm2-github-comments.js
+++ b/admin/js/gm2-github-comments.js
@@ -1,0 +1,26 @@
+(function(global){
+    function init() {
+        var loadBtn = document.getElementById('gm2-load-github-comments');
+        if (!loadBtn) { return; }
+
+        loadBtn.addEventListener('click', function(){
+            var branchSelect = document.getElementById('gm2-github-branch');
+            var branch = '';
+            if (branchSelect && branchSelect.selectedIndex >= 0) {
+                var opt = branchSelect.options[branchSelect.selectedIndex];
+                branch = opt ? opt.value : '';
+            }
+
+            // Placeholder for request logic using `branch`
+            console.log('Fetching comments for branch:', branch);
+        });
+    }
+
+    if (typeof document !== 'undefined') {
+        document.addEventListener('DOMContentLoaded', init);
+    }
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = init;
+    }
+})(this);


### PR DESCRIPTION
## Summary
- guard GitHub comment branch dropdown when it has no options

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run test:js`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68beeb9380d4832796c19fb5b18fa47e