### PR TITLE
Track CSS queue status via options

### DIFF
--- a/admin/class-ae-css-admin.php
+++ b/admin/class-ae-css-admin.php
@@ -149,9 +149,6 @@ class AE_CSS_Admin {
         $url = isset($_POST['critical_url']) ? esc_url_raw(wp_unslash($_POST['critical_url'])) : '';
         if ($url !== '') {
             AE_CSS_Queue::get_instance()->enqueue('critical', [ 'url' => $url ]);
-            $status = get_option('ae_css_job_status', []);
-            $status['critical'] = [ 'status' => 'queued', 'message' => '' ];
-            update_option('ae_css_job_status', $status, false);
         }
         wp_safe_redirect(wp_get_referer() ?: admin_url('admin.php?page=gm2-css-optimization'));
         exit;

--- a/includes/class-ae-css-queue.php
+++ b/includes/class-ae-css-queue.php
@@ -139,6 +139,10 @@ final class AE_CSS_Queue {
         $queue[] = [ 'type' => $type, 'payload' => $payload ];
         \update_option(self::OPTION, $queue, false);
 
+        $status           = \get_option('ae_css_job_status', []);
+        $status[$type]    = [ 'status' => 'queued', 'message' => '' ];
+        \update_option('ae_css_job_status', $status, false);
+
         if (!\wp_next_scheduled('ae_css_queue_runner')) {
             \wp_schedule_event(time(), 'ae_css_queue_5min', 'ae_css_queue_runner');
         }

--- a/includes/cli/class-ae-css-cli.php
+++ b/includes/cli/class-ae-css-cli.php
@@ -22,11 +22,23 @@ class AE_CSS_CLI extends \WP_CLI_Command {
         \WP_CLI::line( sprintf( __( 'Queue length: %d', 'gm2-wordpress-suite' ), count( $queue ) ) );
         if ( empty( $types ) ) {
             \WP_CLI::line( __( 'No pending jobs.', 'gm2-wordpress-suite' ) );
-            return;
+        } else {
+            \WP_CLI::line( __( 'Pending job types:', 'gm2-wordpress-suite' ) );
+            foreach ( $types as $type => $count ) {
+                \WP_CLI::line( sprintf( ' - %s: %d', $type, $count ) );
+            }
         }
-        \WP_CLI::line( __( 'Pending job types:', 'gm2-wordpress-suite' ) );
-        foreach ( $types as $type => $count ) {
-            \WP_CLI::line( sprintf( ' - %s: %d', $type, $count ) );
+
+        $status = \get_option( 'ae_css_job_status', [] );
+        if ( \is_array( $status ) && ! empty( $status ) ) {
+            \WP_CLI::line( __( 'Job status:', 'gm2-wordpress-suite' ) );
+            foreach ( $status as $job => $data ) {
+                $msg = $data['status'] ?? '';
+                if ( ! empty( $data['message'] ) ) {
+                    $msg .= ' - ' . $data['message'];
+                }
+                \WP_CLI::line( sprintf( ' * %s: %s', $job, $msg ) );
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- update AE_CSS_Queue to track job status in persistent options
- simplify admin critical CSS handler now that enqueue updates status
- extend CLI status command to report job statuses

## Testing
- `npm test`
- `vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*


------
https://chatgpt.com/codex/tasks/task_e_68bf313bb30c83278a1cf0e60da2f431