### PR TITLE
Use AE_CSS_Queue for critical CSS jobs

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -295,7 +295,6 @@ function gm2_activate_css_optimizer_defaults() {
             'woocommerce_smart_enqueue'     => '0',
             'elementor_smart_enqueue'       => '0',
             'critical'                      => [],
-            'queue'                         => [],
         ]
     );
     \AE\CSS\AE_CSS_Optimizer::get_instance()->maybe_generate_home_critical();

--- a/includes/class-ae-css-queue.php
+++ b/includes/class-ae-css-queue.php
@@ -116,7 +116,9 @@ final class AE_CSS_Queue {
                     }
                     break;
                 case 'critical':
-                    $optimizer->process_queue();
+                    if (is_array($payload)) {
+                        $optimizer->process_critical_job($payload);
+                    }
                     break;
             }
         } catch (\Throwable $e) {

--- a/tests/test-css-optimizer.php
+++ b/tests/test-css-optimizer.php
@@ -24,7 +24,6 @@ class CssOptimizerTest extends WP_UnitTestCase {
                 'woocommerce_smart_enqueue'     => '0',
                 'elementor_smart_enqueue'       => '0',
                 'critical'                      => [],
-                'queue'                         => [],
             ]
         );
         remove_all_actions('wp_head');
@@ -64,7 +63,6 @@ class CssOptimizerTest extends WP_UnitTestCase {
                 'woocommerce_smart_enqueue'     => '0',
                 'elementor_smart_enqueue'       => '0',
                 'critical'                      => [],
-                'queue'                         => [],
             ],
             get_option('ae_css_settings')
         );
@@ -158,7 +156,6 @@ class CssOptimizerTest extends WP_UnitTestCase {
                 'woocommerce_smart_enqueue'     => '0',
                 'elementor_smart_enqueue'       => '0',
                 'critical'                      => [],
-                'queue'                         => [],
             ]
         );
         $optimizer = AE_CSS_Optimizer::get_instance();
@@ -185,7 +182,6 @@ class CssOptimizerTest extends WP_UnitTestCase {
                 'woocommerce_smart_enqueue'     => '1',
                 'elementor_smart_enqueue'       => '0',
                 'critical'                      => [],
-                'queue'                         => [],
             ]
         );
         $optimizer = AE_CSS_Optimizer::get_instance();
@@ -212,7 +208,6 @@ class CssOptimizerTest extends WP_UnitTestCase {
                 'woocommerce_smart_enqueue'     => '1',
                 'elementor_smart_enqueue'       => '0',
                 'critical'                      => [],
-                'queue'                         => [],
             ]
         );
         add_filter('ae/css/force_keep_style', function ($keep, $handle) {
@@ -246,7 +241,6 @@ class CssOptimizerTest extends WP_UnitTestCase {
                 'woocommerce_smart_enqueue'     => '0',
                 'elementor_smart_enqueue'       => '1',
                 'critical'                      => [],
-                'queue'                         => [],
             ]
         );
         $optimizer = AE_CSS_Optimizer::get_instance();
@@ -280,7 +274,6 @@ class CssOptimizerTest extends WP_UnitTestCase {
                 'woocommerce_smart_enqueue'     => '0',
                 'elementor_smart_enqueue'       => '1',
                 'critical'                      => [],
-                'queue'                         => [],
             ]
         );
         $optimizer = AE_CSS_Optimizer::get_instance();
@@ -305,7 +298,6 @@ class CssOptimizerTest extends WP_UnitTestCase {
                 'woocommerce_smart_enqueue'     => '0',
                 'elementor_smart_enqueue'       => '0',
                 'critical'                      => [ $url => '.critical{color:red;}' ],
-                'queue'                         => [],
             ]
         );
         $optimizer = AE_CSS_Optimizer::get_instance();
@@ -396,7 +388,6 @@ class CssOptimizerTest extends WP_UnitTestCase {
                 'woocommerce_smart_enqueue'     => '0',
                 'elementor_smart_enqueue'       => '0',
                 'critical'                      => [],
-                'queue'                         => [],
             ]
         );
         $optimizer = AE_CSS_Optimizer::get_instance();


### PR DESCRIPTION
## Summary
- Remove settings-based critical CSS queue
- Add critical job handling in AE_CSS_Queue
- Switch admin critical generation to new queue API

## Testing
- `npm test` *(fails: jest: not found)*
- `vendor/bin/phpunit` *(fails: WordPress test library missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2d32da2c8327b50cc0ee4a9e13f7