### PR TITLE
Add color field type support

### DIFF
--- a/admin/js/gm2-fg-wizard.js
+++ b/admin/js/gm2-fg-wizard.js
@@ -141,7 +141,8 @@
             { label: 'Text', value: 'text' },
             { label: 'Textarea', value: 'textarea' },
             { label: 'Select', value: 'select' },
-            { label: 'Number', value: 'number' }
+            { label: 'Number', value: 'number' },
+            { label: 'Color', value: 'color' }
         ];
 
         const addField = () => {

--- a/includes/fields/class-field-color.php
+++ b/includes/fields/class-field-color.php
@@ -1,0 +1,37 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class GM2_Field_Color extends GM2_Field {
+    private static $assets_hooked = false;
+
+    public function __construct( $key, $args = array() ) {
+        parent::__construct( $key, $args, 'color' );
+        if ( ! self::$assets_hooked ) {
+            add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
+            add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
+            self::$assets_hooked = true;
+        }
+    }
+
+    public static function enqueue_assets() {
+        wp_enqueue_style( 'wp-color-picker' );
+        wp_enqueue_script( 'wp-color-picker' );
+        if ( defined( 'GM2_PLUGIN_URL' ) ) {
+            wp_enqueue_style( 'gm2-extra-fields', GM2_PLUGIN_URL . 'admin/css/gm2-extra-fields.css', array( 'wp-color-picker' ), defined( 'GM2_VERSION' ) ? GM2_VERSION : false );
+            wp_enqueue_script( 'gm2-extra-fields', GM2_PLUGIN_URL . 'admin/js/gm2-extra-fields.js', array( 'jquery', 'wp-color-picker' ), defined( 'GM2_VERSION' ) ? GM2_VERSION : false, true );
+        }
+    }
+
+    protected function render_field( $value, $object_id, $context_type, $placeholder = '' ) {
+        $disabled         = disabled( $this->args['disabled'] ?? false, true, false );
+        $placeholder_attr = $placeholder !== '' ? ' placeholder="' . esc_attr( $placeholder ) . '"' : '';
+        echo '<input type="text" class="gm2-color" name="' . esc_attr( $this->key ) . '" value="' . esc_attr( $value ) . '"' . $disabled . $placeholder_attr . ' />';
+    }
+
+    protected function sanitize_field_value( $value ) {
+        $clean = sanitize_hex_color( $value );
+        return $clean ? $clean : '';
+    }
+}

--- a/includes/fields/loader.php
+++ b/includes/fields/loader.php
@@ -17,6 +17,7 @@ require_once __DIR__ . '/class-field-audio.php';
 require_once __DIR__ . '/class-field-video.php';
 require_once __DIR__ . '/class-field-gallery.php';
 require_once __DIR__ . '/class-field-checkbox.php';
+require_once __DIR__ . '/class-field-color.php';
 require_once __DIR__ . '/class-field-radio.php';
 require_once __DIR__ . '/class-field-date.php';
 require_once __DIR__ . '/class-field-time.php';
@@ -113,6 +114,7 @@ function gm2_register_default_field_types() {
     gm2_register_field_type( 'toggle', 'GM2_Field_Toggle' );
     gm2_register_field_type( 'markdown', 'GM2_Field_Markdown' );
     gm2_register_field_type( 'code', 'GM2_Field_Code' );
+    gm2_register_field_type( 'color', 'GM2_Field_Color' );
     gm2_register_field_type( 'oembed', 'GM2_Field_Oembed' );
     gm2_register_field_type( 'gradient', 'GM2_Field_Gradient' );
     gm2_register_field_type( 'icon', 'GM2_Field_Icon' );

--- a/tests/test-field-color.php
+++ b/tests/test-field-color.php
@@ -1,0 +1,48 @@
+<?php
+
+class FieldColorTest extends WP_UnitTestCase {
+    protected $post_id;
+
+    public function setUp(): void {
+        parent::setUp();
+        $this->post_id = self::factory()->post->create();
+    }
+
+    public function tearDown(): void {
+        parent::tearDown();
+        wp_delete_post($this->post_id, true);
+        $_POST    = [];
+        $_REQUEST = [];
+    }
+
+    public function test_color_field_saves_and_retrieves_value() {
+        $fields = [
+            'favorite_color' => [ 'type' => 'color' ],
+        ];
+
+        gm2_save_field_group($fields, $this->post_id, 'post', [
+            'favorite_color' => '#123456',
+        ]);
+
+        $this->assertSame('#123456', get_post_meta($this->post_id, 'favorite_color', true));
+        $this->assertSame('#123456', gm2_field('favorite_color', '', $this->post_id));
+    }
+
+    public function test_invalid_color_clears_value() {
+        $fields = [
+            'favorite_color' => [ 'type' => 'color' ],
+        ];
+
+        gm2_save_field_group($fields, $this->post_id, 'post', [
+            'favorite_color' => '#abcdef',
+        ]);
+        $this->assertSame('#abcdef', get_post_meta($this->post_id, 'favorite_color', true));
+
+        gm2_save_field_group($fields, $this->post_id, 'post', [
+            'favorite_color' => 'not-a-color',
+        ]);
+
+        $this->assertSame('', get_post_meta($this->post_id, 'favorite_color', true));
+        $this->assertSame('', gm2_field('favorite_color', '', $this->post_id));
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated `GM2_Field_Color` class that renders a color picker input and sanitizes values with `sanitize_hex_color`
- register the new color field type and expose it in the field group wizard UI
- cover saving and clearing color values through `gm2_save_field_group` with unit tests

## Testing
- `vendor/bin/phpunit --filter FieldColorTest` *(fails: WordPress test library `/tmp/wordpress-tests-lib` not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68c83c9c356c83208c9584d1dcf3ff2b