### PR TITLE
Add AJAX field key control for Elementor

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -80,6 +80,7 @@ require_once GM2_PLUGIN_DIR . 'includes/gm2-query-builder.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-theme-tools.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-open-in-code.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-field-renderers.php';
+require_once GM2_PLUGIN_DIR . 'includes/elementor/class-gm2-field-key-control.php';
 require_once GM2_PLUGIN_DIR . 'includes/elementor/class-gm2-dynamic-tag.php';
 require_once GM2_PLUGIN_DIR . 'integrations/elementor/class-gm2-cp-elementor-tags.php';
 require_once GM2_PLUGIN_DIR . 'integrations/elementor/class-gm2-cp-elementor-query.php';

--- a/includes/elementor/class-gm2-dynamic-tag.php
+++ b/includes/elementor/class-gm2-dynamic-tag.php
@@ -79,16 +79,9 @@ class GM2_Dynamic_Tag extends Tag {
      * Register controls for the dynamic tag.
      */
     protected function register_controls() {
-        $fields  = self::get_fields();
-        $options = [];
-        foreach ($fields as $path => $data) {
-            $options[$path] = $data['label'];
-        }
-
         $this->add_control('field', [
-            'label'   => __('Field', 'gm2-wordpress-suite'),
-            'type'    => Controls_Manager::SELECT2,
-            'options' => $options,
+            'label' => __('Field', 'gm2-wordpress-suite'),
+            'type'  => GM2_Field_Key_Control::TYPE,
         ]);
 
         $this->add_control('fallback', [

--- a/includes/elementor/class-gm2-field-key-control.php
+++ b/includes/elementor/class-gm2-field-key-control.php
@@ -1,0 +1,127 @@
+<?php
+namespace Gm2\Elementor;
+
+use Elementor\Base_Data_Control;
+use Elementor\Controls_Manager;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Elementor control for selecting GM2 field keys via AJAX.
+ */
+class GM2_Field_Key_Control extends Base_Data_Control {
+    /** Control type identifier. */
+    const TYPE = 'gm2-field-key';
+
+    /**
+     * Register hooks.
+     */
+    public static function init() {
+        add_action('wp_ajax_gm2_field_keys', [__CLASS__, 'ajax_field_keys']);
+        add_action('elementor/controls/register', [__CLASS__, 'register_control']);
+    }
+
+    /**
+     * Register the control with Elementor.
+     *
+     * @param \Elementor\Controls_Manager $controls_manager
+     */
+    public static function register_control($controls_manager) {
+        $controls_manager->register_control(self::TYPE, new self());
+    }
+
+    /**
+     * Control type.
+     */
+    public function get_type() {
+        return self::TYPE;
+    }
+
+    /**
+     * Enqueue assets.
+     */
+    public function enqueue() {
+        wp_enqueue_script(
+            'gm2-field-key-control',
+            GM2_PLUGIN_URL . 'public/js/gm2-field-key-control.js',
+            ['jquery', 'elementor-controls'],
+            defined('GM2_VERSION') ? GM2_VERSION : false,
+            true
+        );
+        wp_localize_script('gm2-field-key-control', 'gm2FieldKey', [
+            'ajax'  => admin_url('admin-ajax.php'),
+            'nonce' => wp_create_nonce('gm2_field_keys'),
+        ]);
+    }
+
+    /**
+     * Render control content.
+     */
+    public function content_template() {
+        ?>
+        <div class="gm2-field-key-control">
+            <select data-setting="{{ data.name }}"></select>
+        </div>
+        <?php
+    }
+
+    /**
+     * Default settings.
+     */
+    protected function get_default_settings() {
+        return [ 'label_block' => true ];
+    }
+
+    /**
+     * AJAX callback returning available field keys for a post type.
+     */
+    public static function ajax_field_keys() {
+        check_ajax_referer('gm2_field_keys', 'nonce');
+        $post_type = sanitize_key($_POST['post_type'] ?? '');
+        $groups    = get_option('gm2_field_groups', []);
+        $fields    = [];
+        if (is_array($groups)) {
+            foreach ($groups as $group) {
+                $scope   = $group['scope'] ?? '';
+                $objects = $group['objects'] ?? [];
+                if ($scope === 'post_type' && $objects && !in_array($post_type, $objects, true)) {
+                    continue;
+                }
+                if (!empty($group['fields']) && is_array($group['fields'])) {
+                    foreach ($group['fields'] as $key => $field) {
+                        self::collect_field($fields, $key, $field);
+                    }
+                }
+            }
+        }
+        wp_send_json_success($fields);
+    }
+
+    /**
+     * Recursively flatten fields.
+     *
+     * @param array  $store
+     * @param string $path
+     * @param array  $field
+     * @param string $prefix
+     */
+    private static function collect_field(&$store, $path, $field, $prefix = '') {
+        $label       = $field['label'] ?? $path;
+        $display     = $prefix ? $prefix . ' › ' . $label : $label; // › is a single right-pointing angle quote
+        $store[$path] = $display;
+        if (!empty($field['fields']) && is_array($field['fields'])) {
+            foreach ($field['fields'] as $sub_key => $sub_field) {
+                self::collect_field($store, $path . '.' . $sub_key, $sub_field, $display);
+            }
+        }
+        if (!empty($field['sub_fields']) && is_array($field['sub_fields'])) {
+            foreach ($field['sub_fields'] as $sub_key => $sub_field) {
+                self::collect_field($store, $path . '.0.' . $sub_key, $sub_field, $display . ' [0]');
+            }
+        }
+    }
+}
+
+GM2_Field_Key_Control::init();

--- a/integrations/elementor/class-gm2-cp-elementor-query.php
+++ b/integrations/elementor/class-gm2-cp-elementor-query.php
@@ -1,6 +1,8 @@
 <?php
 namespace Gm2\Integrations\Elementor;
 
+use Gm2\Elementor\GM2_Field_Key_Control;
+
 if (!defined('ABSPATH')) {
     exit;
 }
@@ -14,6 +16,18 @@ class GM2_CP_Elementor_Query {
      */
     public static function register() {
         add_action('elementor_pro/posts/query/gm2_cp', [__CLASS__, 'apply_query'], 10, 2);
+        add_action('elementor/element/posts/section_query/before_section_end', [__CLASS__, 'add_controls'], 10, 2);
+    }
+
+    /**
+     * Add custom query controls.
+     */
+    public static function add_controls($element, $args) {
+        $element->add_control('gm2_cp_meta_key', [
+            'label' => __('GM2 Field Key', 'gm2-wordpress-suite'),
+            'type'  => GM2_Field_Key_Control::TYPE,
+            'condition' => [ 'query_id' => 'gm2_cp' ],
+        ]);
     }
 
     /**
@@ -43,7 +57,7 @@ class GM2_CP_Elementor_Query {
         // Meta comparisons.
         if (!empty($settings['gm2_cp_meta_key'])) {
             $meta = [
-                'key' => sanitize_key($settings['gm2_cp_meta_key']),
+                'key' => sanitize_text_field($settings['gm2_cp_meta_key']),
             ];
             if ($settings['gm2_cp_meta_value'] !== '') {
                 $meta['value'] = sanitize_text_field($settings['gm2_cp_meta_value']);

--- a/integrations/elementor/class-gm2-cp-elementor-tags.php
+++ b/integrations/elementor/class-gm2-cp-elementor-tags.php
@@ -2,6 +2,7 @@
 namespace Gm2\Integrations\Elementor;
 
 use Elementor\Controls_Manager;
+use Gm2\Elementor\GM2_Field_Key_Control;
 use Elementor\Core\DynamicTags\Tag;
 use Elementor\Modules\DynamicTags\Module;
 
@@ -28,7 +29,7 @@ abstract class Base_GM2_CP_Tag extends Tag {
     protected function register_controls() {
         $this->add_control('field_key', [
             'label' => __('Field Key', 'gm2-wordpress-suite'),
-            'type'  => Controls_Manager::TEXT,
+            'type'  => GM2_Field_Key_Control::TYPE,
         ]);
 
         $this->add_control('fallback', [

--- a/public/js/gm2-field-key-control.js
+++ b/public/js/gm2-field-key-control.js
@@ -1,0 +1,29 @@
+(function($){
+    var Control = elementor.modules.controls.BaseData.extend({
+        onReady: function(){
+            this.ui = { select: this.$el.find("select") };
+            this.fetchOptions();
+        },
+        fetchOptions: function(){
+            var self = this;
+            var postType = elementor.config.document.post ? elementor.config.document.post.post_type : '';
+            if(!postType){
+                return;
+            }
+            $.post(gm2FieldKey.ajax,{ action:'gm2_field_keys', nonce:gm2FieldKey.nonce, post_type:postType },function(resp){
+                if(resp && resp.success){
+                    self.updateOptions(resp.data);
+                }
+            });
+        },
+        updateOptions: function(list){
+            var select = this.ui.select.empty();
+            $.each(list,function(key,label){
+                select.append($('<option>').val(key).text(label));
+            });
+            var current = this.getControlValue();
+            if(current){ select.val(current); }
+        }
+    });
+    elementor.addControlView('gm2-field-key', Control);
+})(jQuery);


### PR DESCRIPTION
## Summary
- add GM2_Field_Key_Control for AJAX-driven field key selection
- wire control into dynamic tags and custom post query integration
- register control in plugin bootstrap and provide JS handler

## Testing
- `vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d63a50e88327ab1604d21404ddea