### PR TITLE
Use queue-based CSS job status for admin notices

### DIFF
--- a/tests/test-ae-css-admin.php
+++ b/tests/test-ae-css-admin.php
@@ -1,0 +1,27 @@
+<?php
+use Gm2\AE_CSS_Admin;
+
+class AeCssAdminNoticesTest extends WP_UnitTestCase {
+    public function test_show_queue_notices_includes_job_types() {
+        $admin_id = self::factory()->user->create(['role' => 'administrator']);
+        wp_set_current_user($admin_id);
+
+        update_option('ae_css_queue', [
+            ['type' => 'snapshot', 'payload' => 'https://example.com'],
+            ['type' => 'purge', 'payload' => '/theme'],
+        ]);
+        update_option('ae_css_job_status', [
+            'purge'    => ['status' => 'running', 'message' => ''],
+            'critical' => ['status' => 'done', 'message' => 'finished'],
+        ]);
+
+        $admin = new AE_CSS_Admin();
+        ob_start();
+        $admin->show_queue_notices();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('Snapshot: queued', $output);
+        $this->assertStringContainsString('Purge: running', $output);
+        $this->assertStringContainsString('Critical: done', $output);
+    }
+}


### PR DESCRIPTION
## Summary
- Display CSS job notices using new `ae_css_queue` and `ae_css_job_status` options
- Include `snapshot`, `purge`, and `critical` job types in status notices
- Add test coverage for CSS admin notices

## Testing
- `php -l admin/class-ae-css-admin.php tests/test-ae-css-admin.php`
- `vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*


------
https://chatgpt.com/codex/tasks/task_e_68bf371472d883278c43468c32a9f156