### PR TITLE
Add admin assets for font performance settings

### DIFF
--- a/modules/font-performance/admin/class-font-performance-admin.php
+++ b/modules/font-performance/admin/class-font-performance-admin.php
@@ -140,6 +140,21 @@ class Font_Performance_Admin {
             file_exists(GM2_PLUGIN_DIR . 'admin/js/gm2-seo.js') ? filemtime(GM2_PLUGIN_DIR . 'admin/js/gm2-seo.js') : GM2_VERSION,
             true
         );
+
+        wp_enqueue_style(
+            'gm2-font-performance-admin',
+            plugin_dir_url(__FILE__) . '../assets/admin.css',
+            [],
+            filemtime(plugin_dir_path(__FILE__) . '../assets/admin.css')
+        );
+
+        wp_enqueue_script(
+            'gm2-font-performance-admin',
+            plugin_dir_url(__FILE__) . '../assets/admin.js',
+            ['jquery'],
+            filemtime(plugin_dir_path(__FILE__) . '../assets/admin.js'),
+            true
+        );
     }
 
     /** Render settings page. */

--- a/modules/font-performance/assets/admin.css
+++ b/modules/font-performance/assets/admin.css
@@ -1,0 +1,19 @@
+.gm2-fonts-repeater {
+    margin-top: 5px;
+}
+
+.gm2-fonts-repeater .gm2-fonts-row {
+    margin-bottom: 5px;
+}
+
+.gm2-fonts-repeater .gm2-fonts-row input[type="text"] {
+    width: 60%;
+}
+
+.gm2-fonts-repeater .gm2-fonts-remove {
+    margin-left: 5px;
+}
+
+.gm2-fonts-repeater .gm2-fonts-add {
+    margin-top: 5px;
+}

--- a/modules/font-performance/assets/admin.js
+++ b/modules/font-performance/assets/admin.js
@@ -1,0 +1,41 @@
+(function($){
+    function initRepeater(name){
+        var textarea = $('[name="gm2seo_fonts['+name+']"]');
+        if(!textarea.length){ return; }
+
+        var wrap = $('<div class="gm2-fonts-repeater"></div>');
+        var list = $('<div class="gm2-fonts-list"></div>').appendTo(wrap);
+        var addBtn = $('<button type="button" class="button gm2-fonts-add">Add</button>').appendTo(wrap);
+
+        function addRow(val){
+            var row = $('<div class="gm2-fonts-row"><input type="text" value="'+(val||'')+'" /> <button type="button" class="button-link-delete gm2-fonts-remove">&times;</button></div>');
+            list.append(row);
+        }
+
+        var initial = textarea.val().split(/\n/).filter(function(v){ return v.trim(); });
+        if(initial.length){
+            initial.forEach(function(v){ addRow(v); });
+        }else{
+            addRow('');
+        }
+
+        textarea.after(wrap).hide();
+
+        addBtn.on('click', function(){ addRow(''); });
+        list.on('click', '.gm2-fonts-remove', function(){ $(this).closest('.gm2-fonts-row').remove(); });
+
+        textarea.closest('form').on('submit', function(){
+            var values = [];
+            list.find('input').each(function(){
+                var v = $(this).val().trim();
+                if(v){ values.push(v); }
+            });
+            textarea.val(values.join('\n'));
+        });
+    }
+
+    $(function(){
+        initRepeater('preload');
+        initRepeater('families');
+    });
+})(jQuery);


### PR DESCRIPTION
## Summary
- add admin.js and admin.css for Font Performance settings
- enqueue module admin assets on Fonts settings page

## Testing
- `npm test`
- `vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_68c05c1dcd348327be1f4d501c78d7da