### PR TITLE
feat: add preset blueprints

### DIFF
--- a/assets/blueprints/presets/courses.json
+++ b/assets/blueprints/presets/courses.json
@@ -1,0 +1,61 @@
+{
+  "post_types": {
+    "course": {
+      "labels": { "name": "Courses", "singular_name": "Course" },
+      "supports": ["title", "editor", "thumbnail"],
+      "has_archive": true,
+      "rewrite": { "slug": "courses" },
+      "menu_icon": "dashicons-welcome-learn-more"
+    }
+  },
+  "taxonomies": {
+    "course_category": {
+      "object_type": ["course"],
+      "labels": { "name": "Course Categories", "singular_name": "Course Category" },
+      "hierarchical": false,
+      "rewrite": { "slug": "course-category" }
+    }
+  },
+  "field_groups": [
+    {
+      "key": "group_course_details",
+      "title": "Course Details",
+      "fields": [
+        {
+          "key": "field_provider",
+          "label": "Provider",
+          "name": "provider",
+          "type": "text",
+          "required": true,
+          "expose_in_rest": true
+        },
+        {
+          "key": "field_course_code",
+          "label": "Course Code",
+          "name": "course_code",
+          "type": "text",
+          "regex": "^[A-Z0-9-]+$",
+          "required": true,
+          "expose_in_rest": true
+        },
+        {
+          "key": "field_course_url",
+          "label": "Course URL",
+          "name": "course_url",
+          "type": "url",
+          "expose_in_rest": true
+        }
+      ]
+    }
+  ],
+  "schema_mappings": {
+    "course": {
+      "type": "Course",
+      "map": {
+        "provider": "provider",
+        "courseCode": "course_code",
+        "url": "course_url"
+      }
+    }
+  }
+}

--- a/assets/blueprints/presets/directory.json
+++ b/assets/blueprints/presets/directory.json
@@ -1,0 +1,66 @@
+{
+  "post_types": {
+    "listing": {
+      "labels": { "name": "Listings", "singular_name": "Listing" },
+      "supports": ["title", "editor", "thumbnail", "custom-fields"],
+      "has_archive": true,
+      "rewrite": { "slug": "listings" },
+      "menu_icon": "dashicons-store"
+    }
+  },
+  "taxonomies": {
+    "listing_category": {
+      "object_type": ["listing"],
+      "labels": { "name": "Listing Categories", "singular_name": "Listing Category" },
+      "hierarchical": true,
+      "rewrite": { "slug": "listing-category" }
+    },
+    "listing_location": {
+      "object_type": ["listing"],
+      "labels": { "name": "Locations", "singular_name": "Location" },
+      "hierarchical": false,
+      "rewrite": { "slug": "listing-location" }
+    }
+  },
+  "field_groups": [
+    {
+      "key": "group_listing_details",
+      "title": "Listing Details",
+      "fields": [
+        {
+          "key": "field_phone",
+          "label": "Phone",
+          "name": "phone",
+          "type": "text",
+          "regex": "^\\+?[0-9\\-\\s]+$",
+          "expose_in_rest": true
+        },
+        {
+          "key": "field_address",
+          "label": "Address",
+          "name": "address",
+          "type": "text",
+          "required": true,
+          "expose_in_rest": true
+        },
+        {
+          "key": "field_website",
+          "label": "Website",
+          "name": "website",
+          "type": "url",
+          "expose_in_rest": true
+        }
+      ]
+    }
+  ],
+  "schema_mappings": {
+    "listing": {
+      "type": "LocalBusiness",
+      "map": {
+        "telephone": "phone",
+        "address.streetAddress": "address",
+        "url": "website"
+      }
+    }
+  }
+}

--- a/assets/blueprints/presets/events.json
+++ b/assets/blueprints/presets/events.json
@@ -1,0 +1,61 @@
+{
+  "post_types": {
+    "event": {
+      "labels": { "name": "Events", "singular_name": "Event" },
+      "supports": ["title", "editor", "thumbnail", "excerpt"],
+      "has_archive": true,
+      "rewrite": { "slug": "events" },
+      "menu_icon": "dashicons-calendar-alt"
+    }
+  },
+  "taxonomies": {
+    "event_type": {
+      "object_type": ["event"],
+      "labels": { "name": "Event Types", "singular_name": "Event Type" },
+      "hierarchical": false,
+      "rewrite": { "slug": "event-type" }
+    }
+  },
+  "field_groups": [
+    {
+      "key": "group_event_details",
+      "title": "Event Details",
+      "fields": [
+        {
+          "key": "field_start_date",
+          "label": "Start Date",
+          "name": "start_date",
+          "type": "datetime",
+          "required": true,
+          "expose_in_rest": true
+        },
+        {
+          "key": "field_end_date",
+          "label": "End Date",
+          "name": "end_date",
+          "type": "datetime",
+          "required": true,
+          "expose_in_rest": true
+        },
+        {
+          "key": "field_location",
+          "label": "Location",
+          "name": "location",
+          "type": "text",
+          "required": true,
+          "expose_in_rest": true
+        }
+      ]
+    }
+  ],
+  "schema_mappings": {
+    "event": {
+      "type": "Event",
+      "map": {
+        "startDate": "start_date",
+        "endDate": "end_date",
+        "location": "location"
+      }
+    }
+  }
+}

