### PR TITLE
Add tests for sanitized field saving and REST exposure

### DIFF
--- a/tests/test-expose-in-rest.php
+++ b/tests/test-expose-in-rest.php
@@ -6,7 +6,10 @@ class ExposeInRestTest extends WP_UnitTestCase {
 
     public function setUp(): void {
         parent::setUp();
-        register_post_type('book');
+        register_post_type('book', [
+            'show_in_rest' => true,
+            'supports'     => [ 'custom-fields' ],
+        ]);
         $this->fields = [
             'isbn' => [
                 'label' => 'ISBN',
@@ -23,8 +26,6 @@ class ExposeInRestTest extends WP_UnitTestCase {
             ],
         ]);
         delete_option(Gm2_REST_Visibility::OPTION);
-        gm2_register_field_groups();
-        Gm2_REST_Visibility::apply_visibility();
     }
 
     public function tearDown(): void {
@@ -34,7 +35,13 @@ class ExposeInRestTest extends WP_UnitTestCase {
         parent::tearDown();
     }
 
+    private function register_field_groups(): void {
+        gm2_register_field_groups();
+        Gm2_REST_Visibility::apply_visibility();
+    }
+
     public function test_field_exposed_in_rest() {
+        $this->register_field_groups();
         $vis = Gm2_REST_Visibility::get_visibility();
         $this->assertTrue($vis['fields']['isbn']);
         $registered = get_registered_meta_keys('post', 'book');
@@ -43,15 +50,51 @@ class ExposeInRestTest extends WP_UnitTestCase {
     }
 
     public function test_saved_meta_visible_via_rest() {
+        $this->register_field_groups();
         $post_id = self::factory()->post->create(['post_type' => 'book']);
-        $_POST['isbn'] = '9781234567';
-        gm2_save_field_group($this->fields, $post_id, 'post');
+        gm2_save_field_group($this->fields, $post_id, 'post', [ 'isbn' => '9781234567' ]);
         $this->assertSame('9781234567', get_post_meta($post_id, 'isbn', true));
 
+        wp_set_current_user(self::factory()->user->create(['role' => 'administrator']));
         $request = new WP_REST_Request('GET', '/wp/v2/book/' . $post_id);
         $request->set_param('context', 'edit');
         $response = rest_get_server()->dispatch($request);
         $data = $response->get_data();
-        $this->assertSame('9781234567', $data['meta']['isbn']);
+        $this->assertContains('9781234567', (array) $data['meta']['isbn']);
+    }
+
+    public function test_expose_in_rest_registers_meta_and_rest_response() {
+        $calls = [];
+        $callback = function ($args, $defaults, $object_type, $meta_key) use (&$calls) {
+            if ($meta_key === 'isbn') {
+                $calls[] = [
+                    'args'        => $args,
+                    'defaults'    => $defaults,
+                    'object_type' => $object_type,
+                    'meta_key'    => $meta_key,
+                ];
+            }
+            return $args;
+        };
+        add_filter('register_meta_args', $callback, 10, 4);
+
+        $this->register_field_groups();
+
+        $this->assertNotEmpty($calls, 'register_meta should be invoked for expose_in_rest fields.');
+        $this->assertSame('post', $calls[0]['object_type']);
+        $this->assertTrue($calls[0]['args']['show_in_rest']);
+        $this->assertSame('book', $calls[0]['args']['object_subtype']);
+
+        $post_id = self::factory()->post->create(['post_type' => 'book']);
+        gm2_save_field_group($this->fields, $post_id, 'post', [ 'isbn' => '9785555555' ]);
+
+        wp_set_current_user(self::factory()->user->create(['role' => 'administrator']));
+        $request = new WP_REST_Request('GET', '/wp/v2/book/' . $post_id);
+        $request->set_param('context', 'edit');
+        $response = rest_get_server()->dispatch($request);
+        $data = $response->get_data();
+        $this->assertContains('9785555555', (array) $data['meta']['isbn']);
+
+        remove_filter('register_meta_args', $callback, 10);
     }
 }


### PR DESCRIPTION
## Summary
- add a regression test ensuring gm2_cp_field_sanitize_text filtered values persist when saving
- expand expose_in_rest coverage to confirm register_meta is called and metadata is exposed in REST responses

## Testing
- vendor/bin/phpunit --filter test_text_field_sanitize_filter_value_saved tests/FieldValidationTest.php
- vendor/bin/phpunit -c /tmp/phpunit-expose.xml --filter test_expose_in_rest_registers_meta_and_rest_response


------
https://chatgpt.com/codex/tasks/task_b_68c841e5e7fc8320a25a4805158d218a