### PR TITLE
Add font performance settings page

### DIFF
--- a/modules/font-performance/assets/admin.js
+++ b/modules/font-performance/assets/admin.js
@@ -36,19 +36,16 @@
 
     $(function(){
         initRepeater('preload');
-        initRepeater('families');
+        initRepeater('preconnect');
 
         function renderVariants(list){
-            var wrap = $('#gm2-variant-suggestions');
-            wrap.empty();
             if(!list || !list.length){ return; }
             list.forEach(function(v){
-                var id = 'gm2-variant-' + v.replace(/[^a-z0-9]/gi, '-');
-                var label = $('<label for="'+id+'"></label>');
-                var chk = $('<input type="checkbox" id="'+id+'" name="gm2seo_fonts[variant_suggestions][]" value="'+v+'" />');
-                if($.inArray(v, GM2FontPerf.selected) !== -1){ chk.prop('checked', true); }
-                label.append(chk).append(' '+v);
-                wrap.append($('<div></div>').append(label));
+                var id = '#gm2-variant-' + v.replace(/[^a-z0-9]/gi, '-');
+                var chk = $(id);
+                if(chk.length){
+                    chk.prop('checked', true);
+                }
             });
             updateSavings();
         }
@@ -83,6 +80,12 @@
         });
 
         $('#gm2-variant-suggestions').on('change', 'input[type="checkbox"]', updateSavings);
+
+        GM2FontPerf.selected.forEach(function(v){
+            var id = '#gm2-variant-' + v.replace(/[^a-z0-9]/gi, '-');
+            var chk = $(id);
+            if(chk.length){ chk.prop('checked', true); }
+        });
 
         fetchVariants();
         updateSavings();

--- a/modules/font-performance/class-font-performance.php
+++ b/modules/font-performance/class-font-performance.php
@@ -430,17 +430,12 @@ class Font_Performance {
         }
     }
 
-    /** Output simple system fallback CSS for specified families. */
+    /** Output a lightweight system font stack when enabled. */
     public static function fallback_css(): void {
-        if (empty(self::$options['enabled']) || empty(self::$options['families'])) {
+        if (empty(self::$options['enabled']) || empty(self::$options['system_fallback_css'])) {
             return;
         }
-        echo "<style id='gm2-font-fallback'>\n";
-        foreach (self::$options['families'] as $family) {
-            $family = esc_html($family);
-            echo "body{font-family:'{$family}',system-ui,sans-serif;}\n";
-        }
-        echo "</style>\n";
+        echo "<style id='gm2-font-fallback'>body{font-family:system-ui,-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,Ubuntu,\"Helvetica Neue\",Arial,\"Noto Sans\",sans-serif;}</style>\n";
     }
 
     /** Register REST route for serving font files with cache headers. */


### PR DESCRIPTION
## Summary
- add SEO Fonts settings page with module toggle, URL controls, variant matrix, and fallback stack
- provide caching guidance, self-host download, and restore remote fonts button
- emit system font stack when fallback is enabled

## Testing
- `vendor/bin/phpunit tests/FontPreloadLinksTest.php tests/test-font-display-swap.php` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c09f4f63c48327a14b5777604da22c