### PR TITLE
Document expose_in_rest flag and sanitize hook usage

### DIFF
--- a/docs/Gm2 CP – Status & Gaps.md
+++ b/docs/Gm2 CP – Status & Gaps.md
@@ -5,7 +5,7 @@
 | Acceptance Criteria | Status | Notes |
 |---------------------|--------|-------|
 | CPT & Taxonomy Builder (UI + API) with export/import of JSON blueprints | Present | Admin builder and CLI export/import functions |
-| Field Groups & Field Types engine, validation, conditional logic, REST visibility, Elementor Dynamic Tags | Partial | Field engine exists with many types and REST visibility but lacks Elementor dynamic tags |
+| Field Groups & Field Types engine, validation, conditional logic, REST visibility, Elementor Dynamic Tags | Partial | Field engine exists with many types and optional REST exposure via `expose_in_rest` but lacks Elementor dynamic tags |
 | Elementor integration (dynamic tags for custom fields, query controls, template helpers, loop compatibility) | Partial | Contains Elementor widgets and SEO panel; missing dynamic tags and query controls |
 | SEO/schema mapping layer per CPT, JSON-LD output for Directory, Event, RealEstateListing, JobPosting, Course, meta title/description templates, canonical/OG/Twitter | Partial | SEO meta and schema templates present; CPT-specific schema types missing |
 | Preset “Blueprints” for Directory, Events, Real Estate, Jobs, Courses | Missing | Recipes documented but no bundled presets |

--- a/docs/api.md
+++ b/docs/api.md
@@ -557,12 +557,14 @@ Location: `modules/network-payload/Compression.php:122`
 apply_filters( 'gm2_compression_htaccess_path', ... );
 ```
 
-### `gm2_cp_field_sanitize_{$this->type}` (filter)
+### `gm2_cp_field_sanitize_{$type}` (filter)
 Location: `includes/fields/class-field-base.php:56`
 
 ```php
-apply_filters( 'gm2_cp_field_sanitize_{$this->type}', ... );
+apply_filters( 'gm2_cp_field_sanitize_{$type}', ... );
 ```
+
+See [Fields and Validation](fields-and-validation.md#rest-exposure) for opting specific fields into REST responses with the `expose_in_rest` flag.
 
 ### `gm2_cp_field_sanitize_{$this->key}` (filter)
 Location: `includes/fields/class-field-base.php:67`

--- a/docs/fields-and-validation.md
+++ b/docs/fields-and-validation.md
@@ -62,18 +62,20 @@ Field groups can be restricted to specific contexts using `location` rules. Each
 
 A group passes when all its rules evaluate true. The field group renders when any group passes.
 
-## REST Visibility
+## REST Exposure
 
-Meta fields are registered with `show_in_rest` enabled by default so values appear in the REST API. Set `'show_in_rest' => false` within a field's `args` to hide it:
+Field values are private in the REST API unless you opt in. Setting `'expose_in_rest' => true` on a field definition registers the meta key so WordPress exposes it over REST with `show_in_rest` enabled:
 
 ```php
 [
-    'slug'  => 'internal_notes',
-    'type'  => 'textarea',
-    'label' => 'Internal Notes',
-    'args'  => [ 'show_in_rest' => false ],
+    'slug'           => 'internal_notes',
+    'type'           => 'textarea',
+    'label'          => 'Internal Notes',
+    'expose_in_rest' => true,
 ]
 ```
+
+Omitting the flag (or leaving it `false`) keeps the field hidden from REST responses.
 
 ## Hooks
 
@@ -86,16 +88,21 @@ add_action( 'gm2_cp_register_field_type', function ( $type, $class ) {
 } );
 ```
 
-### `gm2_cp_field_sanitize_{$type}`
+### `gm2_cp_field_sanitize_{type}`
 Filters the sanitized value for every field of a given type.
 
 ```php
-add_filter( 'gm2_cp_field_sanitize_text', function ( $value, $field ) {
-    return wp_strip_all_tags( $value );
-}, 10, 2 );
+add_filter(
+    'gm2_cp_field_sanitize_{type}', // Replace {type} with the field type slug, e.g. `text`.
+    function ( $value, $field ) {
+        return wp_strip_all_tags( $value );
+    },
+    10,
+    2
+);
 ```
 
-### `gm2_cp_field_sanitize_{$slug}`
+### `gm2_cp_field_sanitize_{slug}`
 Filters the sanitized value before saving. Runs after the type-level filter above so individual slugs can override shared logic.
 
 ```php


### PR DESCRIPTION
## Summary
- document the `expose_in_rest` flag as the opt-in mechanism for REST exposure and refresh the sanitize hook example
- align the API reference with the `gm2_cp_field_sanitize_{type}` filter name and point readers to the REST guidance
- update the status overview to mention optional REST exposure via `expose_in_rest`

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_b_68c838f9ad5883209251ac6c714e5b4e