### PR TITLE
Support nested field groups and repeaters

### DIFF
--- a/includes/fields/class-field-group.php
+++ b/includes/fields/class-field-group.php
@@ -6,10 +6,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 class GM2_Field_Group extends GM2_Field {
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = $this->args['disabled'] ?? false ? ' data-disabled="1"' : '';
-        echo '<div class="gm2-field-group" data-key="' . esc_attr( $this->key ) . '"' . $disabled . '></div>';
+        echo '<div class="gm2-field-group" data-key="' . esc_attr( $this->key ) . '"' . $disabled . '>';
+        $fields = $this->args['fields'] ?? array();
+        gm2_render_field_group( $fields, $object_id, $context_type, null, $this->key );
+        echo '</div>';
     }
 
     public function save( $object_id, $value, $context_type = 'post' ) {
-        // Groups hold sub-fields; nothing to save directly.
+        $fields = $this->args['fields'] ?? array();
+        $vals   = is_array( $value ) ? $value : array();
+        gm2_save_field_group( $fields, $object_id, $context_type, $vals );
     }
 }

--- a/includes/fields/class-field-repeater.php
+++ b/includes/fields/class-field-repeater.php
@@ -5,22 +5,63 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class GM2_Field_Repeater extends GM2_Field {
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
-        $value    = is_array( $value ) ? $value : array();
-        $disabled = disabled( $this->args['disabled'] ?? false, true, false );
-        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
-        echo '<div class="gm2-repeater" data-key="' . esc_attr( $this->key ) . '">';
-        foreach ( $value as $row ) {
-            echo '<div class="gm2-repeater-row"><input type="text" name="' . esc_attr( $this->key ) . '[]" value="' . esc_attr( $row ) . '"' . $disabled . $placeholder_attr . ' /> <button type="button" class="button gm2-repeater-remove">&times;</button></div>';
+        $rows     = is_array( $value ) ? $value : array();
+        $disabled = $this->args['disabled'] ?? false ? ' data-disabled="1"' : '';
+        echo '<div class="gm2-repeater" data-key="' . esc_attr( $this->key ) . '"' . $disabled . '>';
+        $fields = $this->args['sub_fields'] ?? array();
+        foreach ( $rows as $i => $row ) {
+            echo '<div class="gm2-repeater-row">';
+            gm2_render_field_group( $fields, $object_id, $context_type, $row, $this->key . '[' . $i . ']' );
+            echo '<button type="button" class="button gm2-repeater-remove">&times;</button></div>';
         }
-        echo '<div class="gm2-repeater-row"><input type="text" name="' . esc_attr( $this->key ) . '[]" value=""' . $disabled . $placeholder_attr . ' /> <button type="button" class="button gm2-repeater-remove">&times;</button></div>';
+        echo '<div class="gm2-repeater-row gm2-repeater-template" style="display:none;">';
+        gm2_render_field_group( $fields, $object_id, $context_type, array(), $this->key . '[__i__]' );
+        echo '<button type="button" class="button gm2-repeater-remove">&times;</button></div>';
         echo '<p><button type="button" class="button gm2-repeater-add" data-target="' . esc_attr( $this->key ) . '">' . esc_html__( 'Add Row', 'gm2-wordpress-suite' ) . '</button></p>';
         echo '</div>';
     }
 
-    public function sanitize( $value ) {
-        if ( is_array( $value ) ) {
-            return array_filter( array_map( 'sanitize_text_field', $value ) );
+    public function save( $object_id, $value, $context_type = 'post' ) {
+        $rows   = is_array( $value ) ? $value : array();
+        $fields = $this->args['sub_fields'] ?? array();
+        $clean  = array();
+        foreach ( $rows as $row ) {
+            $original_request = $_REQUEST;
+            if ( is_array( $row ) ) {
+                $_REQUEST = array_merge( $_REQUEST, $row );
+            }
+            $row_clean = array();
+            foreach ( $fields as $sub_key => $sub_field ) {
+                if ( ! \Gm2\Gm2_Capability_Manager::can_edit_field( $sub_key, $object_id ) ) {
+                    continue;
+                }
+                $state = gm2_evaluate_conditions( $sub_field, $object_id );
+                if ( ! $state['show'] ) {
+                    continue;
+                }
+                $val   = $row[ $sub_key ] ?? null;
+                $valid = gm2_validate_field( $sub_key, $sub_field, $val, $object_id, $context_type );
+                if ( is_wp_error( $valid ) ) {
+                    $_REQUEST = $original_request;
+                    wp_die( $valid->get_error_message() );
+                }
+                $type  = $sub_field['type'] ?? 'text';
+                $class = gm2_get_field_type_class( $type );
+                if ( $class && class_exists( $class ) ) {
+                    $obj                = new $class( $sub_key, $sub_field );
+                    $row_clean[ $sub_key ] = $obj->sanitize( $val );
+                }
+            }
+            $_REQUEST = $original_request;
+            if ( ! empty( $row_clean ) ) {
+                $clean[] = $row_clean;
+            }
         }
-        return array();
+
+        if ( empty( $clean ) ) {
+            $this->delete_value( $object_id, $context_type );
+        } else {
+            $this->update_value( $object_id, $clean, $context_type );
+        }
     }
 }

--- a/tests/test-field-group-repeater.php
+++ b/tests/test-field-group-repeater.php
@@ -1,0 +1,98 @@
+<?php
+class FieldGroupRepeaterTest extends WP_UnitTestCase {
+    protected $post_id;
+    public function setUp(): void {
+        parent::setUp();
+        $this->post_id = self::factory()->post->create();
+    }
+    public function tearDown(): void {
+        parent::tearDown();
+        wp_delete_post($this->post_id, true);
+        $_POST = [];
+        $_REQUEST = [];
+    }
+    public function test_group_renders_and_saves_children() {
+        $fields = [
+            'info' => [
+                'type' => 'group',
+                'fields' => [
+                    'child_a' => [ 'type' => 'text' ],
+                    'child_b' => [
+                        'type' => 'text',
+                        'conditions' => [
+                            [
+                                'relation' => 'AND',
+                                'conditions' => [
+                                    [
+                                        'relation' => 'AND',
+                                        'target'   => 'child_a',
+                                        'operator' => '=',
+                                        'value'    => 'show',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        ob_start();
+        gm2_render_field_group($fields, $this->post_id, 'post');
+        $html = ob_get_clean();
+        $this->assertStringContainsString('name="info[child_a]"', $html);
+        $this->assertStringContainsString('name="info[child_b]"', $html);
+
+        $_POST['info'] = ['child_a' => 'hide', 'child_b' => 'x'];
+        gm2_save_field_group($fields, $this->post_id, 'post');
+        $this->assertSame('hide', get_post_meta($this->post_id, 'child_a', true));
+        $this->assertSame('', get_post_meta($this->post_id, 'child_b', true));
+
+        $_POST['info'] = ['child_a' => 'show', 'child_b' => 'ok'];
+        gm2_save_field_group($fields, $this->post_id, 'post');
+        $this->assertSame('show', get_post_meta($this->post_id, 'child_a', true));
+        $this->assertSame('ok', get_post_meta($this->post_id, 'child_b', true));
+    }
+
+    public function test_repeater_renders_and_saves_rows() {
+        $fields = [
+            'items' => [
+                'type' => 'repeater',
+                'sub_fields' => [
+                    'name' => [ 'type' => 'text' ],
+                    'count' => [ 'type' => 'number' ],
+                    'note' => [
+                        'type' => 'text',
+                        'conditions' => [
+                            [
+                                'relation' => 'AND',
+                                'conditions' => [
+                                    [
+                                        'relation' => 'AND',
+                                        'target'   => 'count',
+                                        'operator' => '>',
+                                        'value'    => '1',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        ob_start();
+        gm2_render_field_group($fields, $this->post_id, 'post');
+        $html = ob_get_clean();
+        $this->assertStringContainsString('name="items[__i__][name]"', $html);
+
+        $_POST['items'] = [
+            [ 'name' => 'Alpha', 'count' => '2', 'note' => 'n1' ],
+            [ 'name' => 'Beta',  'count' => '1', 'note' => 'n2' ],
+        ];
+        gm2_save_field_group($fields, $this->post_id, 'post');
+        $saved = get_post_meta($this->post_id, 'items', true);
+        $this->assertSame([
+            [ 'name' => 'Alpha', 'count' => '2', 'note' => 'n1' ],
+            [ 'name' => 'Beta',  'count' => '1' ],
+        ], $saved);
+    }
+}


### PR DESCRIPTION
## Summary
- Allow `gm2_render_field_group()` and `gm2_save_field_group()` to handle nested field values and prefixes so conditional logic works at any depth.
- Expand `GM2_Field_Group` to render and save defined child fields.
- Enhance `GM2_Field_Repeater` with `sub_fields`, rendering grouped rows and sanitizing each row on save.
- Add unit tests for grouped and repeater field behaviors.

## Testing
- `vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b2e091288327a9bf1f11e9efe3b7