### PR TITLE
Lazy load video sources

### DIFF
--- a/assets/dist/lazy-embeds.js
+++ b/assets/dist/lazy-embeds.js
@@ -1,15 +1,45 @@
 (function(){
-    const lazy = document.querySelectorAll('iframe[data-src],video[data-src]');
-    if(!lazy.length){return;}
+    const nodes = document.querySelectorAll('iframe[data-src],video[data-src],video[data-srcset],video source[data-src],video source[data-srcset]');
+    const targets = new Set();
+    nodes.forEach(el => {
+        targets.add(el.tagName === 'SOURCE' ? el.parentElement : el);
+    });
+    if(!targets.size){return;}
     const swap = el => {
+        if(el.tagName === 'IFRAME'){
+            const src = el.getAttribute('data-src');
+            if(src){
+                el.setAttribute('src', src);
+                el.removeAttribute('data-src');
+            }
+            return;
+        }
         const src = el.getAttribute('data-src');
         if(src){
             el.setAttribute('src', src);
             el.removeAttribute('data-src');
         }
+        const srcset = el.getAttribute('data-srcset');
+        if(srcset){
+            el.setAttribute('srcset', srcset);
+            el.removeAttribute('data-srcset');
+        }
+        el.querySelectorAll('source[data-src],source[data-srcset]').forEach(source => {
+            const s = source.getAttribute('data-src');
+            if(s){
+                source.setAttribute('src', s);
+                source.removeAttribute('data-src');
+            }
+            const ss = source.getAttribute('data-srcset');
+            if(ss){
+                source.setAttribute('srcset', ss);
+                source.removeAttribute('data-srcset');
+            }
+        });
+        el.load();
     };
     if('IntersectionObserver' in window){
-        const io = new IntersectionObserver((entries) => {
+        const io = new IntersectionObserver(entries => {
             entries.forEach(entry => {
                 if(entry.isIntersecting){
                     swap(entry.target);
@@ -17,8 +47,18 @@
                 }
             });
         });
-        lazy.forEach(el => io.observe(el));
+        targets.forEach(el => {
+            io.observe(el);
+            if(el.tagName === 'VIDEO'){
+                el.addEventListener('click', () => swap(el), { once: true });
+            }
+        });
     } else {
-        lazy.forEach(swap);
+        targets.forEach(el => {
+            if(el.tagName === 'VIDEO'){
+                el.addEventListener('click', () => swap(el), { once: true });
+            }
+            swap(el);
+        });
     }
 })();


### PR DESCRIPTION
## Summary
- Replace video sources with data-src/data-srcset and add lazy loading attributes
- Restore iframe and video sources when visible or clicked

## Testing
- `vendor/bin/phpunit` *(fails: Missing /tmp/wordpress-tests-lib)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1a51dab488327af3bea0e85c72682