### PR TITLE
Add exit after recovered carts reset redirect

### DIFF
--- a/admin/Gm2_Recovered_Carts_Admin.php
+++ b/admin/Gm2_Recovered_Carts_Admin.php
@@ -117,10 +117,11 @@ class Gm2_Recovered_Carts_Admin {
         global $wpdb;
         $wpdb->query("TRUNCATE TABLE {$wpdb->prefix}wc_ac_recovered");
 
-        wp_redirect(admin_url('admin.php?page=gm2-recovered-carts&logs_reset=1'));
         if (defined('GM2_TESTING') && GM2_TESTING) {
             return;
         }
+
+        wp_redirect(admin_url('admin.php?page=gm2-recovered-carts&logs_reset=1'));
         exit;
     }
 }


### PR DESCRIPTION
## Summary
- ensure recovered carts reset handler returns early during tests
- halt further processing immediately after issuing the admin redirect

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68c8914bb2088330ac0bb28589edffaf