### PR TITLE
Add field helpers for currency and contact links

### DIFF
--- a/includes/gm2-theme-tools.php
+++ b/includes/gm2-theme-tools.php
@@ -123,6 +123,80 @@ function gm2_field_image($key, $size = 'full', $attr = [], $object_id = null, $c
 }
 
 /**
+ * Format a numeric field value as currency.
+ *
+ * Fetches a field with {@see gm2_field()} and wraps the formatted amount in a
+ * span element. The returned HTML uses a dollar symbol and two decimal places.
+ *
+ * Example usage:
+ * `echo gm2_field_currency( 'price' );`
+ *
+ * @param string   $key          Meta field key.
+ * @param mixed    $default      Default value if the field is empty.
+ * @param int|null $object_id    Context object ID. Defaults to current post.
+ * @param string   $context_type Context type.
+ * @return string HTML markup or empty string when no value is available.
+ */
+function gm2_field_currency($key, $default = '', $object_id = null, $context_type = 'post') {
+    $value = gm2_field($key, $default, $object_id, $context_type);
+    if ($value === '' || $value === null) {
+        return '';
+    }
+
+    $amount    = (float) preg_replace('/[^0-9.\-]/', '', (string) $value);
+    $formatted = number_format_i18n($amount, 2);
+    return sprintf('<span class="gm2-currency">$%s</span>', esc_html($formatted));
+}
+
+/**
+ * Generate a telephone link from a field value.
+ *
+ * Example usage:
+ * `echo gm2_field_phone_link( 'support_phone' );`
+ *
+ * @param string   $key          Meta field key.
+ * @param mixed    $default      Default value if the field is empty.
+ * @param int|null $object_id    Context object ID. Defaults to current post.
+ * @param string   $context_type Context type.
+ * @return string HTML anchor or empty string when no value is available.
+ */
+function gm2_field_phone_link($key, $default = '', $object_id = null, $context_type = 'post') {
+    $number = gm2_field($key, $default, $object_id, $context_type);
+    if ($number === '' || $number === null) {
+        return '';
+    }
+
+    $tel = preg_replace('/[^0-9+]/', '', (string) $number);
+    if ($tel === '') {
+        return '';
+    }
+
+    return sprintf('<a href="tel:%s">%s</a>', esc_attr($tel), esc_html($number));
+}
+
+/**
+ * Generate a Google Maps link from an address field.
+ *
+ * Example usage:
+ * `echo gm2_field_map_link( 'address' );`
+ *
+ * @param string   $key          Meta field key.
+ * @param mixed    $default      Default value if the field is empty.
+ * @param int|null $object_id    Context object ID. Defaults to current post.
+ * @param string   $context_type Context type.
+ * @return string HTML anchor or empty string when no value is available.
+ */
+function gm2_field_map_link($key, $default = '', $object_id = null, $context_type = 'post') {
+    $address = gm2_field($key, $default, $object_id, $context_type);
+    if ($address === '' || $address === null) {
+        return '';
+    }
+
+    $url = 'https://www.google.com/maps/search/?api=1&query=' . rawurlencode($address);
+    return sprintf('<a href="%s" target="_blank" rel="noopener">%s</a>', esc_url($url), esc_html($address));
+}
+
+/**
  * Locate a field definition from stored field groups.
  *
  * @param string $key Field key.

--- a/tests/test-theme-tools.php
+++ b/tests/test-theme-tools.php
@@ -15,6 +15,27 @@ class ThemeToolsTest extends WP_UnitTestCase {
         $this->assertStringContainsString('src=', $html);
     }
 
+    public function test_currency_phone_and_map_helpers_format_values() {
+        $post_id = self::factory()->post->create([
+            'meta_input' => [
+                'price'   => '1234.5',
+                'phone'   => '(123) 555-7890',
+                'address' => '1600 Amphitheatre Pkwy, Mountain View, CA',
+            ],
+        ]);
+
+        $currency = gm2_field_currency('price', '', $post_id);
+        $this->assertSame('<span class="gm2-currency">$1,234.50</span>', $currency);
+
+        $phone = gm2_field_phone_link('phone', '', $post_id);
+        $this->assertSame('<a href="tel:1235557890">(123) 555-7890</a>', $phone);
+
+        $map_url = 'https://www.google.com/maps/search/?api=1&query=' . rawurlencode('1600 Amphitheatre Pkwy, Mountain View, CA');
+        $expected = '<a href="' . esc_url($map_url) . '" target="_blank" rel="noopener">1600 Amphitheatre Pkwy, Mountain View, CA</a>';
+        $map = gm2_field_map_link('address', '', $post_id);
+        $this->assertSame($expected, $map);
+    }
+
     public function test_theme_json_snippet_is_generated() {
         update_option('gm2_enable_theme_json', '1');
         update_option('gm2_field_groups', [


### PR DESCRIPTION
## Summary
- add `gm2_field_currency()`, `gm2_field_phone_link()`, and `gm2_field_map_link()` helpers
- cover new helpers with tests for formatted output

## Testing
- `php -l includes/gm2-theme-tools.php`
- `php -l tests/test-theme-tools.php`
- `vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `bin/install-wp-tests.sh wordpress_test root '' localhost latest` *(fails: mysqladmin command not found)*
- `npm test` *(fails: 4 failed, 2 skipped, 10 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c5cebfe3c88327af6fad13f5bdcd07