### PR TITLE
Implement persistent REST rate limiting window

### DIFF
--- a/tests/test-rest-rate-limiter.php
+++ b/tests/test-rest-rate-limiter.php
@@ -1,0 +1,62 @@
+<?php
+
+use Gm2\Gm2_REST_Rate_Limiter;
+
+class RestRateLimiterTest extends WP_UnitTestCase {
+
+    private function prepare_request_for_ip(string $ip): array {
+        $_SERVER['REMOTE_ADDR'] = $ip;
+        $key = 'gm2_rl_' . md5($ip);
+        delete_transient($key);
+        $request = new WP_REST_Request('GET', '/gm2/v1/test');
+
+        return [ $request, $key ];
+    }
+
+    protected function tearDown(): void {
+        unset($_SERVER['REMOTE_ADDR']);
+        parent::tearDown();
+    }
+
+    public function test_count_increments_without_resetting_window(): void {
+        [ $request, $key ] = $this->prepare_request_for_ip('198.51.100.10');
+
+        $this->assertNull(Gm2_REST_Rate_Limiter::maybe_limit(null, null, $request));
+        $first_data = get_transient($key);
+        $this->assertIsArray($first_data);
+        $this->assertSame(1, $first_data['count']);
+        $initial_start = $first_data['start'];
+
+        $this->assertNull(Gm2_REST_Rate_Limiter::maybe_limit(null, null, $request));
+        $second_data = get_transient($key);
+        $this->assertIsArray($second_data);
+        $this->assertSame(2, $second_data['count']);
+        $this->assertSame($initial_start, $second_data['start']);
+
+        delete_transient($key);
+    }
+
+    public function test_counts_reset_after_window(): void {
+        [ $request, $key ] = $this->prepare_request_for_ip('198.51.100.11');
+
+        $this->assertNull(Gm2_REST_Rate_Limiter::maybe_limit(null, null, $request));
+        $data = get_transient($key);
+        $this->assertIsArray($data);
+        $this->assertArrayHasKey('start', $data);
+
+        $expired_start = $data['start'] - Gm2_REST_Rate_Limiter::WINDOW - 1;
+        set_transient($key, [
+            'count' => Gm2_REST_Rate_Limiter::LIMIT,
+            'start' => $expired_start,
+        ], 5);
+
+        $this->assertNull(Gm2_REST_Rate_Limiter::maybe_limit(null, null, $request));
+        $after_reset = get_transient($key);
+        $this->assertIsArray($after_reset);
+        $this->assertSame(1, $after_reset['count']);
+        $this->assertGreaterThan($expired_start, $after_reset['start']);
+
+        delete_transient($key);
+    }
+}
+


### PR DESCRIPTION
## Summary
- store the REST rate limiter state as both the request count and the window start time
- keep the window start intact while incrementing counts until the configured window elapses
- add integration coverage to ensure counts persist within the window and reset once it expires

## Testing
- `vendor/bin/phpunit --filter RestRateLimiterTest` *(fails: WordPress test suite is not installed at /tmp/wordpress-tests-lib)*

------
https://chatgpt.com/codex/tasks/task_b_68c93a45e8c48330b93d25f0065e64e1