### PR TITLE
Add test for font cache headers and document server rules

### DIFF
--- a/docs/font-performance-test-plan.md
+++ b/docs/font-performance-test-plan.md
@@ -32,3 +32,27 @@
 1. Request the font REST endpoint.
 2. Inspect response headers to confirm `Cache-Control` and `ETag` values are set for caching.
 3. Verify server rules (e.g., `.htaccess` or Nginx config) send proper caching headers for font files.
+
+### Web Server Configuration
+
+To mirror the REST endpoint's long‑term caching when fonts are served directly by the web server, add rules similar to the following:
+
+**Apache**
+
+```
+<FilesMatch "\.(woff2?|ttf|otf)$">
+    Header set Cache-Control "public, max-age=31536000, immutable"
+    Header set Cross-Origin-Resource-Policy "cross-origin"
+</FilesMatch>
+```
+
+**Nginx**
+
+```
+location ~* \.(woff2?|ttf|otf)$ {
+    add_header Cache-Control "public, max-age=31536000, immutable";
+    add_header Cross-Origin-Resource-Policy "cross-origin";
+}
+```
+
+These directives ensure static font files receive the same caching directives as the plugin's REST endpoint.

--- a/tests/FontCacheHeadersTest.php
+++ b/tests/FontCacheHeadersTest.php
@@ -1,0 +1,49 @@
+<?php
+use Gm2\Font_Performance\Font_Performance;
+
+class FontCacheHeadersTest extends WP_UnitTestCase {
+    public function test_rest_endpoint_sends_cache_headers() {
+        // Create a dummy font file within the WordPress installation.
+        $relative = 'wp-content/fonts/test-font.woff2';
+        $absolute = ABSPATH . $relative;
+        if (!file_exists(dirname($absolute))) {
+            wp_mkdir_p(dirname($absolute));
+        }
+        file_put_contents($absolute, 'DUMMY');
+
+        // Prepare temporary files for the helper script and header output.
+        $script      = tempnam(sys_get_temp_dir(), 'font-script-');
+        $headersFile = tempnam(sys_get_temp_dir(), 'font-headers-');
+
+        $bootstrap = addslashes(dirname(__DIR__) . '/tests/bootstrap.php');
+        $code = <<< 'EOS'
+<?php
+require '$bootstrap';
+use Gm2\Font_Performance\Font_Performance;
+Font_Performance::register_font_route();
+$headersFile = $argv[1];
+$fontFile    = $argv[2];
+register_shutdown_function(function() use ($headersFile) {
+    file_put_contents($headersFile, implode("\n", headers_list()));
+});
+$req = new WP_REST_Request('GET', '/gm2seo/v1/font');
+$req->set_param('file', $fontFile);
+rest_get_server()->dispatch($req);
+EOS;
+        file_put_contents($script, $code);
+
+        // Execute the helper script in a separate PHP process.
+        $cmd = escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($script) . ' ' . escapeshellarg($headersFile) . ' ' . escapeshellarg($relative);
+        exec($cmd, $output, $ret);
+        $this->assertSame(0, $ret, 'Helper script failed to run');
+
+        $headers = file_get_contents($headersFile);
+        $this->assertStringContainsString('Cache-Control: public, max-age=31536000, immutable', $headers);
+        $this->assertStringContainsString('Cross-Origin-Resource-Policy: cross-origin', $headers);
+
+        // Cleanup temporary files and dummy font.
+        unlink($script);
+        unlink($headersFile);
+        unlink($absolute);
+    }
+}


### PR DESCRIPTION
## Summary
- add integration test ensuring font REST endpoint sends long-term caching and CORP headers
- document Apache and Nginx rules to replicate REST font cache headers

## Testing
- `npm test` *(fails: jest not found)*
- `vendor/bin/phpunit tests/FontCacheHeadersTest.php` *(fails: WordPress test suite missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b33b763c83278046500e0ac38b9e