--- a/assets/blueprints/presets/jobs.json
+++ b/assets/blueprints/presets/jobs.json
@@ -1,0 +1,69 @@
+{
+  "post_types": {
+    "job": {
+      "labels": { "name": "Jobs", "singular_name": "Job" },
+      "supports": ["title", "editor"],
+      "has_archive": true,
+      "rewrite": { "slug": "jobs" },
+      "menu_icon": "dashicons-businessperson"
+    }
+  },
+  "taxonomies": {
+    "job_category": {
+      "object_type": ["job"],
+      "labels": { "name": "Job Categories", "singular_name": "Job Category" },
+      "hierarchical": false,
+      "rewrite": { "slug": "job-category" }
+    }
+  },
+  "field_groups": [
+    {
+      "key": "group_job_details",
+      "title": "Job Details",
+      "fields": [
+        {
+          "key": "field_date_posted",
+          "label": "Date Posted",
+          "name": "date_posted",
+          "type": "date",
+          "required": true,
+          "expose_in_rest": true
+        },
+        {
+          "key": "field_employment_type",
+          "label": "Employment Type",
+          "name": "employment_type",
+          "type": "text",
+          "required": true,
+          "expose_in_rest": true
+        },
+        {
+          "key": "field_company",
+          "label": "Company",
+          "name": "company",
+          "type": "text",
+          "required": true,
+          "expose_in_rest": true
+        },
+        {
+          "key": "field_apply_url",
+          "label": "Apply URL",
+          "name": "apply_url",
+          "type": "url",
+          "expose_in_rest": true
+        }
+      ]
+    }
+  ],
+  "schema_mappings": {
+    "job": {
+      "type": "JobPosting",
+      "map": {
+        "datePosted": "date_posted",
+        "employmentType": "employment_type",
+        "hiringOrganization": "company",
+        "url": "apply_url"
+      }
+    }
+  }
+}

--- a/assets/blueprints/presets/real-estate.json
+++ b/assets/blueprints/presets/real-estate.json
@@ -1,0 +1,62 @@
+{
+  "post_types": {
+    "property": {
+      "labels": { "name": "Properties", "singular_name": "Property" },
+      "supports": ["title", "editor", "thumbnail"],
+      "has_archive": true,
+      "rewrite": { "slug": "properties" },
+      "menu_icon": "dashicons-admin-home"
+    }
+  },
+  "taxonomies": {
+    "property_type": {
+      "object_type": ["property"],
+      "labels": { "name": "Property Types", "singular_name": "Property Type" },
+      "hierarchical": true,
+      "rewrite": { "slug": "property-type" }
+    }
+  },
+  "field_groups": [
+    {
+      "key": "group_property_details",
+      "title": "Property Details",
+      "fields": [
+        {
+          "key": "field_price",
+          "label": "Price",
+          "name": "price",
+          "type": "number",
+          "min": 0,
+          "required": true,
+          "expose_in_rest": true
+        },
+        {
+          "key": "field_address",
+          "label": "Address",
+          "name": "address",
+          "type": "text",
+          "required": true,
+          "expose_in_rest": true
+        },
+        {
+          "key": "field_bedrooms",
+          "label": "Bedrooms",
+          "name": "bedrooms",
+          "type": "number",
+          "min": 0,
+          "expose_in_rest": true
+        }
+      ]
+    }
+  ],
+  "schema_mappings": {
+    "property": {
+      "type": "RealEstateListing",
+      "map": {
+        "price": "price",
+        "address.streetAddress": "address",
+        "numberOfRooms": "bedrooms"
+      }
+    }
+  }
+}

--- a/assets/blueprints/schema.json
+++ b/assets/blueprints/schema.json
@@ -30,7 +30,15 @@
         "supports": {
           "type": "array",
           "items": { "type": "string" }
-        }
+        },
+        "labels": { "type": "object", "additionalProperties": { "type": "string" } },
+        "has_archive": { "type": ["boolean", "string"] },
+        "rewrite": {
+          "type": "object",
+          "properties": { "slug": { "type": "string" } },
+          "additionalProperties": { "type": ["string", "boolean"] }
+        },
+        "menu_icon": { "type": "string" }
       },
       "additionalProperties": true
     },
