### PR TITLE
Clarify PHP fallback badge text

### DIFF
--- a/admin/class-ae-css-admin.php
+++ b/admin/class-ae-css-admin.php
@@ -213,7 +213,7 @@ class AE_CSS_Admin {
         $has_node = AE_CSS_Optimizer::has_node_capability();
         $badge_text = $has_node
             ? __( 'Node tools available (PurgeCSS/Penthouse)', 'gm2-wordpress-suite' )
-            : __( 'PHP fallback mode', 'gm2-wordpress-suite' );
+            : __( 'PHP fallback in use', 'gm2-wordpress-suite' );
         $badge_color = $has_node ? '#46b450' : '#dc3232';
 
         echo '<div class="wrap">';


### PR DESCRIPTION
## Summary
- clarify CSS optimizer admin badge when Node tools unavailable

## Testing
- `vendor/bin/phpunit` *(fails: Error: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0ff541d483279f32f1e8bc55b039