### PR TITLE
Add schema mapping admin page for custom post types

### DIFF
--- a/admin/js/gm2-schema-mapping.js
+++ b/admin/js/gm2-schema-mapping.js
@@ -1,0 +1,97 @@
+jQuery(function ($) {
+    const data = window.gm2SchemaMap || {};
+    const $cpt = $('#gm2-schema-cpt');
+    const $type = $('#gm2-schema-type');
+    const $table = $('#gm2-schema-table tbody');
+    const $preset = $('#gm2-preset');
+
+    function addRow(prop = '', field = '') {
+        const row = $('<tr>\
+            <td><input type="text" class="gm2-prop" value="' + prop + '" /></td>\
+            <td><input type="text" class="gm2-field" list="gm2-field-options" value="' + field + '" /></td>\
+            <td><button type="button" class="button gm2-remove">&times;</button></td>\
+        </tr>');
+        $table.append(row);
+    }
+
+    function render(resp) {
+        $type.val(resp.type || '');
+        const list = $('#gm2-field-options').empty();
+        (resp.fields || []).forEach(function (k) {
+            list.append('<option value="' + k + '"></option>');
+        });
+        $table.empty();
+        const map = resp.map || {};
+        Object.keys(map).forEach(function (p) {
+            addRow(p, map[p]);
+        });
+    }
+
+    function fetchMap() {
+        const slug = $cpt.val();
+        if (!slug) {
+            return;
+        }
+        $.get(data.ajax, { action: 'gm2_get_schema_map', nonce: data.nonce, cpt: slug }, function (r) {
+            if (r && r.success) {
+                render(r.data);
+            } else {
+                render({ type: '', map: {}, fields: [] });
+            }
+        });
+    }
+
+    $('#gm2-add-row').on('click', function (e) {
+        e.preventDefault();
+        addRow();
+    });
+
+    $table.on('click', '.gm2-remove', function (e) {
+        e.preventDefault();
+        $(this).closest('tr').remove();
+    });
+
+    $cpt.on('change', fetchMap);
+
+    $preset.on('change', function () {
+        const val = $(this).val();
+        if (!val || !data.presets || !data.presets[val]) {
+            return;
+        }
+        $type.val(val);
+        $table.empty();
+        data.presets[val].forEach(function (p) {
+            addRow(p, '');
+        });
+    });
+
+    $('#gm2-save-schema').on('click', function (e) {
+        e.preventDefault();
+        const slug = $cpt.val();
+        const map = {};
+        $table.find('tr').each(function () {
+            const prop = $(this).find('.gm2-prop').val();
+            const field = $(this).find('.gm2-field').val();
+            if (prop && field) {
+                map[prop] = field;
+            }
+        });
+        $.post(data.ajax, { action: 'gm2_save_schema_map', nonce: data.nonce, cpt: slug, type: $type.val(), map: map }, function (r) {
+            if (r && r.success) {
+                alert(data.saved || 'Saved');
+            }
+        });
+    });
+
+    if (data.postTypes) {
+        Object.keys(data.postTypes).forEach(function (slug) {
+            $cpt.append('<option value="' + slug + '">' + data.postTypes[slug] + '</option>');
+        });
+    }
+
+    if ($cpt.find('option').length) {
+        $cpt.val($cpt.find('option:first').val());
+        fetchMap();
+    }
+});
+

--- a/admin/pages/schema-mapping.php
+++ b/admin/pages/schema-mapping.php
@@ -1,0 +1,33 @@
+<?php
+if ($this->is_locked()) {
+    $this->display_locked_page(esc_html__( 'Schema Mapping', 'gm2-wordpress-suite' ));
+    return;
+}
+if (!$this->can_manage()) {
+    wp_die(esc_html__( 'Permission denied', 'gm2-wordpress-suite' ));
+}
+
+echo '<div class="wrap">';
+echo '<h1>' . esc_html__( 'Schema Mapping', 'gm2-wordpress-suite' ) . '</h1>';
+
+echo '<p><label>' . esc_html__( 'Post Type', 'gm2-wordpress-suite' ) . '<br /><select id="gm2-schema-cpt"></select></label></p>';
+
+echo '<p><label>' . esc_html__( 'Schema @type', 'gm2-wordpress-suite' ) . '<br /><input type="text" id="gm2-schema-type" class="regular-text" /></label></p>';
+
+$presets = [ 'LocalBusiness', 'Event', 'RealEstateListing', 'JobPosting', 'Course' ];
+echo '<p><label>' . esc_html__( 'Preset', 'gm2-wordpress-suite' ) . '<br /><select id="gm2-preset"><option value="">' . esc_html__( 'None', 'gm2-wordpress-suite' ) . '</option>';
+foreach ($presets as $preset) {
+    echo '<option value="' . esc_attr($preset) . '">' . esc_html($preset) . '</option>';
+}
+echo '</select></label></p>';
+
+echo '<table class="widefat fixed" id="gm2-schema-table"><thead><tr><th>' . esc_html__( 'Property', 'gm2-wordpress-suite' ) . '</th><th>' . esc_html__( 'Field Key', 'gm2-wordpress-suite' ) . '</th><th></th></tr></thead><tbody></tbody></table>';
+
+echo '<p><button type="button" class="button" id="gm2-add-row">' . esc_html__( 'Add Property', 'gm2-wordpress-suite' ) . '</button></p>';
+
+echo '<p><button type="button" class="button button-primary" id="gm2-save-schema">' . esc_html__( 'Save Mapping', 'gm2-wordpress-suite' ) . '</button></p>';
+
+echo '<datalist id="gm2-field-options"></datalist>';
+
+echo '</div>';
+


### PR DESCRIPTION
## Summary
- add Schema Mapping submenu under Gm2 Custom Posts
- allow choosing a schema.org @type and mapping CPT fields via UI with presets
- save and load mappings through new AJAX endpoints using gm2_cp_schema_map option

## Testing
- `npm test` *(fails: jest not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d0c98cd48327801b38d9f2739194