### PR TITLE
Add compression diagnostics panel to Network Payload settings

### DIFF
--- a/modules/network-payload/Compression.php
+++ b/modules/network-payload/Compression.php
@@ -1,0 +1,68 @@
+<?php
+namespace Gm2\NetworkPayload;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Compression {
+    /**
+     * Render compression details panel.
+     */
+    public static function render_panel(): void {
+        $tests = [
+            ['label' => __('Front Page', 'gm2-wordpress-suite'), 'url' => home_url('/')],
+            ['label' => __('Plugin CSS', 'gm2-wordpress-suite'), 'url' => GM2_PLUGIN_URL . 'modules/network-payload/assets/admin.css'],
+        ];
+
+        echo '<h2>' . esc_html__('Compression', 'gm2-wordpress-suite') . '</h2>';
+        echo '<table class="widefat striped">';
+        echo '<thead><tr>';
+        echo '<th>' . esc_html__('Resource', 'gm2-wordpress-suite') . '</th>';
+        echo '<th>' . esc_html__('Encoding', 'gm2-wordpress-suite') . '</th>';
+        echo '<th>' . esc_html__('Transfer Size', 'gm2-wordpress-suite') . '</th>';
+        echo '</tr></thead><tbody>';
+
+        foreach ($tests as $test) {
+            $info = self::probe($test['url']);
+            echo '<tr><th scope="row">' . esc_html($test['label']) . '</th>';
+            if ($info) {
+                echo '<td>' . esc_html($info['encoding']) . '</td>';
+                echo '<td>' . esc_html($info['size']) . '</td>';
+            } else {
+                echo '<td colspan="2">' . esc_html__('Error', 'gm2-wordpress-suite') . '</td>';
+            }
+            echo '</tr>';
+        }
+
+        echo '</tbody></table>';
+    }
+
+    /**
+     * Retrieve encoding and size for a URL.
+     */
+    private static function probe(string $url): ?array {
+        $response = wp_remote_head($url, ['timeout' => 5]);
+        if (is_wp_error($response) || 200 !== wp_remote_retrieve_response_code($response)) {
+            $response = wp_remote_get($url, ['timeout' => 5]);
+        }
+        if (is_wp_error($response)) {
+            return null;
+        }
+
+        $headers  = wp_remote_retrieve_headers($response);
+        $encoding = isset($headers['content-encoding']) ? $headers['content-encoding'] : 'none';
+
+        if (isset($headers['content-length'])) {
+            $bytes = (int) $headers['content-length'];
+        } else {
+            $body  = wp_remote_retrieve_body($response);
+            $bytes = strlen($body);
+        }
+
+        return [
+            'encoding' => $encoding,
+            'size'     => size_format($bytes, 2),
+        ];
+    }
+}

--- a/modules/network-payload/Module.php
+++ b/modules/network-payload/Module.php
@@ -5,6 +5,8 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+require_once __DIR__ . '/Compression.php';
+
 class Module {
     private const OPTION_KEY     = 'gm2_netpayload_settings';
     private const STATS_KEY      = 'gm2_netpayload_stats';
@@ -499,6 +501,7 @@ class Module {
                 <input type="hidden" name="gm2_regen_nextgen" value="1" />
                 <?php submit_button(__('Regenerate Next‑Gen Images', 'gm2-wordpress-suite'), 'secondary'); ?>
             </form>
+            <?php Compression::render_panel(); ?>
         </div>
         <?php
     }


### PR DESCRIPTION
## Summary
- add Compression utility that tests front page and plugin CSS using `wp_remote_head`/`wp_remote_get`
- show content-encoding and transfer size in Network Payload Optimizer settings
- load compression panel below existing controls on settings page

## Testing
- `npm test` *(fails: jest not found)*
- `vendor/bin/phpunit` *(fails: require wordpress-tests-lib)*

------
https://chatgpt.com/codex/tasks/task_e_68c19a5d4c548327aad30ee61ac08b33