### PR TITLE
Add validation for CLI flags and safer operations

### DIFF
--- a/tools/node/critical.js
+++ b/tools/node/critical.js
@@ -2,6 +2,7 @@
 const minimist = require('minimist');
 const penthouse = require('penthouse');
 const CleanCSS = require('clean-css');
+const fs = require('fs');
 
 (async () => {
   const args = minimist(process.argv.slice(2), {
@@ -15,15 +16,32 @@ const CleanCSS = require('clean-css');
     }
   });
 
-  const { url, css, width, height } = args;
+  const { url: rawUrl, css: rawCss, width, height } = args;
+
+  const url = typeof rawUrl === 'string' ? rawUrl.trim() : '';
+  const css = typeof rawCss === 'string' ? rawCss.trim() : '';
 
   if (!url || !css) {
     console.error('Usage: node critical.js --url <page url> --css <path to css> [--width <width>] [--height <height>]');
     process.exit(1);
   }
 
+  let parsedUrl;
   try {
-    const critical = await penthouse({ url, css, width, height });
+    parsedUrl = new URL(url);
+  } catch (e) {
+    console.error('Please provide a valid --url.');
+    process.exit(1);
+  }
+
+  const cssFiles = css.split(',').map(f => f.trim()).filter(Boolean);
+  if (!cssFiles.length || !cssFiles.every(f => fs.existsSync(f))) {
+    console.error('CSS file not found.');
+    process.exit(1);
+  }
+
+  try {
+    const critical = await penthouse({ url: parsedUrl.href, css: cssFiles.join(','), width, height });
     const output = new CleanCSS().minify(critical);
     if (output.errors && output.errors.length) {
       console.error(output.errors.join('\n'));


### PR DESCRIPTION
## Summary
- Sanitize and validate `--url` and `--theme` CLI flags
- Guard against missing classes/functions and wrap queue operations
- Harden Node critical CSS script with URL and CSS file checks

## Testing
- `composer install --no-interaction --no-progress`
- `vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `php tests/test-cli/ae-css-cli.php`
- `node tools/node/critical.js` *(fails: Cannot find module 'minimist')*
- `npm install minimist penthouse clean-css --no-audit` *(fails: ERESOLVE could not resolve)*

------
https://chatgpt.com/codex/tasks/task_e_68bf34f951f08327a93e1011687da57c