### PR TITLE
Allow nested schema paths for course instances

### DIFF
--- a/admin/Gm2_Custom_Posts_Admin.php
+++ b/admin/Gm2_Custom_Posts_Admin.php
@@ -1739,10 +1739,18 @@ class Gm2_Custom_Posts_Admin {
                         'provider',
                         'url',
                         'courseCode',
+                        'courseInstance.name',
+                        'courseInstance.description',
+                        'courseInstance.courseMode',
+                        'courseInstance.courseWorkload',
                         'courseInstance.startDate',
                         'courseInstance.endDate',
                         'courseInstance.location.name',
+                        'courseInstance.location.address',
+                        'courseInstance.instructor.name',
                         'courseInstance.offers.price',
+                        'courseInstance.offers.priceCurrency',
+                        'courseInstance.offers.url',
                     ],
                 ],
                 'saved' => esc_html__( 'Schema mapping saved.', 'gm2-wordpress-suite' ),
@@ -2300,9 +2308,17 @@ class Gm2_Custom_Posts_Admin {
         if (!wp_verify_nonce($nonce, 'gm2_schema_map')) {
             wp_send_json_error('nonce');
         }
-        $slug = sanitize_key($_POST['cpt'] ?? '');
-        $type = sanitize_text_field($_POST['type'] ?? '');
-        $map  = $_POST['map'] ?? [];
+        $slug = sanitize_key(wp_unslash($_POST['cpt'] ?? ''));
+        $type = sanitize_text_field(wp_unslash($_POST['type'] ?? ''));
+        $raw_map = $_POST['map'] ?? [];
+        if (is_string($raw_map)) {
+            $decoded = json_decode(wp_unslash($raw_map), true);
+            $map = is_array($decoded) ? $decoded : null;
+        } elseif (is_array($raw_map)) {
+            $map = wp_unslash($raw_map);
+        } else {
+            $map = null;
+        }
         if (!$slug || !is_array($map)) {
             wp_send_json_error('data');
         }

--- a/admin/js/gm2-schema-mapping.js
+++ b/admin/js/gm2-schema-mapping.js
@@ -68,6 +68,9 @@ jQuery(function ($) {
     $('#gm2-save-schema').on('click', function (e) {
         e.preventDefault();
         const slug = $cpt.val();
+        if (!slug) {
+            return;
+        }
         const map = {};
         $table.find('tr').each(function () {
             const prop = $(this).find('.gm2-prop').val();
@@ -76,7 +79,14 @@ jQuery(function ($) {
                 map[prop] = field;
             }
         });
-        $.post(data.ajax, { action: 'gm2_save_schema_map', nonce: data.nonce, cpt: slug, type: $type.val(), map: map }, function (r) {
+        const payload = {
+            action: 'gm2_save_schema_map',
+            nonce: data.nonce,
+            cpt: slug,
+            type: $type.val(),
+            map: JSON.stringify(map),
+        };
+        $.post(data.ajax, payload, function (r) {
             if (r && r.success) {
                 alert(data.saved || 'Saved');
             }


### PR DESCRIPTION
## Summary
- expand the Course schema preset with additional courseInstance mappings
- preserve nested schema property paths by sending the mapping payload as JSON and decoding it server-side

## Testing
- npm test *(fails: e2e tests require a live WordPress backend for REST uploads and admin navigation)*

------
https://chatgpt.com/codex/tasks/task_b_68c84b1c481c8320bebef43d92dd08db