### PR TITLE
Guard CLS Fonts module by front-end filter

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -198,11 +198,13 @@ add_filter('plugin_cls_dimensions_enabled', static function ($enabled) {
 });
 require_once GM2_PLUGIN_DIR . 'modules/cls-reservations.php';
 add_action('init', '\\Plugin\\CLS\\Reservations\\register');
-require_once GM2_PLUGIN_DIR . 'modules/cls-fonts.php';
-add_action('init', '\\Plugin\\CLS\\Fonts\\register');
 add_filter('plugin_cls_fonts_enabled', static function ($enabled) {
     return get_option('plugin_cls_fonts_enabled', '1') === '1';
 });
+if (!is_admin() && apply_filters('plugin_cls_fonts_enabled', true)) {
+    require_once GM2_PLUGIN_DIR . 'modules/cls-fonts.php';
+    add_action('init', '\\Plugin\\CLS\\Fonts\\register');
+}
 require_once GM2_PLUGIN_DIR . 'includes/class-cls-fonts-rest.php';
 \Plugin\CLS\Fonts_REST::init();
 if (get_option('gm2_pretty_versioned_urls', '0') === '1') {


### PR DESCRIPTION
## Summary
- Only load CLS Fonts module when running on the front-end and the module is enabled.
- Preserve existing `plugin_cls_fonts_enabled` filter and register CLS Fonts on `init`.

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*


------
https://chatgpt.com/codex/tasks/task_e_68c58f2efe4483278ea09d0b7f01459f