### PR TITLE
Extend nested schema type inference for nested job fields

### DIFF
--- a/includes/seo/class-gm2-cp-schema.php
+++ b/includes/seo/class-gm2-cp-schema.php
@@ -160,6 +160,10 @@ class Gm2_CP_Schema {
             }
             $ref =& $ref[$seg];
         }
+        if (is_array($ref) && is_array($value)) {
+            $ref = array_replace($ref, $value);
+            return;
+        }
         $ref = $value;
     }
 
@@ -169,13 +173,15 @@ class Gm2_CP_Schema {
     private static function nested_type(string $segment): ?string {
         return match ($segment) {
             'address' => 'PostalAddress',
+            'baseSalary' => 'MonetaryAmount',
+            'courseInstance' => 'CourseInstance',
             'geo' => 'GeoCoordinates',
+            'hiringOrganization' => 'Organization',
             'jobLocation' => 'Place',
             'location' => 'Place',
-            'openingHoursSpecification' => 'OpeningHoursSpecification',
             'offers' => 'Offer',
+            'openingHoursSpecification' => 'OpeningHoursSpecification',
             'organizer' => 'Organization',
-            'courseInstance' => 'CourseInstance',
             default => null,
         };
     }


### PR DESCRIPTION
## Summary
- preserve inferred nested @type metadata when assigning array values to schema nodes
- expand the nested type map to cover MonetaryAmount and Organization structures used by job-related properties

## Testing
- ./vendor/bin/phpunit *(fails: WordPress test library not available in the container)*

------
https://chatgpt.com/codex/tasks/task_b_68c847c29c748320b11a7d2eac2cdbb4