### PR TITLE
Add lite embeds for YouTube/Vimeo iframes

### DIFF
--- a/assets/build/manifest.json
+++ b/assets/build/manifest.json
@@ -10,5 +10,6 @@
   "modules/hcaptcha.js": "modules/hcaptcha.bc1b63fc.js",
   "modules/recaptcha.js": "modules/recaptcha.116c515f.js",
   "modules/tag-manager.js": "modules/tag-manager.bdc0bd50.js",
-  "lazy-embeds.js": "lazy-embeds.js"
+  "lazy-embeds.js": "lazy-embeds.js",
+  "lite-embeds.js": "lite-embeds.js"
 }

--- a/assets/dist/lite-embeds.js
+++ b/assets/dist/lite-embeds.js
@@ -1,0 +1,28 @@
+(function(){
+    const placeholders = document.querySelectorAll('.gm2-lite-embed');
+    if(!placeholders.length){return;}
+    const swap = div => {
+        const src = div.getAttribute('data-src');
+        if(!src){return;}
+        const iframe = document.createElement('iframe');
+        iframe.setAttribute('src', src);
+        iframe.setAttribute('allow', 'accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture');
+        iframe.setAttribute('allowfullscreen', '');
+        iframe.setAttribute('loading', 'lazy');
+        div.replaceWith(iframe);
+    };
+    placeholders.forEach(div => {
+        div.addEventListener('click', () => swap(div), { once:true });
+    });
+    if('IntersectionObserver' in window){
+        const io = new IntersectionObserver(entries => {
+            entries.forEach(entry => {
+                if(entry.isIntersecting){
+                    swap(entry.target);
+                    io.unobserve(entry.target);
+                }
+            });
+        });
+        placeholders.forEach(div => io.observe(div));
+    }
+})();

--- a/modules/network-payload/LiteEmbeds.php
+++ b/modules/network-payload/LiteEmbeds.php
@@ -1,0 +1,115 @@
+<?php
+namespace Gm2\NetworkPayload;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Replace heavy video iframes with lightweight placeholders.
+ */
+class LiteEmbeds {
+    /** Track whether lite embeds exist on the page. */
+    private static bool $has_lite = false;
+
+    /** Boot hooks for lite embeds. */
+    public static function boot(): void {
+        add_filter('the_content', [__CLASS__, 'filter_content'], 20);
+        add_shortcode('gm2_lite_youtube', [__CLASS__, 'shortcode']);
+        add_action('init', [__CLASS__, 'register_block']);
+        add_action('wp_enqueue_scripts', [__CLASS__, 'enqueue_script']);
+    }
+
+    /** Filter content for YouTube/Vimeo iframes and swap with placeholders. */
+    public static function filter_content(string $content): string {
+        if (stripos($content, '<iframe') === false) {
+            return $content;
+        }
+        $content = preg_replace_callback('/<iframe[^>]*><\\/iframe>/i', function ($m) {
+            $tag = $m[0];
+            if (preg_match('/src\\s*=\\s*(["\'])([^"\']+)\\1/i', $tag, $src_m)) {
+                $placeholder = self::build_placeholder($src_m[2]);
+                if ($placeholder) {
+                    self::$has_lite = true;
+                    return $placeholder;
+                }
+            }
+            return $tag;
+        }, $content);
+        return $content;
+    }
+
+    /** Generate placeholder markup for a given embed src. */
+    private static function build_placeholder(string $src): ?string {
+        $poster = '';
+        if (preg_match('#youtube\\.com/embed/([^?&/]+)#i', $src, $m)) {
+            $id = $m[1];
+            $poster = sprintf('https://i.ytimg.com/vi/%s/hqdefault.jpg', rawurlencode($id));
+        } elseif (preg_match('#player\\.vimeo\\.com/video/(\\d+)#i', $src, $m)) {
+            $id = $m[1];
+            $poster = sprintf('https://vumbnail.com/%s.jpg', rawurlencode($id));
+        } else {
+            return null;
+        }
+
+        $src   = esc_url($src);
+        $poster = esc_url($poster);
+
+        return sprintf(
+            '<div class="gm2-lite-embed" data-src="%s"><div class="gm2-lite-embed__poster" style="background-image:url(\'%s\')"></div><button class="gm2-lite-embed__play" aria-label="%s"></button></div>',
+            $src,
+            $poster,
+            esc_attr__('Play video', 'gm2-wordpress-suite')
+        );
+    }
+
+    /** Enqueue helper script if lite embeds were output. */
+    public static function enqueue_script(): void {
+        if (!self::$has_lite) {
+            return;
+        }
+        if (function_exists('ae_seo_register_asset')) {
+            ae_seo_register_asset('gm2-lite-embeds', 'lite-embeds.js');
+        }
+        wp_enqueue_script('gm2-lite-embeds');
+    }
+
+    /** Shortcode handler for YouTube embeds. */
+    public static function shortcode($atts): string {
+        $atts = shortcode_atts(['id' => ''], $atts, 'gm2_lite_youtube');
+        $id = trim($atts['id']);
+        if ($id === '') {
+            return '';
+        }
+        $src = sprintf('https://www.youtube.com/embed/%s', rawurlencode($id));
+        $placeholder = self::build_placeholder($src);
+        if ($placeholder) {
+            self::$has_lite = true;
+            return $placeholder;
+        }
+        return '';
+    }
+
+    /** Register block equivalent to the shortcode. */
+    public static function register_block(): void {
+        if (!function_exists('register_block_type')) {
+            return;
+        }
+        register_block_type('gm2/lite-youtube', [
+            'render_callback' => [__CLASS__, 'render_block'],
+            'attributes'      => [
+                'id' => [
+                    'type'    => 'string',
+                    'default' => '',
+                ],
+            ],
+        ]);
+    }
+
+    /** Render callback for the block. */
+    public static function render_block(array $attributes = []): string {
+        $id = $attributes['id'] ?? '';
+        return self::shortcode(['id' => $id]);
+    }
+}
+

