### PR TITLE
Add image optimizer with next-gen picture support

### DIFF
--- a/includes/class-ae-seo-image-optimizer.php
+++ b/includes/class-ae-seo-image-optimizer.php
@@ -1,0 +1,117 @@
+<?php
+namespace Gm2;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Generic image optimizer that converts <img> tags to <picture> with next-gen sources.
+ */
+final class AE_SEO_Image_Optimizer {
+    /**
+     * Attach hooks for image optimization.
+     */
+    public static function boot(): void {
+        add_filter('wp_get_attachment_image_tag', [ __CLASS__, 'filter_attachment_html' ], 20, 3);
+        add_filter('wp_get_attachment_image', [ __CLASS__, 'filter_attachment_html' ], 20, 5);
+        add_filter('the_content', [ __CLASS__, 'filter_content_images' ], 30);
+    }
+
+    /**
+     * Filter attachment image HTML to output a <picture> element.
+     *
+     * @param string $html          Original HTML.
+     * @param int    $attachment_id Attachment ID.
+     * @return string
+     */
+    public static function filter_attachment_html(string $html, int $attachment_id): string {
+        if (AESEO_LCP_Optimizer::is_already_optimized($attachment_id)) {
+            return $html;
+        }
+        return self::pictureify($html, $attachment_id);
+    }
+
+    /**
+     * Convert <img> tags within post content.
+     *
+     * @param string $content Post content.
+     * @return string
+     */
+    public static function filter_content_images(string $content): string {
+        return preg_replace_callback(
+            '/<img\b[^>]*>/i',
+            static function (array $matches) {
+                $img_tag = $matches[0];
+                $attachment_id = 0;
+                if (preg_match('/wp-image-(\d+)/', $img_tag, $m)) {
+                    $attachment_id = (int) $m[1];
+                }
+                $key = $attachment_id ?: $img_tag;
+                if (AESEO_LCP_Optimizer::is_already_optimized($key)) {
+                    return $img_tag;
+                }
+                return self::pictureify($img_tag, $attachment_id);
+            },
+            $content
+        );
+    }
+
+    /**
+     * Wrap an image tag in a <picture> element with next-gen sources.
+     *
+     * @param string $img_tag       Original img tag.
+     * @param int    $attachment_id Attachment ID if known.
+     * @return string
+     */
+    private static function pictureify(string $img_tag, int $attachment_id = 0): string {
+        if (!preg_match('/src="([^"]+)"/', $img_tag, $src_match)) {
+            return $img_tag;
+        }
+        $src = $src_match[1];
+        $ext = pathinfo(parse_url($src, PHP_URL_PATH) ?? '', PATHINFO_EXTENSION);
+
+        if (!preg_match('/srcset="([^"]+)"/', $img_tag, $srcset_match)) {
+            $srcset = $attachment_id ? (string) \wp_get_attachment_image_srcset($attachment_id) : '';
+            if ($srcset) {
+                $img_tag = preg_replace('/<img/', '<img srcset="' . \esc_attr($srcset) . '"', $img_tag, 1);
+            }
+        } else {
+            $srcset = $srcset_match[1];
+        }
+        if ($srcset === '') {
+            return $img_tag;
+        }
+
+        $sizes = '';
+        if (preg_match('/sizes="([^"]*)"/', $img_tag, $m_sizes)) {
+            $sizes = $m_sizes[1];
+        } elseif ($attachment_id) {
+            $sizes = (string) \wp_get_attachment_image_sizes($attachment_id);
+            if ($sizes) {
+                $img_tag = preg_replace('/<img/', '<img sizes="' . \esc_attr($sizes) . '"', $img_tag, 1);
+            }
+        }
+
+        $sources = '';
+        if (\wp_image_editor_supports(['mime_type' => 'image/avif'])) {
+            AESEO_LCP_Optimizer::maybe_generate_nextgen_files($attachment_id, 'avif');
+            $avif_srcset = AESEO_LCP_Optimizer::convert_srcset_extension($srcset, $ext, 'avif');
+            if (AESEO_LCP_Optimizer::srcset_files_exist($avif_srcset)) {
+                $sources .= sprintf('<source type="image/avif" srcset="%s" sizes="%s" />', \esc_attr($avif_srcset), \esc_attr($sizes));
+            }
+        }
+        if (\wp_image_editor_supports(['mime_type' => 'image/webp'])) {
+            AESEO_LCP_Optimizer::maybe_generate_nextgen_files($attachment_id, 'webp');
+            $webp_srcset = AESEO_LCP_Optimizer::convert_srcset_extension($srcset, $ext, 'webp');
+            if (AESEO_LCP_Optimizer::srcset_files_exist($webp_srcset)) {
+                $sources .= sprintf('<source type="image/webp" srcset="%s" sizes="%s" />', \esc_attr($webp_srcset), \esc_attr($sizes));
+            }
+        }
+        if ($sources === '') {
+            return $img_tag;
+        }
+
+        return '<picture>' . $sources . $img_tag . '</picture>';
+    }
+}

