### PR TITLE
feat: add font performance settings helper

### DIFF
--- a/includes/class-ae-seo-font-manager.php
+++ b/includes/class-ae-seo-font-manager.php
@@ -37,6 +37,16 @@ class AE_SEO_Font_Manager {
         self::schedule_event();
     }
 
+    /** Remove hooks and scheduled events. */
+    public static function disable(): void {
+        remove_filter('style_loader_src', [__CLASS__, 'intercept_style'], 10);
+        remove_filter('wp_resource_hints', [__CLASS__, 'filter_hints'], 10);
+        remove_action('wp_head', [__CLASS__, 'start_head_buffer'], 0);
+        remove_action('wp_head', [__CLASS__, 'end_head_buffer'], PHP_INT_MAX);
+        remove_action(self::CRON_HOOK, [__CLASS__, 'sync_cached_fonts']);
+        wp_clear_scheduled_hook(self::CRON_HOOK);
+    }
+
     /**
      * Register the enable setting on the Reading settings screen.
      */
@@ -86,8 +96,9 @@ class AE_SEO_Font_Manager {
     private static function cache_stylesheet(string $url): ?string {
         $cache = get_option(self::OPTION_CACHE, []);
         $dir   = wp_upload_dir();
-        $base_dir = trailingslashit($dir['basedir']) . 'fonts';
-        $base_url = trailingslashit($dir['baseurl']) . 'fonts';
+        $suffix   = is_multisite() ? '-' . get_current_blog_id() : '';
+        $base_dir = trailingslashit($dir['basedir']) . 'fonts' . $suffix;
+        $base_url = trailingslashit($dir['baseurl']) . 'fonts' . $suffix;
         if (!is_dir($base_dir)) {
             wp_mkdir_p($base_dir);
         }

--- a/modules/font-performance/admin/class-font-performance-admin.php
+++ b/modules/font-performance/admin/class-font-performance-admin.php
@@ -57,7 +57,7 @@ class Font_Performance_Admin {
 
     /** Sanitize submitted values. */
     public static function sanitize(array $input): array {
-        $opts = get_option(self::OPTION_KEY, []);
+        $opts = \Gm2\Font_Performance\Font_Performance::get_settings();
 
         $opts['enabled']             = !empty($input['enabled']);
         $opts['inject_display_swap'] = !empty($input['inject_display_swap']);
@@ -82,7 +82,7 @@ class Font_Performance_Admin {
 
     /** Render checkbox or textarea field. */
     public static function render_field(array $args): void {
-        $options = get_option(self::OPTION_KEY, []);
+        $options = \Gm2\Font_Performance\Font_Performance::get_settings();
         $value   = $options[$args['key']] ?? '';
         switch ($args['type']) {
             case 'checkbox':


### PR DESCRIPTION
## Summary
- add `Font_Performance::get_settings()` helper and early returns when disabled
- stop font manager hooks when feature disabled
- separate self-hosted font cache paths per site in multisite

## Testing
- `npm test`
- `vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*


------
https://chatgpt.com/codex/tasks/task_e_68c05e6a0c908327a38ffe24726f392d