### PR TITLE
Handle AE SEO log write failures

### DIFF
--- a/admin/class-ae-seo-server-hints.php
+++ b/admin/class-ae-seo-server-hints.php
@@ -72,7 +72,11 @@ NGINX;
         }
         $file = $dir . '/js-optimizer.log';
         $time = gmdate('Y-m-d H:i:s');
-        file_put_contents($file, '[' . $time . '] ' . $message . PHP_EOL, FILE_APPEND);
+        $result = file_put_contents($file, '[' . $time . '] ' . $message . PHP_EOL, FILE_APPEND);
+
+        if ($result === false) {
+            error_log('[AE SEO Server Hints] Failed to write log entry to ' . $file . ' for message: ' . $message);
+        }
     }
 
     private function asset_compression_enabled(): bool {


### PR DESCRIPTION
## Summary
- capture the return value from `file_put_contents` when writing log entries
- send an error log message if the log write fails so the issue is visible

## Testing
- php -l admin/class-ae-seo-server-hints.php

------
https://chatgpt.com/codex/tasks/task_b_68c8970c9db883308fefdb4dfffee7be