### PR TITLE
Ensure registries flush rewrite rules safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Detailed reference sheets for the bundled presets are available in [docs/presets
 - [Jobs](docs/presets/jobs.md)
 - [Courses](docs/presets/courses.md)
 
+### Content registry rewrite rules
+
+The content registry wires activation and deactivation hooks that call `flush_rewrite_rules()` so custom structures become available immediately after the plugin toggles. When a new post type or taxonomy is registered, the registry schedules a single rewrite flush after `init` and guards it with `did_action( 'init' )` so the work only runs once per request. Avoid adding extra `flush_rewrite_rules()` calls in your own hooks or performing manual flushes on every request—those patterns can trigger unnecessary database writes and slow responses. Rely on the built-in guard and only trigger manual flushes when debugging rewrite issues.
+
 ## Network Payload Optimizer
 
 The Network Payload Optimizer records Resource Timing data from the admin and tracks a rolling seven‑day average of transferred bytes. Configure the module under **Gm2 → Network Payload** where you can toggle:

--- a/src/Content/Registry/PostTypeRegistry.php
+++ b/src/Content/Registry/PostTypeRegistry.php
@@ -8,6 +8,11 @@ use RuntimeException;
 
 final class PostTypeRegistry
 {
+    public function __construct()
+    {
+        RewriteRulesFlusher::registerHooks();
+    }
+
     public function register(Definition $definition): void
     {
         if (!function_exists('register_post_type')) {
@@ -64,6 +69,8 @@ final class PostTypeRegistry
         register_post_type($slug, $args);
 
         $this->bindTaxonomies($slug, $taxonomies);
+
+        RewriteRulesFlusher::flush();
     }
 
     private function resolveSlug(Definition $definition): string

--- a/src/Content/Registry/RewriteRulesFlusher.php
+++ b/src/Content/Registry/RewriteRulesFlusher.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Gm2\Content\Registry;
+
+final class RewriteRulesFlusher
+{
+    private static bool $hooksRegistered = false;
+    private static bool $rewriteScheduled = false;
+
+    public static function registerHooks(): void
+    {
+        if (self::$hooksRegistered) {
+            return;
+        }
+
+        if (
+            !function_exists('register_activation_hook')
+            || !function_exists('register_deactivation_hook')
+            || !defined('GM2_PLUGIN_DIR')
+        ) {
+            return;
+        }
+
+        $pluginFile = GM2_PLUGIN_DIR . 'gm2-wordpress-suite.php';
+
+        if (
+            !function_exists('plugin_basename')
+            || !function_exists('has_action')
+            || !file_exists($pluginFile)
+        ) {
+            return;
+        }
+
+        $pluginBase = plugin_basename($pluginFile);
+
+        if (!has_action('activate_' . $pluginBase, 'flush_rewrite_rules')) {
+            register_activation_hook($pluginFile, 'flush_rewrite_rules');
+        }
+
+        if (!has_action('deactivate_' . $pluginBase, 'flush_rewrite_rules')) {
+            register_deactivation_hook($pluginFile, 'flush_rewrite_rules');
+        }
+
+        self::$hooksRegistered = true;
+    }
+
+    public static function flush(): void
+    {
+        if (self::$rewriteScheduled || !function_exists('flush_rewrite_rules')) {
+            return;
+        }
+
+        if (function_exists('did_action') && did_action('init')) {
+            flush_rewrite_rules(false);
+            self::$rewriteScheduled = true;
+            return;
+        }
+
+        if (function_exists('add_action')) {
+            add_action('init', static function (): void {
+                if (function_exists('flush_rewrite_rules')) {
+                    flush_rewrite_rules(false);
+                }
+            }, PHP_INT_MAX);
+            self::$rewriteScheduled = true;
+        }
+    }
+}

--- a/src/Content/Registry/TaxonomyRegistry.php
+++ b/src/Content/Registry/TaxonomyRegistry.php
@@ -7,6 +7,11 @@ use RuntimeException;
 
 final class TaxonomyRegistry
 {
+    public function __construct()
+    {
+        RewriteRulesFlusher::registerHooks();
+    }
+
     public function register(
         string $slug,
         string $singular,
@@ -54,6 +59,8 @@ final class TaxonomyRegistry
         $args = apply_filters('gm2/content/taxonomy_args', $args, $slug, $objectTypes);
 
         register_taxonomy($slug, $objectTypes, $args);
+
+        RewriteRulesFlusher::flush();
     }
 
     private function resolveSlug(string $slug, string $singular, string $plural): string


### PR DESCRIPTION
## Summary
- add a shared rewrite rules flusher that registers activation/deactivation hooks and schedules safe flushes
- update the post type and taxonomy registries to wire the helper in their constructors and flush after registration
- document how the registry handles rewrite flushing to discourage costly manual flushes

## Testing
- php -l src/Content/Registry/RewriteRulesFlusher.php
- php -l src/Content/Registry/PostTypeRegistry.php
- php -l src/Content/Registry/TaxonomyRegistry.php

------
https://chatgpt.com/codex/tasks/task_b_68c98036b51c833099425f9f439c823c