### PR TITLE
docs: add font performance test plan

### DIFF
--- a/docs/font-performance-test-plan.md
+++ b/docs/font-performance-test-plan.md
@@ -1,0 +1,34 @@
+# Font Performance Test Plan
+
+## Display-swap Injection
+
+1. Load a page using Google Fonts.
+2. Verify the `display=swap` parameter is appended to each font URL.
+3. Confirm fonts render with `display: swap` by observing fallback text then webfont swap.
+4. Measure layout stability in Lighthouse; cumulative layout shift should remain minimal.
+5. Temporarily disable the injection and note any flash of invisible text (FOIT) or increased CLS.
+
+## Self-host Workflow
+
+1. Trigger the font self-host command or UI action.
+2. Ensure font files download to the local `/fonts/` directory.
+3. Confirm a local stylesheet is enqueued in place of the remote Google Fonts CSS.
+4. Verify the original remote stylesheet is deregistered and no external font requests occur.
+
+## Variant Limiting
+
+1. Configure the plugin to limit loaded font variants (weights/styles).
+2. Load the page and inspect network requests to ensure only the chosen variants are fetched.
+3. Check the font stylesheet to confirm unselected variants are absent.
+
+## Preloading WOFF2 Files
+
+1. Add preload tags for up to three WOFF2 font files in the document head.
+2. Load the page and confirm each preload is requested before render.
+3. Ensure additional font files beyond the first three are not preloaded.
+
+## REST Caching Headers and Server Rules
+
+1. Request the font REST endpoint.
+2. Inspect response headers to confirm `Cache-Control` and `ETag` values are set for caching.
+3. Verify server rules (e.g., `.htaccess` or Nginx config) send proper caching headers for font files.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,8 @@
 
 See [model-cli.md](model-cli.md) for managing custom post types, taxonomies and fields via WP-CLI.
 
+For font optimization checks, review [font-performance-test-plan.md](font-performance-test-plan.md).
+
 This release adds several new SEO and AI options:
 
 - Added an index on the `timestamp` column of the `gm2_analytics_log` table for faster lookups. Existing installations upgrade automatically.


### PR DESCRIPTION
## Summary
- add smoke test plan for font performance features
- link font performance test plan from docs index

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a9eae490832782a880bfb17d00a8