### PR TITLE
Handle invalid regex patterns in field validation

### DIFF
--- a/includes/gm2-custom-posts-functions.php
+++ b/includes/gm2-custom-posts-functions.php
@@ -238,9 +238,16 @@ function gm2_validate_field($key, $field, $value, $object_id = 0, $context_type 
         return new WP_Error('gm2_max', $msg);
     }
 
-    if (!empty($field['regex']) && is_string($value) && !preg_match($field['regex'], $value)) {
-        $msg = $messages['regex'] ?? __('Invalid format.', 'gm2-wordpress-suite');
-        return new WP_Error('gm2_regex', $msg);
+    if (!empty($field['regex']) && is_string($field['regex']) && is_string($value)) {
+        $match = @preg_match($field['regex'], $value);
+        if ($match === false) {
+            $msg = $messages['regex'] ?? __('Invalid format.', 'gm2-wordpress-suite');
+            return new WP_Error('gm2_regex_invalid', $msg);
+        }
+        if ($match === 0) {
+            $msg = $messages['regex'] ?? __('Invalid format.', 'gm2-wordpress-suite');
+            return new WP_Error('gm2_regex', $msg);
+        }
     }
 
     $type = $field['type'] ?? '';

--- a/tests/FieldValidationTest.php
+++ b/tests/FieldValidationTest.php
@@ -23,6 +23,26 @@ class FieldValidationTest extends WP_UnitTestCase {
         $this->assertInstanceOf( WP_Error::class, $res );
     }
 
+    public function test_regex_invalid_pattern_returns_error() {
+        $field = [ 'regex' => '/(unclosed' ];
+        $res   = gm2_validate_field('regex_field', $field, 'value');
+
+        $this->assertInstanceOf( WP_Error::class, $res );
+        $this->assertSame( 'gm2_regex_invalid', $res->get_error_code() );
+    }
+
+    public function test_regex_invalid_pattern_uses_custom_message() {
+        $field = [
+            'regex'    => '/(unclosed',
+            'messages' => [ 'regex' => 'Custom invalid format.' ],
+        ];
+        $res = gm2_validate_field('regex_field', $field, 'value');
+
+        $this->assertInstanceOf( WP_Error::class, $res );
+        $this->assertSame( 'gm2_regex_invalid', $res->get_error_code() );
+        $this->assertSame( 'Custom invalid format.', $res->get_error_message() );
+    }
+
     public function test_measurement_validation_callback() {
         $field = [
             'type' => 'measurement',


### PR DESCRIPTION
## Summary
- guard field regex validation against invalid PCRE patterns and surface a dedicated `gm2_regex_invalid` error via existing messaging
- add PHPUnit coverage that asserts invalid regex patterns are caught and use the configured message

## Testing
- ./vendor/bin/phpunit --bootstrap tests/bootstrap.php --filter regex_invalid tests/FieldValidationTest.php

------
https://chatgpt.com/codex/tasks/task_b_68c861c924908320b9e9115a36ee1e10