### PR TITLE
Add filter and documentation for breadcrumb items

### DIFF
--- a/public/Gm2_SEO_Public.php
+++ b/public/Gm2_SEO_Public.php
@@ -298,6 +298,15 @@ class Gm2_SEO_Public {
         }
     }
 
+    /**
+     * Generate an array of breadcrumb items for the current request.
+     *
+     * Each item in the array must contain `name` and `url` keys. The final
+     * array can be modified via the `gm2_breadcrumb_items` filter to allow
+     * external code to customize or replace the breadcrumb trail.
+     *
+     * @return array<int, array{name:string, url:string}> Breadcrumb items.
+     */
     private function get_breadcrumb_items() {
         if (is_array($this->breadcrumbs_cache)) {
             return $this->breadcrumbs_cache;
@@ -310,7 +319,10 @@ class Gm2_SEO_Public {
         ];
 
         if (is_front_page() || is_home()) {
-            return $breadcrumbs;
+            $breadcrumbs = apply_filters('gm2_breadcrumb_items', $breadcrumbs);
+            $this->breadcrumbs_cache = $breadcrumbs;
+
+            return $this->breadcrumbs_cache;
         }
 
         if (is_singular()) {
@@ -357,6 +369,8 @@ class Gm2_SEO_Public {
                 'url'  => home_url(add_query_arg([], $GLOBALS['wp']->request)),
             ];
         }
+
+        $breadcrumbs = apply_filters('gm2_breadcrumb_items', $breadcrumbs);
 
         $this->breadcrumbs_cache = $breadcrumbs;
 

--- a/readme.txt
+++ b/readme.txt
@@ -366,6 +366,9 @@ Open **Tools → Site Health** to run these diagnostics automatically. The Gm2 S
 Display a breadcrumb trail anywhere using the `[gm2_breadcrumbs]` shortcode. The output
 is an ordered list wrapped in a `<nav>` element with accompanying JSON-LD for search engines.
 You can enable automatic breadcrumbs in the footer from **SEO → Schema**.
+Developers can modify or replace the trail by filtering `gm2_breadcrumb_items`. The
+filter receives an array of items with `name` and `url` keys, allowing custom post
+type modules to supply their own breadcrumb structure.
 
 == Caching ==
 Enable HTML, CSS, and JavaScript minification from the SEO &gt; Performance

--- a/tests/test-breadcrumbs.php
+++ b/tests/test-breadcrumbs.php
@@ -41,4 +41,25 @@ class BreadcrumbsTest extends WP_UnitTestCase {
         $this->assertIsArray($data);
         $this->assertSame('BreadcrumbList', $data['@type']);
     }
+
+    public function test_breadcrumb_items_filter_modifies_output() {
+        $post_id = self::factory()->post->create([
+            'post_title'   => 'Filter Example',
+            'post_content' => 'Content',
+        ]);
+        $seo = new Gm2_SEO_Public();
+        $this->go_to(get_permalink($post_id));
+        setup_postdata(get_post($post_id));
+
+        add_filter('gm2_breadcrumb_items', function ($items) {
+            $items[] = [
+                'name' => 'Filtered Item',
+                'url'  => 'https://example.com/filtered',
+            ];
+            return $items;
+        });
+
+        $output = $seo->gm2_breadcrumbs_shortcode();
+        $this->assertStringContainsString('Filtered Item', $output);
+    }
 }


### PR DESCRIPTION
## Summary
- make breadcrumb items filterable via `gm2_breadcrumb_items`
- document `name` and `url` keys for breadcrumb entries
- test and document breadcrumb filter hook usage

## Testing
- `vendor/bin/phpunit` *(fails: Error: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_68c6d61645508327a838f50d2c2837e8