### PR TITLE
Handle PurgeCSS safelist arrays and regex entries

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -287,7 +287,7 @@ function gm2_activate_css_optimizer_defaults() {
         'ae_css_settings',
         [
             'flags'                         => [],
-            'safelist'                      => '',
+            'safelist'                      => [],
             'exclude_handles'               => [],
             'include_above_the_fold_handles'=> [],
             'generate_critical'             => '0',

--- a/includes/cli/class-ae-css-cli.php
+++ b/includes/cli/class-ae-css-cli.php
@@ -128,12 +128,17 @@ class AE_CSS_CLI extends \WP_CLI_Command {
         }
 
         $css_paths = \glob( trailingslashit( \get_stylesheet_directory() ) . 'css/*.css' ) ?: [];
+        $settings  = \get_option( 'ae_css_settings', [] );
+        $safelist  = [];
+        if ( \is_array( $settings ) && isset( $settings['safelist'] ) ) {
+            $safelist = (array) $settings['safelist'];
+        }
         $queue_obj = AE_CSS_Queue::get_instance();
         foreach ( $urls as $url ) {
             $payload = [
                 'css'      => $css_paths,
                 'html'     => [ $url ],
-                'safelist' => [],
+                'safelist' => $safelist,
             ];
             $queue_obj->enqueue( 'snapshot', $payload );
         }

--- a/tests/test-css-optimizer.php
+++ b/tests/test-css-optimizer.php
@@ -16,7 +16,7 @@ class CssOptimizerTest extends WP_UnitTestCase {
             'ae_css_settings',
             [
                 'flags'                         => [],
-                'safelist'                      => '',
+                'safelist'                      => [],
                 'exclude_handles'               => [],
                 'include_above_the_fold_handles'=> [],
                 'generate_critical'             => '0',
@@ -55,7 +55,7 @@ class CssOptimizerTest extends WP_UnitTestCase {
         $this->assertSame(
             [
                 'flags'                         => [],
-                'safelist'                      => '',
+                'safelist'                      => [],
                 'exclude_handles'               => [],
                 'include_above_the_fold_handles'=> [],
                 'generate_critical'             => '0',
@@ -148,7 +148,7 @@ class CssOptimizerTest extends WP_UnitTestCase {
             'ae_css_settings',
             [
                 'flags'                         => [ 'woo' => '1' ],
-                'safelist'                      => '',
+                'safelist'                      => [],
                 'exclude_handles'               => [],
                 'include_above_the_fold_handles'=> [],
                 'generate_critical'             => '0',
@@ -174,7 +174,7 @@ class CssOptimizerTest extends WP_UnitTestCase {
             'ae_css_settings',
             [
                 'flags'                         => [],
-                'safelist'                      => '',
+                'safelist'                      => [],
                 'exclude_handles'               => [],
                 'include_above_the_fold_handles'=> [],
                 'generate_critical'             => '0',
@@ -200,7 +200,7 @@ class CssOptimizerTest extends WP_UnitTestCase {
             'ae_css_settings',
             [
                 'flags'                         => [],
-                'safelist'                      => '',
+                'safelist'                      => [],
                 'exclude_handles'               => [],
                 'include_above_the_fold_handles'=> [],
                 'generate_critical'             => '0',
@@ -233,7 +233,7 @@ class CssOptimizerTest extends WP_UnitTestCase {
             'ae_css_settings',
             [
                 'flags'                         => [],
-                'safelist'                      => '',
+                'safelist'                      => [],
                 'exclude_handles'               => [],
                 'include_above_the_fold_handles'=> [],
                 'generate_critical'             => '0',
@@ -266,7 +266,7 @@ class CssOptimizerTest extends WP_UnitTestCase {
             'ae_css_settings',
             [
                 'flags'                         => [],
-                'safelist'                      => '',
+                'safelist'                      => [],
                 'exclude_handles'               => [],
                 'include_above_the_fold_handles'=> [],
                 'generate_critical'             => '0',
@@ -290,7 +290,7 @@ class CssOptimizerTest extends WP_UnitTestCase {
             'ae_css_settings',
             [
                 'flags'                         => [],
-                'safelist'                      => '',
+                'safelist'                      => [],
                 'exclude_handles'               => [],
                 'include_above_the_fold_handles'=> [],
                 'generate_critical'             => '1',
@@ -380,7 +380,7 @@ class CssOptimizerTest extends WP_UnitTestCase {
             'ae_css_settings',
             [
                 'flags'                         => [],
-                'safelist'                      => '',
+                'safelist'                      => [],
                 'exclude_handles'               => [],
                 'include_above_the_fold_handles'=> [ 'test' ],
                 'generate_critical'             => '0',


### PR DESCRIPTION
## Summary
- Parse safelist textarea into trimmed selectors and regex entries
- Forward safelist array to PurgeCSS and cron/queue jobs
- Clarify safelist field: one selector or `/regex/` per line

## Testing
- `vendor/bin/phpunit tests/test-css-optimizer.php` *(fails: require_once /tmp/wordpress-tests-lib/includes/functions.php)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3d38b49c8327bd417dae2be91e6f