### PR TITLE
Generate home critical CSS when Node is available

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -296,6 +296,7 @@ function gm2_activate_css_optimizer_defaults() {
             'queue'                         => [],
         ]
     );
+    \AE\CSS\AE_CSS_Optimizer::get_instance()->maybe_generate_home_critical();
 }
 register_activation_hook(__FILE__, 'gm2_activate_css_optimizer_defaults');
 


### PR DESCRIPTION
## Summary
- Generate critical CSS for the home page on activation or when Node tooling becomes available
- Persist critical CSS and update job status for admin visibility

## Testing
- `npm test`
- `vendor/bin/phpunit` *(fails: requires WordPress test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68bf15f0c7ac8327bf971f79314421a0