### PR TITLE
Sanitize wizard action parameters

### DIFF
--- a/admin/Gm2_SEO_Wizard.php
+++ b/admin/Gm2_SEO_Wizard.php
@@ -23,10 +23,13 @@ class Gm2_SEO_Wizard {
     }
 
     public function handle_redirect() {
+        $get_action = isset($_GET['action']) ? sanitize_key(wp_unslash($_GET['action'])) : '';
+        $post_action = isset($_POST['action']) ? sanitize_key(wp_unslash($_POST['action'])) : '';
+
         // Bail out when handling wizard form submissions.
         if (
-            (isset($_GET['action']) && $_GET['action'] === 'gm2_save_wizard') ||
-            (isset($_POST['action']) && $_POST['action'] === 'gm2_save_wizard') ||
+            ($get_action === 'gm2_save_wizard') ||
+            ($post_action === 'gm2_save_wizard') ||
             (isset($_SERVER['SCRIPT_NAME']) && basename($_SERVER['SCRIPT_NAME']) === 'admin-post.php')
         ) {
             return;


### PR DESCRIPTION
## Summary
- sanitize the setup wizard GET and POST action parameters using `sanitize_key`
- reuse the sanitized action values in the redirect guard logic

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68c888c919748330811c99f4e671512f