### PR TITLE
Expose field meta via REST API

### DIFF
--- a/admin/Gm2_Custom_Posts_Admin.php
+++ b/admin/Gm2_Custom_Posts_Admin.php
@@ -986,6 +986,7 @@ class Gm2_Custom_Posts_Admin {
                 'quick_edit'   => !empty($field['quick_edit']),
                 'bulk_edit'    => !empty($field['bulk_edit']),
                 'filter'       => !empty($field['filter']),
+                'expose_in_rest' => !empty($field['expose_in_rest']),
             ];
             if ($type === 'date') {
                 $sanitized['date_min'] = sanitize_text_field($field['date_min'] ?? '');

--- a/admin/js/gm2-fg-wizard.js
+++ b/admin/js/gm2-fg-wizard.js
@@ -1,7 +1,7 @@
 (function(wp){
     const { createElement: el, useState, useEffect } = wp.element;
     const { render } = wp.element;
-    const { Button, TextControl, SelectControl, FormTokenField, PanelBody, Panel, Card, CardBody, Sortable } = wp.components;
+    const { Button, TextControl, SelectControl, FormTokenField, PanelBody, Panel, Card, CardBody, Sortable, ToggleControl } = wp.components;
     const { dispatch } = wp.data;
     const addPassive = !window.AE_PERF_DISABLE_PASSIVE && window.aePerf?.addPassive
         ? window.aePerf.addPassive
@@ -132,7 +132,7 @@
     };
 
     const FieldsStep = ({ data, setData }) => {
-        const [ field, setField ] = useState({ label: '', slug: '', type: 'text' });
+        const [ field, setField ] = useState({ label: '', slug: '', type: 'text', expose_in_rest: false });
         const [ editIndex, setEditIndex ] = useState(null);
         const [ error, setError ] = useState('');
         const [ fieldsOpen, setFieldsOpen ] = useState(true);
@@ -163,12 +163,12 @@
                 fields.push(field);
             }
             setData({ ...data, fields });
-            setField({ label: '', slug: '', type: 'text' });
+            setField({ label: '', slug: '', type: 'text', expose_in_rest: false });
             setEditIndex(null);
         };
 
         const editField = (i) => {
-            setField(data.fields[i]);
+            setField({ expose_in_rest: false, ...data.fields[i] });
             setEditIndex(i);
         };
 
@@ -219,6 +219,12 @@
                 value: field.type,
                 options: fieldTypes,
                 onChange: v => setField({ ...field, type: v })
+            }),
+            el(ToggleControl, {
+                label: 'Expose in REST API',
+                id: 'gm2-field-expose',
+                checked: !!field.expose_in_rest,
+                onChange: v => setField({ ...field, expose_in_rest: v })
             }),
             el(Button, { isPrimary: true, onClick: addField }, editIndex !== null ? 'Update Field' : 'Add Field')
         );
@@ -422,7 +428,8 @@
             const fields = Object.keys(group.fields || {}).map(key => ({
                 slug: key,
                 label: group.fields[key].label || '',
-                type: group.fields[key].type || 'text'
+                type: group.fields[key].type || 'text',
+                expose_in_rest: !!group.fields[key].expose_in_rest
             }));
             const objects = group.objects || [];
             setData({ slug: slug, title: group.title || '', scope: group.scope || 'post_type', objects, fields, location: group.location || [] });

--- a/includes/Gm2_REST_Visibility.php
+++ b/includes/Gm2_REST_Visibility.php
@@ -30,7 +30,22 @@ class Gm2_REST_Visibility {
     }
 
     public static function apply_visibility() : void {
-        $vis = self::get_visibility();
+        $defaults = self::defaults();
+        $groups = get_option('gm2_field_groups', []);
+        if (is_array($groups)) {
+            foreach ($groups as $group) {
+                foreach (($group['fields'] ?? []) as $key => $field) {
+                    if (!empty($field['expose_in_rest'])) {
+                        $defaults['fields'][$key] = true;
+                    }
+                }
+            }
+        }
+
+        $vis = get_option(self::OPTION, []);
+        $vis = wp_parse_args(is_array($vis) ? $vis : [], $defaults);
+        update_option(self::OPTION, $vis);
+
         if (!empty($vis['post_types'])) {
             foreach ($vis['post_types'] as $type => $show) {
                 if (post_type_exists($type)) {

--- a/includes/gm2-custom-posts-functions.php
+++ b/includes/gm2-custom-posts-functions.php
@@ -946,6 +946,31 @@ function gm2_register_field_groups() {
             if (!empty($field['pii'])) {
                 \Gm2\Gm2_Audit_Log::tag_field_as_pii($key, $field['retention'] ?? null);
             }
+            if (!empty($field['expose_in_rest'])) {
+                switch ($scope) {
+                    case 'taxonomy':
+                    case 'term':
+                        foreach (($group['objects'] ?? []) as $tax) {
+                            register_meta('term', $key, [ 'show_in_rest' => true, 'object_subtype' => $tax ]);
+                        }
+                        break;
+                    case 'user':
+                        register_meta('user', $key, [ 'show_in_rest' => true ]);
+                        break;
+                    case 'comment':
+                        register_meta('comment', $key, [ 'show_in_rest' => true ]);
+                        break;
+                    case 'media':
+                        register_meta('post', $key, [ 'show_in_rest' => true, 'object_subtype' => 'attachment' ]);
+                        break;
+                    case 'post_type':
+                    default:
+                        foreach (($group['objects'] ?? []) as $pt) {
+                            register_meta('post', $key, [ 'show_in_rest' => true, 'object_subtype' => $pt ]);
+                        }
+                        break;
+                }
+            }
         }
 
         switch ($scope) {

--- a/tests/test-expose-in-rest.php
+++ b/tests/test-expose-in-rest.php
@@ -1,0 +1,41 @@
+<?php
+use Gm2\Gm2_REST_Visibility;
+
+class ExposeInRestTest extends WP_UnitTestCase {
+    public function setUp(): void {
+        parent::setUp();
+        register_post_type('book');
+        update_option('gm2_field_groups', [
+            'books' => [
+                'title' => 'Books',
+                'scope' => 'post_type',
+                'objects' => ['book'],
+                'fields' => [
+                    'isbn' => [
+                        'label' => 'ISBN',
+                        'type' => 'text',
+                        'expose_in_rest' => true,
+                    ],
+                ],
+            ],
+        ]);
+        delete_option(Gm2_REST_Visibility::OPTION);
+        gm2_register_field_groups();
+        Gm2_REST_Visibility::apply_visibility();
+    }
+
+    public function tearDown(): void {
+        unregister_post_type('book');
+        delete_option('gm2_field_groups');
+        delete_option(Gm2_REST_Visibility::OPTION);
+        parent::tearDown();
+    }
+
+    public function test_field_exposed_in_rest() {
+        $vis = Gm2_REST_Visibility::get_visibility();
+        $this->assertTrue($vis['fields']['isbn']);
+        $registered = get_registered_meta_keys('post', 'book');
+        $this->assertArrayHasKey('isbn', $registered);
+        $this->assertTrue($registered['isbn']['show_in_rest']);
+    }
+}


### PR DESCRIPTION
## Summary
- allow field definitions to opt into REST exposure via `expose_in_rest`
- merge REST visibility defaults with option map
- surface `expose_in_rest` toggle in field-group wizard

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: mysqladmin command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b6003adc8327b3b28710a7a5f82e