### PR TITLE
Add admin interface for CLS layout reservations

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -518,6 +518,15 @@ class Gm2_SEO_Admin {
         );
 
         add_submenu_page(
+            'gm2-seo',
+            esc_html__( 'Layout Reservations', 'gm2-wordpress-suite' ),
+            esc_html__( 'Layout Reservations', 'gm2-wordpress-suite' ),
+            'manage_options',
+            'gm2-cls-reservations',
+            [ $this, 'display_cls_reservations_page' ]
+        );
+
+        add_submenu_page(
             'gm2-ai',
             esc_html__( 'Bulk AI Review', 'gm2-wordpress-suite' ),
             esc_html__( 'Bulk AI Review', 'gm2-wordpress-suite' ),
@@ -7022,6 +7031,10 @@ class Gm2_SEO_Admin {
 
     public function display_lcp_settings_page() {
         require GM2_PLUGIN_DIR . 'admin/views/settings-lcp.php';
+    }
+
+    public function display_cls_reservations_page() {
+        require GM2_PLUGIN_DIR . 'admin/views/settings-cls-reservations.php';
     }
 
     public function cron_process_ai_tax_queue() {

--- a/admin/views/settings-cls-reservations.php
+++ b/admin/views/settings-cls-reservations.php
@@ -1,0 +1,67 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$reservations = get_option('plugin_cls_reservations', []);
+if (!is_array($reservations)) {
+    $reservations = [];
+}
+if (empty($reservations)) {
+    $reservations[] = ['selector' => '', 'min' => '', 'unreserve' => '1'];
+}
+$sticky_header = get_option('plugin_cls_sticky_header', '0');
+$sticky_footer = get_option('plugin_cls_sticky_footer', '0');
+
+echo '<div class="wrap">';
+echo '<h1>' . esc_html__('Layout Reservations', 'gm2-wordpress-suite') . '</h1>';
+if (isset($_GET['settings-updated'])) {
+    echo '<div id="message" class="updated notice is-dismissible"><p>' . esc_html__('Settings saved.', 'gm2-wordpress-suite') . '</p></div>';
+}
+
+echo '<form method="post" action="' . esc_url(admin_url('admin-post.php')) . '">';
+wp_nonce_field('gm2_cls_reservations');
+echo '<input type="hidden" name="action" value="gm2_cls_reservations" />';
+
+echo '<table class="widefat fixed" id="cls-reservations-table">';
+echo '<thead><tr><th>' . esc_html__('Selector', 'gm2-wordpress-suite') . '</th><th>' . esc_html__('Min Height (px)', 'gm2-wordpress-suite') . '</th><th>' . esc_html__('Unreserve when loaded', 'gm2-wordpress-suite') . '</th><th></th></tr></thead>';
+echo '<tbody>';
+foreach ($reservations as $row) {
+    $selector = esc_attr($row['selector'] ?? '');
+    $min = isset($row['min']) ? (int) $row['min'] : '';
+    $checked = (!isset($row['unreserve']) || $row['unreserve'] === '1' || $row['unreserve'] === 1) ? 'checked="checked"' : '';
+    echo '<tr><td><input type="text" name="cls_reservations[][selector]" value="' . $selector . '" /></td><td><input type="number" class="small-text" name="cls_reservations[][min]" value="' . esc_attr($min) . '" /></td><td><input type="checkbox" name="cls_reservations[][unreserve]" value="1" ' . $checked . ' /></td><td><button type="button" class="button remove-reservation">&times;</button></td></tr>';
+}
+echo '</tbody>';
+echo '</table>';
+
+echo '<p><button type="button" class="button" id="add-reservation">' . esc_html__('Add Reservation', 'gm2-wordpress-suite') . '</button></p>';
+
+echo '<h2>' . esc_html__('Sticky Elements', 'gm2-wordpress-suite') . '</h2>';
+echo '<p><label><input type="checkbox" name="cls_sticky_header" value="1" ' . checked($sticky_header, '1', false) . ' /> ' . esc_html__('Reserve space for sticky header', 'gm2-wordpress-suite') . '</label></p>';
+echo '<p><label><input type="checkbox" name="cls_sticky_footer" value="1" ' . checked($sticky_footer, '1', false) . ' /> ' . esc_html__('Reserve space for sticky footer', 'gm2-wordpress-suite') . '</label></p>';
+
+submit_button(esc_html__('Save Settings', 'gm2-wordpress-suite'));
+echo '</form>';
+?>
+<script>
+(function(){
+    const tableBody = document.querySelector('#cls-reservations-table tbody');
+    document.getElementById('add-reservation').addEventListener('click', () => {
+        const row = document.createElement('tr');
+        row.innerHTML = '<td><input type="text" name="cls_reservations[][selector]" value="" /></td>' +
+            '<td><input type="number" class="small-text" name="cls_reservations[][min]" value="" /></td>' +
+            '<td><input type="checkbox" name="cls_reservations[][unreserve]" value="1" checked="checked" /></td>' +
+            '<td><button type="button" class="button remove-reservation">&times;</button></td>';
+        tableBody.appendChild(row);
+    });
+    tableBody.addEventListener('click', (e) => {
+        if (e.target.classList.contains('remove-reservation')) {
+            e.preventDefault();
+            e.target.closest('tr').remove();
+        }
+    });
+})();
+</script>
+<?php
+echo '</div>';

--- a/includes/class-aeseo-settings.php
+++ b/includes/class-aeseo-settings.php
@@ -8,6 +8,7 @@ if (!defined('ABSPATH')) {
 class AESEO_Settings {
     public static function register(): void {
         add_action('admin_post_gm2_lcp_settings', [__CLASS__, 'save_lcp_settings']);
+        add_action('admin_post_gm2_cls_reservations', [__CLASS__, 'save_cls_reservations']);
     }
 
     public static function save_lcp_settings(): void {
@@ -35,6 +36,45 @@ class AESEO_Settings {
         $redirect = wp_get_referer();
         if (!$redirect) {
             $redirect = admin_url('admin.php?page=gm2-lcp-optimization');
+        }
+        $redirect = add_query_arg('settings-updated', 'true', $redirect);
+        wp_safe_redirect($redirect);
+        exit;
+    }
+
+    public static function save_cls_reservations(): void {
+        check_admin_referer('gm2_cls_reservations');
+
+        $rows = isset($_POST['cls_reservations']) && is_array($_POST['cls_reservations']) ? $_POST['cls_reservations'] : [];
+        $sanitized = [];
+        foreach ($rows as $row) {
+            if (!is_array($row)) {
+                continue;
+            }
+            $selector = sanitize_text_field($row['selector'] ?? '');
+            if ($selector === '') {
+                continue;
+            }
+            $min = isset($row['min']) ? absint($row['min']) : 0;
+            $unreserve = isset($row['unreserve']) ? '1' : '0';
+            $sanitized[] = [
+                'selector'  => $selector,
+                'min'       => $min,
+                'unreserve' => $unreserve,
+            ];
+        }
+
+        update_option('plugin_cls_reservations', $sanitized);
+
+        $sticky_header = isset($_POST['cls_sticky_header']) && $_POST['cls_sticky_header'] === '1' ? '1' : '0';
+        update_option('plugin_cls_sticky_header', $sticky_header);
+
+        $sticky_footer = isset($_POST['cls_sticky_footer']) && $_POST['cls_sticky_footer'] === '1' ? '1' : '0';
+        update_option('plugin_cls_sticky_footer', $sticky_footer);
+
+        $redirect = wp_get_referer();
+        if (!$redirect) {
+            $redirect = admin_url('admin.php?page=gm2-cls-reservations');
         }
         $redirect = add_query_arg('settings-updated', 'true', $redirect);
         wp_safe_redirect($redirect);

--- a/modules/cls-reservations.php
+++ b/modules/cls-reservations.php
@@ -27,11 +27,28 @@ function enqueue_assets(): void {
 }
 
 function get_reservations(): array {
-    $reservations = get_option('plugin_cls_reservations', []);
-    if (!is_array($reservations)) {
-        $reservations = [];
+    $rows = get_option('plugin_cls_reservations', []);
+    if (!is_array($rows)) {
+        $rows = [];
     }
-    return array_map('sanitize_text_field', $reservations);
+    $reservations = [];
+    foreach ($rows as $row) {
+        if (!is_array($row)) {
+            continue;
+        }
+        $selector = sanitize_text_field($row['selector'] ?? '');
+        if ($selector === '') {
+            continue;
+        }
+        $min = isset($row['min']) ? absint($row['min']) : 0;
+        $unreserve = !empty($row['unreserve']);
+        $reservations[] = [
+            'selector'  => $selector,
+            'min'       => $min,
+            'unreserve' => $unreserve,
+        ];
+    }
+    return $reservations;
 }
 
 function is_sticky_header_enabled(): bool {


### PR DESCRIPTION
## Summary
- Add Layout Reservations admin submenu and settings view
- Persist custom reservation rows and sticky element options
- Support structured reservation data on front end

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_68c5829c9fc883278009ebb008eb1213