### PR TITLE
Add font-face CSS utility

### DIFF
--- a/modules/font-performance/class-font-css-util.php
+++ b/modules/font-performance/class-font-css-util.php
@@ -1,0 +1,73 @@
+<?php
+namespace Gm2\Font_Performance;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Utility methods for working with @font-face blocks.
+ */
+final class Font_CSS_Util {
+    /**
+     * Parse @font-face rules and normalise them.
+     *
+     * @param string $css Raw CSS to process.
+     * @return string Processed CSS.
+     */
+    public static function process(string $css): string {
+        $opts           = Font_Performance::get_settings();
+        $limit_variants = !empty($opts['limit_variants']);
+        $cache_headers  = !empty($opts['cache_headers']);
+        $allowed        = [];
+        if ($limit_variants && !empty($opts['variant_suggestions']) && is_array($opts['variant_suggestions'])) {
+            $allowed = array_flip(array_map('strtolower', $opts['variant_suggestions']));
+        }
+
+        return (string) preg_replace_callback(
+            '/@font-face\s*{[^}]*}/i',
+            static function (array $m) use ($limit_variants, $allowed, $cache_headers): string {
+                $block = $m[0];
+
+                $weight = '400';
+                if (preg_match('/font-weight\s*:\s*(\d{3}|bold|normal)/i', $block, $w)) {
+                    $val = strtolower($w[1]);
+                    $weight = match ($val) {
+                        'bold' => '700',
+                        'normal' => '400',
+                        default => $val,
+                    };
+                }
+
+                $style = 'normal';
+                if (preg_match('/font-style\s*:\s*(italic|oblique|normal)/i', $block, $s)) {
+                    $style = strtolower($s[1]);
+                }
+
+                $variant_key = strtolower($weight . ' ' . $style);
+                if ($limit_variants && $allowed && !isset($allowed[$variant_key])) {
+                    return '';
+                }
+
+                if (stripos($block, 'font-display') === false) {
+                    $block = preg_replace('/@font-face\s*{/', '@font-face{font-display:swap;', $block, 1);
+                }
+
+                if ($cache_headers) {
+                    $block = preg_replace_callback(
+                        '/url\(([^)]+)\)/i',
+                        static function (array $url_match): string {
+                            $url = trim($url_match[1], "'\" ");
+                            $url = Font_Performance::rewrite_font_src($url);
+                            return 'url(' . $url . ')';
+                        },
+                        $block
+                    );
+                }
+
+                return $block;
+            },
+            $css
+        );
+    }
+}

--- a/modules/font-performance/class-font-performance.php
+++ b/modules/font-performance/class-font-performance.php
@@ -5,6 +5,8 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+require_once __DIR__ . '/class-font-css-util.php';
+
 if (class_exists(__NAMESPACE__ . '\\Font_Performance')) {
     return;
 }

--- a/tests/test-font-css-util.php
+++ b/tests/test-font-css-util.php
@@ -1,0 +1,35 @@
+<?php
+use Gm2\Font_Performance\Font_Performance;
+use Gm2\Font_Performance\Font_CSS_Util;
+
+class FontCssUtilTest extends WP_UnitTestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        $ref = new ReflectionClass(Font_Performance::class);
+        foreach (['hooks_added' => false, 'options' => []] as $prop_name => $value) {
+            $prop = $ref->getProperty($prop_name);
+            $prop->setAccessible(true);
+            $prop->setValue($value);
+        }
+
+        update_option('gm2seo_fonts', [
+            'enabled'             => true,
+            'cache_headers'       => true,
+            'limit_variants'      => true,
+            'variant_suggestions' => ['400 normal'],
+        ]);
+
+        Font_Performance::bootstrap();
+    }
+
+    public function test_process_font_faces(): void {
+        $css = "@font-face{font-family:'Foo';src:url('/wp-content/fonts/foo.woff2');font-weight:400;}" .
+               "@font-face{font-family:'Foo';src:url('/wp-content/fonts/foo-bold.woff2');font-weight:700;}";
+        $out = Font_CSS_Util::process($css);
+
+        $this->assertStringContainsString('font-display:swap', $out);
+        $this->assertStringContainsString('gm2seo/v1/font?file=' . rawurlencode('wp-content/fonts/foo.woff2'), $out);
+        $this->assertStringNotContainsString('foo-bold.woff2', $out);
+    }
+}


### PR DESCRIPTION
## Summary
- add `Font_CSS_Util` for parsing @font-face rules, enforcing `font-display: swap`, limiting variants, and rewriting URLs to REST endpoint
- wire utility into font performance module
- cover utility with unit test

## Testing
- `composer install`
- `./bin/install-wp-tests.sh wordpress_test root '' localhost latest true` *(fails: mysqladmin command not found)*
- `./vendor/bin/phpunit` *(fails: Cannot redeclare class Gm2\Gm2_Abandoned_Carts)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a70cdad883279e585e68ae763a2d