### PR TITLE
Add tests for nested fields and REST exposure

### DIFF
--- a/tests/NestedFieldGroupRepeaterTest.php
+++ b/tests/NestedFieldGroupRepeaterTest.php
@@ -1,0 +1,74 @@
+<?php
+class NestedFieldGroupRepeaterTest extends WP_UnitTestCase {
+    protected $post_id;
+
+    public function setUp(): void {
+        parent::setUp();
+        $this->post_id = self::factory()->post->create();
+    }
+
+    public function tearDown(): void {
+        parent::tearDown();
+        wp_delete_post($this->post_id, true);
+        $_POST = [];
+        $_REQUEST = [];
+    }
+
+    public function test_nested_fields_sanitized_and_saved() {
+        $fields = [
+            'layout' => [
+                'type' => 'group',
+                'fields' => [
+                    'dimensions' => [
+                        'type' => 'group',
+                        'fields' => [
+                            'width' => [ 'type' => 'measurement', 'units' => ['px', 'em'] ],
+                        ],
+                    ],
+                    'shifts' => [
+                        'type' => 'repeater',
+                        'sub_fields' => [
+                            'period' => [ 'type' => 'schedule' ],
+                            'note'   => [ 'type' => 'text' ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $_POST['layout'] = [
+            'dimensions' => [
+                'width' => [ 'value' => '15', 'unit' => 'bad' ],
+            ],
+            'shifts' => [
+                [
+                    'period' => [ 'day' => ['Monday'], 'start' => ['09:00'], 'end' => ['17:00'] ],
+                    'note'   => 'open',
+                ],
+                [
+                    'period' => [ 'day' => ['Tuesday'], 'start' => [''], 'end' => ['18:00'] ],
+                    'note'   => 'invalid',
+                ],
+            ],
+        ];
+
+        gm2_save_field_group($fields, $this->post_id, 'post');
+
+        $this->assertSame(
+            [ 'value' => '15', 'unit' => 'px' ],
+            get_post_meta($this->post_id, 'width', true)
+        );
+
+        $saved = get_post_meta($this->post_id, 'shifts', true);
+        $this->assertSame([
+            [
+                'period' => [ [ 'day' => 'Monday', 'start' => '09:00', 'end' => '17:00' ] ],
+                'note'   => 'open',
+            ],
+            [
+                'period' => [],
+                'note'   => 'invalid',
+            ],
+        ], $saved);
+    }
+}

--- a/tests/test-expose-in-rest.php
+++ b/tests/test-expose-in-rest.php
@@ -2,21 +2,24 @@
 use Gm2\Gm2_REST_Visibility;
 
 class ExposeInRestTest extends WP_UnitTestCase {
+    private $fields;
+
     public function setUp(): void {
         parent::setUp();
         register_post_type('book');
+        $this->fields = [
+            'isbn' => [
+                'label' => 'ISBN',
+                'type'  => 'text',
+                'expose_in_rest' => true,
+            ],
+        ];
         update_option('gm2_field_groups', [
             'books' => [
-                'title' => 'Books',
-                'scope' => 'post_type',
+                'title'   => 'Books',
+                'scope'   => 'post_type',
                 'objects' => ['book'],
-                'fields' => [
-                    'isbn' => [
-                        'label' => 'ISBN',
-                        'type' => 'text',
-                        'expose_in_rest' => true,
-                    ],
-                ],
+                'fields'  => $this->fields,
             ],
         ]);
         delete_option(Gm2_REST_Visibility::OPTION);
@@ -37,5 +40,18 @@ class ExposeInRestTest extends WP_UnitTestCase {
         $registered = get_registered_meta_keys('post', 'book');
         $this->assertArrayHasKey('isbn', $registered);
         $this->assertTrue($registered['isbn']['show_in_rest']);
+    }
+
+    public function test_saved_meta_visible_via_rest() {
+        $post_id = self::factory()->post->create(['post_type' => 'book']);
+        $_POST['isbn'] = '9781234567';
+        gm2_save_field_group($this->fields, $post_id, 'post');
+        $this->assertSame('9781234567', get_post_meta($post_id, 'isbn', true));
+
+        $request = new WP_REST_Request('GET', '/wp/v2/book/' . $post_id);
+        $request->set_param('context', 'edit');
+        $response = rest_get_server()->dispatch($request);
+        $data = $response->get_data();
+        $this->assertSame('9781234567', $data['meta']['isbn']);
     }
 }


### PR DESCRIPTION
## Summary
- test nested group and repeater field sanitization and saving
- add validation callback tests for measurement and schedule field types
- verify expose_in_rest meta registration via gm2_save_field_group and REST API

## Testing
- `composer install`
- `./vendor/bin/phpunit tests/NestedFieldGroupRepeaterTest.php tests/FieldValidationTest.php tests/test-expose-in-rest.php` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `bash bin/install-wp-tests.sh wordpress_test root '' localhost latest` *(fails: mysqladmin command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c5bc9187c883278c088b81c5574a57