### PR TITLE
Add custom post type schema generator

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -90,6 +90,7 @@ require_once GM2_PLUGIN_DIR . 'includes/gm2-model-export.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_Github_Client.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-apply-patch.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-config-versions.php';
+require_once GM2_PLUGIN_DIR . 'includes/seo/class-gm2-cp-schema.php';
 // Temporarily disable Recovery Email Queue.
 // require_once GM2_PLUGIN_DIR . 'includes/Gm2_Abandoned_Carts_Messaging.php';
 require_once GM2_PLUGIN_DIR . 'admin/Gm2_Abandoned_Carts_Admin.php';

--- a/includes/seo/class-gm2-cp-schema.php
+++ b/includes/seo/class-gm2-cp-schema.php
@@ -1,0 +1,180 @@
+<?php
+namespace Gm2;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Output JSON-LD for custom post types using field mappings.
+ */
+class Gm2_CP_Schema {
+    /**
+     * Register hooks.
+     */
+    public static function init(): void {
+        add_action('wp_head', [__CLASS__, 'singular_schema'], 19);
+        add_action('wp_head', [__CLASS__, 'archive_schema'], 19);
+    }
+
+    /**
+     * Output schema for singular views.
+     */
+    public static function singular_schema(): void {
+        if (!is_singular()) {
+            return;
+        }
+        $post = get_queried_object();
+        if (!$post || empty($post->post_type)) {
+            return;
+        }
+        $map = self::get_map($post->post_type);
+        if (!$map) {
+            return;
+        }
+        $schema = self::build_schema($map['type'], $map['map'], $post->ID);
+        if (!$schema) {
+            return;
+        }
+        $schema = apply_filters('gm2_cp_schema_data', $schema, $post->ID, $post->post_type, 'singular');
+        if (apply_filters('gm2_seo_cp_schema', false, $schema, [ 'context' => 'singular', 'id' => $post->ID, 'post_type' => $post->post_type ])) {
+            return;
+        }
+        echo '<script type="application/ld+json">' . wp_json_encode($schema) . "</script>\n";
+    }
+
+    /**
+     * Output ItemList schema for archives.
+     */
+    public static function archive_schema(): void {
+        if (!is_post_type_archive()) {
+            return;
+        }
+        $post_type = get_query_var('post_type');
+        if (is_array($post_type)) {
+            $post_type = reset($post_type);
+        }
+        if (!$post_type) {
+            $post_type = get_post_type();
+        }
+        if (!$post_type) {
+            return;
+        }
+        $map = self::get_map($post_type);
+        if (!$map) {
+            return;
+        }
+        global $wp_query;
+        $items = [];
+        foreach ($wp_query->posts as $index => $post) {
+            $item_schema = self::build_schema($map['type'], $map['map'], $post->ID);
+            if (!$item_schema) {
+                continue;
+            }
+            $items[] = [
+                '@type'    => 'ListItem',
+                'position' => $index + 1,
+                'item'     => $item_schema,
+            ];
+        }
+        if (!$items) {
+            return;
+        }
+        $schema = [
+            '@context'        => 'https://schema.org',
+            '@type'           => 'ItemList',
+            'itemListElement' => $items,
+        ];
+        $schema = apply_filters('gm2_cp_schema_archive_data', $schema, $post_type);
+        if (apply_filters('gm2_seo_cp_schema', false, $schema, [ 'context' => 'archive', 'post_type' => $post_type ])) {
+            return;
+        }
+        echo '<script type="application/ld+json">' . wp_json_encode($schema) . "</script>\n";
+    }
+
+    /**
+     * Retrieve mapping for a post type.
+     *
+     * @param string $post_type
+     * @return array|null
+     */
+    private static function get_map(string $post_type): ?array {
+        $maps = get_option('gm2_cp_schema_map', []);
+        if (!is_array($maps) || empty($maps[$post_type]['type']) || empty($maps[$post_type]['map'])) {
+            return null;
+        }
+        return $maps[$post_type];
+    }
+
+    /**
+     * Build schema array from mapping and field values.
+     *
+     * @param string $type Schema type.
+     * @param array  $map  Property to field key map.
+     * @param int    $post_id Post ID.
+     * @return array|null
+     */
+    private static function build_schema(string $type, array $map, int $post_id): ?array {
+        $schema   = [
+            '@context' => 'https://schema.org',
+            '@type'    => $type,
+        ];
+        $has_data = false;
+        foreach ($map as $prop => $field_key) {
+            $value = gm2_field($field_key, '', $post_id);
+            if ($value === '' || $value === null) {
+                continue;
+            }
+            self::assign($schema, $prop, $value);
+            $has_data = true;
+        }
+        return $has_data ? $schema : null;
+    }
+
+    /**
+     * Assign a value to a nested property path.
+     */
+    private static function assign(array &$schema, string $path, $value): void {
+        $segments = explode('.', $path);
+        $ref =& $schema;
+        foreach ($segments as $seg) {
+            if ($seg === '') {
+                continue;
+            }
+            if (is_numeric($seg)) {
+                $idx = (int) $seg;
+                if (!isset($ref[$idx]) || !is_array($ref[$idx])) {
+                    $ref[$idx] = [];
+                }
+                $ref =& $ref[$idx];
+                continue;
+            }
+            if (!isset($ref[$seg]) || !is_array($ref[$seg])) {
+                $ref[$seg] = [];
+            }
+            if (!isset($ref[$seg]['@type'])) {
+                $t = self::nested_type($seg);
+                if ($t) {
+                    $ref[$seg]['@type'] = $t;
+                }
+            }
+            $ref =& $ref[$seg];
+        }
+        $ref = $value;
+    }
+
+    /**
+     * Map nested property names to schema types.
+     */
+    private static function nested_type(string $segment): ?string {
+        return match ($segment) {
+            'address' => 'PostalAddress',
+            'geo' => 'GeoCoordinates',
+            'openingHoursSpecification' => 'OpeningHoursSpecification',
+            'offers' => 'Offer',
+            default => null,
+        };
+    }
+}
+
+Gm2_CP_Schema::init();


### PR DESCRIPTION
## Summary
- add `Gm2_CP_Schema` to output JSON-LD for custom post types and archives
- wire new schema generator into plugin bootstrap

## Testing
- `php -l includes/seo/class-gm2-cp-schema.php`
- `php -l gm2-wordpress-suite.php`
- `composer install`
- `vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d2d55b588327975ebe49748c831c