--- a/modules/network-payload/Module.php
+++ b/modules/network-payload/Module.php
@@ -24,6 +24,7 @@ class Module {
         'gzip_detection'   => 'detect',
         'fallback_gzip'    => false,
         'smart_lazyload'   => true,
+        'lite_embeds'      => true,
         'asset_budget'     => true,
     ];
 
@@ -70,6 +71,7 @@ class Module {
             $opts['gzip_detection'] !== 'off',
             $opts['fallback_gzip'],
             $opts['smart_lazyload'],
+            $opts['lite_embeds'],
             $opts['asset_budget'],
         ]));
     }
@@ -90,6 +92,10 @@ class Module {
         if (!empty($opts['smart_lazyload'])) {
             require_once __DIR__ . '/Lazyload.php';
             Lazyload::boot();
+        }
+        if (!empty($opts['lite_embeds'])) {
+            require_once __DIR__ . '/LiteEmbeds.php';
+            LiteEmbeds::boot();
         }
         // Actual feature hooks would be added here.
     }
@@ -422,6 +428,14 @@ class Module {
             'restUrl' => rest_url('gm2/v1/netpayload'),
             'nonce'   => wp_create_nonce('wp_rest'),
         ]);
+
+        $opts = self::get_settings();
+        if (!empty($opts['lite_embeds'])) {
+            if (function_exists('ae_seo_register_asset')) {
+                ae_seo_register_asset('gm2-lite-embeds', 'lite-embeds.js');
+            }
+            wp_enqueue_script('gm2-lite-embeds');
+        }
     }
 
     /** Add contextual help tabs. */
@@ -431,6 +445,7 @@ class Module {
             ['gm2_np_nextgen', __('Next‑Gen Images', 'gm2-wordpress-suite'), __('Serve images in modern formats where possible.', 'gm2-wordpress-suite')],
             ['gm2_np_gzip', __('Gzip Detection', 'gm2-wordpress-suite'), __('Detect whether the server compresses responses.', 'gm2-wordpress-suite')],
             ['gm2_np_lazy', __('Smart Lazyload', 'gm2-wordpress-suite'), __('Delay offscreen assets for faster paint.', 'gm2-wordpress-suite')],
+            ['gm2_np_lite', __('Lite Embeds', 'gm2-wordpress-suite'), __('Swap video iframes for click-to-load placeholders.', 'gm2-wordpress-suite')],
             ['gm2_np_budget', __('Asset Budget', 'gm2-wordpress-suite'), __('Alert when pages exceed size thresholds.', 'gm2-wordpress-suite')],
         ];
         foreach ($tabs as $tab) {
@@ -464,6 +479,7 @@ class Module {
             $opts['gzip_detection'] = isset($input['gzip_detection']) ? sanitize_text_field($input['gzip_detection']) : 'detect';
             $opts['fallback_gzip']  = !empty($input['fallback_gzip']);
             $opts['smart_lazyload'] = !empty($input['smart_lazyload']);
+            $opts['lite_embeds']    = !empty($input['lite_embeds']);
             $opts['asset_budget']   = !empty($input['asset_budget']);
             if (is_network_admin()) {
                 update_site_option(self::OPTION_KEY, $opts, false);
@@ -517,6 +533,10 @@ class Module {
                     <tr>
                         <th scope="row"><?php esc_html_e('Smart Lazyload', 'gm2-wordpress-suite'); ?></th>
                         <td><input type="checkbox" name="<?php echo esc_attr(self::OPTION_KEY); ?>[smart_lazyload]" value="1" <?php checked($opts['smart_lazyload']); ?> /></td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php esc_html_e('Lite Embeds', 'gm2-wordpress-suite'); ?></th>
+                        <td><input type="checkbox" name="<?php echo esc_attr(self::OPTION_KEY); ?>[lite_embeds]" value="1" <?php checked($opts['lite_embeds']); ?> /></td>
                     </tr>
                     <tr>
                         <th scope="row"><?php esc_html_e('Asset Budget', 'gm2-wordpress-suite'); ?></th>


### PR DESCRIPTION
## Summary
- add LiteEmbeds module to swap YouTube/Vimeo iframes with clickable placeholders
- expose `[gm2_lite_youtube]` shortcode and block
- conditionally register/enqueue lite-embeds script when enabled

## Testing
- `npm test` *(fails: jest not found)*
- `composer install`
- `vendor/bin/phpunit` *(fails: Missing WordPress test library)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a2805e3c83279469befed929c8d6