### PR TITLE
Initialize CSS queue

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -131,6 +131,7 @@ require_once GM2_PLUGIN_DIR . 'includes/class-aeseo-settings.php';
 
 function gm2_css_optimizer_init() {
     \AE\CSS\AE_CSS_Optimizer::get_instance()->init();
+    \AE\CSS\AE_CSS_Queue::init();
     (new \Gm2\AE_CSS_Admin())->run();
 }
 add_action('init', 'gm2_css_optimizer_init');

--- a/includes/class-ae-css-queue.php
+++ b/includes/class-ae-css-queue.php
@@ -26,6 +26,13 @@ final class AE_CSS_Queue {
     }
 
     /**
+     * Initialize the queue.
+     */
+    public static function init(): void {
+        self::bootstrap();
+    }
+
+    /**
      * Retrieve singleton instance.
      *
      * @return self
@@ -121,5 +128,3 @@ final class AE_CSS_Queue {
         }
     }
 }
-
-AE_CSS_Queue::bootstrap();


### PR DESCRIPTION
## Summary
- add init() helper to AE_CSS_Queue
- initialize CSS queue during CSS optimizer setup

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*


------
https://chatgpt.com/codex/tasks/task_e_68bf24d070688327a2682fb5496570bf