### PR TITLE
Add field registry infrastructure with validation and tests

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -60,6 +60,12 @@ use Gm2\Gm2_Loader;
 use Gm2\Gm2_SEO_Public;
 use Gm2\Gm2_Sitemap;
 use Gm2\Gm2_Abandoned_Carts;
+use Gm2\Fields\FieldGroupRegistry;
+use Gm2\Fields\FieldTypeRegistry;
+use Gm2\Fields\Renderer\AdminMetaBox;
+use Gm2\Fields\Sanitizers\SanitizerRegistry;
+use Gm2\Fields\Storage\MetaRegistrar;
+use Gm2\Fields\Validation\ValidatorRegistry;
 $gm2_autoload = GM2_PLUGIN_DIR . 'vendor/autoload.php';
 if (file_exists($gm2_autoload)) {
     require_once $gm2_autoload;
@@ -203,6 +209,24 @@ function gm2_bootstrap_content_registry(): void {
     do_action('gm2/content/register', $registrar, $postTypes, $taxonomies);
 }
 add_action('init', 'gm2_bootstrap_content_registry', 9);
+
+function gm2_bootstrap_field_groups(): void {
+    $registry = new FieldGroupRegistry(
+        new MetaRegistrar(),
+        FieldTypeRegistry::withDefaults(),
+        ValidatorRegistry::withDefaults(),
+        SanitizerRegistry::withDefaults(),
+        new AdminMetaBox()
+    );
+
+    /**
+     * Allow third parties to register field groups before they are booted.
+     */
+    do_action('gm2/fields/register', $registry);
+
+    $registry->boot();
+}
+add_action('init', 'gm2_bootstrap_field_groups', 11);
 
 $gm2_font_perf_dir = GM2_PLUGIN_DIR . 'modules/font-performance/';
 if (is_dir($gm2_font_perf_dir) && !class_exists('\\Gm2\\Font_Performance\\Font_Performance')) {

--- a/src/Fields/FieldDefinition.php
+++ b/src/Fields/FieldDefinition.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Gm2\Fields;
+
+use Gm2\Fields\Types\FieldTypeInterface;
+
+final class FieldDefinition
+{
+    /**
+     * @param array<string, mixed> $settings
+     */
+    public function __construct(
+        private readonly string $key,
+        private readonly FieldTypeInterface $type,
+        private readonly array $settings = []
+    ) {
+    }
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    public function getType(): FieldTypeInterface
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getSettings(): array
+    {
+        return $this->settings;
+    }
+
+    public function getLabel(): string
+    {
+        $label = $this->settings['label'] ?? $this->key;
+
+        return is_string($label) ? $label : $this->key;
+    }
+
+    public function getDescription(): ?string
+    {
+        $description = $this->settings['description'] ?? null;
+
+        return is_string($description) ? $description : null;
+    }
+
+    public function getDefault(): mixed
+    {
+        return $this->settings['default'] ?? null;
+    }
+
+    public function isRequired(): bool
+    {
+        return (bool) ($this->settings['required'] ?? false);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getRestSettings(): array
+    {
+        $settings = $this->settings['rest'] ?? [];
+
+        return is_array($settings) ? $settings : [];
+    }
+
+    /**
+     * @return array<int|string, mixed>
+     */
+    public function getOptions(): array
+    {
+        $options = $this->settings['options'] ?? [];
+        if (!is_array($options)) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach ($options as $value => $label) {
+            if (is_int($value)) {
+                $value = (string) $value;
+            }
+            if (!is_string($value)) {
+                continue;
+            }
+            $normalized[$value] = is_string($label) ? $label : (string) $label;
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @return array{relation: string, items: array<int, array<string, mixed>>}|null
+     */
+    public function getConditions(): ?array
+    {
+        $conditions = $this->settings['conditions'] ?? [];
+        if (!is_array($conditions) || $conditions === []) {
+            return null;
+        }
+
+        $relation = strtolower((string) ($conditions['relation'] ?? 'and'));
+        if (!in_array($relation, [ 'and', 'or' ], true)) {
+            $relation = 'and';
+        }
+
+        $items = [];
+        foreach ($conditions as $key => $condition) {
+            if ($key === 'relation') {
+                continue;
+            }
+            if (!is_array($condition) || !isset($condition['field'])) {
+                continue;
+            }
+            $items[] = $condition;
+        }
+
+        if ($items === []) {
+            return null;
+        }
+
+        return [
+            'relation' => $relation,
+            'items'    => $items,
+        ];
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getComputedDependencies(): array
+    {
+        $config = $this->settings['computed'] ?? [];
+        if (!is_array($config)) {
+            return [];
+        }
+
+        $deps = $config['dependencies'] ?? [];
+        if (!is_array($deps)) {
+            return [];
+        }
+
+        return array_values(array_filter(array_map(
+            static fn ($dependency) => is_string($dependency) ? $dependency : null,
+            $deps
+        )));
+    }
+
+    public function isComputed(): bool
+    {
+        return $this->type->getName() === 'computed';
+    }
+}

--- a/src/Fields/FieldGroupDefinition.php
+++ b/src/Fields/FieldGroupDefinition.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace Gm2\Fields;
+
+use InvalidArgumentException;
+
+final class FieldGroupDefinition
+{
+    /**
+     * @var array<string, FieldDefinition>
+     */
+    private array $fields;
+
+    /**
+     * @var array{post: string[], term: string[], user: bool}
+     */
+    private array $contexts;
+
+    /**
+     * @var array<string, array<int, string>>
+     */
+    private array $computedGraph;
+
+    /**
+     * @param array<string, mixed>              $config
+     * @param array<string, FieldDefinition>    $fields
+     */
+    public function __construct(
+        private readonly string $key,
+        private readonly array $config,
+        array $fields
+    ) {
+        $this->fields        = $fields;
+        $this->contexts      = $this->normalizeContexts($config);
+        $this->computedGraph = $this->buildComputedGraph();
+    }
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    public function getTitle(): string
+    {
+        $title = $this->config['title'] ?? $this->key;
+
+        return is_string($title) ? $title : $this->key;
+    }
+
+    /**
+     * @return array<string, FieldDefinition>
+     */
+    public function getFields(): array
+    {
+        return $this->fields;
+    }
+
+    public function getField(string $key): FieldDefinition
+    {
+        if (!isset($this->fields[$key])) {
+            throw new InvalidArgumentException(sprintf('Field "%s" is not defined in group "%s".', $key, $this->key));
+        }
+
+        return $this->fields[$key];
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getPostTypes(): array
+    {
+        return $this->contexts['post'];
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getTaxonomies(): array
+    {
+        return $this->contexts['term'];
+    }
+
+    public function appliesToUsers(): bool
+    {
+        return $this->contexts['user'];
+    }
+
+    /**
+     * @return array{post: string[], term: string[], user: bool}
+     */
+    public function getContexts(): array
+    {
+        return $this->contexts;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function getComputedDependencyGraph(): array
+    {
+        return $this->computedGraph;
+    }
+
+    private function buildComputedGraph(): array
+    {
+        $graph = [];
+        foreach ($this->fields as $field) {
+            $deps = $field->getComputedDependencies();
+            if ($deps === []) {
+                continue;
+            }
+            $graph[$field->getKey()] = $deps;
+        }
+
+        $this->assertValidDependencies($graph);
+
+        return $graph;
+    }
+
+    private function assertValidDependencies(array $graph): void
+    {
+        foreach ($graph as $fieldKey => $dependencies) {
+            foreach ($dependencies as $dependency) {
+                if (!isset($this->fields[$dependency])) {
+                    throw new InvalidArgumentException(sprintf(
+                        'Field "%s" depends on undefined field "%s".',
+                        $fieldKey,
+                        $dependency
+                    ));
+                }
+            }
+        }
+
+        $visited = [];
+        $stack   = [];
+        foreach (array_keys($graph) as $fieldKey) {
+            if (!isset($visited[$fieldKey])) {
+                $this->assertAcyclic($fieldKey, $graph, $visited, $stack);
+            }
+        }
+    }
+
+    /**
+     * @param array<string, array<int, string>> $graph
+     * @param array<string, bool>               $visited
+     * @param array<string, bool>               $stack
+     */
+    private function assertAcyclic(string $fieldKey, array $graph, array &$visited, array &$stack): void
+    {
+        $visited[$fieldKey] = true;
+        $stack[$fieldKey]   = true;
+
+        foreach ($graph[$fieldKey] ?? [] as $dependency) {
+            if (!isset($visited[$dependency])) {
+                $this->assertAcyclic($dependency, $graph, $visited, $stack);
+                continue;
+            }
+
+            if ($stack[$dependency] ?? false) {
+                throw new InvalidArgumentException(sprintf(
+                    'Detected circular dependency involving "%s".',
+                    $dependency
+                ));
+            }
+        }
+
+        $stack[$fieldKey] = false;
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     * @return array{post: string[], term: string[], user: bool}
+     */
+    private function normalizeContexts(array $config): array
+    {
+        $contexts = $config['contexts'] ?? [];
+        if (!is_array($contexts)) {
+            $contexts = [];
+        }
+
+        if (isset($config['post_types']) && is_array($config['post_types'])) {
+            $contexts['post'] = $config['post_types'];
+        }
+
+        if (isset($config['taxonomies']) && is_array($config['taxonomies'])) {
+            $contexts['term'] = $config['taxonomies'];
+        }
+
+        if (array_key_exists('users', $config)) {
+            $contexts['user'] = (bool) $config['users'];
+        }
+
+        $postTypes = array_values(array_unique(array_filter(
+            (array) ($contexts['post'] ?? []),
+            static fn ($postType) => is_string($postType) && $postType !== ''
+        )));
+
+        $taxonomies = array_values(array_unique(array_filter(
+            (array) ($contexts['term'] ?? []),
+            static fn ($taxonomy) => is_string($taxonomy) && $taxonomy !== ''
+        )));
+
+        $userContext = $contexts['user'] ?? false;
+        if (is_array($userContext)) {
+            $userContext = $userContext !== [];
+        }
+
+        return [
+            'post' => $postTypes,
+            'term' => $taxonomies,
+            'user' => (bool) $userContext,
+        ];
+    }
+}

--- a/src/Fields/FieldGroupRegistry.php
+++ b/src/Fields/FieldGroupRegistry.php
@@ -1,0 +1,333 @@
+<?php
+
+namespace Gm2\Fields;
+
+use Gm2\Fields\Renderer\AdminMetaBox;
+use Gm2\Fields\Sanitizers\SanitizerRegistry;
+use Gm2\Fields\Storage\MetaRegistrar;
+use Gm2\Fields\Validation\ValidatorRegistry;
+use InvalidArgumentException;
+use WP_Error;
+use WP_REST_Request;
+
+final class FieldGroupRegistry
+{
+    /**
+     * @var array<string, FieldGroupDefinition>
+     */
+    private array $groups = [];
+
+    public function __construct(
+        private readonly MetaRegistrar $metaRegistrar,
+        private readonly FieldTypeRegistry $fieldTypes,
+        private readonly ValidatorRegistry $validatorRegistry,
+        private readonly SanitizerRegistry $sanitizerRegistry,
+        private readonly ?AdminMetaBox $adminRenderer = null
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    public function registerGroup(string $key, array $config): FieldGroupDefinition
+    {
+        if ($key === '') {
+            throw new InvalidArgumentException('Field group key cannot be empty.');
+        }
+
+        $fieldsConfig = $config['fields'] ?? [];
+        if (!is_array($fieldsConfig) || $fieldsConfig === []) {
+            throw new InvalidArgumentException(sprintf('Field group "%s" must define fields.', $key));
+        }
+
+        $definitions = [];
+        foreach ($fieldsConfig as $fieldKey => $settings) {
+            if (!is_string($fieldKey) || $fieldKey === '') {
+                continue;
+            }
+            if (!is_array($settings)) {
+                continue;
+            }
+            $typeName = $settings['type'] ?? 'text';
+            if (!is_string($typeName)) {
+                $typeName = 'text';
+            }
+            $fieldType = $this->fieldTypes->create($typeName, $settings);
+            $definitions[$fieldKey] = new FieldDefinition($fieldKey, $fieldType, $settings);
+        }
+
+        if ($definitions === []) {
+            throw new InvalidArgumentException(sprintf('Field group "%s" does not contain valid fields.', $key));
+        }
+
+        $group = new FieldGroupDefinition($key, $config, $definitions);
+        $this->groups[$key] = $group;
+
+        return $group;
+    }
+
+    public function hasGroup(string $key): bool
+    {
+        return isset($this->groups[$key]);
+    }
+
+    public function getGroup(string $key): FieldGroupDefinition
+    {
+        if (!isset($this->groups[$key])) {
+            throw new InvalidArgumentException(sprintf('Unknown field group "%s".', $key));
+        }
+
+        return $this->groups[$key];
+    }
+
+    /**
+     * @return array<string, FieldGroupDefinition>
+     */
+    public function all(): array
+    {
+        return $this->groups;
+    }
+
+    public function boot(): void
+    {
+        foreach ($this->groups as $group) {
+            foreach ($group->getPostTypes() as $postType) {
+                foreach ($group->getFields() as $field) {
+                    $this->metaRegistrar->registerPostField(
+                        $postType,
+                        $field,
+                        $this->createSanitizeCallback($field),
+                        $this->createValidateCallback($group, $field)
+                    );
+                }
+            }
+
+            foreach ($group->getTaxonomies() as $taxonomy) {
+                foreach ($group->getFields() as $field) {
+                    $this->metaRegistrar->registerTermField(
+                        $taxonomy,
+                        $field,
+                        $this->createSanitizeCallback($field),
+                        $this->createValidateCallback($group, $field)
+                    );
+                }
+            }
+
+            if ($group->appliesToUsers()) {
+                foreach ($group->getFields() as $field) {
+                    $this->metaRegistrar->registerUserField(
+                        $field,
+                        $this->createSanitizeCallback($field),
+                        $this->createValidateCallback($group, $field)
+                    );
+                }
+            }
+
+            if ($this->adminRenderer) {
+                $this->adminRenderer->addGroup($group);
+            }
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $values
+     * @return array<string, mixed>
+     */
+    public function sanitizeGroup(string $groupKey, array $values): array
+    {
+        $group     = $this->getGroup($groupKey);
+        $sanitized = [];
+        foreach ($group->getFields() as $field) {
+            $key          = $field->getKey();
+            $value        = $values[$key] ?? $field->getDefault();
+            $sanitized[$key] = $this->sanitizerRegistry->sanitize($field, $value, $values);
+        }
+
+        return $sanitized;
+    }
+
+    /**
+     * @param array<string, mixed> $values
+     * @return array<string, WP_Error>
+     */
+    public function validateGroup(string $groupKey, array $values): array
+    {
+        $group  = $this->getGroup($groupKey);
+        $errors = [];
+
+        foreach ($group->getFields() as $field) {
+            if ($field->isComputed()) {
+                continue;
+            }
+
+            if (!$this->shouldEvaluateField($group, $field, $values)) {
+                continue;
+            }
+
+            $value = $values[$field->getKey()] ?? null;
+            if ($field->isRequired() && $this->isEmpty($value)) {
+                $errors[$field->getKey()] = new WP_Error(
+                    'gm2_field_required',
+                    sprintf('%s is required.', $field->getLabel()),
+                    [ 'field' => $field->getKey() ]
+                );
+                continue;
+            }
+
+            $result = $this->validatorRegistry->validate($field, $value, $values);
+            if ($result instanceof WP_Error) {
+                $errors[$field->getKey()] = $result;
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function getComputedDependencyGraph(string $groupKey): array
+    {
+        return $this->getGroup($groupKey)->getComputedDependencyGraph();
+    }
+
+    private function createSanitizeCallback(FieldDefinition $field): callable
+    {
+        return function ($value, $metaKey = '', $objectType = '') use ($field) {
+            $default = $field->getDefault();
+            $value   = $value ?? $default;
+
+            return $this->sanitizerRegistry->sanitize($field, $value, [ $field->getKey() => $value ]);
+        };
+    }
+
+    private function createValidateCallback(FieldGroupDefinition $group, FieldDefinition $field): callable
+    {
+        return function ($value, $request = null, $param = '') use ($group, $field) {
+            if ($field->isComputed()) {
+                return true;
+            }
+
+            $contextValues = $this->collectContextValues($group, $request, $field, $value);
+
+            if (!$this->shouldEvaluateField($group, $field, $contextValues)) {
+                return true;
+            }
+
+            if ($field->isRequired() && $this->isEmpty($value)) {
+                return new WP_Error(
+                    'gm2_field_required',
+                    sprintf('%s is required.', $field->getLabel()),
+                    [ 'field' => $field->getKey() ]
+                );
+            }
+
+            return $this->validatorRegistry->validate($field, $value, $contextValues);
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $values
+     */
+    private function shouldEvaluateField(FieldGroupDefinition $group, FieldDefinition $field, array $values): bool
+    {
+        $conditions = $field->getConditions();
+        if ($conditions === null) {
+            return true;
+        }
+
+        $results = [];
+        foreach ($conditions['items'] as $condition) {
+            $otherKey = $condition['field'] ?? '';
+            if (!is_string($otherKey) || $otherKey === '') {
+                continue;
+            }
+            $operator = is_string($condition['operator'] ?? null) ? (string) $condition['operator'] : '==';
+            $expected = $condition['value'] ?? null;
+            $actual   = $values[$otherKey] ?? null;
+            $results[] = $this->evaluateCondition($actual, $operator, $expected);
+        }
+
+        if ($results === []) {
+            return true;
+        }
+
+        if ($conditions['relation'] === 'or') {
+            return in_array(true, $results, true);
+        }
+
+        return !in_array(false, $results, true);
+    }
+
+    private function evaluateCondition(mixed $left, string $operator, mixed $right): bool
+    {
+        return match ($operator) {
+            '===' => $left === $right,
+            '=='  => $left == $right,
+            '!='  => $left != $right,
+            '!==' => $left !== $right,
+            '>'   => is_numeric($left) && is_numeric($right) ? (float) $left > (float) $right : false,
+            '>='  => is_numeric($left) && is_numeric($right) ? (float) $left >= (float) $right : false,
+            '<'   => is_numeric($left) && is_numeric($right) ? (float) $left < (float) $right : false,
+            '<='  => is_numeric($left) && is_numeric($right) ? (float) $left <= (float) $right : false,
+            'in'  => is_array($right) ? in_array($left, $right, true) : false,
+            'not_in' => is_array($right) ? !in_array($left, $right, true) : true,
+            'contains' => $this->contains($left, $right),
+            default => $left == $right,
+        };
+    }
+
+    private function contains(mixed $left, mixed $right): bool
+    {
+        if (is_array($left)) {
+            return in_array($right, $left, true);
+        }
+        if (is_string($left) && is_string($right)) {
+            return str_contains($left, $right);
+        }
+
+        return false;
+    }
+
+    private function isEmpty(mixed $value): bool
+    {
+        if ($value === null) {
+            return true;
+        }
+        if (is_string($value)) {
+            return trim($value) === '';
+        }
+        if (is_array($value)) {
+            return $value === [];
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function collectContextValues(FieldGroupDefinition $group, mixed $request, FieldDefinition $field, mixed $value): array
+    {
+        $values = [];
+        if ($request instanceof WP_REST_Request) {
+            $meta = $request->get_param('meta');
+            foreach ($group->getFields() as $otherField) {
+                $paramValue = $request->get_param($otherField->getKey());
+                if ($paramValue !== null) {
+                    $values[$otherField->getKey()] = $paramValue;
+                    continue;
+                }
+                if (is_array($meta) && array_key_exists($otherField->getKey(), $meta)) {
+                    $values[$otherField->getKey()] = $meta[$otherField->getKey()];
+                }
+            }
+        } elseif (is_array($request)) {
+            $values = $request;
+        }
+
+        $values[$field->getKey()] = $value;
+
+        return $values;
+    }
+}

--- a/src/Fields/FieldTypeRegistry.php
+++ b/src/Fields/FieldTypeRegistry.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Gm2\Fields;
+
+use Gm2\Fields\Types\FieldTypeInterface;
+use InvalidArgumentException;
+
+final class FieldTypeRegistry
+{
+    /**
+     * @var array<string, callable(array<string, mixed>): FieldTypeInterface|class-string<FieldTypeInterface>>
+     */
+    private array $factories = [];
+
+    public static function withDefaults(): self
+    {
+        $registry = new self();
+        $registry->register('text', \Gm2\Fields\Types\TextFieldType::class);
+        $registry->register('textarea', \Gm2\Fields\Types\TextareaFieldType::class);
+        $registry->register('number', \Gm2\Fields\Types\NumberFieldType::class);
+        $registry->register('currency', \Gm2\Fields\Types\CurrencyFieldType::class);
+        $registry->register('select', \Gm2\Fields\Types\SelectFieldType::class);
+        $registry->register('multiselect', \Gm2\Fields\Types\MultiSelectFieldType::class);
+        $registry->register('radio', \Gm2\Fields\Types\RadioFieldType::class);
+        $registry->register('checkbox', \Gm2\Fields\Types\CheckboxFieldType::class);
+        $registry->register('switch', \Gm2\Fields\Types\SwitchFieldType::class);
+        $registry->register('date', \Gm2\Fields\Types\DateFieldType::class);
+        $registry->register('time', \Gm2\Fields\Types\TimeFieldType::class);
+        $registry->register('datetime_tz', \Gm2\Fields\Types\DateTimeTzFieldType::class);
+        $registry->register('daterange', \Gm2\Fields\Types\DateRangeFieldType::class);
+        $registry->register('url', \Gm2\Fields\Types\UrlFieldType::class);
+        $registry->register('email', \Gm2\Fields\Types\EmailFieldType::class);
+        $registry->register('tel', \Gm2\Fields\Types\TelFieldType::class);
+        $registry->register('color', \Gm2\Fields\Types\ColorFieldType::class);
+        $registry->register('image', \Gm2\Fields\Types\ImageFieldType::class);
+        $registry->register('gallery', \Gm2\Fields\Types\GalleryFieldType::class);
+        $registry->register('file', \Gm2\Fields\Types\FileFieldType::class);
+        $registry->register('repeater', \Gm2\Fields\Types\RepeaterFieldType::class);
+        $registry->register('group', \Gm2\Fields\Types\GroupFieldType::class);
+        $registry->register('relationship_post', \Gm2\Fields\Types\RelationshipPostFieldType::class);
+        $registry->register('relationship_term', \Gm2\Fields\Types\RelationshipTermFieldType::class);
+        $registry->register('relationship_user', \Gm2\Fields\Types\RelationshipUserFieldType::class);
+        $registry->register('geopoint', \Gm2\Fields\Types\GeopointFieldType::class);
+        $registry->register('address', \Gm2\Fields\Types\AddressFieldType::class);
+        $registry->register('wysiwyg', \Gm2\Fields\Types\WysiwygFieldType::class);
+        $registry->register('computed', \Gm2\Fields\Types\ComputedFieldType::class);
+
+        return $registry;
+    }
+
+    /**
+     * @param callable(array<string, mixed>): FieldTypeInterface|class-string<FieldTypeInterface> $factory
+     */
+    public function register(string $type, callable|string $factory): void
+    {
+        $this->factories[$type] = $factory;
+    }
+
+    /**
+     * @param array<string, mixed> $settings
+     */
+    public function create(string $type, array $settings): FieldTypeInterface
+    {
+        if (!isset($this->factories[$type])) {
+            throw new InvalidArgumentException(sprintf('Unknown field type "%s".', $type));
+        }
+
+        $factory = $this->factories[$type];
+
+        if (is_string($factory)) {
+            $instance = new $factory();
+            if (!$instance instanceof FieldTypeInterface) {
+                throw new InvalidArgumentException(sprintf('Factory for "%s" must return FieldTypeInterface.', $type));
+            }
+
+            return $instance;
+        }
+
+        $instance = $factory($settings);
+        if (!$instance instanceof FieldTypeInterface) {
+            throw new InvalidArgumentException(sprintf('Factory for "%s" must return FieldTypeInterface.', $type));
+        }
+
+        return $instance;
+    }
+}

--- a/src/Fields/Renderer/AdminMetaBox.php
+++ b/src/Fields/Renderer/AdminMetaBox.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Gm2\Fields\Renderer;
+
+use Gm2\Fields\FieldDefinition;
+use Gm2\Fields\FieldGroupDefinition;
+
+final class AdminMetaBox
+{
+    /**
+     * @var array<string, FieldGroupDefinition>
+     */
+    private array $groups = [];
+
+    private bool $hooksRegistered = false;
+
+    public function addGroup(FieldGroupDefinition $group): void
+    {
+        $this->groups[$group->getKey()] = $group;
+        if (!$this->hooksRegistered) {
+            $this->registerHooks();
+            $this->hooksRegistered = true;
+        }
+    }
+
+    private function registerHooks(): void
+    {
+        add_action('add_meta_boxes', [ $this, 'registerMetaBoxes' ]);
+        add_action('admin_enqueue_scripts', [ $this, 'enqueueAdminAssets' ]);
+        add_action('enqueue_block_editor_assets', [ $this, 'enqueueBlockEditorAssets' ]);
+    }
+
+    public function registerMetaBoxes(string $postType): void
+    {
+        foreach ($this->groups as $group) {
+            if (!in_array($postType, $group->getPostTypes(), true)) {
+                continue;
+            }
+
+            add_meta_box(
+                'gm2_fields_' . $group->getKey(),
+                $group->getTitle(),
+                function ($post) use ($group) {
+                    $this->renderGroupMetaBox($group, (int) $post->ID);
+                },
+                $postType,
+                'side',
+                'default'
+            );
+        }
+    }
+
+    public function enqueueAdminAssets(): void
+    {
+        if ($this->groups === []) {
+            return;
+        }
+
+        wp_enqueue_script('jquery');
+        wp_add_inline_script('jquery', $this->buildConditionalScript(), 'after');
+    }
+
+    public function enqueueBlockEditorAssets(): void
+    {
+        if ($this->groups === []) {
+            return;
+        }
+
+        $data = $this->prepareGroupData();
+        wp_enqueue_script('wp-blocks');
+        wp_add_inline_script('wp-blocks', 'window.GM2FieldGroups = ' . wp_json_encode($data) . ';', 'before');
+    }
+
+    private function renderGroupMetaBox(FieldGroupDefinition $group, int $postId): void
+    {
+        wp_nonce_field('gm2_fields_' . $group->getKey(), 'gm2_fields_nonce_' . $group->getKey());
+
+        echo '<div class="gm2-field-group" data-field-group="' . esc_attr($group->getKey()) . '">';
+        foreach ($group->getFields() as $field) {
+            $value = get_post_meta($postId, $field->getKey(), true);
+            $this->renderFieldControl($field, $value);
+        }
+        echo '</div>';
+    }
+
+    private function renderFieldControl(FieldDefinition $field, mixed $value): void
+    {
+        $conditions = $field->getConditions();
+        $dataAttr   = $conditions ? esc_attr(wp_json_encode($conditions)) : '';
+        $id         = 'gm2_field_' . $field->getKey();
+
+        echo '<p class="gm2-field" data-field-key="' . esc_attr($field->getKey()) . '" data-conditions="' . $dataAttr . '">';
+        echo '<label for="' . esc_attr($id) . '">' . esc_html($field->getLabel()) . '</label>';
+        echo '<input type="text" class="widefat" name="' . esc_attr($field->getKey()) . '" id="' . esc_attr($id) . '" value="' . esc_attr(is_scalar($value) ? (string) $value : '') . '" />';
+        echo '</p>';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function prepareGroupData(): array
+    {
+        $data = [];
+        foreach ($this->groups as $group) {
+            $fields = [];
+            foreach ($group->getFields() as $field) {
+                $fields[] = [
+                    'key'        => $field->getKey(),
+                    'label'      => $field->getLabel(),
+                    'type'       => $field->getType()->getName(),
+                    'conditions' => $field->getConditions(),
+                ];
+            }
+            $data[] = [
+                'key'        => $group->getKey(),
+                'title'      => $group->getTitle(),
+                'post_types' => $group->getPostTypes(),
+                'fields'     => $fields,
+            ];
+        }
+
+        return $data;
+    }
+
+    private function buildConditionalScript(): string
+    {
+        $data = $this->prepareGroupData();
+        $json = wp_json_encode($data);
+
+        return 'window.GM2FieldGroups = ' . $json . ';' .
+            'jQuery(function($){' .
+            'const groups = window.GM2FieldGroups || [];'
+            . 'groups.forEach(function(group){'
+            . 'const container = $(".gm2-field-group[data-field-group="+group.key+"]");'
+            . 'group.fields.forEach(function(field){'
+            . 'const el = container.find("[data-field-key="+field.key+"]");'
+            . 'if(!field.conditions){return;}'
+            . 'const evaluate = function(){'
+            . 'let visible = field.conditions.items.every(function(condition){'
+            . 'const other = container.find("[name="+condition.field+"]");'
+            . 'if(!other.length){return true;}'
+            . 'const value = other.val();'
+            . 'switch(condition.operator){case "==": return value == condition.value;'
+            . 'case "!=": return value != condition.value; default: return true;}'
+            . '});'
+            . 'if(field.conditions.relation === "or"){visible = false; field.conditions.items.forEach(function(condition){'
+            . 'const other = container.find("[name="+condition.field+"]");'
+            . 'if(!other.length){return;}'
+            . 'const value = other.val();'
+            . 'if((condition.operator === "==" && value == condition.value) || (condition.operator === "!=" && value != condition.value)){visible = true;}'
+            . '});}'
+            . 'el.toggle(visible);'
+            . '};'
+            . 'container.on("change", "input, select", evaluate);'
+            . 'evaluate();'
+            . '});'
+            . '});'
+            . '});';
+    }
+}

--- a/src/Fields/Sanitizers/AbstractRelationshipSanitizer.php
+++ b/src/Fields/Sanitizers/AbstractRelationshipSanitizer.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Gm2\Fields\Sanitizers;
+
+use Gm2\Fields\FieldDefinition;
+
+abstract class AbstractRelationshipSanitizer implements FieldSanitizerInterface
+{
+    public function sanitize(FieldDefinition $field, mixed $value, array $context = []): mixed
+    {
+        $multiple = (bool) ($field->getSettings()['multiple'] ?? true);
+        if ($multiple) {
+            if (!is_array($value)) {
+                return [];
+            }
+
+            return array_values(array_filter(
+                array_map(
+                    static fn ($item) => is_numeric($item) ? (int) $item : null,
+                    $value
+                ),
+                static fn ($item) => $item !== null
+            ));
+        }
+
+        if (is_numeric($value)) {
+            return (int) $value;
+        }
+
+        return null;
+    }
+}

--- a/src/Fields/Sanitizers/AddressSanitizer.php
+++ b/src/Fields/Sanitizers/AddressSanitizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Gm2\Fields\Sanitizers;
+
+use Gm2\Fields\FieldDefinition;
+
+final class AddressSanitizer implements FieldSanitizerInterface
+{
+    public function sanitize(FieldDefinition $field, mixed $value, array $context = []): mixed
+    {
+        if (!is_array($value)) {
+            $value = [];
+        }
+
+        $keys = [ 'line1', 'line2', 'city', 'state', 'postal_code', 'country' ];
+        $sanitized = [];
+        foreach ($keys as $key) {
+            $sanitized[$key] = isset($value[$key]) ? sanitize_text_field((string) $value[$key]) : '';
+        }
+
+        return $sanitized;
+    }
+}

--- a/src/Fields/Sanitizers/CheckboxSanitizer.php
+++ b/src/Fields/Sanitizers/CheckboxSanitizer.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Gm2\Fields\Sanitizers;
+
+use Gm2\Fields\FieldDefinition;
+
+final class CheckboxSanitizer implements FieldSanitizerInterface
+{
+    public function sanitize(FieldDefinition $field, mixed $value, array $context = []): mixed
+    {
+        if ($value === null) {
+            return false;
+        }
+
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_string($value)) {
+            $value = strtolower($value);
+            return in_array($value, [ '1', 'true', 'yes', 'on' ], true);
+        }
+
+        return (bool) $value;
+    }
+}

--- a/src/Fields/Sanitizers/ColorSanitizer.php
+++ b/src/Fields/Sanitizers/ColorSanitizer.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Gm2\Fields\Sanitizers;
+
+use Gm2\Fields\FieldDefinition;
+
+final class ColorSanitizer implements FieldSanitizerInterface
+{
+    public function sanitize(FieldDefinition $field, mixed $value, array $context = []): mixed
+    {
+        if (!is_string($value) && !is_scalar($value)) {
+            return $value;
+        }
+
+        $value = strtoupper((string) $value);
+        if (!str_starts_with($value, '#')) {
+            $value = '#' . ltrim($value, '#');
+        }
+
+        return $value;
+    }
+}

--- a/src/Fields/Sanitizers/ComputedSanitizer.php
+++ b/src/Fields/Sanitizers/ComputedSanitizer.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Gm2\Fields\Sanitizers;
+
+use Gm2\Fields\FieldDefinition;
+
+final class ComputedSanitizer implements FieldSanitizerInterface
+{
+    public function sanitize(FieldDefinition $field, mixed $value, array $context = []): mixed
+    {
+        return $value;
+    }
+}

--- a/src/Fields/Sanitizers/CurrencySanitizer.php
+++ b/src/Fields/Sanitizers/CurrencySanitizer.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Gm2\Fields\Sanitizers;
+
+use Gm2\Fields\FieldDefinition;
+
+final class CurrencySanitizer implements FieldSanitizerInterface
+{
+    public function sanitize(FieldDefinition $field, mixed $value, array $context = []): mixed
+    {
+        if ($value === null || $value === '') {
+            return $value;
+        }
+
+        if (is_numeric($value)) {
+            return round((float) $value, 2);
+        }
+
+        return $value;
+    }
+}

--- a/src/Fields/Sanitizers/DateRangeSanitizer.php
+++ b/src/Fields/Sanitizers/DateRangeSanitizer.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Gm2\Fields\Sanitizers;
+
+use Gm2\Fields\FieldDefinition;
+
+final class DateRangeSanitizer implements FieldSanitizerInterface
+{
+    public function sanitize(FieldDefinition $field, mixed $value, array $context = []): mixed
+    {
+        if (!is_array($value)) {
+            return [ 'start' => '', 'end' => '' ];
+        }
+
+        $start = isset($value['start']) ? sanitize_text_field((string) $value['start']) : '';
+        $end   = isset($value['end']) ? sanitize_text_field((string) $value['end']) : '';
+
+        return [ 'start' => $start, 'end' => $end ];
+    }
+}

--- a/src/Fields/Sanitizers/DateSanitizer.php
+++ b/src/Fields/Sanitizers/DateSanitizer.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Gm2\Fields\Sanitizers;
+
+use Gm2\Fields\FieldDefinition;
+
+final class DateSanitizer implements FieldSanitizerInterface
+{
+    public function sanitize(FieldDefinition $field, mixed $value, array $context = []): mixed
+    {
+        if (!is_string($value) && !is_scalar($value)) {
+            return $value;
+        }
+
+        return sanitize_text_field((string) $value);
+    }
+}

--- a/src/Fields/Sanitizers/DateTimeTzSanitizer.php
+++ b/src/Fields/Sanitizers/DateTimeTzSanitizer.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Gm2\Fields\Sanitizers;
+
+use Gm2\Fields\FieldDefinition;
+
+final class DateTimeTzSanitizer implements FieldSanitizerInterface
+{
+    public function sanitize(FieldDefinition $field, mixed $value, array $context = []): mixed
+    {
+        if (!is_string($value) && !is_scalar($value)) {
+            return $value;
+        }
+
+        return sanitize_text_field((string) $value);
+    }
+}

--- a/src/Fields/Sanitizers/EmailSanitizer.php
+++ b/src/Fields/Sanitizers/EmailSanitizer.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Gm2\Fields\Sanitizers;
+
+use Gm2\Fields\FieldDefinition;
+
+final class EmailSanitizer implements FieldSanitizerInterface
+{
+    public function sanitize(FieldDefinition $field, mixed $value, array $context = []): mixed
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!is_string($value) && !is_scalar($value)) {
+            return $value;
+        }
+
+        return sanitize_email((string) $value);
+    }
+}

--- a/src/Fields/Sanitizers/FieldSanitizerInterface.php
+++ b/src/Fields/Sanitizers/FieldSanitizerInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Gm2\Fields\Sanitizers;
+
+use Gm2\Fields\FieldDefinition;
+
+interface FieldSanitizerInterface
+{
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function sanitize(FieldDefinition $field, mixed $value, array $context = []): mixed;
+}

--- a/src/Fields/Sanitizers/FileSanitizer.php
+++ b/src/Fields/Sanitizers/FileSanitizer.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Gm2\Fields\Sanitizers;
+
+use Gm2\Fields\FieldDefinition;
+
+final class FileSanitizer implements FieldSanitizerInterface
+{
+    public function sanitize(FieldDefinition $field, mixed $value, array $context = []): mixed
+    {
+        if (is_numeric($value)) {
+            return (int) $value;
+        }
+
+        return null;
+    }
+}

--- a/src/Fields/Sanitizers/GallerySanitizer.php
+++ b/src/Fields/Sanitizers/GallerySanitizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Gm2\Fields\Sanitizers;
+
+use Gm2\Fields\FieldDefinition;
+
+final class GallerySanitizer implements FieldSanitizerInterface
+{
+    public function sanitize(FieldDefinition $field, mixed $value, array $context = []): mixed
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+
+        return array_values(array_filter(
+            array_map(
+                static fn ($item) => is_numeric($item) ? (int) $item : null,
+                $value
+            ),
+            static fn ($item) => $item !== null
+        ));
+    }
+}

--- a/src/Fields/Sanitizers/GeopointSanitizer.php
+++ b/src/Fields/Sanitizers/GeopointSanitizer.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Gm2\Fields\Sanitizers;
+
+use Gm2\Fields\FieldDefinition;
+
+final class GeopointSanitizer implements FieldSanitizerInterface
+{
+    public function sanitize(FieldDefinition $field, mixed $value, array $context = []): mixed
+    {
+        if (!is_array($value)) {
+            return [ 'lat' => null, 'lng' => null ];
+        }
+
+        $lat = isset($value['lat']) && is_numeric($value['lat']) ? (float) $value['lat'] : null;
+        $lng = isset($value['lng']) && is_numeric($value['lng']) ? (float) $value['lng'] : null;
+
+        return [ 'lat' => $lat, 'lng' => $lng ];
+    }
+}

--- a/src/Fields/Sanitizers/GroupSanitizer.php
+++ b/src/Fields/Sanitizers/GroupSanitizer.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Gm2\Fields\Sanitizers;
+
+use Gm2\Fields\FieldDefinition;
+
+final class GroupSanitizer implements FieldSanitizerInterface
+{
+    public function sanitize(FieldDefinition $field, mixed $value, array $context = []): mixed
+    {
+        return is_array($value) ? $value : [];
+    }
+}

--- a/src/Fields/Sanitizers/ImageSanitizer.php
+++ b/src/Fields/Sanitizers/ImageSanitizer.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Gm2\Fields\Sanitizers;
+
+use Gm2\Fields\FieldDefinition;
+
+final class ImageSanitizer implements FieldSanitizerInterface
+{
+    public function sanitize(FieldDefinition $field, mixed $value, array $context = []): mixed
+    {
+        if (is_numeric($value)) {
+            return (int) $value;
+        }
+
+        return null;
+    }
+}

--- a/src/Fields/Sanitizers/MultiSelectSanitizer.php
+++ b/src/Fields/Sanitizers/MultiSelectSanitizer.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Gm2\Fields\Sanitizers;
+
+use Gm2\Fields\FieldDefinition;
+
+final class MultiSelectSanitizer implements FieldSanitizerInterface
+{
+    public function sanitize(FieldDefinition $field, mixed $value, array $context = []): mixed
+    {
+        if ($value === null) {
+            return [];
+        }
+
+        if (!is_array($value)) {
+            return [];
+        }
+
+        $options = $field->getOptions();
+        $sanitized = [];
+        foreach ($value as $item) {
+            if (!is_scalar($item)) {
+                continue;
+            }
+            $item = (string) $item;
+            if ($options !== [] && !array_key_exists($item, $options)) {
+                continue;
+            }
+            $sanitized[] = sanitize_text_field($item);
+        }
+
+        return array_values(array_unique($sanitized));
+    }
+}

--- a/src/Fields/Sanitizers/NumberSanitizer.php
+++ b/src/Fields/Sanitizers/NumberSanitizer.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Gm2\Fields\Sanitizers;
+
+use Gm2\Fields\FieldDefinition;
+
+final class NumberSanitizer implements FieldSanitizerInterface
+{
+    public function sanitize(FieldDefinition $field, mixed $value, array $context = []): mixed
+    {
+        if ($value === null || $value === '') {
+            return $value;
+        }
+
+        if (is_numeric($value)) {
+            return (float) $value;
+        }
+
+        return $value;
+    }
+}

--- a/src/Fields/Sanitizers/RadioSanitizer.php
+++ b/src/Fields/Sanitizers/RadioSanitizer.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Gm2\Fields\Sanitizers;
+
+use Gm2\Fields\FieldDefinition;
+
+final class RadioSanitizer implements FieldSanitizerInterface
+{
+    public function sanitize(FieldDefinition $field, mixed $value, array $context = []): mixed
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!is_scalar($value)) {
+            return null;
+        }
+
+        $value   = (string) $value;
+        $options = $field->getOptions();
+        if ($options !== [] && !array_key_exists($value, $options)) {
+            return null;
+        }
+
+        return sanitize_text_field($value);
+    }
+}

--- a/src/Fields/Sanitizers/RelationshipPostSanitizer.php
+++ b/src/Fields/Sanitizers/RelationshipPostSanitizer.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Gm2\Fields\Sanitizers;
+
+final class RelationshipPostSanitizer extends AbstractRelationshipSanitizer
+{
+}

--- a/src/Fields/Sanitizers/RelationshipTermSanitizer.php
+++ b/src/Fields/Sanitizers/RelationshipTermSanitizer.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Gm2\Fields\Sanitizers;
+
+final class RelationshipTermSanitizer extends AbstractRelationshipSanitizer
+{
+}

--- a/src/Fields/Sanitizers/RelationshipUserSanitizer.php
+++ b/src/Fields/Sanitizers/RelationshipUserSanitizer.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Gm2\Fields\Sanitizers;
+
+final class RelationshipUserSanitizer extends AbstractRelationshipSanitizer
+{
+}

--- a/src/Fields/Sanitizers/RepeaterSanitizer.php
+++ b/src/Fields/Sanitizers/RepeaterSanitizer.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Gm2\Fields\Sanitizers;
+
+use Gm2\Fields\FieldDefinition;
+
+final class RepeaterSanitizer implements FieldSanitizerInterface
+{
+    public function sanitize(FieldDefinition $field, mixed $value, array $context = []): mixed
+    {
+        return is_array($value) ? array_values($value) : [];
+    }
+}

--- a/src/Fields/Sanitizers/SanitizerRegistry.php
+++ b/src/Fields/Sanitizers/SanitizerRegistry.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Gm2\Fields\Sanitizers;
+
+use Gm2\Fields\FieldDefinition;
+use InvalidArgumentException;
+
+final class SanitizerRegistry
+{
+    /**
+     * @var array<string, FieldSanitizerInterface>
+     */
+    private array $sanitizers = [];
+
+    public static function withDefaults(): self
+    {
+        $registry = new self();
+        $registry->register('text', new TextSanitizer());
+        $registry->register('textarea', new TextareaSanitizer());
+        $registry->register('number', new NumberSanitizer());
+        $registry->register('currency', new CurrencySanitizer());
+        $registry->register('select', new SelectSanitizer());
+        $registry->register('multiselect', new MultiSelectSanitizer());
+        $registry->register('radio', new RadioSanitizer());
+        $registry->register('checkbox', new CheckboxSanitizer());
+        $registry->register('switch', new SwitchSanitizer());
+        $registry->register('date', new DateSanitizer());
+        $registry->register('time', new TimeSanitizer());
+        $registry->register('datetime_tz', new DateTimeTzSanitizer());
+        $registry->register('daterange', new DateRangeSanitizer());
+        $registry->register('url', new UrlSanitizer());
+        $registry->register('email', new EmailSanitizer());
+        $registry->register('tel', new TelSanitizer());
+        $registry->register('color', new ColorSanitizer());
+        $registry->register('image', new ImageSanitizer());
+        $registry->register('gallery', new GallerySanitizer());
+        $registry->register('file', new FileSanitizer());
+        $registry->register('repeater', new RepeaterSanitizer());
+        $registry->register('group', new GroupSanitizer());
+        $registry->register('relationship_post', new RelationshipPostSanitizer());
+        $registry->register('relationship_term', new RelationshipTermSanitizer());
+        $registry->register('relationship_user', new RelationshipUserSanitizer());
+        $registry->register('geopoint', new GeopointSanitizer());
+        $registry->register('address', new AddressSanitizer());
+        $registry->register('wysiwyg', new WysiwygSanitizer());
+        $registry->register('computed', new ComputedSanitizer());
+
+        return $registry;
+    }
+
+    public function register(string $type, FieldSanitizerInterface $sanitizer): void
+    {
+        $this->sanitizers[$type] = $sanitizer;
+    }
+
+    public function get(string $type): FieldSanitizerInterface
+    {
+        if (!isset($this->sanitizers[$type])) {
+            throw new InvalidArgumentException(sprintf('No sanitizer registered for "%s".', $type));
+        }
+
+        return $this->sanitizers[$type];
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function sanitize(FieldDefinition $field, mixed $value, array $context = []): mixed
+    {
+        $type = $field->getType()->getName();
+        if (!isset($this->sanitizers[$type])) {
+            return $value;
+        }
+
+        return $this->sanitizers[$type]->sanitize($field, $value, $context);
+    }
+}

--- a/src/Fields/Sanitizers/SelectSanitizer.php
+++ b/src/Fields/Sanitizers/SelectSanitizer.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Gm2\Fields\Sanitizers;
+
+use Gm2\Fields\FieldDefinition;
+
+final class SelectSanitizer implements FieldSanitizerInterface
+{
+    public function sanitize(FieldDefinition $field, mixed $value, array $context = []): mixed
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!is_scalar($value)) {
+            return $value;
+        }
+
+        $value   = (string) $value;
+        $options = $field->getOptions();
+        if ($options !== [] && !array_key_exists($value, $options)) {
+            return null;
+        }
+
+        return sanitize_text_field($value);
+    }
+}

--- a/src/Fields/Sanitizers/SwitchSanitizer.php
+++ b/src/Fields/Sanitizers/SwitchSanitizer.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Gm2\Fields\Sanitizers;
+
+use Gm2\Fields\FieldDefinition;
+
+final class SwitchSanitizer implements FieldSanitizerInterface
+{
+    public function sanitize(FieldDefinition $field, mixed $value, array $context = []): mixed
+    {
+        if ($value === null) {
+            return false;
+        }
+
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_string($value)) {
+            $value = strtolower($value);
+            return in_array($value, [ '1', 'true', 'yes', 'on' ], true);
+        }
+
+        return (bool) $value;
+    }
+}

--- a/src/Fields/Sanitizers/TelSanitizer.php
+++ b/src/Fields/Sanitizers/TelSanitizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Gm2\Fields\Sanitizers;
+
+use Gm2\Fields\FieldDefinition;
+
+final class TelSanitizer implements FieldSanitizerInterface
+{
+    public function sanitize(FieldDefinition $field, mixed $value, array $context = []): mixed
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!is_string($value) && !is_scalar($value)) {
+            return $value;
+        }
+
+        $value = (string) $value;
+
+        return preg_replace('/[^0-9+()\s\.-]/', '', $value);
+    }
+}

--- a/src/Fields/Sanitizers/TextSanitizer.php
+++ b/src/Fields/Sanitizers/TextSanitizer.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Gm2\Fields\Sanitizers;
+
+use Gm2\Fields\FieldDefinition;
+
+final class TextSanitizer implements FieldSanitizerInterface
+{
+    public function sanitize(FieldDefinition $field, mixed $value, array $context = []): mixed
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_scalar($value)) {
+            return sanitize_text_field((string) $value);
+        }
+
+        return $value;
+    }
+}

--- a/src/Fields/Sanitizers/TextareaSanitizer.php
+++ b/src/Fields/Sanitizers/TextareaSanitizer.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Gm2\Fields\Sanitizers;
+
+use Gm2\Fields\FieldDefinition;
+
+final class TextareaSanitizer implements FieldSanitizerInterface
+{
+    public function sanitize(FieldDefinition $field, mixed $value, array $context = []): mixed
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_scalar($value)) {
+            return wp_kses_post((string) $value);
+        }
+
+        return $value;
+    }
+}

--- a/src/Fields/Sanitizers/TimeSanitizer.php
+++ b/src/Fields/Sanitizers/TimeSanitizer.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Gm2\Fields\Sanitizers;
+
+use Gm2\Fields\FieldDefinition;
+
+final class TimeSanitizer implements FieldSanitizerInterface
+{
+    public function sanitize(FieldDefinition $field, mixed $value, array $context = []): mixed
+    {
+        if (!is_string($value) && !is_scalar($value)) {
+            return $value;
+        }
+
+        return sanitize_text_field((string) $value);
+    }
+}

--- a/src/Fields/Sanitizers/UrlSanitizer.php
+++ b/src/Fields/Sanitizers/UrlSanitizer.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Gm2\Fields\Sanitizers;
+
+use Gm2\Fields\FieldDefinition;
+
+final class UrlSanitizer implements FieldSanitizerInterface
+{
+    public function sanitize(FieldDefinition $field, mixed $value, array $context = []): mixed
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!is_string($value) && !is_scalar($value)) {
+            return $value;
+        }
+
+        return esc_url_raw((string) $value);
+    }
+}

--- a/src/Fields/Sanitizers/WysiwygSanitizer.php
+++ b/src/Fields/Sanitizers/WysiwygSanitizer.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Gm2\Fields\Sanitizers;
+
+use Gm2\Fields\FieldDefinition;
+
+final class WysiwygSanitizer implements FieldSanitizerInterface
+{
+    public function sanitize(FieldDefinition $field, mixed $value, array $context = []): mixed
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_scalar($value)) {
+            return wp_kses_post((string) $value);
+        }
+
+        return $value;
+    }
+}

--- a/src/Fields/Storage/MetaRegistrar.php
+++ b/src/Fields/Storage/MetaRegistrar.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Gm2\Fields\Storage;
+
+use Gm2\Fields\FieldDefinition;
+
+final class MetaRegistrar
+{
+    public function registerPostField(string $postType, FieldDefinition $field, callable $sanitize, callable $validate): void
+    {
+        register_post_meta(
+            $postType,
+            $field->getKey(),
+            $this->buildArgs($field, $sanitize, $validate, 'post', $postType)
+        );
+    }
+
+    public function registerTermField(string $taxonomy, FieldDefinition $field, callable $sanitize, callable $validate): void
+    {
+        register_term_meta(
+            $taxonomy,
+            $field->getKey(),
+            $this->buildArgs($field, $sanitize, $validate, 'term', $taxonomy)
+        );
+    }
+
+    public function registerUserField(FieldDefinition $field, callable $sanitize, callable $validate): void
+    {
+        register_meta(
+            'user',
+            $field->getKey(),
+            $this->buildArgs($field, $sanitize, $validate, 'user', null)
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildArgs(FieldDefinition $field, callable $sanitize, callable $validate, string $objectType, ?string $subType): array
+    {
+        $schema     = $field->getType()->getSchema($field->getSettings());
+        $baseRest   = $field->getType()->getRestSettings($field->getSettings());
+        $customRest = $field->getRestSettings();
+        $showInRest = array_replace_recursive($baseRest, $customRest);
+
+        if (!isset($showInRest['schema'])) {
+            $showInRest['schema'] = $schema;
+        }
+
+        $args = [
+            'type'              => $schema['type'] ?? 'string',
+            'single'            => $field->getType()->isSingle($field->getSettings()),
+            'sanitize_callback' => $sanitize,
+            'validate_callback' => $validate,
+            'auth_callback'     => static fn () => true,
+            'default'           => $field->getDefault(),
+            'show_in_rest'      => $showInRest,
+        ];
+
+        if ($field->getDescription() !== null) {
+            $args['description'] = $field->getDescription();
+        }
+
+        if ($objectType === 'post' || $objectType === 'term') {
+            $args['object_subtype'] = $subType;
+        }
+
+        return $args;
+    }
+}

--- a/src/Fields/Types/AbstractFieldType.php
+++ b/src/Fields/Types/AbstractFieldType.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Gm2\Fields\Types;
+
+abstract class AbstractFieldType implements FieldTypeInterface
+{
+    public function getRestSettings(array $settings): array
+    {
+        return [
+            'schema' => $this->getSchema($settings),
+        ];
+    }
+
+    public function isSingle(array $settings): bool
+    {
+        return !($settings['multiple'] ?? false);
+    }
+}

--- a/src/Fields/Types/AbstractRelationshipFieldType.php
+++ b/src/Fields/Types/AbstractRelationshipFieldType.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Gm2\Fields\Types;
+
+abstract class AbstractRelationshipFieldType extends AbstractFieldType
+{
+    public function getSchema(array $settings): array
+    {
+        $multiple = (bool) ($settings['multiple'] ?? true);
+        if ($multiple) {
+            return [
+                'type'  => 'array',
+                'items' => [ 'type' => 'integer', 'minimum' => 1 ],
+            ];
+        }
+
+        return [
+            'type'    => 'integer',
+            'minimum' => 1,
+        ];
+    }
+
+    public function isSingle(array $settings): bool
+    {
+        return true;
+    }
+}

--- a/src/Fields/Types/AddressFieldType.php
+++ b/src/Fields/Types/AddressFieldType.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Gm2\Fields\Types;
+
+final class AddressFieldType extends AbstractFieldType
+{
+    public function getName(): string
+    {
+        return 'address';
+    }
+
+    public function getSchema(array $settings): array
+    {
+        return [
+            'type'                 => 'object',
+            'properties'           => [
+                'line1'       => [ 'type' => 'string' ],
+                'line2'       => [ 'type' => 'string' ],
+                'city'        => [ 'type' => 'string' ],
+                'state'       => [ 'type' => 'string' ],
+                'postal_code' => [ 'type' => 'string' ],
+                'country'     => [ 'type' => 'string' ],
+            ],
+            'additionalProperties' => false,
+        ];
+    }
+}

--- a/src/Fields/Types/CheckboxFieldType.php
+++ b/src/Fields/Types/CheckboxFieldType.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Gm2\Fields\Types;
+
+final class CheckboxFieldType extends AbstractFieldType
+{
+    public function getName(): string
+    {
+        return 'checkbox';
+    }
+
+    public function getSchema(array $settings): array
+    {
+        return [ 'type' => 'boolean' ];
+    }
+}

--- a/src/Fields/Types/ColorFieldType.php
+++ b/src/Fields/Types/ColorFieldType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Gm2\Fields\Types;
+
+final class ColorFieldType extends AbstractFieldType
+{
+    public function getName(): string
+    {
+        return 'color';
+    }
+
+    public function getSchema(array $settings): array
+    {
+        return [
+            'type'    => 'string',
+            'pattern' => '^#(?:[0-9a-fA-F]{3}){1,2}$',
+        ];
+    }
+}

--- a/src/Fields/Types/ComputedFieldType.php
+++ b/src/Fields/Types/ComputedFieldType.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Gm2\Fields\Types;
+
+final class ComputedFieldType extends AbstractFieldType
+{
+    public function getName(): string
+    {
+        return 'computed';
+    }
+
+    public function getSchema(array $settings): array
+    {
+        $schema = $settings['schema'] ?? null;
+        if (is_array($schema)) {
+            return $schema;
+        }
+
+        $type = $settings['return_type'] ?? 'string';
+        if (!in_array($type, [ 'string', 'number', 'integer', 'boolean', 'array', 'object' ], true)) {
+            $type = 'string';
+        }
+
+        return [ 'type' => $type ];
+    }
+}

--- a/src/Fields/Types/CurrencyFieldType.php
+++ b/src/Fields/Types/CurrencyFieldType.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Gm2\Fields\Types;
+
+final class CurrencyFieldType extends AbstractFieldType
+{
+    public function getName(): string
+    {
+        return 'currency';
+    }
+
+    public function getSchema(array $settings): array
+    {
+        $schema = [
+            'type'       => 'number',
+            'multipleOf' => 0.01,
+        ];
+
+        if (isset($settings['minimum']) && is_numeric($settings['minimum'])) {
+            $schema['minimum'] = (float) $settings['minimum'];
+        }
+        if (isset($settings['maximum']) && is_numeric($settings['maximum'])) {
+            $schema['maximum'] = (float) $settings['maximum'];
+        }
+
+        return $schema;
+    }
+}

--- a/src/Fields/Types/DateFieldType.php
+++ b/src/Fields/Types/DateFieldType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Gm2\Fields\Types;
+
+final class DateFieldType extends AbstractFieldType
+{
+    public function getName(): string
+    {
+        return 'date';
+    }
+
+    public function getSchema(array $settings): array
+    {
+        return [
+            'type'   => 'string',
+            'format' => 'date',
+        ];
+    }
+}

--- a/src/Fields/Types/DateRangeFieldType.php
+++ b/src/Fields/Types/DateRangeFieldType.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Gm2\Fields\Types;
+
+final class DateRangeFieldType extends AbstractFieldType
+{
+    public function getName(): string
+    {
+        return 'daterange';
+    }
+
+    public function getSchema(array $settings): array
+    {
+        return [
+            'type'                 => 'object',
+            'properties'           => [
+                'start' => [ 'type' => 'string', 'format' => 'date' ],
+                'end'   => [ 'type' => 'string', 'format' => 'date' ],
+            ],
+            'required'             => [ 'start', 'end' ],
+            'additionalProperties' => false,
+        ];
+    }
+}

--- a/src/Fields/Types/DateTimeTzFieldType.php
+++ b/src/Fields/Types/DateTimeTzFieldType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Gm2\Fields\Types;
+
+final class DateTimeTzFieldType extends AbstractFieldType
+{
+    public function getName(): string
+    {
+        return 'datetime_tz';
+    }
+
+    public function getSchema(array $settings): array
+    {
+        return [
+            'type'   => 'string',
+            'format' => 'date-time',
+        ];
+    }
+}

--- a/src/Fields/Types/EmailFieldType.php
+++ b/src/Fields/Types/EmailFieldType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Gm2\Fields\Types;
+
+final class EmailFieldType extends AbstractFieldType
+{
+    public function getName(): string
+    {
+        return 'email';
+    }
+
+    public function getSchema(array $settings): array
+    {
+        return [
+            'type'   => 'string',
+            'format' => 'email',
+        ];
+    }
+}

--- a/src/Fields/Types/FieldTypeInterface.php
+++ b/src/Fields/Types/FieldTypeInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Gm2\Fields\Types;
+
+interface FieldTypeInterface
+{
+    public function getName(): string;
+
+    /**
+     * @param array<string, mixed> $settings
+     * @return array<string, mixed>
+     */
+    public function getSchema(array $settings): array;
+
+    /**
+     * @param array<string, mixed> $settings
+     * @return array<string, mixed>
+     */
+    public function getRestSettings(array $settings): array;
+
+    /**
+     * @param array<string, mixed> $settings
+     */
+    public function isSingle(array $settings): bool;
+}

--- a/src/Fields/Types/FileFieldType.php
+++ b/src/Fields/Types/FileFieldType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Gm2\Fields\Types;
+
+final class FileFieldType extends AbstractFieldType
+{
+    public function getName(): string
+    {
+        return 'file';
+    }
+
+    public function getSchema(array $settings): array
+    {
+        return [
+            'type'    => 'integer',
+            'minimum' => 1,
+        ];
+    }
+}

--- a/src/Fields/Types/GalleryFieldType.php
+++ b/src/Fields/Types/GalleryFieldType.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Gm2\Fields\Types;
+
+final class GalleryFieldType extends AbstractFieldType
+{
+    public function getName(): string
+    {
+        return 'gallery';
+    }
+
+    public function getSchema(array $settings): array
+    {
+        return [
+            'type'  => 'array',
+            'items' => [
+                'type'    => 'integer',
+                'minimum' => 1,
+            ],
+        ];
+    }
+}

--- a/src/Fields/Types/GeopointFieldType.php
+++ b/src/Fields/Types/GeopointFieldType.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Gm2\Fields\Types;
+
+final class GeopointFieldType extends AbstractFieldType
+{
+    public function getName(): string
+    {
+        return 'geopoint';
+    }
+
+    public function getSchema(array $settings): array
+    {
+        return [
+            'type'       => 'object',
+            'properties' => [
+                'lat' => [ 'type' => 'number', 'minimum' => -90, 'maximum' => 90 ],
+                'lng' => [ 'type' => 'number', 'minimum' => -180, 'maximum' => 180 ],
+            ],
+            'required'   => [ 'lat', 'lng' ],
+        ];
+    }
+}

--- a/src/Fields/Types/GroupFieldType.php
+++ b/src/Fields/Types/GroupFieldType.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Gm2\Fields\Types;
+
+final class GroupFieldType extends AbstractFieldType
+{
+    public function getName(): string
+    {
+        return 'group';
+    }
+
+    public function getSchema(array $settings): array
+    {
+        $schema = $settings['schema'] ?? null;
+        if (is_array($schema)) {
+            return $schema;
+        }
+
+        return [
+            'type'                 => 'object',
+            'additionalProperties' => true,
+        ];
+    }
+}

--- a/src/Fields/Types/ImageFieldType.php
+++ b/src/Fields/Types/ImageFieldType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Gm2\Fields\Types;
+
+final class ImageFieldType extends AbstractFieldType
+{
+    public function getName(): string
+    {
+        return 'image';
+    }
+
+    public function getSchema(array $settings): array
+    {
+        return [
+            'type'    => 'integer',
+            'minimum' => 1,
+        ];
+    }
+}

--- a/src/Fields/Types/MultiSelectFieldType.php
+++ b/src/Fields/Types/MultiSelectFieldType.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Gm2\Fields\Types;
+
+final class MultiSelectFieldType extends AbstractFieldType
+{
+    public function getName(): string
+    {
+        return 'multiselect';
+    }
+
+    public function getSchema(array $settings): array
+    {
+        $schema = [
+            'type'        => 'array',
+            'items'       => [ 'type' => 'string' ],
+            'uniqueItems' => true,
+        ];
+
+        $options = $settings['options'] ?? [];
+        if (is_array($options) && $options !== []) {
+            $enum = [];
+            foreach ($options as $value => $_label) {
+                if (is_int($value)) {
+                    $value = (string) $value;
+                }
+                if (is_string($value)) {
+                    $enum[] = $value;
+                }
+            }
+            if ($enum !== []) {
+                $schema['items']['enum'] = array_values(array_unique($enum));
+            }
+        }
+
+        return $schema;
+    }
+}

--- a/src/Fields/Types/NumberFieldType.php
+++ b/src/Fields/Types/NumberFieldType.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Gm2\Fields\Types;
+
+final class NumberFieldType extends AbstractFieldType
+{
+    public function getName(): string
+    {
+        return 'number';
+    }
+
+    public function getSchema(array $settings): array
+    {
+        $schema = [ 'type' => 'number' ];
+
+        if (isset($settings['minimum']) && is_numeric($settings['minimum'])) {
+            $schema['minimum'] = (float) $settings['minimum'];
+        }
+        if (isset($settings['maximum']) && is_numeric($settings['maximum'])) {
+            $schema['maximum'] = (float) $settings['maximum'];
+        }
+        if (isset($settings['step']) && is_numeric($settings['step'])) {
+            $schema['multipleOf'] = max(0.0001, (float) $settings['step']);
+        }
+
+        return $schema;
+    }
+}

--- a/src/Fields/Types/RadioFieldType.php
+++ b/src/Fields/Types/RadioFieldType.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Gm2\Fields\Types;
+
+final class RadioFieldType extends AbstractFieldType
+{
+    public function getName(): string
+    {
+        return 'radio';
+    }
+
+    public function getSchema(array $settings): array
+    {
+        $schema = [ 'type' => 'string' ];
+        $options = $settings['options'] ?? [];
+        if (is_array($options) && $options !== []) {
+            $enum = [];
+            foreach ($options as $value => $_label) {
+                if (is_int($value)) {
+                    $value = (string) $value;
+                }
+                if (is_string($value)) {
+                    $enum[] = $value;
+                }
+            }
+            if ($enum !== []) {
+                $schema['enum'] = array_values(array_unique($enum));
+            }
+        }
+
+        return $schema;
+    }
+}

--- a/src/Fields/Types/RelationshipPostFieldType.php
+++ b/src/Fields/Types/RelationshipPostFieldType.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Gm2\Fields\Types;
+
+final class RelationshipPostFieldType extends AbstractRelationshipFieldType
+{
+    public function getName(): string
+    {
+        return 'relationship_post';
+    }
+}

--- a/src/Fields/Types/RelationshipTermFieldType.php
+++ b/src/Fields/Types/RelationshipTermFieldType.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Gm2\Fields\Types;
+
+final class RelationshipTermFieldType extends AbstractRelationshipFieldType
+{
+    public function getName(): string
+    {
+        return 'relationship_term';
+    }
+}

--- a/src/Fields/Types/RelationshipUserFieldType.php
+++ b/src/Fields/Types/RelationshipUserFieldType.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Gm2\Fields\Types;
+
+final class RelationshipUserFieldType extends AbstractRelationshipFieldType
+{
+    public function getName(): string
+    {
+        return 'relationship_user';
+    }
+}

--- a/src/Fields/Types/RepeaterFieldType.php
+++ b/src/Fields/Types/RepeaterFieldType.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Gm2\Fields\Types;
+
+final class RepeaterFieldType extends AbstractFieldType
+{
+    public function getName(): string
+    {
+        return 'repeater';
+    }
+
+    public function getSchema(array $settings): array
+    {
+        $schema = $settings['schema'] ?? null;
+        if (is_array($schema)) {
+            return $schema;
+        }
+
+        return [
+            'type'  => 'array',
+            'items' => [ 'type' => 'object' ],
+        ];
+    }
+
+    public function isSingle(array $settings): bool
+    {
+        return true;
+    }
+}

--- a/src/Fields/Types/SelectFieldType.php
+++ b/src/Fields/Types/SelectFieldType.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Gm2\Fields\Types;
+
+final class SelectFieldType extends AbstractFieldType
+{
+    public function getName(): string
+    {
+        return 'select';
+    }
+
+    public function getSchema(array $settings): array
+    {
+        $schema = [ 'type' => 'string' ];
+        $options = $settings['options'] ?? [];
+        if (is_array($options) && $options !== []) {
+            $enum = [];
+            foreach ($options as $value => $_label) {
+                if (is_int($value)) {
+                    $value = (string) $value;
+                }
+                if (is_string($value)) {
+                    $enum[] = $value;
+                }
+            }
+            if ($enum !== []) {
+                $schema['enum'] = array_values(array_unique($enum));
+            }
+        }
+
+        return $schema;
+    }
+}

--- a/src/Fields/Types/SwitchFieldType.php
+++ b/src/Fields/Types/SwitchFieldType.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Gm2\Fields\Types;
+
+final class SwitchFieldType extends AbstractFieldType
+{
+    public function getName(): string
+    {
+        return 'switch';
+    }
+
+    public function getSchema(array $settings): array
+    {
+        return [ 'type' => 'boolean' ];
+    }
+}

--- a/src/Fields/Types/TelFieldType.php
+++ b/src/Fields/Types/TelFieldType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Gm2\Fields\Types;
+
+final class TelFieldType extends AbstractFieldType
+{
+    public function getName(): string
+    {
+        return 'tel';
+    }
+
+    public function getSchema(array $settings): array
+    {
+        return [
+            'type'    => 'string',
+            'pattern' => '^[0-9+()\\s.-]+$',
+        ];
+    }
+}

--- a/src/Fields/Types/TextFieldType.php
+++ b/src/Fields/Types/TextFieldType.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Gm2\Fields\Types;
+
+final class TextFieldType extends AbstractFieldType
+{
+    public function getName(): string
+    {
+        return 'text';
+    }
+
+    public function getSchema(array $settings): array
+    {
+        $schema = [ 'type' => 'string' ];
+
+        if (isset($settings['max_length']) && is_int($settings['max_length']) && $settings['max_length'] > 0) {
+            $schema['maxLength'] = $settings['max_length'];
+        }
+
+        return $schema;
+    }
+}

--- a/src/Fields/Types/TextareaFieldType.php
+++ b/src/Fields/Types/TextareaFieldType.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Gm2\Fields\Types;
+
+final class TextareaFieldType extends AbstractFieldType
+{
+    public function getName(): string
+    {
+        return 'textarea';
+    }
+
+    public function getSchema(array $settings): array
+    {
+        $schema = [ 'type' => 'string' ];
+
+        if (isset($settings['max_length']) && is_int($settings['max_length']) && $settings['max_length'] > 0) {
+            $schema['maxLength'] = $settings['max_length'];
+        }
+
+        return $schema;
+    }
+}

--- a/src/Fields/Types/TimeFieldType.php
+++ b/src/Fields/Types/TimeFieldType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Gm2\Fields\Types;
+
+final class TimeFieldType extends AbstractFieldType
+{
+    public function getName(): string
+    {
+        return 'time';
+    }
+
+    public function getSchema(array $settings): array
+    {
+        return [
+            'type'    => 'string',
+            'pattern' => '^\\d{2}:\\d{2}(?::\\d{2})?$',
+        ];
+    }
+}

--- a/src/Fields/Types/UrlFieldType.php
+++ b/src/Fields/Types/UrlFieldType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Gm2\Fields\Types;
+
+final class UrlFieldType extends AbstractFieldType
+{
+    public function getName(): string
+    {
+        return 'url';
+    }
+
+    public function getSchema(array $settings): array
+    {
+        return [
+            'type'   => 'string',
+            'format' => 'uri',
+        ];
+    }
+}

--- a/src/Fields/Types/WysiwygFieldType.php
+++ b/src/Fields/Types/WysiwygFieldType.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Gm2\Fields\Types;
+
+final class WysiwygFieldType extends AbstractFieldType
+{
+    public function getName(): string
+    {
+        return 'wysiwyg';
+    }
+
+    public function getSchema(array $settings): array
+    {
+        return [ 'type' => 'string' ];
+    }
+}

--- a/src/Fields/Validation/AbstractFieldValidator.php
+++ b/src/Fields/Validation/AbstractFieldValidator.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Gm2\Fields\Validation;
+
+use Gm2\Fields\FieldDefinition;
+use WP_Error;
+
+abstract class AbstractFieldValidator implements FieldValidatorInterface
+{
+    protected function invalid(FieldDefinition $field, string $message, string $code = 'gm2_field_invalid'): WP_Error
+    {
+        return new WP_Error($code, $message, [ 'field' => $field->getKey() ]);
+    }
+}

--- a/src/Fields/Validation/AbstractRelationshipValidator.php
+++ b/src/Fields/Validation/AbstractRelationshipValidator.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Gm2\Fields\Validation;
+
+use Gm2\Fields\FieldDefinition;
+
+abstract class AbstractRelationshipValidator extends AbstractFieldValidator
+{
+    public function validate(FieldDefinition $field, mixed $value, array $context = []): true|
+    \WP_Error
+    {
+        $multiple = (bool) ($field->getSettings()['multiple'] ?? true);
+
+        if ($value === null || $value === '') {
+            return true;
+        }
+
+        if ($multiple) {
+            if (!is_array($value)) {
+                return $this->invalid($field, sprintf('%s must be an array of IDs.', $field->getLabel()));
+            }
+            foreach ($value as $item) {
+                if (!is_numeric($item)) {
+                    return $this->invalid($field, sprintf('%s must only contain numeric IDs.', $field->getLabel()));
+                }
+            }
+            return true;
+        }
+
+        if (!is_numeric($value)) {
+            return $this->invalid($field, sprintf('%s must reference an ID.', $field->getLabel()));
+        }
+
+        return true;
+    }
+}

--- a/src/Fields/Validation/AddressValidator.php
+++ b/src/Fields/Validation/AddressValidator.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Gm2\Fields\Validation;
+
+use Gm2\Fields\FieldDefinition;
+
+final class AddressValidator extends AbstractFieldValidator
+{
+    public function validate(FieldDefinition $field, mixed $value, array $context = []): true|
+    \WP_Error
+    {
+        if ($value === null || $value === '') {
+            return true;
+        }
+
+        if (!is_array($value)) {
+            return $this->invalid($field, sprintf('%s must be an object.', $field->getLabel()));
+        }
+
+        return true;
+    }
+}

--- a/src/Fields/Validation/CheckboxValidator.php
+++ b/src/Fields/Validation/CheckboxValidator.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Gm2\Fields\Validation;
+
+use Gm2\Fields\FieldDefinition;
+
+final class CheckboxValidator extends AbstractFieldValidator
+{
+    public function validate(FieldDefinition $field, mixed $value, array $context = []): true|
+    \WP_Error
+    {
+        if (is_null($value) || is_bool($value) || is_numeric($value) || $value === '') {
+            return true;
+        }
+
+        if (is_string($value)) {
+            return true;
+        }
+
+        return $this->invalid($field, sprintf('%s must be a boolean value.', $field->getLabel()));
+    }
+}

--- a/src/Fields/Validation/ColorValidator.php
+++ b/src/Fields/Validation/ColorValidator.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Gm2\Fields\Validation;
+
+use Gm2\Fields\FieldDefinition;
+
+final class ColorValidator extends AbstractFieldValidator
+{
+    public function validate(FieldDefinition $field, mixed $value, array $context = []): true|
+    \WP_Error
+    {
+        if ($value === null || $value === '') {
+            return true;
+        }
+
+        if (!is_string($value) && !is_scalar($value)) {
+            return $this->invalid($field, sprintf('%s must be a string.', $field->getLabel()));
+        }
+
+        $value = (string) $value;
+        if (!preg_match('/^#(?:[0-9a-fA-F]{3}){1,2}$/', $value)) {
+            return $this->invalid($field, sprintf('%s must be a valid hex color.', $field->getLabel()));
+        }
+
+        return true;
+    }
+}

--- a/src/Fields/Validation/ComputedValidator.php
+++ b/src/Fields/Validation/ComputedValidator.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Gm2\Fields\Validation;
+
+use Gm2\Fields\FieldDefinition;
+
+final class ComputedValidator extends AbstractFieldValidator
+{
+    public function validate(FieldDefinition $field, mixed $value, array $context = []): true|
+    \WP_Error
+    {
+        return true;
+    }
+}

--- a/src/Fields/Validation/CurrencyValidator.php
+++ b/src/Fields/Validation/CurrencyValidator.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Gm2\Fields\Validation;
+
+use Gm2\Fields\FieldDefinition;
+
+final class CurrencyValidator extends AbstractFieldValidator
+{
+    public function validate(FieldDefinition $field, mixed $value, array $context = []): true|
+    \WP_Error
+    {
+        if ($value === null || $value === '') {
+            return true;
+        }
+
+        if (is_numeric($value)) {
+            return true;
+        }
+
+        return $this->invalid($field, sprintf('%s must be numeric.', $field->getLabel()));
+    }
+}

--- a/src/Fields/Validation/DateRangeValidator.php
+++ b/src/Fields/Validation/DateRangeValidator.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Gm2\Fields\Validation;
+
+use DateTimeImmutable;
+use Gm2\Fields\FieldDefinition;
+
+final class DateRangeValidator extends AbstractFieldValidator
+{
+    public function validate(FieldDefinition $field, mixed $value, array $context = []): true|
+    \WP_Error
+    {
+        if ($value === null || $value === '') {
+            return true;
+        }
+
+        if (!is_array($value)) {
+            return $this->invalid($field, sprintf('%s must be an array with start and end.', $field->getLabel()));
+        }
+
+        $start = $value['start'] ?? null;
+        $end   = $value['end'] ?? null;
+        if (!is_string($start) || !is_string($end)) {
+            return $this->invalid($field, sprintf('%s must include start and end dates.', $field->getLabel()));
+        }
+
+        $startDate = DateTimeImmutable::createFromFormat('Y-m-d', $start);
+        $endDate   = DateTimeImmutable::createFromFormat('Y-m-d', $end);
+        if ($startDate === false || $startDate->format('Y-m-d') !== $start) {
+            return $this->invalid($field, sprintf('%s has an invalid start date.', $field->getLabel()));
+        }
+        if ($endDate === false || $endDate->format('Y-m-d') !== $end) {
+            return $this->invalid($field, sprintf('%s has an invalid end date.', $field->getLabel()));
+        }
+
+        if ($endDate < $startDate) {
+            return $this->invalid($field, sprintf('%s end date must be after start date.', $field->getLabel()));
+        }
+
+        return true;
+    }
+}

--- a/src/Fields/Validation/DateTimeTzValidator.php
+++ b/src/Fields/Validation/DateTimeTzValidator.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Gm2\Fields\Validation;
+
+use DateTimeImmutable;
+use Gm2\Fields\FieldDefinition;
+
+final class DateTimeTzValidator extends AbstractFieldValidator
+{
+    public function validate(FieldDefinition $field, mixed $value, array $context = []): true|
+    \WP_Error
+    {
+        if ($value === null || $value === '') {
+            return true;
+        }
+
+        if (!is_string($value)) {
+            return $this->invalid($field, sprintf('%s must be a datetime string.', $field->getLabel()));
+        }
+
+        $date = DateTimeImmutable::createFromFormat(DATE_ATOM, $value);
+        if ($date === false) {
+            $date = new DateTimeImmutable($value);
+        }
+
+        if ($date === false) {
+            return $this->invalid($field, sprintf('%s must be a valid datetime.', $field->getLabel()));
+        }
+
+        return true;
+    }
+}

--- a/src/Fields/Validation/DateValidator.php
+++ b/src/Fields/Validation/DateValidator.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Gm2\Fields\Validation;
+
+use DateTimeImmutable;
+use Gm2\Fields\FieldDefinition;
+
+final class DateValidator extends AbstractFieldValidator
+{
+    public function validate(FieldDefinition $field, mixed $value, array $context = []): true|
+    \WP_Error
+    {
+        if ($value === null || $value === '') {
+            return true;
+        }
+
+        if (!is_string($value)) {
+            return $this->invalid($field, sprintf('%s must be a date string.', $field->getLabel()));
+        }
+
+        $date = DateTimeImmutable::createFromFormat('Y-m-d', $value);
+        if ($date === false || $date->format('Y-m-d') !== $value) {
+            return $this->invalid($field, sprintf('%s must be a valid date (Y-m-d).', $field->getLabel()));
+        }
+
+        return true;
+    }
+}

--- a/src/Fields/Validation/EmailValidator.php
+++ b/src/Fields/Validation/EmailValidator.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Gm2\Fields\Validation;
+
+use Gm2\Fields\FieldDefinition;
+
+final class EmailValidator extends AbstractFieldValidator
+{
+    public function validate(FieldDefinition $field, mixed $value, array $context = []): true|
+    \WP_Error
+    {
+        if ($value === null || $value === '') {
+            return true;
+        }
+
+        if (!is_string($value) && !is_scalar($value)) {
+            return $this->invalid($field, sprintf('%s must be an email string.', $field->getLabel()));
+        }
+
+        $value = (string) $value;
+        if (!is_email($value)) {
+            return $this->invalid($field, sprintf('%s must be a valid email.', $field->getLabel()));
+        }
+
+        return true;
+    }
+}

--- a/src/Fields/Validation/FieldValidatorInterface.php
+++ b/src/Fields/Validation/FieldValidatorInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Gm2\Fields\Validation;
+
+use Gm2\Fields\FieldDefinition;
+use WP_Error;
+
+interface FieldValidatorInterface
+{
+    /**
+     * @param array<string, mixed> $context
+     * @return true|WP_Error
+     */
+    public function validate(FieldDefinition $field, mixed $value, array $context = []);
+}

--- a/src/Fields/Validation/FileValidator.php
+++ b/src/Fields/Validation/FileValidator.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Gm2\Fields\Validation;
+
+use Gm2\Fields\FieldDefinition;
+
+final class FileValidator extends AbstractFieldValidator
+{
+    public function validate(FieldDefinition $field, mixed $value, array $context = []): true|
+    \WP_Error
+    {
+        if ($value === null || $value === '') {
+            return true;
+        }
+
+        if (is_numeric($value)) {
+            return true;
+        }
+
+        return $this->invalid($field, sprintf('%s must reference an attachment ID.', $field->getLabel()));
+    }
+}

--- a/src/Fields/Validation/GalleryValidator.php
+++ b/src/Fields/Validation/GalleryValidator.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Gm2\Fields\Validation;
+
+use Gm2\Fields\FieldDefinition;
+
+final class GalleryValidator extends AbstractFieldValidator
+{
+    public function validate(FieldDefinition $field, mixed $value, array $context = []): true|
+    \WP_Error
+    {
+        if ($value === null || $value === '') {
+            return true;
+        }
+
+        if (!is_array($value)) {
+            return $this->invalid($field, sprintf('%s must be an array of attachment IDs.', $field->getLabel()));
+        }
+
+        foreach ($value as $item) {
+            if (!is_numeric($item)) {
+                return $this->invalid($field, sprintf('%s must only contain attachment IDs.', $field->getLabel()));
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Fields/Validation/GeopointValidator.php
+++ b/src/Fields/Validation/GeopointValidator.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Gm2\Fields\Validation;
+
+use Gm2\Fields\FieldDefinition;
+
+final class GeopointValidator extends AbstractFieldValidator
+{
+    public function validate(FieldDefinition $field, mixed $value, array $context = []): true|
+    \WP_Error
+    {
+        if ($value === null || $value === '') {
+            return true;
+        }
+
+        if (!is_array($value)) {
+            return $this->invalid($field, sprintf('%s must be an object with lat/lng.', $field->getLabel()));
+        }
+
+        $lat = $value['lat'] ?? null;
+        $lng = $value['lng'] ?? null;
+        if (!is_numeric($lat) || !is_numeric($lng)) {
+            return $this->invalid($field, sprintf('%s must contain numeric latitude and longitude.', $field->getLabel()));
+        }
+
+        $lat = (float) $lat;
+        $lng = (float) $lng;
+        if ($lat < -90 || $lat > 90 || $lng < -180 || $lng > 180) {
+            return $this->invalid($field, sprintf('%s coordinates are out of range.', $field->getLabel()));
+        }
+
+        return true;
+    }
+}

--- a/src/Fields/Validation/GroupValidator.php
+++ b/src/Fields/Validation/GroupValidator.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Gm2\Fields\Validation;
+
+use Gm2\Fields\FieldDefinition;
+
+final class GroupValidator extends AbstractFieldValidator
+{
+    public function validate(FieldDefinition $field, mixed $value, array $context = []): true|
+    \WP_Error
+    {
+        if ($value === null || $value === '') {
+            return true;
+        }
+
+        if (!is_array($value)) {
+            return $this->invalid($field, sprintf('%s must be an object.', $field->getLabel()));
+        }
+
+        return true;
+    }
+}

--- a/src/Fields/Validation/ImageValidator.php
+++ b/src/Fields/Validation/ImageValidator.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Gm2\Fields\Validation;
+
+use Gm2\Fields\FieldDefinition;
+
+final class ImageValidator extends AbstractFieldValidator
+{
+    public function validate(FieldDefinition $field, mixed $value, array $context = []): true|
+    \WP_Error
+    {
+        if ($value === null || $value === '') {
+            return true;
+        }
+
+        if (is_numeric($value)) {
+            return true;
+        }
+
+        return $this->invalid($field, sprintf('%s must reference an attachment ID.', $field->getLabel()));
+    }
+}

--- a/src/Fields/Validation/MultiSelectValidator.php
+++ b/src/Fields/Validation/MultiSelectValidator.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Gm2\Fields\Validation;
+
+use Gm2\Fields\FieldDefinition;
+
+final class MultiSelectValidator extends AbstractFieldValidator
+{
+    public function validate(FieldDefinition $field, mixed $value, array $context = []): true|
+    \WP_Error
+    {
+        if ($value === null || $value === '') {
+            return true;
+        }
+
+        if (!is_array($value)) {
+            return $this->invalid($field, sprintf('%s must be an array.', $field->getLabel()));
+        }
+
+        $options = $field->getOptions();
+        foreach ($value as $item) {
+            if (!is_scalar($item)) {
+                return $this->invalid($field, sprintf('%s contains an invalid value.', $field->getLabel()));
+            }
+            $item = (string) $item;
+            if ($options !== [] && !array_key_exists($item, $options)) {
+                return $this->invalid($field, sprintf('%s contains an invalid selection.', $field->getLabel()));
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Fields/Validation/NumberValidator.php
+++ b/src/Fields/Validation/NumberValidator.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Gm2\Fields\Validation;
+
+use Gm2\Fields\FieldDefinition;
+
+final class NumberValidator extends AbstractFieldValidator
+{
+    public function validate(FieldDefinition $field, mixed $value, array $context = []): true|
+    \WP_Error
+    {
+        if ($value === null || $value === '') {
+            return true;
+        }
+
+        if (is_numeric($value)) {
+            return true;
+        }
+
+        return $this->invalid($field, sprintf('%s must be numeric.', $field->getLabel()));
+    }
+}

--- a/src/Fields/Validation/RadioValidator.php
+++ b/src/Fields/Validation/RadioValidator.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Gm2\Fields\Validation;
+
+use Gm2\Fields\FieldDefinition;
+
+final class RadioValidator extends AbstractFieldValidator
+{
+    public function validate(FieldDefinition $field, mixed $value, array $context = []): true|
+    \WP_Error
+    {
+        if ($value === null || $value === '') {
+            return true;
+        }
+
+        if (!is_scalar($value)) {
+            return $this->invalid($field, sprintf('%s must be a scalar value.', $field->getLabel()));
+        }
+
+        $value   = (string) $value;
+        $options = $field->getOptions();
+        if ($options !== [] && !array_key_exists($value, $options)) {
+            return $this->invalid($field, sprintf('%s has an invalid selection.', $field->getLabel()));
+        }
+
+        return true;
+    }
+}

--- a/src/Fields/Validation/RelationshipPostValidator.php
+++ b/src/Fields/Validation/RelationshipPostValidator.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Gm2\Fields\Validation;
+
+final class RelationshipPostValidator extends AbstractRelationshipValidator
+{
+}

--- a/src/Fields/Validation/RelationshipTermValidator.php
+++ b/src/Fields/Validation/RelationshipTermValidator.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Gm2\Fields\Validation;
+
+final class RelationshipTermValidator extends AbstractRelationshipValidator
+{
+}

--- a/src/Fields/Validation/RelationshipUserValidator.php
+++ b/src/Fields/Validation/RelationshipUserValidator.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Gm2\Fields\Validation;
+
+final class RelationshipUserValidator extends AbstractRelationshipValidator
+{
+}

--- a/src/Fields/Validation/RepeaterValidator.php
+++ b/src/Fields/Validation/RepeaterValidator.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Gm2\Fields\Validation;
+
+use Gm2\Fields\FieldDefinition;
+
+final class RepeaterValidator extends AbstractFieldValidator
+{
+    public function validate(FieldDefinition $field, mixed $value, array $context = []): true|
+    \WP_Error
+    {
+        if ($value === null || $value === '') {
+            return true;
+        }
+
+        if (!is_array($value)) {
+            return $this->invalid($field, sprintf('%s must be an array of rows.', $field->getLabel()));
+        }
+
+        return true;
+    }
+}

--- a/src/Fields/Validation/SelectValidator.php
+++ b/src/Fields/Validation/SelectValidator.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Gm2\Fields\Validation;
+
+use Gm2\Fields\FieldDefinition;
+
+final class SelectValidator extends AbstractFieldValidator
+{
+    public function validate(FieldDefinition $field, mixed $value, array $context = []): true|
+    \WP_Error
+    {
+        if ($value === null || $value === '') {
+            return true;
+        }
+
+        if (!is_scalar($value)) {
+            return $this->invalid($field, sprintf('%s must be a scalar value.', $field->getLabel()));
+        }
+
+        $value   = (string) $value;
+        $options = $field->getOptions();
+        if ($options !== [] && !array_key_exists($value, $options)) {
+            return $this->invalid($field, sprintf('%s has an invalid selection.', $field->getLabel()));
+        }
+
+        return true;
+    }
+}

--- a/src/Fields/Validation/SwitchValidator.php
+++ b/src/Fields/Validation/SwitchValidator.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Gm2\Fields\Validation;
+
+use Gm2\Fields\FieldDefinition;
+
+final class SwitchValidator extends AbstractFieldValidator
+{
+    public function validate(FieldDefinition $field, mixed $value, array $context = []): true|
+    \WP_Error
+    {
+        if (is_null($value) || is_bool($value) || is_numeric($value) || $value === '') {
+            return true;
+        }
+
+        if (is_string($value)) {
+            return true;
+        }
+
+        return $this->invalid($field, sprintf('%s must be a boolean value.', $field->getLabel()));
+    }
+}

--- a/src/Fields/Validation/TelValidator.php
+++ b/src/Fields/Validation/TelValidator.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Gm2\Fields\Validation;
+
+use Gm2\Fields\FieldDefinition;
+
+final class TelValidator extends AbstractFieldValidator
+{
+    public function validate(FieldDefinition $field, mixed $value, array $context = []): true|
+    \WP_Error
+    {
+        if ($value === null || $value === '') {
+            return true;
+        }
+
+        if (!is_string($value) && !is_scalar($value)) {
+            return $this->invalid($field, sprintf('%s must be a phone string.', $field->getLabel()));
+        }
+
+        $value = (string) $value;
+        if (!preg_match('/^[0-9+()\s\.-]+$/', $value)) {
+            return $this->invalid($field, sprintf('%s must be a valid phone number.', $field->getLabel()));
+        }
+
+        return true;
+    }
+}

--- a/src/Fields/Validation/TextValidator.php
+++ b/src/Fields/Validation/TextValidator.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Gm2\Fields\Validation;
+
+use Gm2\Fields\FieldDefinition;
+
+final class TextValidator extends AbstractFieldValidator
+{
+    public function validate(FieldDefinition $field, mixed $value, array $context = []): true|
+    \WP_Error
+    {
+        if ($value === null || $value === '') {
+            return true;
+        }
+
+        if (is_scalar($value)) {
+            return true;
+        }
+
+        return $this->invalid($field, sprintf('%s must be a string value.', $field->getLabel()));
+    }
+}

--- a/src/Fields/Validation/TextareaValidator.php
+++ b/src/Fields/Validation/TextareaValidator.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Gm2\Fields\Validation;
+
+use Gm2\Fields\FieldDefinition;
+
+final class TextareaValidator extends AbstractFieldValidator
+{
+    public function validate(FieldDefinition $field, mixed $value, array $context = []): true|
+    \WP_Error
+    {
+        if ($value === null || $value === '') {
+            return true;
+        }
+
+        if (is_scalar($value)) {
+            return true;
+        }
+
+        return $this->invalid($field, sprintf('%s must be a string value.', $field->getLabel()));
+    }
+}

--- a/src/Fields/Validation/TimeValidator.php
+++ b/src/Fields/Validation/TimeValidator.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Gm2\Fields\Validation;
+
+use Gm2\Fields\FieldDefinition;
+
+final class TimeValidator extends AbstractFieldValidator
+{
+    public function validate(FieldDefinition $field, mixed $value, array $context = []): true|
+    \WP_Error
+    {
+        if ($value === null || $value === '') {
+            return true;
+        }
+
+        if (!is_string($value)) {
+            return $this->invalid($field, sprintf('%s must be a time string.', $field->getLabel()));
+        }
+
+        if (!preg_match('/^\d{2}:\d{2}(?::\d{2})?$/', $value)) {
+            return $this->invalid($field, sprintf('%s must be a valid time (HH:MM or HH:MM:SS).', $field->getLabel()));
+        }
+
+        return true;
+    }
+}

--- a/src/Fields/Validation/UrlValidator.php
+++ b/src/Fields/Validation/UrlValidator.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Gm2\Fields\Validation;
+
+use Gm2\Fields\FieldDefinition;
+
+final class UrlValidator extends AbstractFieldValidator
+{
+    public function validate(FieldDefinition $field, mixed $value, array $context = []): true|
+    \WP_Error
+    {
+        if ($value === null || $value === '') {
+            return true;
+        }
+
+        if (!is_string($value) && !is_scalar($value)) {
+            return $this->invalid($field, sprintf('%s must be a URL string.', $field->getLabel()));
+        }
+
+        $value = (string) $value;
+        if (filter_var($value, FILTER_VALIDATE_URL) === false) {
+            return $this->invalid($field, sprintf('%s must be a valid URL.', $field->getLabel()));
+        }
+
+        return true;
+    }
+}

--- a/src/Fields/Validation/ValidatorRegistry.php
+++ b/src/Fields/Validation/ValidatorRegistry.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Gm2\Fields\Validation;
+
+use Gm2\Fields\FieldDefinition;
+use InvalidArgumentException;
+use WP_Error;
+
+final class ValidatorRegistry
+{
+    /**
+     * @var array<string, FieldValidatorInterface>
+     */
+    private array $validators = [];
+
+    public static function withDefaults(): self
+    {
+        $registry = new self();
+        $registry->register('text', new TextValidator());
+        $registry->register('textarea', new TextareaValidator());
+        $registry->register('number', new NumberValidator());
+        $registry->register('currency', new CurrencyValidator());
+        $registry->register('select', new SelectValidator());
+        $registry->register('multiselect', new MultiSelectValidator());
+        $registry->register('radio', new RadioValidator());
+        $registry->register('checkbox', new CheckboxValidator());
+        $registry->register('switch', new SwitchValidator());
+        $registry->register('date', new DateValidator());
+        $registry->register('time', new TimeValidator());
+        $registry->register('datetime_tz', new DateTimeTzValidator());
+        $registry->register('daterange', new DateRangeValidator());
+        $registry->register('url', new UrlValidator());
+        $registry->register('email', new EmailValidator());
+        $registry->register('tel', new TelValidator());
+        $registry->register('color', new ColorValidator());
+        $registry->register('image', new ImageValidator());
+        $registry->register('gallery', new GalleryValidator());
+        $registry->register('file', new FileValidator());
+        $registry->register('repeater', new RepeaterValidator());
+        $registry->register('group', new GroupValidator());
+        $registry->register('relationship_post', new RelationshipPostValidator());
+        $registry->register('relationship_term', new RelationshipTermValidator());
+        $registry->register('relationship_user', new RelationshipUserValidator());
+        $registry->register('geopoint', new GeopointValidator());
+        $registry->register('address', new AddressValidator());
+        $registry->register('wysiwyg', new WysiwygValidator());
+        $registry->register('computed', new ComputedValidator());
+
+        return $registry;
+    }
+
+    public function register(string $type, FieldValidatorInterface $validator): void
+    {
+        $this->validators[$type] = $validator;
+    }
+
+    public function get(string $type): FieldValidatorInterface
+    {
+        if (!isset($this->validators[$type])) {
+            throw new InvalidArgumentException(sprintf('No validator registered for "%s".', $type));
+        }
+
+        return $this->validators[$type];
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     * @return true|WP_Error
+     */
+    public function validate(FieldDefinition $field, mixed $value, array $context = []): true|WP_Error
+    {
+        $type = $field->getType()->getName();
+        if (!isset($this->validators[$type])) {
+            return true;
+        }
+
+        return $this->validators[$type]->validate($field, $value, $context);
+    }
+}

--- a/src/Fields/Validation/WysiwygValidator.php
+++ b/src/Fields/Validation/WysiwygValidator.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Gm2\Fields\Validation;
+
+use Gm2\Fields\FieldDefinition;
+
+final class WysiwygValidator extends AbstractFieldValidator
+{
+    public function validate(FieldDefinition $field, mixed $value, array $context = []): true|
+    \WP_Error
+    {
+        if ($value === null || $value === '') {
+            return true;
+        }
+
+        if (is_scalar($value)) {
+            return true;
+        }
+
+        return $this->invalid($field, sprintf('%s must be a string.', $field->getLabel()));
+    }
+}

--- a/tests/Fields/FieldGroupRegistryTest.php
+++ b/tests/Fields/FieldGroupRegistryTest.php
@@ -1,0 +1,94 @@
+<?php
+
+use Gm2\Fields\FieldGroupRegistry;
+use Gm2\Fields\FieldTypeRegistry;
+use Gm2\Fields\Renderer\AdminMetaBox;
+use Gm2\Fields\Sanitizers\SanitizerRegistry;
+use Gm2\Fields\Storage\MetaRegistrar;
+use Gm2\Fields\Validation\ValidatorRegistry;
+
+class FieldGroupRegistryTest extends WP_UnitTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        register_post_type('library_book', [
+            'show_in_rest' => true,
+            'supports'     => [ 'custom-fields' ],
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        unregister_post_type('library_book');
+        parent::tearDown();
+    }
+
+    public function test_registers_meta_schema_and_dependencies(): void
+    {
+        $registry = $this->createRegistry();
+
+        $registry->registerGroup('library_book_details', [
+            'title'    => 'Library Book Details',
+            'contexts' => [
+                'post' => [ 'library_book' ],
+            ],
+            'fields'   => [
+                'has_isbn' => [
+                    'type'    => 'switch',
+                    'label'   => 'Has ISBN',
+                    'default' => false,
+                ],
+                'isbn' => [
+                    'type'       => 'text',
+                    'label'      => 'ISBN',
+                    'conditions' => [
+                        'relation' => 'and',
+                        [
+                            'field'    => 'has_isbn',
+                            'operator' => '==',
+                            'value'    => true,
+                        ],
+                    ],
+                ],
+                'price' => [
+                    'type'  => 'number',
+                    'label' => 'Price',
+                ],
+                'tax' => [
+                    'type'  => 'number',
+                    'label' => 'Tax',
+                ],
+                'total' => [
+                    'type'     => 'computed',
+                    'computed' => [
+                        'dependencies' => [ 'price', 'tax' ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $registry->boot();
+
+        $registered = get_registered_meta_keys('post', 'library_book');
+        $this->assertArrayHasKey('isbn', $registered);
+        $this->assertSame('string', $registered['isbn']['type']);
+        $this->assertArrayHasKey('schema', $registered['isbn']['show_in_rest']);
+
+        $graph = $registry->getComputedDependencyGraph('library_book_details');
+        $this->assertSame([
+            'total' => [ 'price', 'tax' ],
+        ], $graph);
+    }
+
+    private function createRegistry(): FieldGroupRegistry
+    {
+        return new FieldGroupRegistry(
+            new MetaRegistrar(),
+            FieldTypeRegistry::withDefaults(),
+            ValidatorRegistry::withDefaults(),
+            SanitizerRegistry::withDefaults(),
+            new AdminMetaBox()
+        );
+    }
+}

--- a/tests/Fields/RestRoundtripTest.php
+++ b/tests/Fields/RestRoundtripTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use Gm2\Fields\FieldGroupRegistry;
+use Gm2\Fields\FieldTypeRegistry;
+use Gm2\Fields\Renderer\AdminMetaBox;
+use Gm2\Fields\Sanitizers\SanitizerRegistry;
+use Gm2\Fields\Storage\MetaRegistrar;
+use Gm2\Fields\Validation\ValidatorRegistry;
+
+class RestRoundtripTest extends WP_UnitTestCase
+{
+    private FieldGroupRegistry $registry;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        register_post_type('library_book', [
+            'show_in_rest' => true,
+            'supports'     => [ 'custom-fields', 'title' ],
+        ]);
+
+        $this->registry = new FieldGroupRegistry(
+            new MetaRegistrar(),
+            FieldTypeRegistry::withDefaults(),
+            ValidatorRegistry::withDefaults(),
+            SanitizerRegistry::withDefaults(),
+            new AdminMetaBox()
+        );
+
+        $this->registry->registerGroup('library_book_details', [
+            'contexts' => [ 'post' => [ 'library_book' ] ],
+            'fields'   => [
+                'published_on' => [ 'type' => 'date' ],
+                'contact_email' => [ 'type' => 'email' ],
+                'genres' => [
+                    'type'    => 'multiselect',
+                    'options' => [ 'fiction' => 'Fiction', 'history' => 'History' ],
+                ],
+            ],
+        ]);
+
+        $this->registry->boot();
+    }
+
+    protected function tearDown(): void
+    {
+        unregister_post_type('library_book');
+        parent::tearDown();
+    }
+
+    public function test_rest_roundtrip_creates_and_reads_meta(): void
+    {
+        wp_set_current_user(self::factory()->user->create([ 'role' => 'administrator' ]));
+
+        $request = new WP_REST_Request('POST', '/wp/v2/library_book');
+        $request->set_body_params([
+            'title' => 'REST Book',
+            'status' => 'publish',
+            'meta' => [
+                'published_on' => '2024-05-01',
+                'contact_email' => ' author@example.com ',
+                'genres' => [ 'fiction', 'unknown' ],
+            ],
+        ]);
+
+        $response = rest_get_server()->dispatch($request);
+        $this->assertSame(201, $response->get_status());
+
+        $data = $response->get_data();
+        $postId = $data['id'];
+
+        $this->assertSame('2024-05-01', get_post_meta($postId, 'published_on', true));
+        $this->assertSame('author@example.com', get_post_meta($postId, 'contact_email', true));
+        $this->assertSame([ 'fiction' ], get_post_meta($postId, 'genres', true));
+
+        $getRequest = new WP_REST_Request('GET', '/wp/v2/library_book/' . $postId);
+        $getRequest->set_param('context', 'edit');
+        $getResponse = rest_get_server()->dispatch($getRequest);
+        $this->assertSame(200, $getResponse->get_status());
+
+        $restData = $getResponse->get_data();
+        $this->assertSame('2024-05-01', $restData['meta']['published_on']);
+        $this->assertSame('author@example.com', $restData['meta']['contact_email']);
+        $this->assertSame([ 'fiction' ], (array) $restData['meta']['genres']);
+    }
+}

--- a/tests/Fields/ValidationTest.php
+++ b/tests/Fields/ValidationTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use Gm2\Fields\FieldGroupRegistry;
+use Gm2\Fields\FieldTypeRegistry;
+use Gm2\Fields\Sanitizers\SanitizerRegistry;
+use Gm2\Fields\Storage\MetaRegistrar;
+use Gm2\Fields\Validation\ValidatorRegistry;
+
+class ValidationTest extends WP_UnitTestCase
+{
+    public function test_conditional_validation_skips_hidden_fields(): void
+    {
+        $registry = $this->createRegistry();
+        $registry->registerGroup('contact', [
+            'contexts' => [ 'post' => [ 'post' ] ],
+            'fields'   => [
+                'subscribe' => [
+                    'type'  => 'checkbox',
+                    'label' => 'Subscribe',
+                ],
+                'email' => [
+                    'type'       => 'email',
+                    'label'      => 'Email',
+                    'conditions' => [
+                        'relation' => 'and',
+                        [
+                            'field'    => 'subscribe',
+                            'operator' => '==',
+                            'value'    => true,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $errors = $registry->validateGroup('contact', [
+            'subscribe' => false,
+            'email'     => 'not-an-email',
+        ]);
+
+        $this->assertSame([], $errors, 'Email should not validate when subscribe is false.');
+
+        $errors = $registry->validateGroup('contact', [
+            'subscribe' => true,
+            'email'     => 'not-an-email',
+        ]);
+
+        $this->assertArrayHasKey('email', $errors);
+        $this->assertInstanceOf(WP_Error::class, $errors['email']);
+    }
+
+    public function test_sanitization_applies_per_field_rules(): void
+    {
+        $registry = $this->createRegistry();
+        $registry->registerGroup('contact', [
+            'contexts' => [ 'post' => [ 'post' ] ],
+            'fields'   => [
+                'subscribe' => [ 'type' => 'checkbox' ],
+                'email'     => [ 'type' => 'email' ],
+            ],
+        ]);
+
+        $sanitized = $registry->sanitizeGroup('contact', [
+            'subscribe' => 'yes',
+            'email'     => ' user@example.com ',
+        ]);
+
+        $this->assertTrue($sanitized['subscribe']);
+        $this->assertSame('user@example.com', $sanitized['email']);
+    }
+
+    private function createRegistry(): FieldGroupRegistry
+    {
+        return new FieldGroupRegistry(
+            new MetaRegistrar(),
+            FieldTypeRegistry::withDefaults(),
+            ValidatorRegistry::withDefaults(),
+            SanitizerRegistry::withDefaults(),
+            null
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add a FieldGroupRegistry with typed field definitions, dependency tracking, sanitization, and validation support
- provide PHP 8.1 typed field classes plus dedicated validator and sanitizer services with WordPress meta registration helpers and admin rendering
- cover the new registry, validation logic, and REST serialization with focused PHPUnit tests

## Testing
- `vendor/bin/phpunit tests/Fields/FieldGroupRegistryTest.php tests/Fields/ValidationTest.php tests/Fields/RestRoundtripTest.php` *(fails: WordPress test suite is not available because mysqladmin is missing)*

------
https://chatgpt.com/codex/tasks/task_b_68c99cb754c4833087c71f365376a451