### PR TITLE
Add optional utility CSS

### DIFF
--- a/admin/class-ae-css-admin.php
+++ b/admin/class-ae-css-admin.php
@@ -22,6 +22,7 @@ use AE\CSS\AE_CSS_Queue;
         'async_load_noncritical'        => '0',
         'woocommerce_smart_enqueue'     => '0',
         'elementor_smart_enqueue'       => '0',
+        'utility_css'                   => '0',
         'critical'                      => [],
         'logs'                          => [],
     ];
@@ -164,6 +165,7 @@ HTML;
         $async     = isset($input['async_load_noncritical']) && $input['async_load_noncritical'] === '1' ? '1' : '0';
         $woo       = isset($input['woocommerce_smart_enqueue']) && $input['woocommerce_smart_enqueue'] === '1' ? '1' : '0';
         $elementor = isset($input['elementor_smart_enqueue']) && $input['elementor_smart_enqueue'] === '1' ? '1' : '0';
+        $utility   = isset($input['utility_css']) && $input['utility_css'] === '1' ? '1' : '0';
         $enabled   = isset($input['enabled']) && $input['enabled'] === '1' ? '1' : '0';
 
         $current['exclude_handles']              = $exclude;
@@ -172,6 +174,7 @@ HTML;
         $current['async_load_noncritical']       = $async;
         $current['woocommerce_smart_enqueue']    = $woo;
         $current['elementor_smart_enqueue']      = $elementor;
+        $current['utility_css']                  = $utility;
         if (array_key_exists('enabled', $input)) {
             $current['enabled'] = $enabled;
         }
@@ -412,6 +415,7 @@ HTML;
         $async    = $settings['async_load_noncritical'] ?? '0';
         $woo_smart = $settings['woocommerce_smart_enqueue'] ?? '0';
         $elementor_smart = $settings['elementor_smart_enqueue'] ?? '0';
+        $utility = $settings['utility_css'] ?? '0';
         $enabled = $settings['enabled'] ?? '1';
 
         $all_handles = [];
@@ -475,6 +479,12 @@ HTML;
         echo '<label style="display:block;"><input type="checkbox" name="ae_css_settings[woocommerce_smart_enqueue]" value="1" ' . $checked . ' /> ' . esc_html__( 'Only load WooCommerce styles on WooCommerce pages', 'gm2-wordpress-suite' ) . '</label>';
         $checked = $elementor_smart === '1' ? 'checked="checked"' : '';
         echo '<label style="display:block;"><input type="checkbox" name="ae_css_settings[elementor_smart_enqueue]" value="1" ' . $checked . ' /> ' . esc_html__( 'Only load Elementor styles on Elementor pages', 'gm2-wordpress-suite' ) . '</label>';
+        echo '</td></tr>';
+
+        // Utility CSS toggle
+        echo '<tr><th scope="row">' . esc_html__( 'Utility CSS', 'gm2-wordpress-suite' ) . '</th><td>';
+        $checked = $utility === '1' ? 'checked="checked"' : '';
+        echo '<label><input type="checkbox" name="ae_css_settings[utility_css]" value="1" ' . $checked . ' /> ' . esc_html__( 'Load AE utility CSS', 'gm2-wordpress-suite' ) . '</label>';
         echo '</td></tr>';
 
         // Safelist textarea