--- a/includes/class-aeseo-lcp-optimizer.php
+++ b/includes/class-aeseo-lcp-optimizer.php
@@ -1223,7 +1223,7 @@ final class AESEO_LCP_Optimizer {
      * @param string $to_ext   New extension.
      * @return string
      */
-    private static function convert_srcset_extension(string $srcset, string $from_ext, string $to_ext): string {
+    public static function convert_srcset_extension(string $srcset, string $from_ext, string $to_ext): string {
         $sources   = array_map('trim', explode(',', $srcset));
         $converted = [];
         foreach ($sources as $source) {
@@ -1245,7 +1245,7 @@ final class AESEO_LCP_Optimizer {
      * @param string $srcset Srcset string.
      * @return bool
      */
-    private static function srcset_files_exist(string $srcset): bool {
+    public static function srcset_files_exist(string $srcset): bool {
         $uploads = wp_get_upload_dir();
         $sources = array_map('trim', explode(',', $srcset));
         foreach ($sources as $source) {
@@ -1267,7 +1267,7 @@ final class AESEO_LCP_Optimizer {
      * @param int    $attachment_id Attachment ID.
      * @param string $ext           Extension to generate (webp or avif).
      */
-    private static function maybe_generate_nextgen_files(int $attachment_id, string $ext): void {
+    public static function maybe_generate_nextgen_files(int $attachment_id, string $ext): void {
         if (!in_array($ext, [ 'webp', 'avif' ], true)) {
             return;
         }

--- a/includes/class-aeseo-plugin.php
+++ b/includes/class-aeseo-plugin.php
@@ -28,6 +28,7 @@ final class AESEO_Plugin {
         }
 
         require_once __DIR__ . '/class-aeseo-lcp-optimizer.php';
+        require_once __DIR__ . '/class-ae-seo-image-optimizer.php';
 
         add_action(
             'template_redirect',
@@ -36,6 +37,7 @@ final class AESEO_Plugin {
                     return;
                 }
                 AESEO_LCP_Optimizer::boot();
+                AE_SEO_Image_Optimizer::boot();
             },
             0
         );

--- a/tests/ImageOptimizerTest.php
+++ b/tests/ImageOptimizerTest.php
@@ -1,0 +1,36 @@
+<?php
+use Gm2\AE_SEO_Image_Optimizer;
+use Gm2\AESEO_LCP_Optimizer;
+
+/**
+ * Image optimizer integration tests.
+ */
+class ImageOptimizerTest extends WP_UnitTestCase {
+    public function set_up() : void {
+        parent::set_up();
+        AESEO_LCP_Optimizer::boot();
+        AE_SEO_Image_Optimizer::boot();
+    }
+
+    /**
+     * Ensure attachment images are wrapped in a picture element.
+     */
+    public function test_attachment_image_wrapped_in_picture(): void {
+        $id = self::factory()->attachment->create_upload_object(DIR_TESTDATA . '/images/canola.jpg');
+        $html = wp_get_attachment_image($id, 'thumbnail');
+        $this->assertStringContainsString('<picture>', $html);
+        $this->assertMatchesRegularExpression('/image\/(avif|webp)/', $html);
+    }
+
+    /**
+     * Ensure images inside post content are converted.
+     */
+    public function test_content_images_wrapped_in_picture(): void {
+        $id = self::factory()->attachment->create_upload_object(DIR_TESTDATA . '/images/canola.jpg');
+        $src = wp_get_attachment_url($id);
+        $content = sprintf('<p>Test</p><img class="wp-image-%d" src="%s" />', $id, $src);
+        $filtered = apply_filters('the_content', $content);
+        $this->assertStringContainsString('<picture>', $filtered);
+        $this->assertMatchesRegularExpression('/image\/(avif|webp)/', $filtered);
+    }
+}


### PR DESCRIPTION
## Summary
- Add AE_SEO_Image_Optimizer to wrap images in `<picture>` with AVIF/WebP sources and reuse LCP optimizer utilities
- Expose helper methods in `AESEO_LCP_Optimizer` for generating next-gen files
- Boot the new optimizer alongside existing LCP logic
- Add tests for attachment and content image conversion

## Testing
- `vendor/bin/phpunit tests/ImageOptimizerTest.php` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b77b654c8327ad57139a47eea26a