### PR TITLE
Add reserved box CSS rule

### DIFF
--- a/assets/css/cls-reserved.css
+++ b/assets/css/cls-reserved.css
@@ -12,3 +12,10 @@
     width: 100%;
     height: 100%;
 }
+
+.cls-reserved-box {
+    display: block;
+    min-height: inherit;
+    background: transparent;
+    transition: background-color 0.3s ease;
+}


### PR DESCRIPTION
## Summary
- add `.cls-reserved-box` rule with transparent background, inherited height, and transition
- confirm modules enqueue shared `cls-reserved` stylesheet

## Testing
- `vendor/bin/phpunit` *(fails: missing /tmp/wordpress-tests-lib)*
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: dependency resolution conflict)*

------
https://chatgpt.com/codex/tasks/task_e_68c585000f80832785e4bd85a77d9759