### PR TITLE
Document blueprint presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ wp gm2 blueprint import assets/blueprints/samples/directory.json assets/blueprin
 
 Imports are validated against `assets/blueprints/schema.json` and sample blueprints live in `assets/blueprints/samples/`.
 
+Detailed reference sheets for the bundled presets are available in [docs/presets/](docs/presets/):
+
+- [Directory](docs/presets/directory.md)
+- [Events](docs/presets/events.md)
+- [Real Estate](docs/presets/real-estate.md)
+- [Jobs](docs/presets/jobs.md)
+- [Courses](docs/presets/courses.md)
+
 ## Network Payload Optimizer
 
 The Network Payload Optimizer records Resource Timing data from the admin and tracks a rolling seven‑day average of transferred bytes. Configure the module under **Gm2 → Network Payload** where you can toggle:

--- a/docs/presets/README.md
+++ b/docs/presets/README.md
@@ -1,0 +1,9 @@
+# Blueprint Presets
+
+Detailed breakdowns of the bundled blueprint presets, including custom post type slugs, taxonomies, field groups, schema mappings and Elementor guidance:
+
+- [Directory](directory.md)
+- [Events](events.md)
+- [Real Estate](real-estate.md)
+- [Jobs](jobs.md)
+- [Courses](courses.md)

--- a/docs/presets/courses.md
+++ b/docs/presets/courses.md
@@ -1,0 +1,35 @@
+# Courses Preset
+
+## Custom Post Type
+
+- **Slug:** `course`
+- **Purpose:** Publishes course overviews with long-form descriptions and featured imagery at `/courses/` with the learn-more icon in the admin sidebar.
+- **Editor Template:** Locks in a grouped block pattern (heading, summary paragraph, Elementor Template shortcode) so course pages stay consistent while allowing Elementor to power the hero.
+
+## Taxonomies
+
+| Taxonomy | Hierarchical | Purpose |
+| --- | --- | --- |
+| `course_category` | No | Buckets courses into subjects or programs for filtering the archive. |
+
+## Field Groups
+
+### Course Details
+
+| Field | Type | Validation & Notes |
+| --- | --- | --- |
+| `provider` | Text | Required provider name exposed in REST. |
+| `course_code` | Text | Required code validated against `^[A-Z0-9-]+$` and exposed in REST. |
+| `course_url` | URL | Optional canonical course link exposed in REST. |
+
+## Schema Mapping
+
+- **Schema Type:** `Course`
+- **Mappings:**
+  - `provider` ← `provider`
+  - `courseCode` ← `course_code`
+  - `url` ← `course_url`
+
+## Elementor Notes
+
+Enter the saved Elementor template ID in `[elementor-template id=""]` to inject a tailored hero or CTA layout while the locked group guarantees consistent base content for every course.

--- a/docs/presets/directory.md
+++ b/docs/presets/directory.md
@@ -1,0 +1,36 @@
+# Directory Preset
+
+## Custom Post Type
+
+- **Slug:** `listing`
+- **Purpose:** Local business listings with support for classic details (title, long-form description, featured image, and custom fields) published under `/listings/` with an archive page and store icon in the menu.
+- **Editor Template:** Block editor template locks insertion and opens with a grouped layout containing a heading, intro paragraph, and an Elementor Template shortcode placeholder so sites can swap in a custom Elementor design without rebuilding the structure.
+
+## Taxonomies
+
+| Taxonomy | Hierarchical | Purpose |
+| --- | --- | --- |
+| `listing_category` | Yes | Categorises listings into business types for browsing and filtering. |
+| `listing_location` | No | Tags listings with cities or neighbourhoods for location-based filtering. |
+
+## Field Groups
+
+### Listing Details
+
+| Field | Type | Validation & Notes |
+| --- | --- | --- |
+| `phone` | Text | Optional. Validated with the pattern `^\+?[0-9\-\s]+$` and exposed in the REST API. |
+| `address` | Text | Required address line stored in REST for mapping and schema usage. |
+| `website` | URL | Optional URL stored in REST for call-to-action links. |
+
+## Schema Mapping
+
+- **Schema Type:** `LocalBusiness`
+- **Mappings:**
+  - `telephone` ← `phone`
+  - `address.streetAddress` ← `address`
+  - `url` ← `website`
+
+## Elementor Notes
+
+The template encourages pairing native blocks with Elementor by leaving `[elementor-template id=""]` in place. Replace the blank ID with a saved Elementor template to render a richer hero while the locked group preserves consistent structure across listings.

