### PR TITLE
Handle remote mirror write failures

### DIFF
--- a/includes/Gm2_Remote_Mirror.php
+++ b/includes/Gm2_Remote_Mirror.php
@@ -282,7 +282,11 @@ class Gm2_Remote_Mirror {
 
         $body = wp_remote_retrieve_body($response);
         wp_mkdir_p(dirname($path));
-        file_put_contents($path, $body);
+
+        $bytes_written = file_put_contents($path, $body);
+        if ($bytes_written === false) {
+            return new \WP_Error('gm2_remote_mirror_write_failed', 'Failed to write remote script to cache.');
+        }
 
         return [
             'path' => $path,


### PR DESCRIPTION
## Summary
- capture the result of caching remote scripts
- surface a WP_Error when the cache write fails instead of returning success metadata

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68c888003a048330bf2949f17d970c6c