### PR TITLE
Add registry coverage tests

### DIFF
--- a/tests/Content/Registry/PostTypeRegistryTest.php
+++ b/tests/Content/Registry/PostTypeRegistryTest.php
@@ -1,0 +1,125 @@
+<?php
+
+use Gm2\Content\Model\Definition;
+use Gm2\Content\Registry\PostTypeRegistry;
+use InvalidArgumentException;
+use RuntimeException;
+
+class PostTypeRegistryTest extends WP_UnitTestCase
+{
+    private PostTypeRegistry $registry;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!function_exists('gm2_cp_register_type')) {
+            require_once GM2_PLUGIN_DIR . 'includes/class-gm2-cp-register.php';
+        }
+
+        $this->registry = new PostTypeRegistry();
+        delete_option('gm2_custom_posts_config');
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (['library_book', 'legacy_book'] as $slug) {
+            if (post_type_exists($slug)) {
+                unregister_post_type($slug);
+            }
+        }
+
+        delete_option('gm2_custom_posts_config');
+
+        parent::tearDown();
+    }
+
+    public function test_register_builds_expected_arguments(): void
+    {
+        $capturedArgs = null;
+        $capturedSlug = null;
+
+        $callback = static function (array $args, string $slug, $legacyArgs = null): array use (&$capturedArgs, &$capturedSlug) {
+            $capturedArgs = $args;
+            $capturedSlug = $slug;
+
+            return $args;
+        };
+
+        add_filter('gm2_register_post_type_args', $callback, 10, 3);
+
+        $definition = new Definition(
+            ' library book ',
+            ' Library Book ',
+            ' Library Books ',
+            [
+                'menu_name' => ' Library Items ',
+            ],
+            ['title', 'editor', 'editor', 123],
+            ' Library Archive ',
+            ' dashicons-book ',
+            [
+                'slug' => ' Library & Books ',
+                'with_front' => '0',
+                'hierarchical' => '1',
+            ],
+            ' story ',
+            ['genre', 'topic', 'genre', null],
+            [
+                'public' => false,
+            ]
+        );
+
+        $this->registry->register($definition);
+
+        remove_filter('gm2_register_post_type_args', $callback, 10);
+
+        $this->assertSame('library_book', $capturedSlug);
+        $this->assertIsArray($capturedArgs);
+
+        $this->assertSame('dashicons-book', $capturedArgs['menu_icon']);
+        $this->assertTrue($capturedArgs['show_in_rest']);
+        $this->assertTrue($capturedArgs['map_meta_cap']);
+        $this->assertSame('story', $capturedArgs['capability_type']);
+        $this->assertSame(['title', 'editor'], $capturedArgs['supports']);
+        $this->assertSame([
+            'slug' => sanitize_title(' Library & Books '),
+            'with_front' => false,
+            'hierarchical' => true,
+        ], $capturedArgs['rewrite']);
+        $this->assertSame(['genre', 'topic'], $capturedArgs['taxonomies']);
+        $this->assertSame(sanitize_title(' Library Archive '), $capturedArgs['has_archive']);
+        $this->assertFalse($capturedArgs['public']);
+        $this->assertSame('Library Items', $capturedArgs['labels']['menu_name']);
+        $this->assertSame('Library Book', $capturedArgs['labels']['singular_name']);
+        $this->assertSame('Library Books', $capturedArgs['labels']['name']);
+
+        $registered = get_post_type_object('library_book');
+        $this->assertNotNull($registered);
+        $this->assertTrue($registered->show_in_rest);
+        $this->assertTrue($registered->map_meta_cap);
+        $this->assertSame('story', $registered->capability_type);
+    }
+
+    public function test_register_rejects_invalid_slug(): void
+    {
+        $definition = new Definition('***', 'Example', 'Examples');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The post type key cannot be empty.');
+
+        $this->registry->register($definition);
+    }
+
+    public function test_register_detects_existing_slug(): void
+    {
+        gm2_cp_register_type('legacy_book', ['public' => true]);
+
+        $definition = new Definition('legacy_book', 'Legacy Book', 'Legacy Books');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Post type "legacy_book" already exists.');
+
+        $this->registry->register($definition);
+    }
+}

--- a/tests/Content/Registry/RewriteRulesFlusherTest.php
+++ b/tests/Content/Registry/RewriteRulesFlusherTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use Gm2\Content\Registry\PostTypeRegistry;
+use Gm2\Content\Registry\RewriteRulesFlusher;
+use ReflectionClass;
+
+class RewriteRulesFlusherTest extends WP_UnitTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->resetFlusherState();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetFlusherState();
+        parent::tearDown();
+    }
+
+    public function test_activation_and_deactivation_hooks_registered(): void
+    {
+        if (!function_exists('register_activation_hook') || !function_exists('register_deactivation_hook') || !function_exists('plugin_basename')) {
+            require_once ABSPATH . 'wp-admin/includes/plugin.php';
+        }
+
+        $pluginFile = GM2_PLUGIN_DIR . 'gm2-wordpress-suite.php';
+        $pluginBase = plugin_basename($pluginFile);
+
+        remove_action('activate_' . $pluginBase, 'flush_rewrite_rules');
+        remove_action('deactivate_' . $pluginBase, 'flush_rewrite_rules');
+
+        $this->setFlusherProperty('hooksRegistered', false);
+
+        new PostTypeRegistry();
+
+        $this->assertSame(10, has_action('activate_' . $pluginBase, 'flush_rewrite_rules'));
+        $this->assertSame(10, has_action('deactivate_' . $pluginBase, 'flush_rewrite_rules'));
+    }
+
+    private function resetFlusherState(): void
+    {
+        if (defined('GM2_PLUGIN_DIR') && function_exists('plugin_basename')) {
+            $pluginFile = GM2_PLUGIN_DIR . 'gm2-wordpress-suite.php';
+            if (file_exists($pluginFile)) {
+                $pluginBase = plugin_basename($pluginFile);
+                remove_action('activate_' . $pluginBase, 'flush_rewrite_rules');
+                remove_action('deactivate_' . $pluginBase, 'flush_rewrite_rules');
+            }
+        }
+
+        $this->setFlusherProperty('hooksRegistered', false);
+        $this->setFlusherProperty('rewriteScheduled', false);
+    }
+
+    private function setFlusherProperty(string $property, bool $value): void
+    {
+        $reflection = new ReflectionClass(RewriteRulesFlusher::class);
+        $prop = $reflection->getProperty($property);
+        $prop->setAccessible(true);
+        $prop->setValue(null, $value);
+    }
+}