--- a/assets/css/ae-utility.css
+++ b/assets/css/ae-utility.css
@@ -1,0 +1,25 @@
+:root{
+  --ae-spacing-xs:.25rem;
+  --ae-spacing-sm:.5rem;
+  --ae-spacing-md:1rem;
+  --ae-spacing-lg:2rem;
+  --ae-font-sm:.875rem;
+  --ae-font-md:1rem;
+  --ae-font-lg:1.25rem;
+}
+
+.container{width:min(100% - 2rem,60rem);margin-inline:auto;}
+.grid{display:grid;gap:var(--ae-spacing-md);}
+.flex{display:flex;gap:var(--ae-spacing-md);}
+.hidden{display:none !important;}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;}
+.btn{display:inline-block;padding:var(--ae-spacing-sm) var(--ae-spacing-md);border:1px solid currentColor;border-radius:4px;font-size:var(--ae-font-md);text-decoration:none;background:transparent;cursor:pointer;}
+.btn--primary{color:#fff;background:#0073aa;border-color:#0073aa;}
+
+@supports (container-type:inline-size){
+  .container{container-type:inline-size;}
+  @container (min-width:40rem){
+    .grid[data-cols="2"]{grid-template-columns:repeat(2,1fr);}
+    .grid[data-cols="3"]{grid-template-columns:repeat(3,1fr);}
+  }
+}

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -113,6 +113,7 @@ require_once GM2_PLUGIN_DIR . 'includes/functions-assets.php';
 require_once GM2_PLUGIN_DIR . 'includes/Perf/Enqueue.php';
 require_once GM2_PLUGIN_DIR . 'includes/class-ae-css-optimizer.php';
 require_once GM2_PLUGIN_DIR . 'includes/class-ae-css-queue.php';
+require_once GM2_PLUGIN_DIR . 'includes/class-ae-utility-css.php';
 require_once GM2_PLUGIN_DIR . 'includes/class-ae-seo-js-detector.php';
 require_once GM2_PLUGIN_DIR . 'includes/class-ae-seo-js-manager.php';
 require_once GM2_PLUGIN_DIR . 'includes/class-ae-seo-js-controller.php';
@@ -157,6 +158,7 @@ add_action('init', 'gm2_css_optimizer_init');
 \Gm2\AESEO_Settings::register();
 \Gm2\Perf\Enqueue::init();
 \Gm2\Perf\Settings::init();
+\Gm2\AE_Utility_CSS::init();
 \Gm2\AE_SEO_Font_Manager::init();
 if (get_option('gm2_pretty_versioned_urls', '0') === '1') {
     \Gm2\Gm2_Version_Route_Apache::maybe_apply();
@@ -295,6 +297,7 @@ function gm2_activate_css_optimizer_defaults() {
             'async_load_noncritical'        => '0',
             'woocommerce_smart_enqueue'     => '0',
             'elementor_smart_enqueue'       => '0',
+            'utility_css'                   => '0',
             'critical'                      => [],
             'logs'                          => [],
         ]

--- a/includes/class-ae-utility-css.php
+++ b/includes/class-ae-utility-css.php
@@ -1,0 +1,37 @@
+<?php
+namespace Gm2;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Optional tiny utility CSS.
+ */
+class AE_Utility_CSS {
+    /**
+     * Hook into enqueue.
+     */
+    public static function init(): void {
+        add_action('wp_enqueue_scripts', [ __CLASS__, 'enqueue' ], 1);
+    }
+
+    /**
+     * Conditionally enqueue the utility stylesheet.
+     */
+    public static function enqueue(): void {
+        $settings = get_option('ae_css_settings', []);
+        $enabled = isset($settings['utility_css']) && $settings['utility_css'] === '1';
+        $enabled = apply_filters('ae/css/utility_enabled', $enabled);
+        if (!$enabled) {
+            return;
+        }
+
+        $file = GM2_PLUGIN_DIR . 'assets/css/ae-utility.css';
+        $src  = GM2_PLUGIN_URL . 'assets/css/ae-utility.css';
+        $ver  = file_exists($file) ? (string) filemtime($file) : GM2_VERSION;
+
+        wp_register_style('ae-utility', $src, [], $ver);
+        wp_enqueue_style('ae-utility');
+    }
+}

--- a/tests/test-css-optimizer.php
+++ b/tests/test-css-optimizer.php
@@ -25,6 +25,7 @@ class CssOptimizerTest extends WP_UnitTestCase {
                 'async_load_noncritical'        => '0',
                 'woocommerce_smart_enqueue'     => '0',
                 'elementor_smart_enqueue'       => '0',
+                'utility_css'                   => '0',
                 'critical'                      => [],
                 'logs'                          => [],
             ]
@@ -66,6 +67,7 @@ class CssOptimizerTest extends WP_UnitTestCase {
                 'async_load_noncritical'        => '0',
                 'woocommerce_smart_enqueue'     => '0',
                 'elementor_smart_enqueue'       => '0',
+                'utility_css'                   => '0',
                 'critical'                      => [],
                 'logs'                          => [],
             ],
@@ -161,6 +163,7 @@ class CssOptimizerTest extends WP_UnitTestCase {
                 'async_load_noncritical'        => '0',
                 'woocommerce_smart_enqueue'     => '0',
                 'elementor_smart_enqueue'       => '0',
+                'utility_css'                   => '0',
                 'critical'                      => [],
                 'logs'                          => [],
             ]
@@ -189,6 +192,7 @@ class CssOptimizerTest extends WP_UnitTestCase {
                 'async_load_noncritical'        => '0',
                 'woocommerce_smart_enqueue'     => '1',
                 'elementor_smart_enqueue'       => '0',
+                'utility_css'                   => '0',
                 'critical'                      => [],
                 'logs'                          => [],
             ]
@@ -217,6 +221,7 @@ class CssOptimizerTest extends WP_UnitTestCase {
                 'async_load_noncritical'        => '0',
                 'woocommerce_smart_enqueue'     => '1',
                 'elementor_smart_enqueue'       => '0',
+                'utility_css'                   => '0',
                 'critical'                      => [],
                 'logs'                          => [],
             ]
@@ -252,6 +257,7 @@ class CssOptimizerTest extends WP_UnitTestCase {
                 'async_load_noncritical'        => '0',
                 'woocommerce_smart_enqueue'     => '0',
                 'elementor_smart_enqueue'       => '1',
+                'utility_css'                   => '0',
                 'critical'                      => [],
                 'logs'                          => [],
             ]
@@ -287,6 +293,7 @@ class CssOptimizerTest extends WP_UnitTestCase {
                 'async_load_noncritical'        => '0',
                 'woocommerce_smart_enqueue'     => '0',
                 'elementor_smart_enqueue'       => '1',
+                'utility_css'                   => '0',
                 'critical'                      => [],
                 'logs'                          => [],
             ]
@@ -313,6 +320,7 @@ class CssOptimizerTest extends WP_UnitTestCase {
                 'async_load_noncritical'        => '1',
                 'woocommerce_smart_enqueue'     => '0',
                 'elementor_smart_enqueue'       => '0',
+                'utility_css'                   => '0',
                 'critical'                      => [ $url => '.critical{color:red;}' ],
                 'logs'                          => [],
             ]
@@ -352,6 +360,7 @@ class CssOptimizerTest extends WP_UnitTestCase {
                 'async_load_noncritical'        => '1',
                 'woocommerce_smart_enqueue'     => '0',
                 'elementor_smart_enqueue'       => '0',
+                'utility_css'                   => '0',
                 'critical'                      => [ $url => '.critical{color:red;}' ],
                 'logs'                          => [],
             ]
@@ -447,6 +456,7 @@ class CssOptimizerTest extends WP_UnitTestCase {
                 'async_load_noncritical'        => '1',
                 'woocommerce_smart_enqueue'     => '0',
                 'elementor_smart_enqueue'       => '0',
+                'utility_css'                   => '0',
                 'critical'                      => [ $url => '.critical{color:red;}' ],
                 'logs'                          => [],
             ]
@@ -514,6 +524,7 @@ class CssOptimizerTest extends WP_UnitTestCase {
                 'async_load_noncritical'        => '1',
                 'woocommerce_smart_enqueue'     => '0',
                 'elementor_smart_enqueue'       => '0',
+                'utility_css'                   => '0',
                 'critical'                      => [ $url => '.critical{color:red;}' ],
                 'logs'                          => [],
             ]
@@ -591,6 +602,7 @@ class CssOptimizerTest extends WP_UnitTestCase {
                 'async_load_noncritical'        => '0',
                 'woocommerce_smart_enqueue'     => '0',
                 'elementor_smart_enqueue'       => '0',
+                'utility_css'                   => '0',
                 'critical'                      => [],
                 'logs'                          => [],
             ]


### PR DESCRIPTION
## Summary
- add small utility stylesheet with spacing, layout, and button helpers
- add setting and hook to optionally enqueue the utility CSS early
- update tests and activation defaults for new utility toggle

## Testing
- `npm test` *(fails: jest not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf62b6d1888327b34c4db0f422cc88