### PR TITLE
Filter font preloads to valid woff2 URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,6 +506,7 @@ Each request writes a line to `wp-content/ae-seo/logs/js-optimizer.log` recordin
 - **Lazy widget loading** defers fetching embeds until interaction using `aeLazy` triggers.
 - **Tag Manager consolidation** merges analytics and pixel tags into a single module.
 - **Self‑hosted fonts** mirror Google Fonts locally; run `wp gm2 fonts sync` after changing fonts to refresh the cache.
+- **Font preloading** emits up to three `<link rel="preload" as="font" type="font/woff2" crossorigin>` tags for valid WOFF2 URLs.
 
 Enable modules on demand:
 

--- a/modules/font-performance/admin/class-font-performance-admin.php
+++ b/modules/font-performance/admin/class-font-performance-admin.php
@@ -35,7 +35,7 @@ class Font_Performance_Admin {
             'inject_display_swap' => ['type' => 'checkbox', 'label' => __('Inject display=swap', 'gm2-wordpress-suite')],
             'google_url_rewrite'  => ['type' => 'checkbox', 'label' => __('Rewrite Google URLs', 'gm2-wordpress-suite')],
             'preconnect'          => ['type' => 'textarea', 'label' => __('Preconnect URLs (one per line)', 'gm2-wordpress-suite')],
-            'preload'             => ['type' => 'textarea', 'label' => __('Preload URLs (one per line)', 'gm2-wordpress-suite')],
+            'preload'             => ['type' => 'textarea', 'label' => __('Preload font URLs (.woff2, one per line)', 'gm2-wordpress-suite')],
             'self_host'           => ['type' => 'checkbox', 'label' => __('Self-host fonts', 'gm2-wordpress-suite')],
             'families'            => ['type' => 'textarea', 'label' => __('Font families (one per line)', 'gm2-wordpress-suite')],
             'limit_variants'      => ['type' => 'checkbox', 'label' => __('Limit variants', 'gm2-wordpress-suite')],

--- a/modules/font-performance/class-font-performance.php
+++ b/modules/font-performance/class-font-performance.php
@@ -254,13 +254,25 @@ class Font_Performance {
         }
     }
 
-    /** Output preload link tags. */
+    /** Output preload link tags for up to three unique WOFF2 fonts. */
     public static function preload_links(): void {
-        if (empty(self::$options['enabled'])) {
+        if (empty(self::$options['enabled']) || empty(self::$options['preload'])) {
             return;
         }
-        foreach (self::$options['preload'] as $url) {
-            printf("<link rel='preload' href='%s' as='style' />\n", esc_url($url));
+
+        $urls = array_filter(
+            self::$options['preload'],
+            static function ($url) {
+                return filter_var($url, FILTER_VALIDATE_URL)
+                    && preg_match('/\.woff2(\?.*)?$/i', $url);
+            }
+        );
+
+        foreach (array_slice(array_values(array_unique($urls)), 0, 3) as $url) {
+            printf(
+                '<link rel="preload" as="font" type="font/woff2" href="%s" crossorigin>' . "\n",
+                esc_url($url)
+            );
         }
     }
 

--- a/readme.txt
+++ b/readme.txt
@@ -45,6 +45,7 @@ Key features include:
 * Lazy widget loading defers embeds until interaction using `aeLazy` triggers.
 * Tag manager consolidation merges analytics and pixel tags into a single module.
 * Self-hosted fonts mirror Google Fonts locally; run `wp gm2 fonts sync` after changing fonts to refresh the cache.
+* WOFF2 font preloading outputs up to three `<link rel="preload" as="font" type="font/woff2" crossorigin>` tags for valid URLs.
 
 Enable modules via `aeLazy`:
 

--- a/tests/FontPreloadLinksTest.php
+++ b/tests/FontPreloadLinksTest.php
@@ -1,0 +1,55 @@
+<?php
+use Gm2\Font_Performance\Font_Performance;
+
+class FontPreloadLinksTest extends WP_UnitTestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        remove_all_actions('wp_head');
+
+        $ref  = new ReflectionClass(Font_Performance::class);
+        $prop = $ref->getProperty('hooks_added');
+        $prop->setAccessible(true);
+        $prop->setValue(null, false);
+        $prop = $ref->getProperty('options');
+        $prop->setAccessible(true);
+        $prop->setValue(null, []);
+    }
+
+    public function test_preloads_only_valid_woff2_fonts(): void {
+        update_option('gm2seo_fonts', [
+            'enabled'             => true,
+            'inject_display_swap' => false,
+            'google_url_rewrite'  => false,
+            'preconnect'          => [],
+            'preload'             => [
+                'https://example.com/a.woff2',
+                'https://example.com/a.woff2',
+                'https://example.com/b.woff2?ver=1',
+                'https://example.com/c.woff2',
+                'https://example.com/d.woff2',
+                'https://example.com/style.css',
+                'https://example.com/e.woff',
+                'not-a-url',
+            ],
+            'self_host'           => false,
+            'families'            => [],
+            'limit_variants'      => false,
+            'system_fallback_css' => false,
+            'cache_headers'       => false,
+        ]);
+        Font_Performance::bootstrap();
+
+        ob_start();
+        do_action('wp_head');
+        $html = ob_get_clean();
+
+        $this->assertSame(3, substr_count($html, 'rel="preload"'));
+        $this->assertStringContainsString('rel="preload" as="font" type="font/woff2" href="https://example.com/a.woff2" crossorigin', $html);
+        $this->assertStringContainsString('href="https://example.com/b.woff2?ver=1"', $html);
+        $this->assertStringContainsString('href="https://example.com/c.woff2"', $html);
+        $this->assertStringNotContainsString('style.css', $html);
+        $this->assertStringNotContainsString('d.woff2', $html);
+        $this->assertStringNotContainsString('.woff"', $html);
+    }
+}


### PR DESCRIPTION
## Summary
- filter user-defined font preloads to valid `.woff2` URLs, dedupe and cap at three, outputting `<link rel="preload" as="font" type="font/woff2" crossorigin>`
- clarify admin option and docs to reference WOFF2 font preloading
- add regression test verifying only unique woff2 fonts are preloaded

## Testing
- `vendor/bin/phpunit --no-configuration --bootstrap tests/bootstrap.php tests/FontPreloadLinksTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68c06b4eda7c8327b3d978f3dd319f2e