### PR TITLE
feat(seo): add CPT meta templates and disable filters

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -106,6 +106,8 @@ class Gm2_SEO_Admin {
         add_option('ae_perf_no_thrash', '0');
         add_option('ae_perf_passive_listeners', '0');
         add_option('ae_perf_dom_audit', '0');
+        add_option('gm2_title_templates', []);
+        add_option('gm2_description_templates', []);
 
         $this->migrate_js_option_names();
 
@@ -1011,6 +1013,19 @@ class Gm2_SEO_Admin {
             echo '<tr><th scope="row">' . esc_html__( 'Noindex out-of-stock products', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="gm2_noindex_oos" value="1" ' . checked($oos, '1', false) . '></td></tr>';
             echo '<tr><th scope="row">' . esc_html__( 'Variation canonical points to parent', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="gm2_variation_canonical_parent" value="1" ' . checked($canon_parent, '1', false) . '></td></tr>';
             echo '<tr><th scope="row">' . esc_html__( 'Enable meta keywords tag', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="gm2_meta_keywords_enabled" value="1" ' . checked($meta_keywords, '1', false) . '></td></tr>';
+
+            echo '<tr><th colspan="2">' . esc_html__( 'Title & Description Templates', 'gm2-wordpress-suite' ) . '</th></tr>';
+            $title_templates = get_option('gm2_title_templates', []);
+            $desc_templates  = get_option('gm2_description_templates', []);
+            $post_types      = get_post_types(['public' => true], 'objects');
+            foreach ($post_types as $slug => $pt_obj) {
+                $label       = $pt_obj->labels->singular_name ?? $slug;
+                $title_value = $title_templates[$slug] ?? '';
+                $desc_value  = $desc_templates[$slug] ?? '';
+                echo '<tr><th scope="row">' . sprintf(esc_html__( 'Title Template (%s)', 'gm2-wordpress-suite' ), esc_html($label)) . '</th><td><input type="text" name="gm2_title_templates[' . esc_attr($slug) . ']" value="' . esc_attr($title_value) . '" class="large-text" /></td></tr>';
+                echo '<tr><th scope="row">' . sprintf(esc_html__( 'Description Template (%s)', 'gm2-wordpress-suite' ), esc_html($label)) . '</th><td><textarea name="gm2_description_templates[' . esc_attr($slug) . ']" rows="2" class="large-text">' . esc_textarea($desc_value) . '</textarea></td></tr>';
+            }
+            echo '<tr><td colspan="2"><p class="description">' . esc_html__( 'Available placeholders: {site_name}, {post_title}, {post_excerpt}', 'gm2-wordpress-suite' ) . '</p></td></tr>';
             echo '</tbody></table>';
             submit_button( esc_html__( 'Save Settings', 'gm2-wordpress-suite' ) );
             echo '</form>';
@@ -2977,6 +2992,20 @@ class Gm2_SEO_Admin {
 
         $meta_keywords = isset($_POST['gm2_meta_keywords_enabled']) ? '1' : '0';
         update_option('gm2_meta_keywords_enabled', $meta_keywords);
+
+        $title_templates = isset($_POST['gm2_title_templates']) ? (array) $_POST['gm2_title_templates'] : [];
+        $clean_titles    = [];
+        foreach ($title_templates as $pt => $tpl) {
+            $clean_titles[sanitize_key($pt)] = sanitize_text_field($tpl);
+        }
+        update_option('gm2_title_templates', $clean_titles);
+
+        $desc_templates = isset($_POST['gm2_description_templates']) ? (array) $_POST['gm2_description_templates'] : [];
+        $clean_desc     = [];
+        foreach ($desc_templates as $pt => $tpl) {
+            $clean_desc[sanitize_key($pt)] = sanitize_textarea_field($tpl);
+        }
+        update_option('gm2_description_templates', $clean_desc);
 
         wp_redirect(admin_url('admin.php?page=gm2-seo&tab=meta&updated=1'));
         exit;

--- a/docs/api.md
+++ b/docs/api.md
@@ -691,10 +691,38 @@ apply_filters( 'gm2_lazy_meta_loader', ... );
 ```
 
 ### `gm2_meta_tags` (filter)
-Location: `public/Gm2_SEO_Public.php:568`
+Location: `public/Gm2_SEO_Public.php:597`
 
 ```php
 apply_filters( 'gm2_meta_tags', ... );
+```
+
+### `gm2_seo_disable_output` (filter)
+Location: `public/Gm2_SEO_Public.php:498`
+
+```php
+apply_filters( 'gm2_seo_disable_output', false );
+```
+
+### `gm2_seo_disable_canonical` (filter)
+Location: `public/Gm2_SEO_Public.php:1313`
+
+```php
+apply_filters( 'gm2_seo_disable_canonical', false );
+```
+
+### `gm2_seo_disable_og_tags` (filter)
+Location: `public/Gm2_SEO_Public.php:576`
+
+```php
+apply_filters( 'gm2_seo_disable_og_tags', false );
+```
+
+### `gm2_seo_disable_twitter_tags` (filter)
+Location: `public/Gm2_SEO_Public.php:593`
+
+```php
+apply_filters( 'gm2_seo_disable_twitter_tags', false );
 ```
 
 ### `gm2_model_locked` (filter)


### PR DESCRIPTION
## Summary
- allow admins to define per-CPT title and description templates
- fall back to templates when post meta is empty
- add filters to disable canonical, OG, Twitter, or all SEO outputs

## Testing
- `npm test` *(fails: fetch failed in e2e tests, syntax errors)*
- `vendor/bin/phpunit` *(fails: missing wordpress-tests-lib)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d43ffc7483278fbb3cb8c68c21d9