### PR TITLE
Add Elementor loop grid and archive hooks

### DIFF
--- a/integrations/elementor/class-gm2-cp-elementor-query.php
+++ b/integrations/elementor/class-gm2-cp-elementor-query.php
@@ -17,7 +17,10 @@ class GM2_CP_Elementor_Query {
      */
     public static function register() {
         add_action('elementor_pro/posts/query/gm2_cp', [__CLASS__, 'apply_query'], 10, 2);
+        add_action('elementor/query/gm2_cp', [__CLASS__, 'apply_query'], 10, 2);
         add_action('elementor/element/posts/section_query/before_section_end', [__CLASS__, 'add_controls'], 10, 2);
+        add_action('elementor/element/loop-grid/section_query/before_section_end', [__CLASS__, 'add_controls'], 10, 2);
+        add_action('elementor/element/archive-posts/section_query/before_section_end', [__CLASS__, 'add_controls'], 10, 2);
     }
 
     /**


### PR DESCRIPTION
## Summary
- add the `elementor/query/gm2_cp` hook so Loop Grid widgets receive the custom query handler
- show the GM2 custom query controls on Loop Grid and Archive Posts widgets alongside Posts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68c8306eb21883209ffeb6848e9a43fb