@@ -40,6 +48,13 @@
         "object_type": {
           "type": "array",
           "items": { "type": "string" }
+        },
+        "labels": { "type": "object", "additionalProperties": { "type": "string" } },
+        "hierarchical": { "type": "boolean" },
+        "rewrite": {
+          "type": "object",
+          "properties": { "slug": { "type": "string" } },
+          "additionalProperties": { "type": ["string", "boolean"] }
         }
       },
       "additionalProperties": true
@@ -57,13 +72,18 @@
       "required": ["key", "title", "fields"],
       "additionalProperties": true
     },
-    "field": {
+      "field": {
       "type": "object",
       "properties": {
         "key": { "type": "string" },
         "label": { "type": "string" },
         "name": { "type": "string" },
-        "type": { "type": "string" }
+        "type": { "type": "string" },
+        "required": { "type": "boolean" },
+        "regex": { "type": "string" },
+        "min": { "type": ["number", "integer"] },
+        "max": { "type": ["number", "integer"] },
+        "expose_in_rest": { "type": "boolean" }
       },
       "required": ["key", "label", "name", "type"],
       "additionalProperties": true

--- a/tests/BlueprintPresetsTest.php
+++ b/tests/BlueprintPresetsTest.php
@@ -1,0 +1,21 @@
+<?php
+class BlueprintPresetsTest extends WP_UnitTestCase {
+    public function test_presets_validate_and_import() {
+        $files = glob(GM2_PLUGIN_DIR . 'assets/blueprints/presets/*.json');
+        $this->assertNotEmpty($files, 'No preset blueprints found');
+        foreach ($files as $file) {
+            delete_option('gm2_custom_posts_config');
+            delete_option('gm2_field_groups');
+            delete_option('gm2_cp_schema_map');
+            $json = file_get_contents($file);
+            $data = json_decode($json, true);
+            $this->assertIsArray($data, basename($file) . ' decoded');
+            $this->assertTrue(true === gm2_validate_blueprint($data), basename($file) . ' validation');
+            $result = gm2_model_import($json);
+            $this->assertTrue(true === $result, basename($file) . ' import');
+            $config = get_option('gm2_custom_posts_config');
+            $this->assertIsArray($config);
+            $this->assertNotEmpty($config['post_types']);
+        }
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -28,6 +28,25 @@ if (!defined('GM2_TESTING')) {
     define('GM2_TESTING', true);
 }
 function _manually_load_plugin() {
+    if (!class_exists('Elementor\\Base_Data_Control')) {
+        eval('namespace Elementor; abstract class Base_Data_Control { public function get_type(){return "";} public function enqueue(){} public function content_template(){} protected function get_default_settings(){return [];} }');
+    }
+    if (!class_exists('Elementor\\Controls_Manager')) {
+        eval('namespace Elementor; class Controls_Manager { const TEXT = "text"; }');
+    }
+    if (!class_exists('Elementor\\Plugin')) {
+        eval('namespace Elementor; class Plugin { public static $instance; public $widgets_manager; public function __construct(){ self::$instance=$this; $this->widgets_manager=new class { public function register_control($id,$ctrl){} public function register_tag($tag){} public function register_group($n,$a=[]){} }; } }');
+        new \Elementor\Plugin();
+    }
+    if (!class_exists('Elementor\\Core\\DynamicTags\\Tag')) {
+        eval('namespace Elementor\\Core\\DynamicTags; abstract class Tag { protected function add_control($id,$args=[]){} public function get_settings($key=null){ return null; } }');
+    }
+    if (!class_exists('Elementor\\Modules\\DynamicTags\\Module')) {
+        eval('namespace Elementor\\Modules\\DynamicTags; class Module { const TEXT_CATEGORY="text"; const URL_CATEGORY="url"; const IMAGE_CATEGORY="image"; const MEDIA_CATEGORY="media"; const NUMBER_CATEGORY="number"; const COLOR_CATEGORY="color"; const GALLERY_CATEGORY="gallery"; const DATETIME_CATEGORY="date"; public function register_tag($tag){} public function register_group($name,$args=[]){} }');
+    }
+    if (!class_exists('ElementorPro\\Modules\\Posts\\Widgets\\Posts')) {
+        eval('namespace ElementorPro\\Modules\\Posts\\Widgets; class Posts { public function get_settings(){ return []; } }');
+    }
     require dirname(__DIR__) . '/gm2-wordpress-suite.php';
 }
 tests_add_filter('muplugins_loaded', '_manually_load_plugin');


### PR DESCRIPTION
## Summary
- add preset blueprints for directory, events, real estate, jobs, and courses
- expand blueprint schema for additional post type, taxonomy, and field options
- add PHPUnit coverage for importing preset blueprints

## Testing
- `vendor/bin/phpunit tests/BlueprintPresetsTest.php` *(fails: Undefined array key "type")*

------
https://chatgpt.com/codex/tasks/task_e_68c6de7e9a408327bf3f97cc4c1d4d51