### PR TITLE
Ensure analytics cookies are secure and HTTP-only

### DIFF
--- a/includes/Gm2_Analytics.php
+++ b/includes/Gm2_Analytics.php
@@ -84,7 +84,7 @@ class Gm2_Analytics {
         }
 
         if (!isset($_COOKIE[self::COOKIE_NAME]) || $_COOKIE[self::COOKIE_NAME] !== $id) {
-            setcookie(self::COOKIE_NAME, $id, time() + YEAR_IN_SECONDS * 2, COOKIEPATH, COOKIE_DOMAIN);
+            setcookie(self::COOKIE_NAME, $id, time() + YEAR_IN_SECONDS * 2, COOKIEPATH, COOKIE_DOMAIN, is_ssl(), true);
             $_COOKIE[self::COOKIE_NAME] = $id;
         }
 
@@ -94,7 +94,7 @@ class Gm2_Analytics {
     private function get_session_id() {
         if (!isset($_COOKIE[self::SESSION_COOKIE])) {
             $session = wp_generate_uuid4();
-            setcookie(self::SESSION_COOKIE, $session, 0, COOKIEPATH, COOKIE_DOMAIN);
+            setcookie(self::SESSION_COOKIE, $session, 0, COOKIEPATH, COOKIE_DOMAIN, is_ssl(), true);
             $_COOKIE[self::SESSION_COOKIE] = $session;
         }
         return sanitize_text_field($_COOKIE[self::SESSION_COOKIE]);


### PR DESCRIPTION
## Summary
- mark the analytics identifier cookie as secure when on SSL and enforce HTTP-only access
- apply the same secure and HTTP-only settings to the analytics session cookie

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68c8864e4244833094722f643cbc4d1c