### PR TITLE
Add CLS reservations module

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -196,6 +196,8 @@ add_filter('plugin_cls_dimensions_enabled', static function ($enabled) {
     }
     return $enabled;
 });
+require_once GM2_PLUGIN_DIR . 'modules/cls-reservations.php';
+add_action('init', '\\Plugin\\CLS\\Reservations\\register');
 if (get_option('gm2_pretty_versioned_urls', '0') === '1') {
     \Gm2\Gm2_Version_Route_Apache::maybe_apply();
 }

--- a/modules/cls-reservations.php
+++ b/modules/cls-reservations.php
@@ -1,0 +1,47 @@
+<?php
+namespace Plugin\CLS\Reservations;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+function register(): void {
+    if (is_admin() || false === apply_filters('plugin_cls_reservations_enabled', true)) {
+        return;
+    }
+    add_action('wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_assets');
+}
+
+function enqueue_assets(): void {
+    if (is_admin()) {
+        return;
+    }
+    wp_enqueue_style('cls-reserved', GM2_PLUGIN_URL . 'assets/css/cls-reserved.css', [], GM2_VERSION);
+    wp_enqueue_script('cls-reservations', GM2_PLUGIN_URL . 'assets/js/cls-reservations.js', [], GM2_VERSION, true);
+    wp_script_add_data('cls-reservations', 'defer', true);
+    wp_localize_script('cls-reservations', 'clsReservations', [
+        'reservations' => get_reservations(),
+        'stickyHeader' => is_sticky_header_enabled(),
+        'stickyFooter' => is_sticky_footer_enabled(),
+    ]);
+}
+
+function get_reservations(): array {
+    $reservations = get_option('plugin_cls_reservations', []);
+    if (!is_array($reservations)) {
+        $reservations = [];
+    }
+    return array_map('sanitize_text_field', $reservations);
+}
+
+function is_sticky_header_enabled(): bool {
+    $val = get_option('plugin_cls_sticky_header', '0');
+    $val = sanitize_text_field((string) $val);
+    return $val === '1';
+}
+
+function is_sticky_footer_enabled(): bool {
+    $val = get_option('plugin_cls_sticky_footer', '0');
+    $val = sanitize_text_field((string) $val);
+    return $val === '1';
+}


### PR DESCRIPTION
## Summary
- Add `CLS\Reservations` module for front-end reservations configuration
- Load reservations module during plugin init

## Testing
- `phpunit` *(fails: command not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c581f2cce483279be3d48d0cf45260