### PR TITLE
Clear remote mirror refresh hook on deactivation

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -376,6 +376,8 @@ function gm2_deactivate_plugin() {
         wp_unschedule_event($ts, 'gm2_analytics_purge');
     }
 
+    wp_clear_scheduled_hook('gm2_remote_mirror_refresh');
+
     Gm2_Abandoned_Carts::clear_scheduled_event();
 }
 register_deactivation_hook(__FILE__, 'gm2_deactivate_plugin');


### PR DESCRIPTION
## Summary
- clear the `gm2_remote_mirror_refresh` scheduled hook when the plugin is deactivated to prevent lingering cron jobs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68c8857b4994833085108b4b3c23248a