--- a/docs/presets/events.md
+++ b/docs/presets/events.md
@@ -1,0 +1,35 @@
+# Events Preset
+
+## Custom Post Type
+
+- **Slug:** `event`
+- **Purpose:** Publishes event details with support for long-form content, featured imagery, and excerpts under `/events/` with a calendar icon in the admin menu.
+- **Editor Template:** Uses a locked block group containing a heading, summary paragraph, and Elementor Template shortcode placeholder so editors can drop in a saved Elementor hero layout while preserving baseline structure.
+
+## Taxonomies
+
+| Taxonomy | Hierarchical | Purpose |
+| --- | --- | --- |
+| `event_type` | No | Labels events by type (e.g., workshop, webinar) for filtering and archive navigation. |
+
+## Field Groups
+
+### Event Details
+
+| Field | Type | Validation & Notes |
+| --- | --- | --- |
+| `start_date` | DateTime | Required start timestamp exposed in REST responses. |
+| `end_date` | DateTime | Required end timestamp exposed in REST responses. |
+| `location` | Text | Required venue or meeting details, also exposed through REST for maps. |
+
+## Schema Mapping
+
+- **Schema Type:** `Event`
+- **Mappings:**
+  - `startDate` ← `start_date`
+  - `endDate` ← `end_date`
+  - `location` ← `location`
+
+## Elementor Notes
+
+Embed an Elementor design by filling in the `[elementor-template id=""]` placeholder. The locked group keeps the core heading and summary in place while letting Elementor control the hero or schedule layout.

--- a/docs/presets/jobs.md
+++ b/docs/presets/jobs.md
@@ -1,0 +1,37 @@
+# Jobs Preset
+
+## Custom Post Type
+
+- **Slug:** `job`
+- **Purpose:** Promotes job postings with detailed descriptions under `/jobs/` using the businessperson icon in the admin menu.
+- **Editor Template:** Starts with a locked block group (heading, summary paragraph, Elementor Template shortcode) so teams can blend core content with a reusable Elementor layout.
+
+## Taxonomies
+
+| Taxonomy | Hierarchical | Purpose |
+| --- | --- | --- |
+| `job_category` | No | Groups roles by department or discipline for filtering job archives. |
+
+## Field Groups
+
+### Job Details
+
+| Field | Type | Validation & Notes |
+| --- | --- | --- |
+| `date_posted` | Date | Required posting date exposed in REST feeds. |
+| `employment_type` | Text | Required employment type (full-time, contract, etc.) exposed in REST. |
+| `company` | Text | Required hiring organisation name available through REST. |
+| `apply_url` | URL | Optional application link exposed in REST. |
+
+## Schema Mapping
+
+- **Schema Type:** `JobPosting`
+- **Mappings:**
+  - `datePosted` ← `date_posted`
+  - `employmentType` ← `employment_type`
+  - `hiringOrganization` ← `company`
+  - `url` ← `apply_url`
+
+## Elementor Notes
+
+Swap the blank ID in `[elementor-template id=""]` for a saved Elementor layout to control the hero or call-to-action while the locked block group preserves consistent structure across job entries.

--- a/docs/presets/real-estate.md
+++ b/docs/presets/real-estate.md
@@ -1,0 +1,35 @@
+# Real Estate Preset
+
+## Custom Post Type
+
+- **Slug:** `property`
+- **Purpose:** Lists property inventory with long-form descriptions and featured media under `/properties/`, surfaced in the admin with the home icon.
+- **Editor Template:** Provides a locked block group with a headline, intro paragraph, and Elementor Template shortcode so editors can swap in a bespoke Elementor hero while retaining consistent structure.
+
+## Taxonomies
+
+| Taxonomy | Hierarchical | Purpose |
+| --- | --- | --- |
+| `property_type` | Yes | Segments listings by property type (e.g., apartment, commercial) for archive filtering. |
+
+## Field Groups
+
+### Property Details
+
+| Field | Type | Validation & Notes |
+| --- | --- | --- |
+| `price` | Number | Required, minimum `0`, exposed in REST for feeds and schema. |
+| `address` | Text | Required street address, REST exposed for mapping and schema. |
+| `bedrooms` | Number | Optional count with a minimum of `0`, exposed in REST. |
+
+## Schema Mapping
+
+- **Schema Type:** `RealEstateListing`
+- **Mappings:**
+  - `price` ← `price`
+  - `address.streetAddress` ← `address`
+  - `numberOfRooms` ← `bedrooms`
+
+## Elementor Notes
+
+Populate the `[elementor-template id=""]` shortcode with a saved Elementor template to drive the hero or gallery while the locked block group keeps the base layout intact across property pages.


### PR DESCRIPTION
## Summary
- add a presets documentation section covering directory, events, real estate, jobs, and courses blueprints
- document each preset's custom post type, taxonomy, field group, schema mappings, and Elementor template notes
- link the new documentation from the README for easier discovery

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68c85b269afc83209da7511b85690d7b