### PR TITLE
Add next-gen image options for Network Payload Optimizer

### DIFF
--- a/tests/NetworkPayloadTest.php
+++ b/tests/NetworkPayloadTest.php
@@ -23,6 +23,10 @@ class NetworkPayloadTest extends WP_UnitTestCase {
         $opts = get_option('gm2_netpayload_settings');
         $this->assertIsArray($opts);
         $this->assertTrue($opts['nextgen_images']);
+        $this->assertTrue($opts['webp']);
+        $this->assertTrue($opts['avif']);
+        $this->assertFalse($opts['no_originals']);
+        $this->assertEquals(2560, $opts['big_image_cap']);
         $this->assertSame('detect', $opts['gzip_detection']);
         $this->assertTrue($opts['smart_lazyload']);
         $this->assertTrue($opts['asset_budget']);


### PR DESCRIPTION
## Summary
- expose WebP/AVIF toggles, original conversion skip, and big image cap setting
- save new options with defaults and warn when server lacks format support
- cover default values in NetworkPayload tests

## Testing
- `vendor/bin/phpunit tests/NetworkPayloadTest.php` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): Failed to open stream: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68c0c84dfbf88327a6fffda30421f34f