### PR TITLE
Add new field types for measurements and related objects

### DIFF
--- a/includes/fields/class-field-json.php
+++ b/includes/fields/class-field-json.php
@@ -1,0 +1,23 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class GM2_Field_JSON extends GM2_Field {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
+        $disabled         = disabled( $this->args['disabled'] ?? false, true, false );
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
+        echo '<textarea name="' . esc_attr( $this->key ) . '" rows="5" cols="40"' . $disabled . $placeholder_attr . '>' . esc_textarea( $value ) . '</textarea>';
+    }
+
+    public function sanitize( $value ) {
+        if ( '' === trim( $value ) ) {
+            return '';
+        }
+        $decoded = json_decode( $value, true );
+        if ( json_last_error() !== JSON_ERROR_NONE ) {
+            return '';
+        }
+        return wp_json_encode( $decoded );
+    }
+}

--- a/includes/fields/class-field-measurement.php
+++ b/includes/fields/class-field-measurement.php
@@ -1,0 +1,33 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class GM2_Field_Measurement extends GM2_Field {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
+        $value    = is_array( $value ) ? $value : array();
+        $val      = $value['value'] ?? '';
+        $unit_val = $value['unit'] ?? '';
+        $disabled = disabled( $this->args['disabled'] ?? false, true, false );
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
+        $units = $this->args['units'] ?? array( 'px', 'em', '%' );
+
+        echo '<input type="number" name="' . esc_attr( $this->key ) . '[value]" value="' . esc_attr( $val ) . '"' . $disabled . $placeholder_attr . ' /> ';
+        echo '<select name="' . esc_attr( $this->key ) . '[unit]"' . $disabled . '>';
+        foreach ( $units as $unit ) {
+            $selected = selected( $unit_val, $unit, false );
+            echo '<option value="' . esc_attr( $unit ) . '"' . $selected . '>' . esc_html( $unit ) . '</option>';
+        }
+        echo '</select>';
+    }
+
+    public function sanitize( $value ) {
+        $units = $this->args['units'] ?? array( 'px', 'em', '%' );
+        if ( ! is_array( $value ) ) {
+            return array( 'value' => '', 'unit' => $units[0] );
+        }
+        $val = isset( $value['value'] ) && is_numeric( $value['value'] ) ? $value['value'] : '';
+        $unit = isset( $value['unit'] ) && in_array( $value['unit'], $units, true ) ? $value['unit'] : $units[0];
+        return array( 'value' => $val, 'unit' => $unit );
+    }
+}

--- a/includes/fields/class-field-post-object.php
+++ b/includes/fields/class-field-post-object.php
@@ -1,0 +1,24 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class GM2_Field_Post_Object extends GM2_Field {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
+        $disabled = disabled( $this->args['disabled'] ?? false, true, false );
+        $post_type = $this->args['post_type'] ?? 'post';
+        $posts = get_posts( array( 'post_type' => $post_type, 'numberposts' => -1 ) );
+        echo '<select name="' . esc_attr( $this->key ) . '"' . $disabled . '>';
+        echo '<option value="">' . esc_html__( 'Select', 'gm2-wordpress-suite' ) . '</option>';
+        foreach ( $posts as $post ) {
+            $selected = selected( (int) $value, $post->ID, false );
+            echo '<option value="' . esc_attr( $post->ID ) . '"' . $selected . '>' . esc_html( get_the_title( $post ) ) . '</option>';
+        }
+        echo '</select>';
+    }
+
+    public function sanitize( $value ) {
+        $post_id = intval( $value );
+        return get_post( $post_id ) ? $post_id : 0;
+    }
+}

--- a/includes/fields/class-field-schedule.php
+++ b/includes/fields/class-field-schedule.php
@@ -1,0 +1,61 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class GM2_Field_Schedule extends GM2_Field {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
+        $value    = is_array( $value ) ? $value : array();
+        $disabled = disabled( $this->args['disabled'] ?? false, true, false );
+        $days     = array( 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday' );
+        echo '<div class="gm2-schedule" data-key="' . esc_attr( $this->key ) . '">';
+        foreach ( $value as $row ) {
+            $day   = $row['day'] ?? '';
+            $start = $row['start'] ?? '';
+            $end   = $row['end'] ?? '';
+            echo '<div class="gm2-schedule-row">';
+            echo '<select name="' . esc_attr( $this->key ) . '[day][]"' . $disabled . '>';
+            foreach ( $days as $d ) {
+                $selected = selected( $day, $d, false );
+                echo '<option value="' . esc_attr( $d ) . '"' . $selected . '>' . esc_html( $d ) . '</option>';
+            }
+            echo '</select> ';
+            echo '<input type="time" name="' . esc_attr( $this->key ) . '[start][]" value="' . esc_attr( $start ) . '"' . $disabled . ' /> ';
+            echo '<input type="time" name="' . esc_attr( $this->key ) . '[end][]" value="' . esc_attr( $end ) . '"' . $disabled . ' /> ';
+            echo '<button type="button" class="button gm2-schedule-remove">&times;</button>';
+            echo '</div>';
+        }
+        echo '<div class="gm2-schedule-row">';
+        echo '<select name="' . esc_attr( $this->key ) . '[day][]"' . $disabled . '>';
+        foreach ( $days as $d ) {
+            echo '<option value="' . esc_attr( $d ) . '">' . esc_html( $d ) . '</option>';
+        }
+        echo '</select> ';
+        echo '<input type="time" name="' . esc_attr( $this->key ) . '[start][]" value=""' . $disabled . ' /> ';
+        echo '<input type="time" name="' . esc_attr( $this->key ) . '[end][]" value=""' . $disabled . ' /> ';
+        echo '<button type="button" class="button gm2-schedule-remove">&times;</button>';
+        echo '</div>';
+        echo '<p><button type="button" class="button gm2-schedule-add" data-target="' . esc_attr( $this->key ) . '">' . esc_html__( 'Add Time', 'gm2-wordpress-suite' ) . '</button></p>';
+        echo '</div>';
+    }
+
+    public function sanitize( $value ) {
+        $clean = array();
+        if ( is_array( $value ) && isset( $value['day'], $value['start'], $value['end'] ) ) {
+            $count = count( $value['day'] );
+            for ( $i = 0; $i < $count; $i++ ) {
+                $day   = sanitize_text_field( $value['day'][ $i ] ?? '' );
+                $start = sanitize_text_field( $value['start'][ $i ] ?? '' );
+                $end   = sanitize_text_field( $value['end'][ $i ] ?? '' );
+                if ( $day && $start && $end ) {
+                    $clean[] = array(
+                        'day'   => $day,
+                        'start' => $start,
+                        'end'   => $end,
+                    );
+                }
+            }
+        }
+        return $clean;
+    }
+}

