### PR TITLE
Add AE CSS exclude handle persistence test and docs

### DIFF
--- a/admin/class-ae-css-admin.php
+++ b/admin/class-ae-css-admin.php
@@ -53,7 +53,7 @@ class AE_CSS_Admin {
     $list[] = '.keep-me';
     return $list;
 } );</code></pre>
-<p><code>ae/css/exclude_handles</code> – Prevent handles from async loading.</p>
+<p><code>ae/css/exclude_handles</code> – Prevent handles from async loading. Filter can alter the list at runtime.</p>
 <pre><code>add_filter( 'ae/css/exclude_handles', function ( $handles ) {
     $handles[] = 'plugin-style';
     return $handles;

--- a/tests/test-ae-css-admin.php
+++ b/tests/test-ae-css-admin.php
@@ -49,3 +49,20 @@ class AeCssAdminHelpTabsTest extends WP_UnitTestCase {
         $this->assertStringContainsString('ae_css_settings', $content);
     }
 }
+
+class AeCssAdminSanitizeSettingsTest extends WP_UnitTestCase {
+    public function test_exclude_handles_persist_after_sanitize(): void {
+        wp_register_style('alpha', 'https://example.com/alpha.css');
+        wp_register_style('beta', 'https://example.com/beta.css');
+
+        $input     = ['exclude_handles' => ['alpha', 'beta']];
+        $sanitized = AE_CSS_Admin::sanitize_settings($input);
+        update_option('ae_css_settings', $sanitized);
+
+        $saved = get_option('ae_css_settings');
+        $this->assertSame(['alpha', 'beta'], $saved['exclude_handles']);
+
+        wp_deregister_style('alpha');
+        wp_deregister_style('beta');
+    }
+}


### PR DESCRIPTION
## Summary
- test AE_CSS_Admin::sanitize_settings persisting excluded handles
- note in help tab that `ae/css/exclude_handles` filter can modify handles at runtime

## Testing
- `vendor/bin/phpunit` *(fails: Cannot redeclare class Gm2\Gm2_Abandoned_Carts)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5712adcc8327ace919730ccca979