--- a/tests/Content/Registry/TaxonomyRegistryTest.php
+++ b/tests/Content/Registry/TaxonomyRegistryTest.php
@@ -1,0 +1,117 @@
+<?php
+
+use Gm2\Content\Registry\TaxonomyRegistry;
+use InvalidArgumentException;
+use RuntimeException;
+
+class TaxonomyRegistryTest extends WP_UnitTestCase
+{
+    private TaxonomyRegistry $registry;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!function_exists('gm2_cp_register_taxonomy')) {
+            require_once GM2_PLUGIN_DIR . 'includes/class-gm2-cp-register.php';
+        }
+
+        $this->registry = new TaxonomyRegistry();
+        delete_option('gm2_custom_posts_config');
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (['topic-items', 'legacy_topic'] as $slug) {
+            if (taxonomy_exists($slug)) {
+                unregister_taxonomy($slug);
+            }
+        }
+
+        delete_option('gm2_custom_posts_config');
+
+        parent::tearDown();
+    }
+
+    public function test_register_builds_expected_arguments(): void
+    {
+        $capturedArgs = null;
+        $capturedSlug = null;
+        $capturedObjectTypes = null;
+
+        $callback = static function (array $args, string $slug, array $objectTypes) use (&$capturedArgs, &$capturedSlug, &$capturedObjectTypes): array {
+            $capturedArgs = $args;
+            $capturedSlug = $slug;
+            $capturedObjectTypes = $objectTypes;
+
+            return $args;
+        };
+
+        add_filter('gm2/content/taxonomy_args', $callback, 10, 3);
+
+        $this->registry->register(
+            ' topic-items ',
+            ' Topic Item ',
+            ' Topic Items ',
+            ['book', 'library_book', 'book', 123],
+            [
+                'labels' => [
+                    'menu_name' => ' Topics ',
+                ],
+                'rewrite' => [
+                    'slug' => ' Topics & More ',
+                    'with_front' => '',
+                    'hierarchical' => '1',
+                ],
+                'hierarchical' => '1',
+                'capability_type' => ' topic ',
+                'public' => false,
+            ]
+        );
+
+        remove_filter('gm2/content/taxonomy_args', $callback, 10);
+
+        $this->assertSame('topic-items', $capturedSlug);
+        $this->assertSame(['book', 'library_book'], $capturedObjectTypes);
+        $this->assertTrue($capturedArgs['show_in_rest']);
+        $this->assertSame([
+            'slug' => sanitize_title(' Topics & More '),
+            'with_front' => false,
+            'hierarchical' => true,
+        ], $capturedArgs['rewrite']);
+        $this->assertTrue($capturedArgs['hierarchical']);
+        $this->assertSame([
+            'manage_terms' => 'manage_topic_terms',
+            'edit_terms' => 'edit_topic_terms',
+            'delete_terms' => 'delete_topic_terms',
+            'assign_terms' => 'assign_topic_terms',
+        ], $capturedArgs['capabilities']);
+        $this->assertFalse($capturedArgs['public']);
+        $this->assertSame('Topic Items', $capturedArgs['labels']['name']);
+        $this->assertSame('Topic Item', $capturedArgs['labels']['singular_name']);
+        $this->assertSame('Topics', $capturedArgs['labels']['menu_name']);
+
+        $taxonomy = get_taxonomy('topic-items');
+        $this->assertNotNull($taxonomy);
+        $this->assertTrue($taxonomy->show_in_rest);
+        $this->assertTrue($taxonomy->hierarchical);
+    }
+
+    public function test_register_rejects_invalid_slug(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The taxonomy key cannot be empty.');
+
+        $this->registry->register('***', 'Example', 'Examples', ['post']);
+    }
+
+    public function test_register_detects_existing_slug(): void
+    {
+        gm2_cp_register_taxonomy('legacy_topic', 'post', ['public' => true]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Taxonomy "legacy_topic" already exists.');
+
+        $this->registry->register('legacy_topic', 'Legacy Topic', 'Legacy Topics', ['post']);
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests covering PostTypeRegistry argument preparation and collision detection through the legacy helper
- add taxonomy registry tests to verify argument sanitization and duplicate slug handling using gm2_cp_register_taxonomy
- add a RewriteRulesFlusher test that confirms activation and deactivation hooks register rewrite flushing

## Testing
- vendor/bin/phpunit tests/Content/Registry *(fails: WordPress tests library not installed in container)*

------
https://chatgpt.com/codex/tasks/task_b_68c984c760448330b627d3a5be598e42