### PR TITLE
feat: add Elementor posts query integration

### DIFF
--- a/docs/elementor-query-examples.md
+++ b/docs/elementor-query-examples.md
@@ -1,0 +1,20 @@
+# Elementor Query Examples
+
+The Gm2 WordPress Suite adds a **GM2 CP** option to Elementor Pro's Posts widget. Selecting this query ID reads additional controls and converts them into `WP_Query` arguments.
+
+## Examples
+
+1. **Filter by post type and taxonomy**
+   - Choose **GM2 CP** as the query.
+   - Set *Post Type* to `event`.
+   - Select taxonomy `location` with term IDs `12` and `34`.
+
+2. **Price range and meta comparison**
+   - Provide a *Meta Key* of `_stock` with compare `>` and value `0` to show in-stock items.
+   - Set *Price Min* to `10` and *Price Max* to `100` to restrict results.
+
+3. **Date and geodistance**
+   - Enter *Date After* `2024-01-01`.
+   - Supply latitude `40.7128`, longitude `-74.0060` and radius `25` (km) to find nearby posts.
+
+These controls map to `post_type`, `tax_query`, `meta_query`, `date_query` and geo bounding boxes, allowing advanced filtering without custom code.

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -82,6 +82,7 @@ require_once GM2_PLUGIN_DIR . 'includes/gm2-open-in-code.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-field-renderers.php';
 require_once GM2_PLUGIN_DIR . 'includes/elementor/class-gm2-dynamic-tag.php';
 require_once GM2_PLUGIN_DIR . 'integrations/elementor/class-gm2-cp-elementor-tags.php';
+require_once GM2_PLUGIN_DIR . 'integrations/elementor/class-gm2-cp-elementor-query.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-schema-tooltips.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-editorial-comments.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-model-export.php';

