### PR TITLE
Add schema mappings export and samples

### DIFF
--- a/assets/blueprints/samples/courses.json
+++ b/assets/blueprints/samples/courses.json
@@ -1,0 +1,37 @@
+{
+  "post_types": {
+    "course": {
+      "label": "Course",
+      "public": true,
+      "supports": ["title", "editor", "thumbnail"]
+    }
+  },
+  "taxonomies": {
+    "course_category": {
+      "object_type": ["course"],
+      "label": "Course Categories",
+      "hierarchical": false
+    }
+  },
+  "field_groups": [
+    {
+      "key": "group_course_details",
+      "title": "Course Details",
+      "fields": [
+        {"key": "field_provider", "label": "Provider", "name": "provider", "type": "text"},
+        {"key": "field_course_code", "label": "Course Code", "name": "course_code", "type": "text"},
+        {"key": "field_course_url", "label": "Course URL", "name": "course_url", "type": "url"}
+      ]
+    }
+  ],
+  "schema_mappings": {
+    "course": {
+      "type": "Course",
+      "map": {
+        "provider": "provider",
+        "courseCode": "course_code",
+        "url": "course_url"
+      }
+    }
+  }
+}

--- a/assets/blueprints/samples/events.json
+++ b/assets/blueprints/samples/events.json
@@ -23,5 +23,15 @@
         {"key": "field_location", "label": "Location", "name": "location", "type": "text"}
       ]
     }
-  ]
+  ],
+  "schema_mappings": {
+    "event": {
+      "type": "Event",
+      "map": {
+        "startDate": "start_date",
+        "endDate": "end_date",
+        "location": "location"
+      }
+    }
+  }
 }

--- a/assets/blueprints/samples/jobs.json
+++ b/assets/blueprints/samples/jobs.json
@@ -1,0 +1,37 @@
+{
+  "post_types": {
+    "job": {
+      "label": "Job",
+      "public": true,
+      "supports": ["title", "editor"]
+    }
+  },
+  "taxonomies": {
+    "job_category": {
+      "object_type": ["job"],
+      "label": "Job Categories",
+      "hierarchical": false
+    }
+  },
+  "field_groups": [
+    {
+      "key": "group_job_details",
+      "title": "Job Details",
+      "fields": [
+        {"key": "field_date_posted", "label": "Date Posted", "name": "date_posted", "type": "date"},
+        {"key": "field_employment_type", "label": "Employment Type", "name": "employment_type", "type": "text"},
+        {"key": "field_company", "label": "Company", "name": "company", "type": "text"}
+      ]
+    }
+  ],
+  "schema_mappings": {
+    "job": {
+      "type": "JobPosting",
+      "map": {
+        "datePosted": "date_posted",
+        "employmentType": "employment_type",
+        "hiringOrganization": "company"
+      }
+    }
+  }
+}

--- a/assets/blueprints/samples/real-estate.json
+++ b/assets/blueprints/samples/real-estate.json
@@ -1,33 +1,33 @@
 {
   "post_types": {
-    "listing": {
-      "label": "Listing",
+    "property": {
+      "label": "Property",
       "public": true,
       "supports": ["title", "editor", "thumbnail"]
     }
   },
   "taxonomies": {
-    "listing_category": {
-      "object_type": ["listing"],
-      "label": "Listing Categories",
+    "property_type": {
+      "object_type": ["property"],
+      "label": "Property Types",
       "hierarchical": true
     }
   },
   "field_groups": [
     {
-      "key": "group_listing_details",
-      "title": "Listing Details",
+      "key": "group_property_details",
+      "title": "Property Details",
       "fields": [
-        {"key": "field_phone", "label": "Phone", "name": "phone", "type": "text"},
+        {"key": "field_price", "label": "Price", "name": "price", "type": "number"},
         {"key": "field_address", "label": "Address", "name": "address", "type": "text"}
       ]
     }
   ],
   "schema_mappings": {
-    "listing": {
-      "type": "LocalBusiness",
+    "property": {
+      "type": "RealEstateListing",
       "map": {
-        "telephone": "phone",
+        "price": "price",
         "address": "address"
       }
     }

--- a/assets/blueprints/schema.json
+++ b/assets/blueprints/schema.json
@@ -14,6 +14,10 @@
     "field_groups": {
       "type": "array",
       "items": { "$ref": "#/definitions/fieldGroup" }
+    },
+    "schema_mappings": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#/definitions/schemaMapping" }
     }
   },
   "additionalProperties": false,
@@ -63,6 +67,18 @@
       },
       "required": ["key", "label", "name", "type"],
       "additionalProperties": true
+    },
+    "schemaMapping": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string" },
+        "map": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        }
+      },
+      "required": ["type", "map"],
+      "additionalProperties": false
     }
   }
 }

--- a/includes/gm2-model-export.php
+++ b/includes/gm2-model-export.php
@@ -19,10 +19,15 @@ if (!function_exists('gm2_model_export')) {
         if (!is_array($field_groups)) {
             $field_groups = [];
         }
+        $schema_maps = get_option('gm2_cp_schema_map', []);
+        if (!is_array($schema_maps)) {
+            $schema_maps = [];
+        }
         $data = [
-            'post_types'   => $config['post_types'] ?? [],
-            'taxonomies'   => $config['taxonomies'] ?? [],
-            'field_groups' => $field_groups,
+            'post_types'      => $config['post_types'] ?? [],
+            'taxonomies'      => $config['taxonomies'] ?? [],
+            'field_groups'    => $field_groups,
+            'schema_mappings' => $schema_maps,
         ];
         switch ($format) {
             case 'array':
@@ -99,6 +104,7 @@ if (!function_exists('gm2_model_import')) {
         ];
         update_option('gm2_custom_posts_config', $config);
         update_option('gm2_field_groups', $data['field_groups'] ?? []);
+        update_option('gm2_cp_schema_map', $data['schema_mappings'] ?? []);
         return true;
     }
 }
@@ -130,6 +136,9 @@ if (!function_exists('gm2_model_generate_plugin')) {
         $code .= "    \$groups = " . var_export($data['field_groups'] ?? [], true) . ";\n";
         $code .= "    \$existing = get_option('gm2_field_groups', []);\n";
         $code .= "    update_option('gm2_field_groups', array_merge(\$existing, \$groups));\n";
+        $code .= "    \$maps = " . var_export($data['schema_mappings'] ?? [], true) . ";\n";
+        $code .= "    \$existing_maps = get_option('gm2_cp_schema_map', []);\n";
+        $code .= "    update_option('gm2_cp_schema_map', array_merge(\$existing_maps, \$maps));\n";
         $code .= "});\n";
 
         $tmp_dir = sys_get_temp_dir() . '/gm2_model_' . uniqid();


### PR DESCRIPTION
## Summary
- add `schema_mappings` to blueprint schema
- include schema mappings in model export/import and plugin generation
- add sample blueprints for directory, events, real estate, jobs and courses

## Testing
- `vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d6fcc824832793424e6c6598ff3d