### PR TITLE
Handle additional CPT and taxonomy arguments

### DIFF
--- a/admin/Gm2_Custom_Posts_Admin.php
+++ b/admin/Gm2_Custom_Posts_Admin.php
@@ -905,7 +905,7 @@ class Gm2_Custom_Posts_Admin {
         if (!is_array($args)) {
             return $sanitized_args;
         }
-        $bool_keys = [ 'public', 'hierarchical', 'publicly_queryable', 'show_ui', 'show_in_menu', 'show_in_nav_menus', 'show_in_admin_bar', 'exclude_from_search', 'has_archive', 'show_in_rest', 'map_meta_cap', 'show_admin_column', 'show_tagcloud', 'show_in_quick_edit' ];
+        $bool_keys = [ 'public', 'hierarchical', 'publicly_queryable', 'show_ui', 'show_in_menu', 'show_in_nav_menus', 'show_in_admin_bar', 'exclude_from_search', 'has_archive', 'show_in_rest', 'map_meta_cap', 'show_admin_column', 'show_tagcloud', 'show_in_quick_edit', 'delete_with_user', 'can_export' ];
         foreach ($args as $arg) {
             $a_key = sanitize_key($arg['key'] ?? '');
             if (!$a_key) {
@@ -943,6 +943,9 @@ class Gm2_Custom_Posts_Admin {
                     $val['hierarchical'] = !empty($value['hierarchical']);
                     $val['feeds']        = !empty($value['feeds']);
                     $val['pages']        = !empty($value['pages']);
+                    if (isset($value['ep_mask'])) {
+                        $val['ep_mask'] = sanitize_text_field($value['ep_mask']);
+                    }
                 }
             } elseif ($a_key === 'capabilities') {
                 if (is_string($value)) {
@@ -968,6 +971,20 @@ class Gm2_Custom_Posts_Admin {
                         $val = $parts[0] ?? '';
                     }
                 }
+            } elseif ($a_key === 'taxonomies') {
+                if (is_array($value)) {
+                    $val = array_values(array_filter(array_map('sanitize_key', $value)));
+                } else {
+                    $val = array_values(array_filter(array_map('sanitize_key', explode(',', (string) $value))));
+                }
+            } elseif ($a_key === 'description') {
+                $val = sanitize_textarea_field($value);
+            } elseif ($a_key === 'rest_base') {
+                $val = sanitize_key($value);
+            } elseif ($a_key === 'rest_namespace') {
+                $val = sanitize_text_field($value);
+            } elseif ($a_key === 'rest_controller_class') {
+                $val = sanitize_text_field($value);
             } elseif ($a_key === 'template') {
                 if (is_string($value)) {
                     $value = json_decode(wp_unslash($value), true);

--- a/admin/js/gm2-custom-posts-admin.js
+++ b/admin/js/gm2-custom-posts-admin.js
@@ -146,7 +146,7 @@ jQuery(function($){
 
     function showArgControl(key, value){
         var wrap = $('#gm2-arg-value-wrap').empty();
-        var boolKeys = ['public','hierarchical','publicly_queryable','show_ui','show_in_menu','show_in_nav_menus','show_in_admin_bar','exclude_from_search','has_archive','show_in_rest','map_meta_cap'];
+        var boolKeys = ['public','hierarchical','publicly_queryable','show_ui','show_in_menu','show_in_nav_menus','show_in_admin_bar','exclude_from_search','has_archive','show_in_rest','map_meta_cap','delete_with_user','can_export'];
         if(boolKeys.indexOf(key) !== -1){
             var chk = $('<label><input type="checkbox" id="gm2-arg-value" value="1"/> '+key+'</label>');
             if(value){ chk.find('input').prop('checked', true); }
@@ -166,11 +166,23 @@ jQuery(function($){
             $.each(['with_front','hierarchical','feeds','pages'], function(i, opt){
                 html += '<label><input type="checkbox" class="gm2-rewrite-flag" id="gm2-rewrite-'+opt+'" value="1"/> '+opt.replace('_',' ')+'</label><br/>';
             });
+            html += '<p><label>ep_mask<br/><input type="text" id="gm2-rewrite-ep_mask" class="regular-text" /></label></p>';
             wrap.append(html);
             if(value && typeof value === 'object'){
                 $('#gm2-rewrite-slug').val(value.slug || '');
                 $.each(['with_front','hierarchical','feeds','pages'], function(i,opt){ if(value[opt]) $('#gm2-rewrite-'+opt).prop('checked', true); });
+                if(value.ep_mask) $('#gm2-rewrite-ep_mask').val(value.ep_mask);
             }
+        }else if(key === 'taxonomies'){
+            wrap.append('<input type="text" id="gm2-arg-value" class="regular-text" />');
+            if($.isArray(value)){
+                $('#gm2-arg-value').val(value.join(', '));
+            }else{
+                $('#gm2-arg-value').val(value);
+            }
+        }else if(key === 'description'){
+            wrap.append('<textarea id="gm2-arg-value" class="large-text"></textarea>');
+            $('#gm2-arg-value').val(value || '');
         }else{
             wrap.append('<input type="text" id="gm2-arg-value" class="regular-text" />');
             if(typeof value === 'object'){
@@ -312,7 +324,7 @@ jQuery(function($){
         var idx = $('#gm2-arg-index').val();
         var key = $('#gm2-arg-key').val();
         var val;
-        var boolKeys = ['public','hierarchical','publicly_queryable','show_ui','show_in_menu','show_in_nav_menus','show_in_admin_bar','exclude_from_search','has_archive','show_in_rest','map_meta_cap'];
+        var boolKeys = ['public','hierarchical','publicly_queryable','show_ui','show_in_menu','show_in_nav_menus','show_in_admin_bar','exclude_from_search','has_archive','show_in_rest','map_meta_cap','delete_with_user','can_export'];
         if(boolKeys.indexOf(key) !== -1){
             val = $('#gm2-arg-value').is(':checked');
         }else if(key === 'supports'){
@@ -326,6 +338,11 @@ jQuery(function($){
                 feeds: $('#gm2-rewrite-feeds').is(':checked'),
                 pages: $('#gm2-rewrite-pages').is(':checked')
             };
+            var ep = $('#gm2-rewrite-ep_mask').val();
+            if(ep){ val.ep_mask = ep; }
+        }else if(key === 'taxonomies'){
+            var rawTax = $('#gm2-arg-value').val();
+            val = rawTax.split(',').map(function(s){ return $.trim(s); }).filter(function(s){ return s.length; });
         }else if(key === 'capability_type'){
             var raw = $('#gm2-arg-value').val();
             var parts = raw.split(',').map(function(s){ return $.trim(s); }).filter(function(s){ return s.length; });

--- a/admin/js/gm2-custom-tax-admin.js
+++ b/admin/js/gm2-custom-tax-admin.js
@@ -28,6 +28,24 @@ jQuery(function($){
             var chk = $('<label><input type="checkbox" id="gm2-tax-arg-value" value="1"/> '+key+'</label>');
             if(value){ chk.find('input').prop('checked', true); }
             wrap.append(chk);
+        }else if(key === 'rewrite'){
+            var html = '<p><label>Slug<br/><input type="text" id="gm2-tax-rewrite-slug" class="regular-text" /></label></p>';
+            $.each(['with_front','hierarchical'], function(i,opt){
+                html += '<label><input type="checkbox" id="gm2-tax-rewrite-'+opt+'" value="1"/> '+opt.replace('_',' ')+'</label><br/>';
+            });
+            html += '<p><label>ep_mask<br/><input type="text" id="gm2-tax-rewrite-ep_mask" class="regular-text" /></label></p>';
+            wrap.append(html);
+            if(value && typeof value === 'object'){
+                $('#gm2-tax-rewrite-slug').val(value.slug || '');
+                $.each(['with_front','hierarchical'], function(i,opt){ if(value[opt]) $('#gm2-tax-rewrite-'+opt).prop('checked', true); });
+                if(value.ep_mask) $('#gm2-tax-rewrite-ep_mask').val(value.ep_mask);
+            }
+        }else if(key === 'capabilities'){
+            wrap.append('<textarea id="gm2-tax-arg-value" class="large-text"></textarea>');
+            if(typeof value === 'object'){
+                value = JSON.stringify(value);
+            }
+            $('#gm2-tax-arg-value').val(value || '');
         }else{
             wrap.append('<input type="text" id="gm2-tax-arg-value" class="regular-text" />');
             $('#gm2-tax-arg-value').val(value);
@@ -84,7 +102,24 @@ jQuery(function($){
     $('#gm2-tax-arg-save').on('click', function(){
         var idx = $('#gm2-tax-arg-index').val();
         var key = $('#gm2-tax-arg-key').val();
-        var val = (key === 'public' || key === 'hierarchical') ? $('#gm2-tax-arg-value').is(':checked') : $('#gm2-tax-arg-value').val();
+        var boolKeys = ['public','hierarchical','show_ui','show_in_nav_menus','show_admin_column','show_tagcloud','show_in_quick_edit','show_in_rest'];
+        var val;
+        if(boolKeys.indexOf(key) !== -1){
+            val = $('#gm2-tax-arg-value').is(':checked');
+        }else if(key === 'rewrite'){
+            val = {
+                slug: $('#gm2-tax-rewrite-slug').val(),
+                with_front: $('#gm2-tax-rewrite-with_front').is(':checked'),
+                hierarchical: $('#gm2-tax-rewrite-hierarchical').is(':checked')
+            };
+            var ep = $('#gm2-tax-rewrite-ep_mask').val();
+            if(ep){ val.ep_mask = ep; }
+        }else if(key === 'capabilities'){
+            try { val = JSON.parse($('#gm2-tax-arg-value').val() || '{}'); }
+            catch(e){ val = {}; }
+        }else{
+            val = $('#gm2-tax-arg-value').val();
+        }
         var obj = { key:key, value:val, conditions: gm2Conditions.getData($('#gm2-tax-conditions')) };
         if(idx === ''){ args.push(obj); } else { args[idx] = obj; }
         saveAll(function(){ $('#gm2-tax-arg-form').hide(); });

--- a/tests/test-custom-posts.php
+++ b/tests/test-custom-posts.php
@@ -324,12 +324,18 @@ class CustomPostsFieldsTest extends WP_UnitTestCase {
                         'capabilities' => [ 'value' => [ 'edit_post' => 'edit_movie' ] ],
                         'template' => [ 'value' => [ [ 'core/paragraph', [ 'placeholder' => 'Add summary...' ] ] ] ],
                         'template_lock' => [ 'value' => 'all' ],
+                        'description' => [ 'value' => 'Film posts' ],
+                        'delete_with_user' => [ 'value' => true ],
+                        'rest_namespace' => [ 'value' => 'gm2/v1' ],
+                        'taxonomies' => [ 'value' => [ 'genre' ] ],
+                        'can_export' => [ 'value' => true ],
                     ],
                 ],
             ],
             'taxonomies' => [],
         ]);
 
+        register_taxonomy('genre', []);
         gm2_register_custom_posts();
         $pt = get_post_type_object('movie');
 
@@ -349,6 +355,7 @@ class CustomPostsFieldsTest extends WP_UnitTestCase {
         $this->assertTrue($pt->show_in_rest);
         $this->assertSame('film', $pt->rest_base);
         $this->assertSame('WP_REST_Posts_Controller', $pt->rest_controller_class);
+        $this->assertSame('gm2/v1', $pt->rest_namespace);
         $this->assertSame('films', $pt->rewrite['slug']);
         $this->assertTrue($pt->rewrite['with_front']);
         $this->assertTrue($pt->rewrite['hierarchical']);
@@ -359,5 +366,9 @@ class CustomPostsFieldsTest extends WP_UnitTestCase {
         $this->assertSame('edit_movie', $pt->cap->edit_post);
         $this->assertSame([ [ 'core/paragraph', [ 'placeholder' => 'Add summary...' ] ] ], $pt->template);
         $this->assertSame('all', $pt->template_lock);
+        $this->assertSame('Film posts', $pt->description);
+        $this->assertTrue($pt->delete_with_user);
+        $this->assertTrue($pt->can_export);
+        $this->assertContains('genre', $pt->taxonomies);
     }
 }


### PR DESCRIPTION
## Summary
- extend sanitize_args_array to support more post type and taxonomy arguments
- add UI handling for new CPT and taxonomy args in admin scripts
- test registration of post type with new arguments

## Testing
- `npm test` *(fails: jest: not found)*
- `vendor/bin/phpunit` *(fails: WordPress test suite missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a515544c832788850bbef01b44c2