### PR TITLE
Add Elementor templates and SEO defaults to preset blueprints

### DIFF
--- a/assets/blueprints/presets/courses.json
+++ b/assets/blueprints/presets/courses.json
@@ -5,7 +5,47 @@
       "supports": ["title", "editor", "thumbnail"],
       "has_archive": true,
       "rewrite": { "slug": "courses" },
-      "menu_icon": "dashicons-welcome-learn-more"
+      "menu_icon": "dashicons-welcome-learn-more",
+      "template": [
+        [
+          "core/group",
+          {
+            "metadata": { "name": "Course Layout" },
+            "layout": { "type": "constrained" }
+          },
+          [
+            [
+              "core/heading",
+              { "level": 2, "placeholder": "Course headline or hero text" }
+            ],
+            [
+              "core/paragraph",
+              { "placeholder": "Introduce the course or launch Elementor to design the section." }
+            ],
+            [
+              "core/shortcode",
+              { "text": "[elementor-template id=\"\"]" }
+            ]
+          ]
+        ]
+      ],
+      "template_lock": "insert",
+      "seo": {
+        "meta_title": "{{title}} – Course Overview",
+        "meta_description": "{{description}}",
+        "canonical": "{{permalink}}",
+        "open_graph": {
+          "title": "{{title}}",
+          "description": "{{description}}",
+          "image": "{{image}}"
+        },
+        "twitter": {
+          "card": "summary_large_image",
+          "title": "{{title}}",
+          "description": "{{description}}",
+          "image": "{{image}}"
+        }
+      }
     }
   },
   "taxonomies": {

--- a/assets/blueprints/presets/directory.json
+++ b/assets/blueprints/presets/directory.json
@@ -5,7 +5,47 @@
       "supports": ["title", "editor", "thumbnail", "custom-fields"],
       "has_archive": true,
       "rewrite": { "slug": "listings" },
-      "menu_icon": "dashicons-store"
+      "menu_icon": "dashicons-store",
+      "template": [
+        [
+          "core/group",
+          {
+            "metadata": { "name": "Listing Layout" },
+            "layout": { "type": "constrained" }
+          },
+          [
+            [
+              "core/heading",
+              { "level": 2, "placeholder": "Business headline or tagline" }
+            ],
+            [
+              "core/paragraph",
+              { "placeholder": "Spotlight the listing or switch to Elementor to customise." }
+            ],
+            [
+              "core/shortcode",
+              { "text": "[elementor-template id=\"\"]" }
+            ]
+          ]
+        ]
+      ],
+      "template_lock": "insert",
+      "seo": {
+        "meta_title": "{{title}} – Business Listing",
+        "meta_description": "{{description}}",
+        "canonical": "{{permalink}}",
+        "open_graph": {
+          "title": "{{title}}",
+          "description": "{{description}}",
+          "image": "{{image}}"
+        },
+        "twitter": {
+          "card": "summary_large_image",
+          "title": "{{title}}",
+          "description": "{{description}}",
+          "image": "{{image}}"
+        }
+      }
     }
   },
   "taxonomies": {

--- a/assets/blueprints/presets/events.json
+++ b/assets/blueprints/presets/events.json
@@ -5,7 +5,47 @@
       "supports": ["title", "editor", "thumbnail", "excerpt"],
       "has_archive": true,
       "rewrite": { "slug": "events" },
-      "menu_icon": "dashicons-calendar-alt"
+      "menu_icon": "dashicons-calendar-alt",
+      "template": [
+        [
+          "core/group",
+          {
+            "metadata": { "name": "Event Layout" },
+            "layout": { "type": "constrained" }
+          },
+          [
+            [
+              "core/heading",
+              { "level": 2, "placeholder": "Event headline or hero" }
+            ],
+            [
+              "core/paragraph",
+              { "placeholder": "Share key event highlights or switch to Elementor for a custom design." }
+            ],
+            [
+              "core/shortcode",
+              { "text": "[elementor-template id=\"\"]" }
+            ]
+          ]
+        ]
+      ],
+      "template_lock": "insert",
+      "seo": {
+        "meta_title": "{{title}} – Event Details",
+        "meta_description": "{{description}}",
+        "canonical": "{{permalink}}",
+        "open_graph": {
+          "title": "{{title}}",
+          "description": "{{description}}",
+          "image": "{{image}}"
+        },
+        "twitter": {
+          "card": "summary_large_image",
+          "title": "{{title}}",
+          "description": "{{description}}",
+          "image": "{{image}}"
+        }
+      }
     }
   },
   "taxonomies": {

--- a/assets/blueprints/presets/jobs.json
+++ b/assets/blueprints/presets/jobs.json
@@ -5,7 +5,47 @@
       "supports": ["title", "editor"],
       "has_archive": true,
       "rewrite": { "slug": "jobs" },
-      "menu_icon": "dashicons-businessperson"
+      "menu_icon": "dashicons-businessperson",
+      "template": [
+        [
+          "core/group",
+          {
+            "metadata": { "name": "Job Layout" },
+            "layout": { "type": "constrained" }
+          },
+          [
+            [
+              "core/heading",
+              { "level": 2, "placeholder": "Role headline or strapline" }
+            ],
+            [
+              "core/paragraph",
+              { "placeholder": "Outline the opportunity or jump into Elementor for a richer layout." }
+            ],
+            [
+              "core/shortcode",
+              { "text": "[elementor-template id=\"\"]" }
+            ]
+          ]
+        ]
+      ],
+      "template_lock": "insert",
+      "seo": {
+        "meta_title": "{{title}} – Job Opportunity",
+        "meta_description": "{{description}}",
+        "canonical": "{{permalink}}",
+        "open_graph": {
+          "title": "{{title}}",
+          "description": "{{description}}",
+          "image": "{{image}}"
+        },
+        "twitter": {
+          "card": "summary_large_image",
+          "title": "{{title}}",
+          "description": "{{description}}",
+          "image": "{{image}}"
+        }
+      }
     }
   },
   "taxonomies": {

--- a/assets/blueprints/presets/real-estate.json
+++ b/assets/blueprints/presets/real-estate.json
@@ -5,7 +5,47 @@
       "supports": ["title", "editor", "thumbnail"],
       "has_archive": true,
       "rewrite": { "slug": "properties" },
-      "menu_icon": "dashicons-admin-home"
+      "menu_icon": "dashicons-admin-home",
+      "template": [
+        [
+          "core/group",
+          {
+            "metadata": { "name": "Property Layout" },
+            "layout": { "type": "constrained" }
+          },
+          [
+            [
+              "core/heading",
+              { "level": 2, "placeholder": "Property highlight or strapline" }
+            ],
+            [
+              "core/paragraph",
+              { "placeholder": "Showcase the property or open Elementor to craft a custom hero." }
+            ],
+            [
+              "core/shortcode",
+              { "text": "[elementor-template id=\"\"]" }
+            ]
+          ]
+        ]
+      ],
+      "template_lock": "insert",
+      "seo": {
+        "meta_title": "{{title}} – Property Listing",
+        "meta_description": "{{description}}",
+        "canonical": "{{permalink}}",
+        "open_graph": {
+          "title": "{{title}}",
+          "description": "{{description}}",
+          "image": "{{image}}"
+        },
+        "twitter": {
+          "card": "summary_large_image",
+          "title": "{{title}}",
+          "description": "{{description}}",
+          "image": "{{image}}"
+        }
+      }
     }
   },
   "taxonomies": {


### PR DESCRIPTION
## Summary
- add Elementor-oriented block templates and template locking to each preset custom post type
- provide per-type SEO defaults covering meta title, description, canonical and Open Graph/Twitter fallbacks
- verify the updated blueprints validate against the existing JSON schema

## Testing
- `python - <<'PY' ...` (blueprint schema validation)
- `vendor/bin/phpunit --filter BlueprintPresetsTest` *(fails: requires WordPress tests bootstrap at /tmp/wordpress-tests-lib)*

------
https://chatgpt.com/codex/tasks/task_b_68c855abf8488320879ac5a905d231da