### PR TITLE
Sanitize request input in conditional evaluation

### DIFF
--- a/includes/gm2-custom-posts-functions.php
+++ b/includes/gm2-custom-posts-functions.php
@@ -55,9 +55,14 @@ function gm2_evaluate_conditions($item, $post_id = 0) {
             }
             // Determine the current value from request or post meta.
             if (isset($_REQUEST[$target])) {
-                $current = $_REQUEST[$target];
+                $current = wp_unslash($_REQUEST[$target]);
                 if (is_array($current)) {
                     $current = reset($current);
+                }
+                if (is_scalar($current) || $current === null) {
+                    $current = sanitize_text_field((string) $current);
+                } else {
+                    $current = '';
                 }
             } else {
                 $current = ($post_id) ? get_post_meta($post_id, $target, true) : '';

--- a/tests/test-conditions-sanitization.php
+++ b/tests/test-conditions-sanitization.php
@@ -1,0 +1,68 @@
+<?php
+
+class Gm2EvaluateConditionsSanitizationTest extends WP_UnitTestCase {
+    public function setUp(): void {
+        parent::setUp();
+        $_REQUEST = [];
+    }
+
+    public function tearDown(): void {
+        parent::tearDown();
+        $_REQUEST = [];
+    }
+
+    private function build_field_with_condition(array $condition): array {
+        return [
+            'conditions' => [
+                [
+                    'conditions' => [
+                        array_merge(
+                            [
+                                'relation' => 'AND',
+                                'operator' => '=',
+                            ],
+                            $condition
+                        ),
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function test_request_value_is_sanitized_before_evaluation(): void {
+        $_REQUEST['example_field'] = '  match  ';
+        $field = $this->build_field_with_condition([
+            'target' => 'example_field',
+            'value'  => 'match',
+        ]);
+
+        $state = gm2_evaluate_conditions($field, 0);
+
+        $this->assertTrue($state['show']);
+    }
+
+    public function test_array_request_value_is_sanitized_before_evaluation(): void {
+        $_REQUEST['example_field'] = [ ' match ' ];
+        $field = $this->build_field_with_condition([
+            'target' => 'example_field',
+            'value'  => 'match',
+        ]);
+
+        $state = gm2_evaluate_conditions($field, 0);
+
+        $this->assertTrue($state['show']);
+    }
+
+    public function test_numeric_comparison_is_preserved_after_sanitization(): void {
+        $_REQUEST['price'] = '10';
+        $field = $this->build_field_with_condition([
+            'target'   => 'price',
+            'operator' => '>',
+            'value'    => '5',
+        ]);
+
+        $state = gm2_evaluate_conditions($field, 0);
+
+        $this->assertTrue($state['show']);
+    }
+}


### PR DESCRIPTION
## Summary
- sanitize gm2 condition evaluations by unslashing and sanitizing request-derived values before comparisons
- add unit tests ensuring sanitized request input still satisfies equality and numeric operators

## Testing
- ./vendor/bin/phpunit --filter Gm2EvaluateConditionsSanitizationTest *(fails: WordPress test suite bootstrap missing in container)*

------
https://chatgpt.com/codex/tasks/task_b_68c8604b7ffc83208d36a81b28b24da9