--- a/integrations/elementor/class-gm2-cp-elementor-query.php
+++ b/integrations/elementor/class-gm2-cp-elementor-query.php
@@ -1,0 +1,133 @@
+<?php
+namespace Gm2\Integrations\Elementor;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Translate Elementor query controls into WP_Query args.
+ */
+class GM2_CP_Elementor_Query {
+    /**
+     * Register Elementor query hook.
+     */
+    public static function register() {
+        add_action('elementor_pro/posts/query/gm2_cp', [__CLASS__, 'apply_query'], 10, 2);
+    }
+
+    /**
+     * Apply custom query arguments from widget settings.
+     *
+     * @param \WP_Query                                 $query   Query instance.
+     * @param \ElementorPro\Modules\Posts\Widgets\Posts $widget Widget instance.
+     */
+    public static function apply_query($query, $widget) {
+        $settings = $widget->get_settings();
+        $args     = [];
+
+        // Post type selection.
+        if (!empty($settings['gm2_cp_post_type'])) {
+            $args['post_type'] = array_map('sanitize_key', (array) $settings['gm2_cp_post_type']);
+        }
+
+        // Taxonomy terms.
+        if (!empty($settings['gm2_cp_taxonomy']) && !empty($settings['gm2_cp_terms'])) {
+            $args['tax_query'][] = [
+                'taxonomy' => sanitize_key($settings['gm2_cp_taxonomy']),
+                'field'    => 'term_id',
+                'terms'    => array_map('absint', (array) $settings['gm2_cp_terms']),
+            ];
+        }
+
+        // Meta comparisons.
+        if (!empty($settings['gm2_cp_meta_key'])) {
+            $meta = [
+                'key' => sanitize_key($settings['gm2_cp_meta_key']),
+            ];
+            if ($settings['gm2_cp_meta_value'] !== '') {
+                $meta['value'] = sanitize_text_field($settings['gm2_cp_meta_value']);
+            }
+            if (!empty($settings['gm2_cp_meta_compare'])) {
+                $meta['compare'] = strtoupper($settings['gm2_cp_meta_compare']);
+            }
+            if (!empty($settings['gm2_cp_meta_type'])) {
+                $meta['type'] = sanitize_text_field($settings['gm2_cp_meta_type']);
+            }
+            $args['meta_query'][] = $meta;
+        }
+
+        // Date range.
+        if (!empty($settings['gm2_cp_date_after']) || !empty($settings['gm2_cp_date_before'])) {
+            $date = ['inclusive' => true];
+            if (!empty($settings['gm2_cp_date_after'])) {
+                $date['after'] = sanitize_text_field($settings['gm2_cp_date_after']);
+            }
+            if (!empty($settings['gm2_cp_date_before'])) {
+                $date['before'] = sanitize_text_field($settings['gm2_cp_date_before']);
+            }
+            $args['date_query'][] = $date;
+        }
+
+        // Price range.
+        if ($settings['gm2_cp_price_min'] !== '' || $settings['gm2_cp_price_max'] !== '') {
+            $min   = $settings['gm2_cp_price_min'] !== '' ? floatval($settings['gm2_cp_price_min']) : null;
+            $max   = $settings['gm2_cp_price_max'] !== '' ? floatval($settings['gm2_cp_price_max']) : null;
+            $range = array_filter([$min, $max], static function ($v) {
+                return $v !== null;
+            });
+            if ($range) {
+                $compare = 'BETWEEN';
+                if (count($range) === 1) {
+                    $compare = $min !== null ? '>=' : '<=';
+                }
+                $args['meta_query'][] = [
+                    'key'     => sanitize_key($settings['gm2_cp_price_key'] ?? '_price'),
+                    'value'   => $range,
+                    'compare' => $compare,
+                    'type'    => 'NUMERIC',
+                ];
+            }
+        }
+
+        // Geodistance via bounding box around coordinates.
+        if (
+            $settings['gm2_cp_geo_lat'] !== '' &&
+            $settings['gm2_cp_geo_lng'] !== '' &&
+            $settings['gm2_cp_geo_radius'] !== ''
+        ) {
+            $lat     = floatval($settings['gm2_cp_geo_lat']);
+            $lng     = floatval($settings['gm2_cp_geo_lng']);
+            $radius  = floatval($settings['gm2_cp_geo_radius']);
+            $lat_key = sanitize_key($settings['gm2_cp_geo_lat_key'] ?? 'gm2_geo_lat');
+            $lng_key = sanitize_key($settings['gm2_cp_geo_lng_key'] ?? 'gm2_geo_lng');
+
+            $lat_range = [$lat - ($radius / 111.045), $lat + ($radius / 111.045)];
+            $lng_range = [$lng - ($radius / (111.045 * cos(deg2rad($lat)))), $lng + ($radius / (111.045 * cos(deg2rad($lat))))];
+
+            $args['meta_query'][] = [
+                'key'     => $lat_key,
+                'value'   => $lat_range,
+                'compare' => 'BETWEEN',
+                'type'    => 'DECIMAL',
+            ];
+            $args['meta_query'][] = [
+                'key'     => $lng_key,
+                'value'   => $lng_range,
+                'compare' => 'BETWEEN',
+                'type'    => 'DECIMAL',
+            ];
+        }
+
+        // Merge with existing query vars.
+        foreach ($args as $key => $value) {
+            $existing = $query->get($key);
+            if (is_array($existing) && is_array($value)) {
+                $query->set($key, array_merge($existing, $value));
+            } else {
+                $query->set($key, $value);
+            }
+        }
+    }
+}
+GM2_CP_Elementor_Query::register();


### PR DESCRIPTION
## Summary
- interpret GM2 CP query controls for Elementor's Posts widget
- load the new query handler in the main plugin bootstrap
- document how to filter posts by type, taxonomy, meta, price, date and geodistance

## Testing
- `vendor/bin/phpunit` *(fails: missing WordPress test library)*
- `npm test` *(fails: e2e tests and environment issues)*

------
https://chatgpt.com/codex/tasks/task_e_68c5cdce233483279eb7002b1aa4c557