### PR TITLE
Add type-specific field sanitization hook

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -557,8 +557,15 @@ Location: `modules/network-payload/Compression.php:122`
 apply_filters( 'gm2_compression_htaccess_path', ... );
 ```
 
+### `gm2_cp_field_sanitize_{$this->type}` (filter)
+Location: `includes/fields/class-field-base.php:56`
+
+```php
+apply_filters( 'gm2_cp_field_sanitize_{$this->type}', ... );
+```
+
 ### `gm2_cp_field_sanitize_{$this->key}` (filter)
-Location: `includes/fields/class-field-base.php:53`
+Location: `includes/fields/class-field-base.php:67`
 
 ```php
 apply_filters( 'gm2_cp_field_sanitize_{$this->key}', ... );

--- a/docs/fields-and-validation.md
+++ b/docs/fields-and-validation.md
@@ -86,8 +86,17 @@ add_action( 'gm2_cp_register_field_type', function ( $type, $class ) {
 } );
 ```
 
+### `gm2_cp_field_sanitize_{$type}`
+Filters the sanitized value for every field of a given type.
+
+```php
+add_filter( 'gm2_cp_field_sanitize_text', function ( $value, $field ) {
+    return wp_strip_all_tags( $value );
+}, 10, 2 );
+```
+
 ### `gm2_cp_field_sanitize_{$slug}`
-Filters the sanitized value before saving.
+Filters the sanitized value before saving. Runs after the type-level filter above so individual slugs can override shared logic.
 
 ```php
 add_filter( 'gm2_cp_field_sanitize_custom_slug', function ( $value, $field ) {

--- a/includes/fields/class-field-audio.php
+++ b/includes/fields/class-field-audio.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Audio extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'audio' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
         $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';

--- a/includes/fields/class-field-badge.php
+++ b/includes/fields/class-field-badge.php
@@ -7,7 +7,7 @@ class GM2_Field_Badge extends GM2_Field {
     private static $assets_hooked = false;
 
     public function __construct( $key, $args = array() ) {
-        parent::__construct( $key, $args );
+        parent::__construct( $key, $args, 'badge' );
         if ( ! self::$assets_hooked ) {
             add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
             add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );

--- a/includes/fields/class-field-base.php
+++ b/includes/fields/class-field-base.php
@@ -6,10 +6,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 abstract class GM2_Field {
     protected $key;
     protected $args;
+    /**
+     * Field type identifier.
+     *
+     * @var string
+     */
+    protected $type;
 
-    public function __construct( $key, $args = array() ) {
+    public function __construct( $key, $args = array(), $type = '' ) {
         $this->key  = $key;
         $this->args = is_array( $args ) ? $args : array();
+        $this->type = $type;
     }
 
     public function render_admin( $value, $object_id, $context_type ) {
@@ -41,6 +48,18 @@ abstract class GM2_Field {
      */
     public function sanitize( $value ) {
         $value = $this->sanitize_field_value( $value );
+
+        /**
+         * Filters the sanitized value for a field type.
+         *
+         * The dynamic portion of the hook name, {$this->type}, refers to the field type.
+         *
+         * @param mixed     $value Sanitized value.
+         * @param GM2_Field $this  Field instance.
+         */
+        if ( $this->type ) {
+            $value = apply_filters( "gm2_cp_field_sanitize_{$this->type}", $value, $this );
+        }
 
         /**
          * Filters the sanitized value for a field.

--- a/includes/fields/class-field-checkbox.php
+++ b/includes/fields/class-field-checkbox.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Checkbox extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'checkbox' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $checked  = checked( $value, '1', false );
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );

--- a/includes/fields/class-field-code.php
+++ b/includes/fields/class-field-code.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Code extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'code' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $language = $this->args['language'] ?? 'php';
         if ( $context_type === 'public' ) {

--- a/includes/fields/class-field-commerce.php
+++ b/includes/fields/class-field-commerce.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Commerce extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'commerce' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
         $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';

--- a/includes/fields/class-field-computed.php
+++ b/includes/fields/class-field-computed.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Computed extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'computed' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $value    = $this->calculate_value( $object_id, $context_type );
         $disabled = $this->args['disabled'] ?? false ? ' data-disabled="1"' : '';

--- a/includes/fields/class-field-date.php
+++ b/includes/fields/class-field-date.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Date extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'date' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
         $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';

--- a/includes/fields/class-field-daterange.php
+++ b/includes/fields/class-field-daterange.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Daterange extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'daterange' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
         $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';

--- a/includes/fields/class-field-datetime.php
+++ b/includes/fields/class-field-datetime.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Datetime extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'datetime' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
         $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';

--- a/includes/fields/class-field-design.php
+++ b/includes/fields/class-field-design.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Design extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'design' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
         $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';

--- a/includes/fields/class-field-email.php
+++ b/includes/fields/class-field-email.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Email extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'email' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
         $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';

--- a/includes/fields/class-field-file.php
+++ b/includes/fields/class-field-file.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_File extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'file' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
         $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';

--- a/includes/fields/class-field-flexible.php
+++ b/includes/fields/class-field-flexible.php
@@ -32,6 +32,10 @@ if ( ! defined( 'ABSPATH' ) ) {
  * values for the fields defined within that layout.
  */
 class GM2_Field_Flexible extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'flexible' );
+    }
+
     /**
      * Render the flexible content field.
      *

--- a/includes/fields/class-field-gallery.php
+++ b/includes/fields/class-field-gallery.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Gallery extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'gallery' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
         $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';

--- a/includes/fields/class-field-geospatial.php
+++ b/includes/fields/class-field-geospatial.php
@@ -7,7 +7,7 @@ class GM2_Field_Geospatial extends GM2_Field {
     private static $assets_hooked = false;
 
     public function __construct( $key, $args = array() ) {
-        parent::__construct( $key, $args );
+        parent::__construct( $key, $args, 'geo' );
 
         if ( ! self::$assets_hooked ) {
             add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );

--- a/includes/fields/class-field-gradient.php
+++ b/includes/fields/class-field-gradient.php
@@ -7,7 +7,7 @@ class GM2_Field_Gradient extends GM2_Field {
     private static $assets_hooked = false;
 
     public function __construct( $key, $args = array() ) {
-        parent::__construct( $key, $args );
+        parent::__construct( $key, $args, 'gradient' );
         if ( ! self::$assets_hooked ) {
             add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
             add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );

--- a/includes/fields/class-field-group.php
+++ b/includes/fields/class-field-group.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Group extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'group' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = $this->args['disabled'] ?? false ? ' data-disabled="1"' : '';
         echo '<div class="gm2-field-group" data-key="' . esc_attr( $this->key ) . '"' . $disabled . '>';

--- a/includes/fields/class-field-icon.php
+++ b/includes/fields/class-field-icon.php
@@ -7,7 +7,7 @@ class GM2_Field_Icon extends GM2_Field {
     private static $assets_hooked = false;
 
     public function __construct( $key, $args = array() ) {
-        parent::__construct( $key, $args );
+        parent::__construct( $key, $args, 'icon' );
         if ( ! self::$assets_hooked ) {
             add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
             add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );

--- a/includes/fields/class-field-json.php
+++ b/includes/fields/class-field-json.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_JSON extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'json' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled         = disabled( $this->args['disabled'] ?? false, true, false );
         $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';

--- a/includes/fields/class-field-markdown.php
+++ b/includes/fields/class-field-markdown.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Markdown extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'markdown' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         if ( $context_type === 'public' ) {
             echo gm2_render_markdown( (string) $value );

--- a/includes/fields/class-field-measurement.php
+++ b/includes/fields/class-field-measurement.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Measurement extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'measurement' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $value    = is_array( $value ) ? $value : array();
         $val      = $value['value'] ?? '';

--- a/includes/fields/class-field-media.php
+++ b/includes/fields/class-field-media.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Media extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'media' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
         $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';

--- a/includes/fields/class-field-message.php
+++ b/includes/fields/class-field-message.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Message extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'message' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = $this->args['disabled'] ?? false ? ' data-disabled="1"' : '';
         echo '<div class="gm2-field-message"' . $disabled . '>' . esc_html( $this->args['message'] ?? '' ) . '</div>';

--- a/includes/fields/class-field-number.php
+++ b/includes/fields/class-field-number.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Number extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'number' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
         $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';

--- a/includes/fields/class-field-oembed.php
+++ b/includes/fields/class-field-oembed.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Oembed extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'oembed' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         if ( $context_type === 'public' ) {
             echo gm2_render_oembed( (string) $value );

--- a/includes/fields/class-field-phone.php
+++ b/includes/fields/class-field-phone.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Phone extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'phone' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
         $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';

--- a/includes/fields/class-field-post-object.php
+++ b/includes/fields/class-field-post-object.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Post_Object extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'post_object' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
         $post_type = $this->args['post_type'] ?? 'post';

--- a/includes/fields/class-field-price.php
+++ b/includes/fields/class-field-price.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Price extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'price' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
         $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';

--- a/includes/fields/class-field-radio.php
+++ b/includes/fields/class-field-radio.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Radio extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'radio' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $options  = $this->args['options'] ?? array();
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );

--- a/includes/fields/class-field-rating.php
+++ b/includes/fields/class-field-rating.php
@@ -7,7 +7,7 @@ class GM2_Field_Rating extends GM2_Field {
     private static $assets_hooked = false;
 
     public function __construct( $key, $args = array() ) {
-        parent::__construct( $key, $args );
+        parent::__construct( $key, $args, 'rating' );
         if ( ! self::$assets_hooked ) {
             add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
             add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );

--- a/includes/fields/class-field-relationship.php
+++ b/includes/fields/class-field-relationship.php
@@ -21,7 +21,7 @@ class GM2_Field_Relationship extends GM2_Field {
     private $sync = 'two-way';
 
     public function __construct( $key, $args = array() ) {
-        parent::__construct( $key, $args );
+        parent::__construct( $key, $args, 'relationship' );
         $this->rel_type = in_array( $args['relationship_type'] ?? 'post', array( 'post', 'term', 'user', 'role' ), true ) ? $args['relationship_type'] : 'post';
         $this->sync     = in_array( $args['sync'] ?? 'two-way', array( 'none', 'one-way', 'two-way' ), true ) ? $args['sync'] : 'two-way';
     }

--- a/includes/fields/class-field-repeater.php
+++ b/includes/fields/class-field-repeater.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Repeater extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'repeater' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $rows     = is_array( $value ) ? $value : array();
         $disabled = $this->args['disabled'] ?? false ? ' data-disabled="1"' : '';

--- a/includes/fields/class-field-schedule.php
+++ b/includes/fields/class-field-schedule.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Schedule extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'schedule' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $value    = is_array( $value ) ? $value : array();
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );

--- a/includes/fields/class-field-select.php
+++ b/includes/fields/class-field-select.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Select extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'select' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $options  = $this->args['options'] ?? array();
         $multiple = ! empty( $this->args['multiple'] );

--- a/includes/fields/class-field-sku.php
+++ b/includes/fields/class-field-sku.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Sku extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'sku' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
         $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';

--- a/includes/fields/class-field-stock.php
+++ b/includes/fields/class-field-stock.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Stock extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'stock' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
         $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';

--- a/includes/fields/class-field-taxonomy-terms.php
+++ b/includes/fields/class-field-taxonomy-terms.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Taxonomy_Terms extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'taxonomy_terms' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $value    = is_array( $value ) ? $value : array();
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );

--- a/includes/fields/class-field-text.php
+++ b/includes/fields/class-field-text.php
@@ -4,5 +4,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Text extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'text' );
+    }
+
     // Inherits base behavior
 }

--- a/includes/fields/class-field-textarea.php
+++ b/includes/fields/class-field-textarea.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Textarea extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'textarea' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
         $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';

--- a/includes/fields/class-field-time.php
+++ b/includes/fields/class-field-time.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Time extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'time' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
         $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';

--- a/includes/fields/class-field-toggle.php
+++ b/includes/fields/class-field-toggle.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Toggle extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'toggle' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $checked  = checked( $value, '1', false );
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );

--- a/includes/fields/class-field-url.php
+++ b/includes/fields/class-field-url.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Url extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'url' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
         $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';

--- a/includes/fields/class-field-user.php
+++ b/includes/fields/class-field-user.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_User extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'user' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
         $users = get_users();

--- a/includes/fields/class-field-video.php
+++ b/includes/fields/class-field-video.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Video extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'video' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $disabled = disabled( $this->args['disabled'] ?? false, true, false );
         $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';

--- a/includes/fields/class-field-wysiwyg.php
+++ b/includes/fields/class-field-wysiwyg.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class GM2_Field_Wysiwyg extends GM2_Field {
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'wysiwyg' );
+    }
+
     protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
         $settings = array(
             'textarea_name' => $this->key,


### PR DESCRIPTION
## Summary
- add a type property to the base field class and call a new type-specific sanitization filter before the slug filter
- ensure every field class passes its registered type to the base constructor so the new hook resolves correctly
- document the new filter alongside existing sanitization hooks in the API and validation guides

## Testing
- vendor/bin/phpunit *(fails: WordPress tests library not present in the container)*

------
https://chatgpt.com/codex/tasks/task_b_68c835ffe184832082158aa2974258d5