### PR TITLE
Use safe parser for computed field formulas

### DIFF
--- a/includes/fields/class-field-computed.php
+++ b/includes/fields/class-field-computed.php
@@ -44,26 +44,282 @@ class GM2_Field_Computed extends GM2_Field {
     protected function evaluate_formula( $formula, $object_id, $context_type ) {
         preg_match_all( '/{([A-Za-z0-9_\-]+)}/', $formula, $matches );
         $replacements = array();
+
         foreach ( $matches[1] as $key ) {
-            $val = $this->get_meta_value( $object_id, $key, $context_type );
-            if ( is_numeric( $val ) ) {
-                $replacements[ '{' . $key . '}' ] = $val;
-            } else {
-                $replacements[ '{' . $key . '}' ] = '\'' . str_replace( '\'', '\\' . '\'', (string) $val ) . '\'';
+            $raw_value = $this->get_meta_value( $object_id, $key, $context_type );
+            $numeric   = $this->sanitize_numeric_value( $raw_value );
+
+            if ( null === $numeric ) {
+                return null;
             }
+
+            $replacements[ '{' . $key . '}' ] = $numeric;
         }
+
         $expr = strtr( $formula, $replacements );
 
-        $without_strings = preg_replace( '/(["\']).*?\1/', '', $expr );
-        if ( preg_match( '/[^0-9+\-*\/().\'" ]/', $without_strings ) ) {
+        if ( preg_match( '/[^0-9+\-*\/().\s]/', $expr ) ) {
             return null;
         }
 
-        try {
-            // phpcs:ignore -- expression is sanitized above.
-            return eval( 'return ' . $expr . ';' );
-        } catch ( \Throwable $e ) {
+        $expr   = trim( $expr );
+        $result = $this->evaluate_numeric_expression( $expr );
+
+        if ( null === $result ) {
             return null;
+        }
+
+        if ( is_nan( $result ) || is_infinite( $result ) ) {
+            return null;
+        }
+
+        if ( abs( $result - round( $result ) ) < 1e-9 ) {
+            return (int) round( $result );
+        }
+
+        return $result;
+    }
+
+    protected function sanitize_numeric_value( $value ) {
+        if ( null === $value || '' === $value ) {
+            return '0';
+        }
+
+        if ( is_bool( $value ) ) {
+            return $value ? '1' : '0';
+        }
+
+        if ( is_int( $value ) || is_float( $value ) ) {
+            return (string) $value;
+        }
+
+        $value = trim( (string) $value );
+
+        if ( '' === $value ) {
+            return '0';
+        }
+
+        if ( preg_match( '/^-?(?:\d+\.?\d*|\d*\.\d+)$/', $value ) ) {
+            return $value;
+        }
+
+        if ( is_numeric( $value ) ) {
+            $value = (string) (float) $value;
+
+            if ( preg_match( '/^-?(?:\d+\.?\d*|\d*\.\d+)$/', $value ) ) {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
+    protected function evaluate_numeric_expression( $expression ) {
+        if ( '' === $expression ) {
+            return null;
+        }
+
+        $length   = strlen( $expression );
+        $position = 0;
+
+        $result = $this->parse_expression_level( $expression, $position, $length );
+
+        if ( null === $result ) {
+            return null;
+        }
+
+        $this->skip_whitespace( $expression, $position, $length );
+
+        if ( $position !== $length ) {
+            return null;
+        }
+
+        return $result;
+    }
+
+    private function parse_expression_level( $expression, &$position, $length ) {
+        $value = $this->parse_term( $expression, $position, $length );
+
+        if ( null === $value ) {
+            return null;
+        }
+
+        while ( true ) {
+            $this->skip_whitespace( $expression, $position, $length );
+
+            if ( $position >= $length ) {
+                break;
+            }
+
+            $operator = $expression[ $position ];
+
+            if ( '+' !== $operator && '-' !== $operator ) {
+                break;
+            }
+
+            $position++;
+
+            $right = $this->parse_term( $expression, $position, $length );
+
+            if ( null === $right ) {
+                return null;
+            }
+
+            if ( '+' === $operator ) {
+                $value += $right;
+            } else {
+                $value -= $right;
+            }
+        }
+
+        return $value;
+    }
+
+    private function parse_term( $expression, &$position, $length ) {
+        $value = $this->parse_factor( $expression, $position, $length );
+
+        if ( null === $value ) {
+            return null;
+        }
+
+        while ( true ) {
+            $this->skip_whitespace( $expression, $position, $length );
+
+            if ( $position >= $length ) {
+                break;
+            }
+
+            $operator = $expression[ $position ];
+
+            if ( '*' !== $operator && '/' !== $operator ) {
+                break;
+            }
+
+            $position++;
+
+            $right = $this->parse_factor( $expression, $position, $length );
+
+            if ( null === $right ) {
+                return null;
+            }
+
+            if ( '/' === $operator ) {
+                if ( abs( $right ) < 1e-12 ) {
+                    return null;
+                }
+
+                $value /= $right;
+            } else {
+                $value *= $right;
+            }
+        }
+
+        return $value;
+    }
+
+    private function parse_factor( $expression, &$position, $length ) {
+        $this->skip_whitespace( $expression, $position, $length );
+
+        if ( $position >= $length ) {
+            return null;
+        }
+
+        $sign = 1;
+
+        while ( $position < $length ) {
+            $char = $expression[ $position ];
+
+            if ( '+' === $char ) {
+                $position++;
+                $this->skip_whitespace( $expression, $position, $length );
+                continue;
+            }
+
+            if ( '-' === $char ) {
+                $sign *= -1;
+                $position++;
+                $this->skip_whitespace( $expression, $position, $length );
+                continue;
+            }
+
+            break;
+        }
+
+        if ( $position >= $length ) {
+            return null;
+        }
+
+        $char = $expression[ $position ];
+
+        if ( '(' === $char ) {
+            $position++;
+            $value = $this->parse_expression_level( $expression, $position, $length );
+
+            if ( null === $value ) {
+                return null;
+            }
+
+            $this->skip_whitespace( $expression, $position, $length );
+
+            if ( $position >= $length || ')' !== $expression[ $position ] ) {
+                return null;
+            }
+
+            $position++;
+
+            return $sign * $value;
+        }
+
+        $number = $this->parse_number( $expression, $position, $length );
+
+        if ( null === $number ) {
+            return null;
+        }
+
+        return $sign * $number;
+    }
+
+    private function parse_number( $expression, &$position, $length ) {
+        $this->skip_whitespace( $expression, $position, $length );
+
+        $start     = $position;
+        $has_digit = false;
+        $has_dot   = false;
+
+        while ( $position < $length ) {
+            $char = $expression[ $position ];
+
+            if ( ctype_digit( $char ) ) {
+                $has_digit = true;
+                $position++;
+                continue;
+            }
+
+            if ( '.' === $char && ! $has_dot ) {
+                $has_dot = true;
+                $position++;
+                continue;
+            }
+
+            break;
+        }
+
+        if ( ! $has_digit ) {
+            return null;
+        }
+
+        $number_str = substr( $expression, $start, $position - $start );
+
+        if ( '' === $number_str || '.' === $number_str || '-' === $number_str || '+' === $number_str ) {
+            return null;
+        }
+
+        return (float) $number_str;
+    }
+
+    private function skip_whitespace( $expression, &$position, $length ) {
+        while ( $position < $length && ctype_space( $expression[ $position ] ) ) {
+            $position++;
         }
     }
 

--- a/tests/test-field-computed.php
+++ b/tests/test-field-computed.php
@@ -6,7 +6,7 @@ class FieldComputedTest extends WP_UnitTestCase {
         update_post_meta( $post_id, 'a', 5 );
         update_post_meta( $post_id, 'b', 2 );
 
-        $field = new GM2_Field_Computed( 'total', [ 'formula' => '{a} * {b} + 1' ] );
+        $field = new GM2_Field_Computed( 'total', [ 'formula' => '({a} * {b}) + 1' ] );
         $field->save( $post_id, null );
 
         $this->assertSame( 11, get_post_meta( $post_id, 'total', true ) );
@@ -17,15 +17,35 @@ class FieldComputedTest extends WP_UnitTestCase {
         $this->assertStringContainsString( '11', $out );
     }
 
-    public function test_string_formula() {
+    public function test_invalid_formula_is_rejected() {
         $post_id = self::factory()->post->create();
-        update_post_meta( $post_id, 'first', 'John' );
-        update_post_meta( $post_id, 'last', 'Doe' );
+        update_post_meta( $post_id, 'a', 5 );
 
-        $field = new GM2_Field_Computed( 'full', [ 'formula' => "{first} . ' ' . {last}" ] );
+        $field = new GM2_Field_Computed( 'total', [ 'formula' => '{a} + system("ls")' ] );
         $field->save( $post_id, null );
 
-        $this->assertSame( 'John Doe', get_post_meta( $post_id, 'full', true ) );
+        $this->assertSame( '', get_post_meta( $post_id, 'total', true ) );
+    }
+
+    public function test_formula_cannot_execute_php_code() {
+        self::$executed = false;
+
+        $post_id = self::factory()->post->create();
+        update_post_meta( $post_id, 'a', 'FieldComputedTest::trigger()' );
+
+        $field = new GM2_Field_Computed( 'total', [ 'formula' => '{a} + 1' ] );
+        $field->save( $post_id, null );
+
+        $this->assertSame( '', get_post_meta( $post_id, 'total', true ) );
+        $this->assertFalse( self::$executed );
+    }
+
+    public static $executed = false;
+
+    public static function trigger() {
+        self::$executed = true;
+
+        return 99;
     }
 }
 


### PR DESCRIPTION
## Summary
- replace the computed field's eval-based formula handling with numeric sanitization and a recursive-descent parser
- treat placeholder values as numbers only and reject formulas containing non-arithmetic characters
- expand FieldComputed tests to cover valid arithmetic, invalid input, and attempts at PHP execution

## Testing
- ./vendor/bin/phpunit tests/test-field-computed.php *(fails: WordPress test suite bootstrap missing)*

------
https://chatgpt.com/codex/tasks/task_b_68c8a4e3a58483308a1b45ba6bd8e9e9