### PR TITLE
docs: add schema mapping and SEO guide

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,7 @@
 See [model-cli.md](model-cli.md) for managing custom post types, taxonomies and fields via WP-CLI.
 For a reference on field types, conditional logic and validation hooks, see [fields-and-validation.md](fields-and-validation.md).
 For guidance on using the suite with Elementor, see [using-with-elementor.md](using-with-elementor.md).
+For schema mapping and SEO integration examples, see [schema-mapping-and-seo.md](schema-mapping-and-seo.md).
 
 For font optimization checks, review [font-performance-test-plan.md](font-performance-test-plan.md).
 

--- a/docs/recipes/courses/README.md
+++ b/docs/recipes/courses/README.md
@@ -2,6 +2,8 @@
 
 Course listing with Open in Code output.
 
+See the [Schema Mapping and SEO guide](../../schema-mapping-and-seo.md) for mapping presets, JSON-LD examples and SEO hooks.
+
 ```php
 register_post_type( 'gm2_course', [
     'label' => 'Course',

--- a/docs/recipes/directory/README.md
+++ b/docs/recipes/directory/README.md
@@ -2,6 +2,8 @@
 
 Minimal example showing how to register a Directory custom post type with schema annotations.
 
+See the [Schema Mapping and SEO guide](../../schema-mapping-and-seo.md) for mapping presets, JSON-LD examples and SEO hooks.
+
 ```php
 register_post_type( 'gm2_directory', [
     'label' => 'Directory',

--- a/docs/recipes/events/README.md
+++ b/docs/recipes/events/README.md
@@ -2,6 +2,8 @@
 
 Registers an Event post type and demonstrates Open in Code for generated schema.
 
+See the [Schema Mapping and SEO guide](../../schema-mapping-and-seo.md) for mapping presets, JSON-LD examples and SEO hooks.
+
 ```php
 register_post_type( 'gm2_event', [
     'label' => 'Event',

--- a/docs/recipes/jobs/README.md
+++ b/docs/recipes/jobs/README.md
@@ -2,6 +2,8 @@
 
 Job board example using schema tooltips.
 
+See the [Schema Mapping and SEO guide](../../schema-mapping-and-seo.md) for mapping presets, JSON-LD examples and SEO hooks.
+
 ```php
 register_post_type( 'gm2_job', [
     'label' => 'Job',

--- a/docs/recipes/real-estate/README.md
+++ b/docs/recipes/real-estate/README.md
@@ -2,6 +2,8 @@
 
 Example snippet for real estate listings.
 
+See the [Schema Mapping and SEO guide](../../schema-mapping-and-seo.md) for mapping presets, JSON-LD examples and SEO hooks.
+
 ```php
 register_post_type( 'gm2_property', [
     'label' => 'Property',

--- a/docs/schema-mapping-and-seo.md
+++ b/docs/schema-mapping-and-seo.md
@@ -1,0 +1,75 @@
+# Schema Mapping and SEO
+
+This guide explains how to map content types to schema.org models and expose SEO metadata.
+
+## Mapping UI Walkthrough and Vertical Presets
+
+Open **Gm2 → Schema Mapping** in the WordPress admin to map custom post types and taxonomies to schema.org properties.
+
+1. Select a post type from the dropdown.
+2. Choose a vertical preset such as **Course**, **Directory**, **Event**, **Job** or **Real Estate** to pre‑populate common properties.
+3. Use the field picker to match each schema property with a meta field or block attribute.
+4. Save your map to generate JSON‑LD automatically on the front end.
+
+Presets provide a quick starting point for popular verticals while still allowing individual fields to be customised.
+
+## JSON‑LD Output Examples
+
+### Singular Page
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Event",
+  "name": "Sample Event",
+  "startDate": "2024-08-01T19:00:00",
+  "location": {
+    "@type": "Place",
+    "name": "Example Venue"
+  }
+}
+```
+
+### Archive Page
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "name": "Event Archive",
+  "hasPart": [{
+    "@type": "Event",
+    "name": "Sample Event"
+  }]
+}
+```
+
+The singular schema is filtered through `gm2_cp_schema_data` while archives use `gm2_cp_schema_archive_data`. Use `gm2_seo_cp_schema` to disable output entirely or swap in a custom schema array.
+
+## Meta Templates and SEO Plugin Hooks
+
+The suite renders title, description and keyword tags based on the post context. Developers can customise the markup or inject tags from third‑party SEO plugins.
+
+```php
+add_filter( 'gm2_meta_tags', function ( $html, $data ) {
+    // Replace the default tags with output from a different SEO plugin.
+    return my_seo_plugin_render_tags( $data );
+}, 10, 2 );
+```
+
+Templates accept tokens like `{title}`, `{excerpt}` and `{site_name}`. Override them globally via the `gm2_meta_title_template` and `gm2_meta_description_template` filters or per post type with `gm2_meta_template_{post_type}`.
+
+Third‑party plugins can also modify JSON‑LD before it is printed:
+
+```php
+add_filter( 'gm2_cp_schema_data', function ( $schema, $post_id ) {
+    $schema['publisher'] = [
+        '@type' => 'Organization',
+        'name'  => get_bloginfo( 'name' )
+    ];
+    return $schema;
+}, 10, 2 );
+```
+
+These hooks allow SEO platforms like Yoast SEO or Rank Math to integrate with the suite without disabling its built‑in features.
+


### PR DESCRIPTION
## Summary
- document schema mapping UI with presets and SEO hooks
- show JSON-LD outputs for singular and archive pages
- link schema mapping guide from docs index and recipe guides

## Testing
- `vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `npm test` *(fails: fetch failed; SyntaxError: Missing initializer in const declaration)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d94ae7a083278e7f9e97b3065e47