### PR TITLE
Add module to fix media dimensions and aspect ratios

### DIFF
--- a/admin/views/settings-lcp.php
+++ b/admin/views/settings-lcp.php
@@ -15,6 +15,7 @@ $defaults = [
     'responsive_picture_nextgen' => '0',
     'add_preconnect'           => '0',
     'add_preload'              => '0',
+    'fix_media_dimensions'     => '1',
 ];
 $settings = array_merge($defaults, $settings);
 
@@ -36,6 +37,7 @@ $fields = [
     'responsive_picture_nextgen' => esc_html__('Serve responsive <picture> with next-gen formats', 'gm2-wordpress-suite'),
     'add_preconnect'           => esc_html__('Preconnect to LCP origin', 'gm2-wordpress-suite'),
     'add_preload'              => esc_html__('Preload LCP image', 'gm2-wordpress-suite'),
+    'fix_media_dimensions'     => esc_html__('Fix image & media dimensions to prevent layout shifts', 'gm2-wordpress-suite'),
 ];
 
 foreach ($fields as $key => $label) {

--- a/assets/css/cls-reserved.css
+++ b/assets/css/cls-reserved.css
@@ -1,0 +1,14 @@
+.cls-embed-wrap {
+    position: relative;
+    width: 100%;
+}
+
+.cls-embed-wrap iframe,
+.cls-embed-wrap embed,
+.cls-embed-wrap object {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}

--- a/assets/js/cls-aspect-ratio.js
+++ b/assets/js/cls-aspect-ratio.js
@@ -1,0 +1,21 @@
+/**
+ * Reserve aspect ratios for media.
+ */
+
+document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('[data-aspect]').forEach((el) => {
+        const ratio = el.dataset.aspect;
+        if (ratio) {
+            el.style.aspectRatio = ratio;
+        }
+    });
+    document.querySelectorAll('img[data-w][data-h]').forEach((img) => {
+        if (!img.getAttribute('width') && !img.getAttribute('height')) {
+            const w = parseInt(img.dataset.w, 10);
+            const h = parseInt(img.dataset.h, 10);
+            if (w > 0 && h > 0) {
+                img.style.aspectRatio = `${w} / ${h}`;
+            }
+        }
+    });
+});

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -183,6 +183,19 @@ if (is_dir($gm2_netpayload_dir) && file_exists($gm2_netpayload_dir . 'Module.php
     register_activation_hook(__FILE__, ['\\Gm2\\NetworkPayload\\Module', 'activate']);
     register_deactivation_hook(__FILE__, ['\\Gm2\\NetworkPayload\\Module', 'deactivate']);
 }
+
+require_once GM2_PLUGIN_DIR . 'modules/cls-dimensions.php';
+add_action('init', '\\Plugin\\CLS\\Dimensions\\register');
+add_filter('plugin_cls_dimensions_enabled', static function ($enabled) {
+    $settings = get_option('aeseo_lcp_settings', []);
+    if (!is_array($settings)) {
+        $settings = [];
+    }
+    if (isset($settings['fix_media_dimensions'])) {
+        return $settings['fix_media_dimensions'] === '1';
+    }
+    return $enabled;
+});
 if (get_option('gm2_pretty_versioned_urls', '0') === '1') {
     \Gm2\Gm2_Version_Route_Apache::maybe_apply();
 }

--- a/includes/class-aeseo-settings.php
+++ b/includes/class-aeseo-settings.php
@@ -20,6 +20,7 @@ class AESEO_Settings {
             'responsive_picture_nextgen' => '0',
             'add_preconnect'           => '0',
             'add_preload'              => '0',
+            'fix_media_dimensions'     => '1',
         ];
 
         $submitted = isset($_POST['aeseo_lcp_settings']) && is_array($_POST['aeseo_lcp_settings']) ? $_POST['aeseo_lcp_settings'] : [];

--- a/modules/cls-dimensions.php
+++ b/modules/cls-dimensions.php
@@ -1,0 +1,203 @@
+<?php
+namespace Plugin\CLS\Dimensions;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+function register(): void {
+    if (is_admin() || false === apply_filters('plugin_cls_dimensions_enabled', true)) {
+        return;
+    }
+    add_filter('the_content', __NAMESPACE__ . '\\filter_content', 20);
+    add_filter('wp_get_attachment_image_attributes', __NAMESPACE__ . '\\filter_image_attrs', 10, 3);
+    add_filter('embed_oembed_html', __NAMESPACE__ . '\\wrap_oembed', 10, 4);
+    add_filter('oembed_result', __NAMESPACE__ . '\\wrap_oembed', 10, 4);
+    add_action('wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_assets');
+}
+
+function filter_content($content) {
+    if (!class_exists('DOMDocument') || !function_exists('libxml_use_internal_errors')) {
+        return $content;
+    }
+    if (stripos($content, '<img') === false && stripos($content, '<video') === false && stripos($content, '<iframe') === false) {
+        return $content;
+    }
+    libxml_use_internal_errors(true);
+    $doc = new \DOMDocument();
+    $doc->loadHTML('<?xml encoding="utf-8" ?>' . $content, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+    libxml_clear_errors();
+
+    foreach ($doc->getElementsByTagName('img') as $img) {
+        if (!$img->hasAttribute('decoding')) {
+            $img->setAttribute('decoding', 'async');
+        }
+        $width = $img->getAttribute('width');
+        $height = $img->getAttribute('height');
+        if (!$width || !$height) {
+            $src = $img->getAttribute('src');
+            $dims = get_image_dimensions($src);
+            if ($dims) {
+                [$w, $h] = $dims;
+                if (!$width) {
+                    $img->setAttribute('width', (string) $w);
+                }
+                if (!$height) {
+                    $img->setAttribute('height', (string) $h);
+                }
+                $width = $img->getAttribute('width');
+                $height = $img->getAttribute('height');
+            }
+        }
+        if ((!$width || !$height) && $img->hasAttribute('srcset')) {
+            $candidate = trim(explode(',', $img->getAttribute('srcset'))[0]);
+            $url = trim(explode(' ', $candidate)[0]);
+            $dims = parse_dims_from_url($url);
+            if ($dims) {
+                [$dw, $dh] = $dims;
+                if (!$img->hasAttribute('data-w')) {
+                    $img->setAttribute('data-w', (string) $dw);
+                }
+                if (!$img->hasAttribute('data-h')) {
+                    $img->setAttribute('data-h', (string) $dh);
+                }
+            }
+        }
+    }
+
+    foreach ($doc->getElementsByTagName('video') as $video) {
+        $width = $video->getAttribute('width');
+        $height = $video->getAttribute('height');
+        if (!$width || !$height) {
+            $poster = $video->getAttribute('poster');
+            if ($poster) {
+                $dims = get_image_dimensions($poster);
+                if ($dims) {
+                    [$w, $h] = $dims;
+                    if (!$width) {
+                        $video->setAttribute('width', (string) $w);
+                    }
+                    if (!$height) {
+                        $video->setAttribute('height', (string) $h);
+                    }
+                    $width = $video->getAttribute('width');
+                    $height = $video->getAttribute('height');
+                }
+            }
+        }
+        if (!$width || !$height) {
+            if (!$video->hasAttribute('data-aspect')) {
+                $video->setAttribute('data-aspect', '16/9');
+            }
+        }
+    }
+
+    foreach ($doc->getElementsByTagName('iframe') as $iframe) {
+        if (false === apply_filters('plugin_cls_dimensions_wrap_oembed', true)) {
+            continue;
+        }
+        $width = (int) $iframe->getAttribute('width');
+        $height = (int) $iframe->getAttribute('height');
+        $aspect = ($width > 0 && $height > 0) ? $width . '/' . $height : '16/9';
+        $parent = $iframe->parentNode;
+        if ($parent instanceof \DOMElement) {
+            $class = ' ' . $parent->getAttribute('class') . ' ';
+            if (strpos($class, ' wp-block-embed__wrapper ') !== false) {
+                $style = $parent->getAttribute('style');
+                if (strpos($style, 'aspect-ratio') === false) {
+                    $parent->setAttribute('style', trim($style . ' aspect-ratio:' . $aspect));
+                }
+                continue;
+            }
+            if (strpos($class, ' cls-embed-wrap ') !== false) {
+                if (!$parent->hasAttribute('data-aspect')) {
+                    $parent->setAttribute('data-aspect', $aspect);
+                }
+                continue;
+            }
+        }
+        $wrapper = $doc->createElement('div');
+        $wrapper->setAttribute('class', 'cls-embed-wrap');
+        $wrapper->setAttribute('data-aspect', $aspect);
+        $parent->replaceChild($wrapper, $iframe);
+        $wrapper->appendChild($iframe);
+    }
+
+    return $doc->saveHTML();
+}
+
+function filter_image_attrs($attr, $attachment, $size) {
+    if (empty($attr['width']) || empty($attr['height'])) {
+        $meta = wp_get_attachment_metadata($attachment->ID ?? $attachment);
+        if (is_array($meta)) {
+            if (empty($attr['width']) && !empty($meta['width'])) {
+                $attr['width'] = $meta['width'];
+            }
+            if (empty($attr['height']) && !empty($meta['height'])) {
+                $attr['height'] = $meta['height'];
+            }
+        }
+    }
+    if (!isset($attr['decoding'])) {
+        $attr['decoding'] = 'async';
+    }
+    return $attr;
+}
+
+function wrap_oembed($html) {
+    if (false === apply_filters('plugin_cls_dimensions_wrap_oembed', true)) {
+        return $html;
+    }
+    if (strpos($html, 'cls-embed-wrap') !== false) {
+        return $html;
+    }
+    if (!preg_match('/<iframe[^>]*>/i', $html)) {
+        return $html;
+    }
+    $aspect = '16/9';
+    if (preg_match('/width="(\d+)"/i', $html, $w) && preg_match('/height="(\d+)"/i', $html, $h) && (int) $h[1] > 0) {
+        $aspect = $w[1] . '/' . $h[1];
+    } elseif (stripos($html, 'soundcloud') !== false) {
+        $aspect = '1/1';
+    }
+    return '<div class="cls-embed-wrap" data-aspect="' . esc_attr($aspect) . '">' . $html . '</div>';
+}
+
+function enqueue_assets(): void {
+    if (is_admin()) {
+        return;
+    }
+    wp_enqueue_style('cls-reserved', GM2_PLUGIN_URL . 'assets/css/cls-reserved.css', [], GM2_VERSION);
+    wp_enqueue_script('cls-aspect-ratio', GM2_PLUGIN_URL . 'assets/js/cls-aspect-ratio.js', [], GM2_VERSION, true);
+    wp_script_add_data('cls-aspect-ratio', 'defer', true);
+}
+
+function get_image_dimensions(string $src): ?array {
+    $id = attachment_url_to_postid($src);
+    if ($id) {
+        $meta = wp_get_attachment_metadata($id);
+        if (is_array($meta) && !empty($meta['width']) && !empty($meta['height'])) {
+            return [(int) $meta['width'], (int) $meta['height']];
+        }
+        $file = get_attached_file($id);
+        if ($file && file_exists($file)) {
+            $info = @getimagesize($file);
+            if ($info) {
+                return [(int) $info[0], (int) $info[1]];
+            }
+        }
+    } else {
+        $info = @getimagesize($src);
+        if ($info) {
+            return [(int) $info[0], (int) $info[1]];
+        }
+    }
+    return null;
+}
+
+function parse_dims_from_url(string $url): ?array {
+    if (preg_match('/-([0-9]+)x([0-9]+)\./', $url, $m)) {
+        return [(int) $m[1], (int) $m[2]];
+    }
+    return null;
+}


### PR DESCRIPTION
## Summary
- add CLS dimensions module to infer image/video sizes, wrap oEmbeds and enqueue aspect ratio assets
- provide JS and CSS to reserve layout space
- add admin toggle for automatic media dimensions

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: missing MySQL server)*
- `npm test` *(fails: some e2e tests and fetch errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c57ffc22e883279f37a9695b24312e