### PR TITLE
Add sticky element reservation selectors and padding logic

### DIFF
--- a/admin/views/settings-cls-reservations.php
+++ b/admin/views/settings-cls-reservations.php
@@ -12,6 +12,8 @@ if (empty($reservations)) {
 }
 $sticky_header = get_option('plugin_cls_sticky_header', '0');
 $sticky_footer = get_option('plugin_cls_sticky_footer', '0');
+$sticky_header_selector = get_option('plugin_cls_sticky_header_selector', '');
+$sticky_footer_selector = get_option('plugin_cls_sticky_footer_selector', '');
 
 echo '<div class="wrap">';
 echo '<h1>' . esc_html__('Layout Reservations', 'gm2-wordpress-suite') . '</h1>';
@@ -38,8 +40,10 @@ echo '</table>';
 echo '<p><button type="button" class="button" id="add-reservation">' . esc_html__('Add Reservation', 'gm2-wordpress-suite') . '</button></p>';
 
 echo '<h2>' . esc_html__('Sticky Elements', 'gm2-wordpress-suite') . '</h2>';
-echo '<p><label><input type="checkbox" name="cls_sticky_header" value="1" ' . checked($sticky_header, '1', false) . ' /> ' . esc_html__('Reserve space for sticky header', 'gm2-wordpress-suite') . '</label></p>';
-echo '<p><label><input type="checkbox" name="cls_sticky_footer" value="1" ' . checked($sticky_footer, '1', false) . ' /> ' . esc_html__('Reserve space for sticky footer', 'gm2-wordpress-suite') . '</label></p>';
+echo '<p><label><input type="checkbox" name="cls_sticky_header" value="1" ' . checked($sticky_header, '1', false) . ' /> ' . esc_html__('Reserve space for sticky header', 'gm2-wordpress-suite') . '</label><br />';
+echo '<input type="text" name="cls_sticky_header_selector" value="' . esc_attr($sticky_header_selector) . '" placeholder="' . esc_attr__('Selector override (optional)', 'gm2-wordpress-suite') . '" class="regular-text" /></p>';
+echo '<p><label><input type="checkbox" name="cls_sticky_footer" value="1" ' . checked($sticky_footer, '1', false) . ' /> ' . esc_html__('Reserve space for sticky footer', 'gm2-wordpress-suite') . '</label><br />';
+echo '<input type="text" name="cls_sticky_footer_selector" value="' . esc_attr($sticky_footer_selector) . '" placeholder="' . esc_attr__('Selector override (optional)', 'gm2-wordpress-suite') . '" class="regular-text" /></p>';
 
 submit_button(esc_html__('Save Settings', 'gm2-wordpress-suite'));
 echo '</form>';

--- a/includes/class-aeseo-settings.php
+++ b/includes/class-aeseo-settings.php
@@ -69,8 +69,14 @@ class AESEO_Settings {
         $sticky_header = isset($_POST['cls_sticky_header']) && $_POST['cls_sticky_header'] === '1' ? '1' : '0';
         update_option('plugin_cls_sticky_header', $sticky_header);
 
+        $sticky_header_selector = isset($_POST['cls_sticky_header_selector']) ? sanitize_text_field((string) $_POST['cls_sticky_header_selector']) : '';
+        update_option('plugin_cls_sticky_header_selector', $sticky_header_selector);
+
         $sticky_footer = isset($_POST['cls_sticky_footer']) && $_POST['cls_sticky_footer'] === '1' ? '1' : '0';
         update_option('plugin_cls_sticky_footer', $sticky_footer);
+
+        $sticky_footer_selector = isset($_POST['cls_sticky_footer_selector']) ? sanitize_text_field((string) $_POST['cls_sticky_footer_selector']) : '';
+        update_option('plugin_cls_sticky_footer_selector', $sticky_footer_selector);
 
         $redirect = wp_get_referer();
         if (!$redirect) {

--- a/modules/cls-reservations.php
+++ b/modules/cls-reservations.php
@@ -23,6 +23,8 @@ function enqueue_assets(): void {
         'reservations' => get_reservations(),
         'stickyHeader' => is_sticky_header_enabled(),
         'stickyFooter' => is_sticky_footer_enabled(),
+        'stickyHeaderSelector' => get_sticky_header_selector(),
+        'stickyFooterSelector' => get_sticky_footer_selector(),
     ]);
 }
 
@@ -61,4 +63,16 @@ function is_sticky_footer_enabled(): bool {
     $val = get_option('plugin_cls_sticky_footer', '0');
     $val = sanitize_text_field((string) $val);
     return $val === '1';
+}
+
+function get_sticky_header_selector(): string {
+    $val = get_option('plugin_cls_sticky_header_selector', '');
+    $val = sanitize_text_field((string) $val);
+    return $val;
+}
+
+function get_sticky_footer_selector(): string {
+    $val = get_option('plugin_cls_sticky_footer_selector', '');
+    $val = sanitize_text_field((string) $val);
+    return $val;
 }


### PR DESCRIPTION
## Summary
- Allow configuring sticky header/footer selectors alongside reservation toggles
- Measure sticky elements on first paint and apply fixed body padding
- Persist sticky selector settings via admin save handler

## Testing
- `npm test` *(fails: Test Suites: 4 failed, 2 skipped, 10 passed, 14 of 16 total)*
- `vendor/bin/phpunit` *(fails: missing WordPress test library)*

------
https://chatgpt.com/codex/tasks/task_e_68c585b10344832786e978cb3ff1481b