### PR TITLE
Add nonce verification for bulk cart deletions

### DIFF
--- a/admin/Gm2_Abandoned_Carts_Admin.php
+++ b/admin/Gm2_Abandoned_Carts_Admin.php
@@ -182,6 +182,7 @@ class Gm2_Abandoned_Carts_Admin {
         if (!empty($_REQUEST['paged'])) {
             echo '<input type="hidden" name="paged" value="' . absint($_REQUEST['paged']) . '" />';
         }
+        $table->render_bulk_actions_nonce_field();
         $table->display();
         echo '</form></div>';
     }

--- a/admin/Gm2_Recovered_Carts_Admin.php
+++ b/admin/Gm2_Recovered_Carts_Admin.php
@@ -70,6 +70,7 @@ class Gm2_Recovered_Carts_Admin {
         if (!empty($_REQUEST['paged'])) {
             echo '<input type="hidden" name="paged" value="' . absint($_REQUEST['paged']) . '" />';
         }
+        $table->render_bulk_actions_nonce_field();
         $table->display();
         echo '</form></div>';
     }

--- a/admin/class-gm2-ac-table.php
+++ b/admin/class-gm2-ac-table.php
@@ -56,10 +56,15 @@ class GM2_AC_Table extends \WP_List_Table {
         ];
     }
 
+    public function render_bulk_actions_nonce_field() {
+        wp_nonce_field('bulk-' . $this->_args['plural']);
+    }
+
     public function process_bulk_action() {
         if ($this->current_action() !== 'delete') {
             return;
         }
+        check_admin_referer('bulk-' . $this->_args['plural']);
         $ids = isset($_REQUEST['id']) ? (array) $_REQUEST['id'] : [];
         $ids = array_map('absint', $ids);
         $ids = array_filter($ids);


### PR DESCRIPTION
## Summary
- verify the bulk delete action nonce before deleting cart records
- expose a helper to render the bulk action nonce field and include it in the admin forms

## Testing
- composer install
- ./vendor/bin/phpunit *(fails: missing wordpress-tests-lib)*

------
https://chatgpt.com/codex/tasks/task_b_68c8958569a0833097b3de5ded3eb126