--- a/includes/fields/class-field-taxonomy-terms.php
+++ b/includes/fields/class-field-taxonomy-terms.php
@@ -1,0 +1,32 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class GM2_Field_Taxonomy_Terms extends GM2_Field {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
+        $value    = is_array( $value ) ? $value : array();
+        $disabled = disabled( $this->args['disabled'] ?? false, true, false );
+        $taxonomy = $this->args['taxonomy'] ?? 'category';
+        $terms    = get_terms( array( 'taxonomy' => $taxonomy, 'hide_empty' => false ) );
+        echo '<select name="' . esc_attr( $this->key ) . '[]" multiple' . $disabled . '>';
+        foreach ( $terms as $term ) {
+            $selected = in_array( $term->term_id, $value, true ) ? ' selected' : '';
+            echo '<option value="' . esc_attr( $term->term_id ) . '"' . $selected . '>' . esc_html( $term->name ) . '</option>';
+        }
+        echo '</select>';
+    }
+
+    public function sanitize( $value ) {
+        $value = is_array( $value ) ? $value : array();
+        $taxonomy = $this->args['taxonomy'] ?? 'category';
+        $clean  = array();
+        foreach ( $value as $term_id ) {
+            $term_id = intval( $term_id );
+            if ( $term_id && get_term( $term_id, $taxonomy ) ) {
+                $clean[] = $term_id;
+            }
+        }
+        return $clean;
+    }
+}

--- a/includes/fields/class-field-user.php
+++ b/includes/fields/class-field-user.php
@@ -1,0 +1,23 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class GM2_Field_User extends GM2_Field {
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
+        $disabled = disabled( $this->args['disabled'] ?? false, true, false );
+        $users = get_users();
+        echo '<select name="' . esc_attr( $this->key ) . '"' . $disabled . '>';
+        echo '<option value="">' . esc_html__( 'Select', 'gm2-wordpress-suite' ) . '</option>';
+        foreach ( $users as $user ) {
+            $selected = selected( (int) $value, $user->ID, false );
+            echo '<option value="' . esc_attr( $user->ID ) . '"' . $selected . '>' . esc_html( $user->display_name ) . '</option>';
+        }
+        echo '</select>';
+    }
+
+    public function sanitize( $value ) {
+        $user_id = intval( $value );
+        return get_user_by( 'id', $user_id ) ? $user_id : 0;
+    }
+}

--- a/includes/fields/loader.php
+++ b/includes/fields/loader.php
@@ -43,6 +43,12 @@ require_once __DIR__ . '/class-field-gradient.php';
 require_once __DIR__ . '/class-field-icon.php';
 require_once __DIR__ . '/class-field-badge.php';
 require_once __DIR__ . '/class-field-rating.php';
+require_once __DIR__ . '/class-field-measurement.php';
+require_once __DIR__ . '/class-field-schedule.php';
+require_once __DIR__ . '/class-field-json.php';
+require_once __DIR__ . '/class-field-post-object.php';
+require_once __DIR__ . '/class-field-taxonomy-terms.php';
+require_once __DIR__ . '/class-field-user.php';
 
 $gm2_field_types = array();
 
@@ -96,5 +102,11 @@ function gm2_register_default_field_types() {
     gm2_register_field_type( 'icon', 'GM2_Field_Icon' );
     gm2_register_field_type( 'badge', 'GM2_Field_Badge' );
     gm2_register_field_type( 'rating', 'GM2_Field_Rating' );
+    gm2_register_field_type( 'measurement', 'GM2_Field_Measurement' );
+    gm2_register_field_type( 'schedule', 'GM2_Field_Schedule' );
+    gm2_register_field_type( 'json', 'GM2_Field_JSON' );
+    gm2_register_field_type( 'post_object', 'GM2_Field_Post_Object' );
+    gm2_register_field_type( 'taxonomy_terms', 'GM2_Field_Taxonomy_Terms' );
+    gm2_register_field_type( 'user', 'GM2_Field_User' );
 }
 add_action( 'init', 'gm2_register_default_field_types' );


### PR DESCRIPTION
## Summary
- add measurement, schedule, JSON, post object, taxonomy terms, and user field classes
- register new fields and load their classes

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: dependency conflict)*
- `vendor/bin/phpunit` *(fails: missing WordPress test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b1fc64d48327bee1bd57e697e8a7