### PR TITLE
Add asset budget limit and admin bar warning

### DIFF
--- a/modules/network-payload/assets/admin.js
+++ b/modules/network-payload/assets/admin.js
@@ -17,7 +17,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 'X-WP-Nonce': gm2Netpayload.nonce,
                 'Content-Type': 'application/json'
             },
-            body: JSON.stringify({ payload: Math.round(total / 1024) })
+            body: JSON.stringify({ payload: Math.round(total / 1024), budget: gm2Netpayload.budget })
         });
     } catch (e) {}
 });

--- a/tests/NetworkPayloadTest.php
+++ b/tests/NetworkPayloadTest.php
@@ -30,17 +30,21 @@ class NetworkPayloadTest extends WP_UnitTestCase {
         $this->assertSame('detect', $opts['gzip_detection']);
         $this->assertTrue($opts['smart_lazyload']);
         $this->assertTrue($opts['asset_budget']);
+        $this->assertEquals(1258291, $opts['asset_budget_limit']);
     }
 
     public function test_rest_endpoint_updates_average() {
         $request = new WP_REST_Request('POST', '/gm2/v1/netpayload');
         $request->set_param('payload', 100);
+        $request->set_param('budget', 2000);
         rest_get_server()->dispatch($request);
         $stats = get_option('gm2_netpayload_stats');
         $this->assertEquals(100, $stats['average']);
+        $this->assertEquals(2000, $stats['budget']);
 
         $request2 = new WP_REST_Request('POST', '/gm2/v1/netpayload');
         $request2->set_param('payload', 300);
+        $request2->set_param('budget', 2000);
         rest_get_server()->dispatch($request2);
         $stats = get_option('gm2_netpayload_stats');
         $this->assertEquals(200, $stats['average']);


### PR DESCRIPTION
## Summary
- expose configurable asset budget limit in Network Payload settings and pass it through REST stats
- audit enqueued handles, summing total bytes and flagging over-budget pages in the admin bar
- track budget threshold in rolling stats and client beacon

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: could not resolve dependency rollup-plugin-terser)*
- `vendor/bin/phpunit` *(fails: WordPress test suite missing)*
- `php -l modules/network-payload/Module.php modules/network-payload/HandleAuditor.php tests/NetworkPayloadTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68c1ad636f808327aa34c0e79bf08efc