### PR TITLE
Add compression check and admin notice

### DIFF
--- a/admin/class-ae-seo-server-hints.php
+++ b/admin/class-ae-seo-server-hints.php
@@ -8,6 +8,8 @@ if (!defined('ABSPATH')) {
 class AE_SEO_Server_Hints {
     public function run(): void {
         add_action('admin_menu', [ $this, 'add_page' ]);
+        add_action('admin_notices', [ $this, 'maybe_notice' ]);
+        add_action('admin_init', [ $this, 'handle_notice_actions' ]);
     }
 
     public function add_page(): void {
@@ -73,6 +75,88 @@ NGINX;
         file_put_contents($file, '[' . $time . '] ' . $message . PHP_EOL, FILE_APPEND);
     }
 
+    private function asset_compression_enabled(): bool {
+        $url      = includes_url('js/jquery/jquery.min.js');
+        $response = wp_remote_head($url, [ 'timeout' => 5 ]);
+        if (is_wp_error($response)) {
+            return true;
+        }
+        $encoding = wp_remote_retrieve_header($response, 'content-encoding');
+        if (is_array($encoding)) {
+            $encoding = implode(', ', $encoding);
+        }
+        $encoding = strtolower((string) $encoding);
+        return strpos($encoding, 'gzip') !== false || strpos($encoding, 'br') !== false;
+    }
+
+    private function write_htaccess_snippet(?array &$backups = null): bool {
+        $apache       = $this->get_apache_snippet();
+        $file         = ABSPATH . '.htaccess';
+        $backup_glob  = ABSPATH . '.htaccess.ae-seo.bak.*';
+        $old_backups  = glob($backup_glob) ?: [];
+
+        if ($this->htaccess_writable()) {
+            if (file_exists($file)) {
+                $backup = $file . '.ae-seo.bak.' . time();
+                if (@copy($file, $backup)) {
+                    foreach ($old_backups as $old) {
+                        if ($old !== $backup) {
+                            @unlink($old);
+                        }
+                    }
+                    $this->log_message('.htaccess backup created: ' . basename($backup));
+                    if (is_array($backups)) {
+                        $backups = [ $backup ];
+                    }
+                } else {
+                    $this->log_message('Failed to create .htaccess backup');
+                }
+            }
+            if (@file_put_contents($file, PHP_EOL . $apache . PHP_EOL, FILE_APPEND) !== false) {
+                $this->log_message('.htaccess updated with AE Server Hints');
+                return true;
+            }
+            $this->log_message('Failed to write .htaccess');
+        } else {
+            $this->log_message('Unable to write .htaccess');
+        }
+        return false;
+    }
+
+    public function handle_notice_actions(): void {
+        if (is_apache() && isset($_POST['ae_seo_write_htaccess']) && check_admin_referer('ae_seo_write_htaccess')) {
+            $success = $this->write_htaccess_snippet();
+            add_action('admin_notices', function () use ($success) {
+                if ($success) {
+                    echo '<div class="updated"><p>' . esc_html__( '.htaccess updated.', 'gm2-wordpress-suite' ) . '</p></div>';
+                } else {
+                    echo '<div class="error"><p>' . esc_html__( 'Unable to write .htaccess.', 'gm2-wordpress-suite' ) . '</p></div>';
+                }
+            });
+        }
+    }
+
+    public function maybe_notice(): void {
+        if (!current_user_can('manage_options') || $this->asset_compression_enabled()) {
+            return;
+        }
+
+        echo '<div class="notice notice-warning"><p>' . esc_html__( 'Gzip or Brotli compression is not enabled. ', 'gm2-wordpress-suite' ) . '</p>';
+        $link = admin_url('tools.php?page=ae-seo-server-hints');
+
+        if (is_apache() && $this->htaccess_writable()) {
+            echo '<form method="post" style="display:inline-block;margin-right:8px;">';
+            wp_nonce_field('ae_seo_write_htaccess');
+            echo '<input type="hidden" name="ae_seo_write_htaccess" value="1" />';
+            echo '<input type="submit" class="button button-primary" value="' . esc_attr__( 'Write .htaccess', 'gm2-wordpress-suite' ) . '" />';
+            echo '</form>';
+            echo '<a class="button" href="' . esc_url($link) . '">' . esc_html__( 'Manual instructions', 'gm2-wordpress-suite' ) . '</a>';
+        } else {
+            echo '<a class="button" href="' . esc_url($link) . '">' . esc_html__( 'View instructions', 'gm2-wordpress-suite' ) . '</a>';
+        }
+        echo '</div>';
+    }
+
     public function render_page(): void {
         $apache       = $this->get_apache_snippet();
         $nginx        = $this->get_nginx_snippet();
@@ -125,32 +209,10 @@ NGINX;
         }
 
         if (is_apache() && isset($_POST['ae_seo_write_htaccess']) && check_admin_referer('ae_seo_write_htaccess')) {
-            $file = ABSPATH . '.htaccess';
-            if ($this->htaccess_writable()) {
-                if (file_exists($file)) {
-                    $backup = $file . '.ae-seo.bak.' . time();
-                    if (@copy($file, $backup)) {
-                        foreach ($backups as $old) {
-                            if ($old !== $backup) {
-                                @unlink($old);
-                            }
-                        }
-                        $this->log_message('.htaccess backup created: ' . basename($backup));
-                        $backups = [ $backup ];
-                    } else {
-                        $this->log_message('Failed to create .htaccess backup');
-                    }
-                }
-                if (@file_put_contents($file, PHP_EOL . $apache . PHP_EOL, FILE_APPEND) !== false) {
-                    echo '<div class="updated"><p>' . esc_html__( '.htaccess updated.', 'gm2-wordpress-suite' ) . '</p></div>';
-                    $this->log_message('.htaccess updated with AE Server Hints');
-                } else {
-                    echo '<div class="error"><p>' . esc_html__( 'Unable to write .htaccess.', 'gm2-wordpress-suite' ) . '</p></div>';
-                    $this->log_message('Failed to write .htaccess');
-                }
+            if ($this->write_htaccess_snippet($backups)) {
+                echo '<div class="updated"><p>' . esc_html__( '.htaccess updated.', 'gm2-wordpress-suite' ) . '</p></div>';
             } else {
                 echo '<div class="error"><p>' . esc_html__( 'Unable to write .htaccess.', 'gm2-wordpress-suite' ) . '</p></div>';
-                $this->log_message('Unable to write .htaccess');
             }
         }
 


### PR DESCRIPTION
## Summary
- detect asset compression via wp_remote_head and inspect Content-Encoding
- show admin warning with option to write server hints when gzip/br missing
- consolidate htaccess writing into reusable helper

## Testing
- `vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0bbc9738083279ea2f7fc48bffd55