### PR TITLE
Add Elementor dynamic tags for GM2 fields

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -91,7 +91,7 @@ require_once GM2_PLUGIN_DIR . 'includes/gm2-theme-tools.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-open-in-code.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-field-renderers.php';
 require_once GM2_PLUGIN_DIR . 'includes/elementor/class-gm2-field-key-control.php';
-require_once GM2_PLUGIN_DIR . 'includes/elementor/class-gm2-dynamic-tag.php';
+require_once GM2_PLUGIN_DIR . 'src/Elementor/bootstrap.php';
 require_once GM2_PLUGIN_DIR . 'integrations/elementor/class-gm2-cp-elementor-tags.php';
 require_once GM2_PLUGIN_DIR . 'integrations/elementor/class-gm2-cp-elementor-query.php';
 require_once GM2_PLUGIN_DIR . 'integrations/elementor/class-gm2-cp-form-action.php';

--- a/src/Elementor/DynamicTags/GM2_Dynamic_Tag_Group.php
+++ b/src/Elementor/DynamicTags/GM2_Dynamic_Tag_Group.php
@@ -1,0 +1,1042 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gm2\Elementor\DynamicTags;
+
+use DateTimeImmutable;
+use Exception;
+use Gm2\Elementor\DynamicTags\Tag\AddressMapLink;
+use Gm2\Elementor\DynamicTags\Tag\ComputedValue;
+use Gm2\Elementor\DynamicTags\Tag\FieldValue;
+use Gm2\Fields\FieldDefinition;
+use Gm2\Fields\FieldGroupDefinition;
+use Gm2\Fields\FieldTypeRegistry;
+use Gm2\Fields\Sanitizers\SanitizerRegistry;
+use Gm2\Fields\Types\FieldTypeInterface;
+use InvalidArgumentException;
+use WP_Post;
+use WP_Term;
+use WP_User;
+use function esc_url_raw;
+use function get_option;
+use function get_post;
+use function get_post_meta;
+use function get_post_type;
+use function get_post_type_object;
+use function get_term;
+use function get_term_meta;
+use function get_user_by;
+use function get_user_meta;
+use function get_queried_object;
+use function get_queried_object_id;
+use function is_array;
+use function is_numeric;
+use function is_string;
+use function number_format_i18n;
+use function rawurlencode;
+use function sanitize_hex_color;
+use function sanitize_key;
+use function sanitize_text_field;
+use function trim;
+use function wp_date;
+use function wp_get_attachment_url;
+use function wp_strip_all_tags;
+use Elementor\Modules\DynamicTags\Module;
+
+final class GM2_Dynamic_Tag_Group
+{
+    private const GROUP = 'gm2';
+
+    private static ?self $instance = null;
+
+    private FieldTypeRegistry $fieldTypes;
+
+    private SanitizerRegistry $sanitizers;
+
+    /**
+     * @var array<string, FieldGroupDefinition>
+     */
+    private array $groups = [];
+
+    /**
+     * @var array<string, array{group: FieldGroupDefinition, field: FieldDefinition}>
+     */
+    private array $fieldIndex = [];
+
+    /**
+     * @var array<string, array<string, string>>
+     */
+    private array $postTypeFields = [];
+
+    /**
+     * @var array<string, array<string, array<int, string>>>
+     */
+    private array $computedGraphs = [];
+
+    /**
+     * @var array<string, array<string, mixed>>
+     */
+    private array $valueCache = [];
+
+    private string $snapshot = '';
+
+    private function __construct(?FieldTypeRegistry $fieldTypes = null, ?SanitizerRegistry $sanitizers = null)
+    {
+        $this->fieldTypes = $fieldTypes ?? FieldTypeRegistry::withDefaults();
+        $this->sanitizers = $sanitizers ?? SanitizerRegistry::withDefaults();
+        $this->loadGroups();
+    }
+
+    public static function instance(): self
+    {
+        return self::$instance ??= new self();
+    }
+
+    public function refresh(): void
+    {
+        $this->snapshot   = '';
+        $this->groups     = [];
+        $this->fieldIndex = [];
+        $this->postTypeFields = [];
+        $this->computedGraphs = [];
+        $this->valueCache = [];
+        $this->loadGroups(true);
+    }
+
+    public function register(Module $module): void
+    {
+        $module->register_group(self::GROUP, [
+            'title' => __('GM2 Fields', 'gm2-wordpress-suite'),
+        ]);
+
+        FieldValue::setGroup($this);
+        ComputedValue::setGroup($this);
+        AddressMapLink::setGroup($this);
+
+        $module->register_tag(FieldValue::class);
+        $module->register_tag(ComputedValue::class);
+        $module->register_tag(AddressMapLink::class);
+    }
+
+    public function getGroupName(): string
+    {
+        return self::GROUP;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getPostTypeOptions(): array
+    {
+        $this->loadGroups();
+
+        $options = ['' => __('Current Post', 'gm2-wordpress-suite')];
+        foreach ($this->postTypeFields as $postType => $_fields) {
+            $object = get_post_type_object($postType);
+            $label  = $object ? $object->labels->singular_name : ucfirst(str_replace('_', ' ', $postType));
+            $options[$postType] = $label;
+        }
+
+        return $options;
+    }
+
+    /**
+     * @param array<int, string> $allowedTypes
+     *
+     * @return array<string, string>
+     */
+    public function getFieldOptions(?string $postType = null, bool $includeComputed = true, array $allowedTypes = []): array
+    {
+        $this->loadGroups();
+
+        $options = [];
+        $targets = $postType ? [$postType] : array_keys($this->postTypeFields);
+
+        foreach ($targets as $type) {
+            if (!isset($this->postTypeFields[$type])) {
+                continue;
+            }
+            foreach ($this->postTypeFields[$type] as $compoundKey => $label) {
+                $field = $this->fieldIndex[$compoundKey]['field'] ?? null;
+                if (!$field) {
+                    continue;
+                }
+                if (!$includeComputed && $field->isComputed()) {
+                    continue;
+                }
+                if ($allowedTypes !== [] && !in_array($field->getType()->getName(), $allowedTypes, true)) {
+                    continue;
+                }
+                $options[$compoundKey] = $label . ' (' . $type . ')';
+            }
+        }
+
+        return $options;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getComputedFieldOptions(?string $postType = null): array
+    {
+        return $this->getFieldOptions($postType, true, ['computed']);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getMapFieldOptions(?string $postType = null): array
+    {
+        return $this->getFieldOptions($postType, false, ['geopoint', 'address']);
+    }
+
+    /**
+     * @return array{group: FieldGroupDefinition, field: FieldDefinition}|null
+     */
+    public function findField(string $compoundKey): ?array
+    {
+        $this->loadGroups();
+
+        return $this->fieldIndex[$compoundKey] ?? null;
+    }
+
+    public function getCategories(FieldDefinition $field): array
+    {
+        return $this->categoriesForType($field->getType());
+    }
+
+    public function getComputedCategories(FieldDefinition $field): array
+    {
+        $settings   = $field->getSettings()['computed'] ?? [];
+        $returnType = is_array($settings) ? ($settings['return_type'] ?? null) : null;
+        if (!is_string($returnType)) {
+            $returnType = 'string';
+        }
+
+        return match ($returnType) {
+            'number', 'integer' => [Module::NUMBER_CATEGORY],
+            'date', 'datetime', 'datetime_tz' => [Module::DATETIME_CATEGORY],
+            default => [Module::TEXT_CATEGORY],
+        };
+    }
+
+    public function getFormattedValue(string $compoundKey, ?string $postType = null, ?array $context = null): mixed
+    {
+        $fieldData = $this->findField($compoundKey);
+        if ($fieldData === null) {
+            return null;
+        }
+
+        [$group, $field] = [$fieldData['group'], $fieldData['field']];
+        $context = $context ?? $this->resolveContext($postType, $group);
+        if (($context['id'] ?? 0) <= 0) {
+            return null;
+        }
+
+        $value = $this->getSanitizedFieldValue($group, $field, $context);
+
+        return $this->formatValue($field, $value, $context);
+    }
+
+    public function getSanitizedValue(string $compoundKey, ?string $postType = null, ?array $context = null): mixed
+    {
+        $fieldData = $this->findField($compoundKey);
+        if ($fieldData === null) {
+            return null;
+        }
+
+        [$group, $field] = [$fieldData['group'], $fieldData['field']];
+        $context = $context ?? $this->resolveContext($postType, $group);
+        if (($context['id'] ?? 0) <= 0) {
+            return null;
+        }
+
+        return $this->getSanitizedFieldValue($group, $field, $context);
+    }
+
+    public function formatFallback(FieldDefinition $field, mixed $fallback): mixed
+    {
+        $fallback ??= '';
+        $type = $field->getType()->getName();
+
+        return match ($type) {
+            'image', 'media', 'file' => [
+                'id'  => 0,
+                'url' => is_string($fallback) ? esc_url_raw($fallback) : '',
+            ],
+            'gallery' => [],
+            default => is_string($fallback) ? sanitize_text_field($fallback) : (string) $fallback,
+        };
+    }
+
+    public function isEmptyValue(mixed $value): bool
+    {
+        if ($value === null) {
+            return true;
+        }
+
+        if (is_string($value)) {
+            return trim($value) === '';
+        }
+
+        if (is_array($value)) {
+            if ($value === []) {
+                return true;
+            }
+            if (isset($value['url'])) {
+                return trim((string) $value['url']) === '';
+            }
+            if (isset($value['ids'])) {
+                return $value['ids'] === [];
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array{type: string, id: int, post_type: string}
+     */
+    public function resolveContext(?string $postType = null, ?FieldGroupDefinition $group = null): array
+    {
+        $postType = is_string($postType) ? $postType : '';
+
+        if ($group && $postType === '') {
+            $postTypes = $this->getPostTypesForGroup($group);
+            if ($postTypes !== []) {
+                $postType = $postTypes[0];
+            }
+        }
+
+        $id = 0;
+        $object = get_post();
+        if ($object instanceof WP_Post) {
+            if ($postType === '' || $object->post_type === $postType) {
+                $id = (int) $object->ID;
+                $postType = $object->post_type;
+            }
+        }
+
+        if ($id === 0) {
+            $loopId = get_the_ID();
+            if ($loopId) {
+                $type = get_post_type($loopId) ?: '';
+                if ($postType === '' || $postType === $type) {
+                    $id = (int) $loopId;
+                    $postType = $type ?: $postType;
+                }
+            }
+        }
+
+        if ($id === 0) {
+            $queriedId = get_queried_object_id();
+            if ($queriedId) {
+                $id = (int) $queriedId;
+                $object = get_queried_object();
+                if ($object instanceof WP_Post) {
+                    $postType = $object->post_type;
+                }
+            }
+        }
+
+        return [
+            'type'      => 'post',
+            'id'        => $id,
+            'post_type' => $postType,
+        ];
+    }
+
+    private function loadGroups(bool $force = false): void
+    {
+        $raw = get_option('gm2_field_groups', []);
+        $snapshot = is_array($raw) ? md5(serialize($raw)) : '';
+        if (!$force && $snapshot === $this->snapshot) {
+            return;
+        }
+
+        $this->snapshot        = $snapshot;
+        $this->groups          = [];
+        $this->fieldIndex      = [];
+        $this->postTypeFields  = [];
+        $this->computedGraphs  = [];
+        $this->valueCache      = [];
+
+        if (!is_array($raw) || $raw === []) {
+            return;
+        }
+
+        foreach ($raw as $key => $config) {
+            if (!is_array($config)) {
+                continue;
+            }
+            $groupKey = $this->determineGroupKey($key, $config);
+            if ($groupKey === '') {
+                continue;
+            }
+
+            $group = $this->createGroupDefinition($groupKey, $config);
+            if (!$group) {
+                continue;
+            }
+
+            $this->groups[$groupKey] = $group;
+            $this->computedGraphs[$groupKey] = $group->getComputedDependencyGraph();
+
+            foreach ($group->getFields() as $field) {
+                $compound = $groupKey . '::' . $field->getKey();
+                $this->fieldIndex[$compound] = [
+                    'group' => $group,
+                    'field' => $field,
+                ];
+            }
+
+            $postTypes = $this->getPostTypesForGroup($group, $config);
+            foreach ($postTypes as $postType) {
+                foreach ($group->getFields() as $field) {
+                    $compound = $groupKey . '::' . $field->getKey();
+                    $label    = $group->getTitle() . ' – ' . $field->getLabel();
+                    $this->postTypeFields[$postType][$compound] = $label;
+                }
+            }
+        }
+    }
+
+    private function determineGroupKey(string|int $key, array $config): string
+    {
+        if (is_string($key) && $key !== '') {
+            return sanitize_key($key);
+        }
+
+        $possible = $config['key'] ?? $config['slug'] ?? $config['id'] ?? null;
+        if (is_string($possible) && $possible !== '') {
+            return sanitize_key($possible);
+        }
+
+        if (isset($config['title']) && is_string($config['title'])) {
+            return sanitize_key($config['title']);
+        }
+
+        return '';
+    }
+
+    private function createGroupDefinition(string $key, array $config): ?FieldGroupDefinition
+    {
+        $fieldsConfig = $config['fields'] ?? [];
+        if (!is_array($fieldsConfig) || $fieldsConfig === []) {
+            return null;
+        }
+
+        $definitions = [];
+        foreach ($fieldsConfig as $fieldKey => $settings) {
+            if (!is_string($fieldKey) || $fieldKey === '' || !is_array($settings)) {
+                continue;
+            }
+            $typeName = is_string($settings['type'] ?? null) ? $settings['type'] : 'text';
+
+            try {
+                $type = $this->fieldTypes->create($typeName, $settings);
+            } catch (InvalidArgumentException) {
+                continue;
+            }
+
+            $definitions[$fieldKey] = new FieldDefinition($fieldKey, $type, $settings);
+        }
+
+        if ($definitions === []) {
+            return null;
+        }
+
+        try {
+            return new FieldGroupDefinition($key, $config, $definitions);
+        } catch (InvalidArgumentException) {
+            return null;
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getPostTypesForGroup(FieldGroupDefinition $group, ?array $config = null): array
+    {
+        $postTypes = $group->getPostTypes();
+        if ($postTypes !== []) {
+            return $postTypes;
+        }
+
+        $config ??= [];
+        $raw = $config['post_types'] ?? $config['objects'] ?? [];
+        if (!is_array($raw)) {
+            return [];
+        }
+
+        $filtered = [];
+        foreach ($raw as $item) {
+            if (is_string($item) && $item !== '') {
+                $filtered[] = $item;
+            }
+        }
+
+        return array_values(array_unique($filtered));
+    }
+
+    private function getSanitizedFieldValue(FieldGroupDefinition $group, FieldDefinition $field, array $context): mixed
+    {
+        $contextKey = $this->contextCacheKey($context);
+        $compound   = $group->getKey() . '::' . $field->getKey();
+
+        if (isset($this->valueCache[$contextKey][$compound])) {
+            return $this->valueCache[$contextKey][$compound];
+        }
+
+        if ($field->isComputed()) {
+            $value = $this->resolveComputed($group, $field, $context);
+        } else {
+            $raw = $this->fetchRawValue($field, $context);
+            if (($raw === null || $raw === '') && $field->getDefault() !== null) {
+                $raw = $field->getDefault();
+            }
+            $value = $this->sanitizers->sanitize($field, $raw, $context);
+        }
+
+        $this->valueCache[$contextKey][$compound] = $value;
+
+        return $value;
+    }
+
+    private function fetchRawValue(FieldDefinition $field, array $context): mixed
+    {
+        $key = $field->getKey();
+        switch ($context['type']) {
+            case 'term':
+                return get_term_meta($context['id'], $key, true);
+            case 'user':
+                return get_user_meta($context['id'], $key, true);
+            default:
+                return get_post_meta($context['id'], $key, true);
+        }
+    }
+
+    private function contextCacheKey(array $context): string
+    {
+        $type = $context['type'] ?? 'post';
+        $id   = (int) ($context['id'] ?? 0);
+
+        return $type . ':' . $id;
+    }
+
+    private function formatValue(FieldDefinition $field, mixed $value, array $context): mixed
+    {
+        $type = $field->getType()->getName();
+
+        return match ($type) {
+            'currency' => $this->formatCurrency($value, $field->getSettings()),
+            'number' => is_numeric($value) ? number_format_i18n((float) $value) : $value,
+            'date' => is_string($value) ? $this->formatDate($value) : $value,
+            'time' => is_string($value) ? $this->formatTime($value) : $value,
+            'datetime_tz' => is_string($value) ? $this->formatDateTime($value) : $value,
+            'image', 'media', 'file' => $this->formatAttachment($value, $field->getSettings()),
+            'gallery' => $this->formatGallery($value),
+            'relationship_post' => $this->formatRelationshipPosts($value, $field),
+            'relationship_term' => $this->formatRelationshipTerms($value, $field),
+            'relationship_user' => $this->formatRelationshipUsers($value, $field),
+            'color' => is_string($value) ? sanitize_hex_color($value) : $value,
+            'computed' => $this->formatComputed($value, $field->getSettings()),
+            default => $value,
+        };
+    }
+
+    private function formatCurrency(mixed $value, array $settings): mixed
+    {
+        if (!is_numeric($value)) {
+            return $value;
+        }
+        $precision = is_numeric($settings['precision'] ?? null) ? (int) $settings['precision'] : 2;
+        $formatted = number_format_i18n((float) $value, $precision);
+        $symbol = '';
+        if (isset($settings['symbol']) && is_string($settings['symbol'])) {
+            $symbol = $settings['symbol'];
+        } else {
+            $symbol = $this->currencySymbol($settings['currency'] ?? null);
+        }
+
+        if ($symbol !== '') {
+            return $symbol . $formatted;
+        }
+
+        $code = is_string($settings['currency'] ?? null) ? $settings['currency'] : '';
+        if ($code !== '') {
+            return $code . ' ' . $formatted;
+        }
+
+        return $formatted;
+    }
+
+    private function currencySymbol(mixed $currency): string
+    {
+        if (!is_string($currency) || $currency === '') {
+            return '';
+        }
+
+        return match (strtoupper($currency)) {
+            'USD' => '$',
+            'EUR' => '€',
+            'GBP' => '£',
+            'JPY' => '¥',
+            'AUD' => '$',
+            'CAD' => '$',
+            default => '',
+        };
+    }
+
+    private function formatDate(string $value): string
+    {
+        $timestamp = strtotime($value);
+        if ($timestamp === false) {
+            return $value;
+        }
+
+        return wp_date(get_option('date_format'), $timestamp);
+    }
+
+    private function formatTime(string $value): string
+    {
+        $timestamp = strtotime($value);
+        if ($timestamp === false) {
+            return $value;
+        }
+
+        return wp_date(get_option('time_format'), $timestamp);
+    }
+
+    private function formatDateTime(string $value): string
+    {
+        try {
+            $date = new DateTimeImmutable($value);
+        } catch (Exception) {
+            $timestamp = strtotime($value);
+            if ($timestamp === false) {
+                return $value;
+            }
+
+            return wp_date(get_option('date_format') . ' ' . get_option('time_format') . ' T', $timestamp);
+        }
+
+        $timestamp = $date->getTimestamp();
+
+        return wp_date(get_option('date_format') . ' ' . get_option('time_format') . ' T', $timestamp);
+    }
+
+    private function formatAttachment(mixed $value, array $settings): array
+    {
+        $id = 0;
+        $url = '';
+
+        if (is_numeric($value) && (int) $value > 0) {
+            $id  = (int) $value;
+            $url = wp_get_attachment_url($id) ?: '';
+        } elseif (is_string($value) && $value !== '') {
+            $url = esc_url_raw($value);
+        }
+
+        if ($url === '' && isset($settings['default']) && is_string($settings['default'])) {
+            $url = esc_url_raw($settings['default']);
+        }
+
+        return [
+            'id'  => $id,
+            'url' => $url,
+        ];
+    }
+
+    private function formatGallery(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+
+        $items = [];
+        foreach ($value as $id) {
+            if (!is_numeric($id)) {
+                continue;
+            }
+            $attachmentId = (int) $id;
+            $items[] = [
+                'id'  => $attachmentId,
+                'url' => wp_get_attachment_url($attachmentId) ?: '',
+            ];
+        }
+
+        return $items;
+    }
+
+    private function formatRelationshipPosts(mixed $value, FieldDefinition $field): string
+    {
+        $ids = $this->normalizeRelationshipIds($value, $field);
+        if ($ids === []) {
+            return '';
+        }
+
+        $titles = [];
+        foreach ($ids as $id) {
+            $post = get_post($id);
+            if ($post instanceof WP_Post) {
+                $titles[] = wp_strip_all_tags($post->post_title);
+            }
+        }
+
+        return implode(', ', $titles);
+    }
+
+    private function formatRelationshipTerms(mixed $value, FieldDefinition $field): string
+    {
+        $ids = $this->normalizeRelationshipIds($value, $field);
+        if ($ids === []) {
+            return '';
+        }
+
+        $names = [];
+        foreach ($ids as $id) {
+            $term = get_term($id);
+            if ($term instanceof WP_Term) {
+                $names[] = sanitize_text_field($term->name);
+            }
+        }
+
+        return implode(', ', $names);
+    }
+
+    private function formatRelationshipUsers(mixed $value, FieldDefinition $field): string
+    {
+        $ids = $this->normalizeRelationshipIds($value, $field);
+        if ($ids === []) {
+            return '';
+        }
+
+        $names = [];
+        foreach ($ids as $id) {
+            $user = get_user_by('id', $id);
+            if ($user instanceof WP_User) {
+                $names[] = sanitize_text_field($user->display_name);
+            }
+        }
+
+        return implode(', ', $names);
+    }
+
+    private function formatComputed(mixed $value, array $settings): mixed
+    {
+        if (isset($settings['format']) && $settings['format'] === 'currency') {
+            return $this->formatCurrency($value, $settings + ['precision' => $settings['precision'] ?? 2]);
+        }
+
+        $returnType = is_string($settings['return_type'] ?? null) ? $settings['return_type'] : 'string';
+        if (in_array($returnType, ['number', 'integer'], true) && is_numeric($value)) {
+            $precision = is_numeric($settings['precision'] ?? null) ? (int) $settings['precision'] : 2;
+            return number_format_i18n((float) $value, $precision);
+        }
+
+        return $value;
+    }
+
+    private function normalizeRelationshipIds(mixed $value, FieldDefinition $field): array
+    {
+        $settings = $field->getSettings();
+        $multiple = (bool) ($settings['multiple'] ?? true);
+
+        if ($multiple) {
+            if (!is_array($value)) {
+                return [];
+            }
+            $ids = [];
+            foreach ($value as $item) {
+                if (is_numeric($item)) {
+                    $ids[] = (int) $item;
+                }
+            }
+
+            return array_values(array_unique($ids));
+        }
+
+        if (is_numeric($value)) {
+            return [ (int) $value ];
+        }
+
+        return [];
+    }
+
+    private function resolveComputed(FieldGroupDefinition $group, FieldDefinition $field, array $context): mixed
+    {
+        $graph = $this->computedGraphs[$group->getKey()] ?? [];
+        $dependencies = $graph[$field->getKey()] ?? $field->getComputedDependencies();
+
+        $values = [];
+        foreach ($dependencies as $dependencyKey) {
+            $dependency = $group->getField($dependencyKey);
+            $values[$dependencyKey] = $this->getSanitizedFieldValue($group, $dependency, $context);
+        }
+
+        $settings = $field->getSettings()['computed'] ?? [];
+        $settings = is_array($settings) ? $settings : [];
+
+        if (isset($settings['formula']) && is_string($settings['formula'])) {
+            return $this->evaluateFormula($settings['formula'], $values);
+        }
+
+        if (isset($settings['callback']) && is_callable($settings['callback'])) {
+            return ($settings['callback'])($values, $context);
+        }
+
+        return null;
+    }
+
+    private function evaluateFormula(string $formula, array $values): mixed
+    {
+        if (!preg_match_all('/{([^}]+)}/', $formula, $matches)) {
+            return null;
+        }
+
+        $replacements = [];
+        foreach ($matches[1] as $key) {
+            if (!array_key_exists($key, $values)) {
+                return null;
+            }
+            $numeric = $this->sanitizeNumericValue($values[$key]);
+            if ($numeric === null) {
+                return null;
+            }
+            $replacements['{' . $key . '}'] = $numeric;
+        }
+
+        $expression = strtr($formula, $replacements);
+        if (preg_match('/[^0-9+\-*\/().\s]/', $expression)) {
+            return null;
+        }
+
+        return $this->evaluateNumericExpression(trim($expression));
+    }
+
+    private function sanitizeNumericValue(mixed $value): ?string
+    {
+        if ($value === null || $value === '') {
+            return '0';
+        }
+
+        if (is_bool($value)) {
+            return $value ? '1' : '0';
+        }
+
+        if (is_int($value) || is_float($value)) {
+            return (string) $value;
+        }
+
+        if (is_string($value)) {
+            $filtered = trim($value);
+            if ($filtered === '') {
+                return '0';
+            }
+            if (preg_match('/^-?(?:\d+\.?\d*|\d*\.\d+)$/', $filtered)) {
+                return $filtered;
+            }
+            if (is_numeric($filtered)) {
+                return (string) (float) $filtered;
+            }
+        }
+
+        return null;
+    }
+
+    private function evaluateNumericExpression(string $expression): mixed
+    {
+        if ($expression === '') {
+            return null;
+        }
+
+        $length = strlen($expression);
+        $position = 0;
+
+        $value = $this->parseExpressionLevel($expression, $position, $length);
+        if ($value === null) {
+            return null;
+        }
+
+        $this->skipWhitespace($expression, $position, $length);
+        if ($position !== $length) {
+            return null;
+        }
+
+        return $value;
+    }
+
+    private function parseExpressionLevel(string $expression, int &$position, int $length): ?float
+    {
+        $value = $this->parseTerm($expression, $position, $length);
+        if ($value === null) {
+            return null;
+        }
+
+        while (true) {
+            $this->skipWhitespace($expression, $position, $length);
+            if ($position >= $length) {
+                break;
+            }
+
+            $operator = $expression[$position];
+            if ($operator !== '+' && $operator !== '-') {
+                break;
+            }
+            $position++;
+
+            $right = $this->parseTerm($expression, $position, $length);
+            if ($right === null) {
+                return null;
+            }
+
+            $value = $operator === '+' ? $value + $right : $value - $right;
+        }
+
+        return $value;
+    }
+
+    private function parseTerm(string $expression, int &$position, int $length): ?float
+    {
+        $value = $this->parseFactor($expression, $position, $length);
+        if ($value === null) {
+            return null;
+        }
+
+        while (true) {
+            $this->skipWhitespace($expression, $position, $length);
+            if ($position >= $length) {
+                break;
+            }
+
+            $operator = $expression[$position];
+            if ($operator !== '*' && $operator !== '/') {
+                break;
+            }
+            $position++;
+
+            $right = $this->parseFactor($expression, $position, $length);
+            if ($right === null) {
+                return null;
+            }
+
+            $value = $operator === '*' ? $value * $right : ($right != 0.0 ? $value / $right : null);
+            if ($value === null) {
+                return null;
+            }
+        }
+
+        return $value;
+    }
+
+    private function parseFactor(string $expression, int &$position, int $length): ?float
+    {
+        $this->skipWhitespace($expression, $position, $length);
+        if ($position >= $length) {
+            return null;
+        }
+
+        $char = $expression[$position];
+        if ($char === '(') {
+            $position++;
+            $value = $this->parseExpressionLevel($expression, $position, $length);
+            if ($value === null) {
+                return null;
+            }
+            $this->skipWhitespace($expression, $position, $length);
+            if ($position >= $length || $expression[$position] !== ')') {
+                return null;
+            }
+            $position++;
+
+            return $value;
+        }
+
+        $start = $position;
+        if ($char === '+' || $char === '-') {
+            $position++;
+        }
+
+        while ($position < $length && (ctype_digit($expression[$position]) || $expression[$position] === '.')) {
+            $position++;
+        }
+
+        if ($start === $position) {
+            return null;
+        }
+
+        $number = substr($expression, $start, $position - $start);
+
+        return is_numeric($number) ? (float) $number : null;
+    }
+
+    private function skipWhitespace(string $expression, int &$position, int $length): void
+    {
+        while ($position < $length && ctype_space($expression[$position])) {
+            $position++;
+        }
+    }
+
+    private function categoriesForType(FieldTypeInterface $type): array
+    {
+        return match ($type->getName()) {
+            'url', 'email', 'tel' => [Module::URL_CATEGORY],
+            'image' => [Module::IMAGE_CATEGORY],
+            'media', 'file' => [Module::MEDIA_CATEGORY],
+            'gallery' => [Module::GALLERY_CATEGORY],
+            'number', 'currency' => [Module::NUMBER_CATEGORY],
+            'date', 'time', 'datetime_tz' => [Module::DATETIME_CATEGORY],
+            'color' => [Module::COLOR_CATEGORY],
+            default => [Module::TEXT_CATEGORY],
+        };
+    }
+
+    public function buildMapUrl(string $compoundKey, ?string $postType = null, ?array $context = null): ?string
+    {
+        $value = $this->getSanitizedValue($compoundKey, $postType, $context);
+        if ($value === null) {
+            return null;
+        }
+
+        $query = $this->mapQueryFromValue($value);
+        if ($query === null || $query === '') {
+            return null;
+        }
+
+        return 'https://www.google.com/maps/search/?api=1&query=' . rawurlencode($query);
+    }
+
+    private function mapQueryFromValue(mixed $value): ?string
+    {
+        if (is_array($value)) {
+            if (isset($value['lat'], $value['lng']) && is_numeric($value['lat']) && is_numeric($value['lng'])) {
+                return $this->formatCoordinate((float) $value['lat']) . ',' . $this->formatCoordinate((float) $value['lng']);
+            }
+
+            $parts = [];
+            foreach (['line1', 'line2', 'city', 'state', 'postal_code', 'country'] as $key) {
+                if (isset($value[$key]) && is_string($value[$key]) && $value[$key] !== '') {
+                    $parts[] = $value[$key];
+                }
+            }
+            if ($parts !== []) {
+                return implode(' ', $parts);
+            }
+        }
+
+        if (is_string($value) && $value !== '') {
+            return $value;
+        }
+
+        return null;
+    }
+
+    private function formatCoordinate(float $value): string
+    {
+        $formatted = number_format($value, 6, '.', '');
+
+        return rtrim(rtrim($formatted, '0'), '.');
+    }
+}

--- a/src/Elementor/DynamicTags/Tag/AddressMapLink.php
+++ b/src/Elementor/DynamicTags/Tag/AddressMapLink.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gm2\Elementor\DynamicTags\Tag;
+
+use Elementor\Modules\DynamicTags\Module;
+use Gm2\Fields\FieldDefinition;
+use Gm2\Fields\FieldGroupDefinition;
+use function esc_url_raw;
+use function is_string;
+
+final class AddressMapLink extends FieldValue
+{
+    public function get_name(): string
+    {
+        return 'gm2_address_map_link';
+    }
+
+    public function get_title(): string
+    {
+        return __('GM2 Map Link', 'gm2-wordpress-suite');
+    }
+
+    public function get_categories(): array
+    {
+        return [ Module::URL_CATEGORY ];
+    }
+
+    protected function fieldOptions(?string $postType): array
+    {
+        return $this->group()->getMapFieldOptions($postType);
+    }
+
+    protected function valueFromGroup(FieldGroupDefinition $group, FieldDefinition $field, string $compoundKey, ?string $postType): mixed
+    {
+        $url = $this->group()->buildMapUrl($compoundKey, $postType);
+        if ($url === null) {
+            return [ 'url' => '' ];
+        }
+
+        return [ 'url' => $url ];
+    }
+
+    protected function fallbackForField(FieldDefinition $field, mixed $fallback): mixed
+    {
+        $url = is_string($fallback) ? esc_url_raw($fallback) : '';
+
+        return [ 'url' => $url ];
+    }
+}

--- a/src/Elementor/DynamicTags/Tag/ComputedValue.php
+++ b/src/Elementor/DynamicTags/Tag/ComputedValue.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gm2\Elementor\DynamicTags\Tag;
+
+use Elementor\Modules\DynamicTags\Module;
+
+final class ComputedValue extends FieldValue
+{
+    public function get_name(): string
+    {
+        return 'gm2_computed_value';
+    }
+
+    public function get_title(): string
+    {
+        return __('GM2 Computed Field', 'gm2-wordpress-suite');
+    }
+
+    public function get_categories(): array
+    {
+        $fieldKey = (string) ($this->get_settings('field_key') ?? '');
+        if ($fieldKey === '') {
+            return [ Module::TEXT_CATEGORY ];
+        }
+
+        $fieldData = $this->group()->findField($fieldKey);
+        if ($fieldData === null) {
+            return [ Module::TEXT_CATEGORY ];
+        }
+
+        return $this->group()->getComputedCategories($fieldData['field']);
+    }
+
+    protected function fieldOptions(?string $postType): array
+    {
+        return $this->group()->getComputedFieldOptions($postType);
+    }
+}

--- a/src/Elementor/DynamicTags/Tag/FieldValue.php
+++ b/src/Elementor/DynamicTags/Tag/FieldValue.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gm2\Elementor\DynamicTags\Tag;
+
+use Elementor\Controls_Manager;
+use Elementor\Core\DynamicTags\Tag;
+use Elementor\Modules\DynamicTags\Module;
+use Gm2\Elementor\DynamicTags\GM2_Dynamic_Tag_Group;
+use Gm2\Fields\FieldDefinition;
+use Gm2\Fields\FieldGroupDefinition;
+use function is_string;
+use function sanitize_text_field;
+use function trim;
+
+class FieldValue extends Tag
+{
+    private static ?GM2_Dynamic_Tag_Group $group = null;
+
+    /**
+     * @var array<string, array<string, mixed>>
+     */
+    private array $registeredControls = [];
+
+    /**
+     * @var array<string, mixed>
+     */
+    private array $settings = [];
+
+    public static function setGroup(GM2_Dynamic_Tag_Group $group): void
+    {
+        self::$group = $group;
+    }
+
+    protected function group(): GM2_Dynamic_Tag_Group
+    {
+        return self::$group ?? GM2_Dynamic_Tag_Group::instance();
+    }
+
+    public function get_name(): string
+    {
+        return 'gm2_field_value';
+    }
+
+    public function get_title(): string
+    {
+        return __('GM2 Field Value', 'gm2-wordpress-suite');
+    }
+
+    public function get_group(): string
+    {
+        return $this->group()->getGroupName();
+    }
+
+    public function get_categories(): array
+    {
+        $fieldKey = (string) ($this->get_settings('field_key') ?? '');
+        if ($fieldKey === '') {
+            return [ Module::TEXT_CATEGORY ];
+        }
+
+        $fieldData = $this->group()->findField($fieldKey);
+        if ($fieldData === null) {
+            return [ Module::TEXT_CATEGORY ];
+        }
+
+        return $this->group()->getCategories($fieldData['field']);
+    }
+
+    protected function register_controls(): void
+    {
+        $this->add_control('post_type', [
+            'label'   => __('Post Type', 'gm2-wordpress-suite'),
+            'type'    => Controls_Manager::SELECT,
+            'options' => $this->group()->getPostTypeOptions(),
+            'default' => '',
+        ]);
+
+        $this->add_control('field_key', [
+            'label'   => __('Field', 'gm2-wordpress-suite'),
+            'type'    => Controls_Manager::SELECT2,
+            'options' => $this->fieldOptions(null),
+        ]);
+
+        $this->add_control('fallback', [
+            'label' => __('Fallback', 'gm2-wordpress-suite'),
+            'type'  => Controls_Manager::TEXT,
+        ]);
+    }
+
+    protected function add_control($id, $args = []): void
+    {
+        $this->registeredControls[$id] = $args;
+        parent::add_control($id, $args);
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public function get_registered_controls(): array
+    {
+        return $this->registeredControls;
+    }
+
+    public function set_settings(array $settings): void
+    {
+        $this->settings = $settings;
+    }
+
+    public function get_settings($key = null): mixed
+    {
+        if ($key === null) {
+            return $this->settings;
+        }
+
+        return $this->settings[$key] ?? null;
+    }
+
+    public function get_value(array $options = []): mixed
+    {
+        $fieldKey = (string) ($this->get_settings('field_key') ?? '');
+        if ($fieldKey === '') {
+            return $this->get_settings('fallback');
+        }
+
+        $fieldData = $this->group()->findField($fieldKey);
+        if ($fieldData === null) {
+            return $this->get_settings('fallback');
+        }
+
+        $postType = $this->normalizePostType($this->get_settings('post_type'));
+        $value    = $this->valueFromGroup($fieldData['group'], $fieldData['field'], $fieldKey, $postType);
+
+        if ($this->group()->isEmptyValue($value)) {
+            return $this->fallbackForField($fieldData['field'], $this->get_settings('fallback'));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function fieldOptions(?string $postType): array
+    {
+        return $this->group()->getFieldOptions($postType, false);
+    }
+
+    protected function valueFromGroup(FieldGroupDefinition $group, FieldDefinition $field, string $compoundKey, ?string $postType): mixed
+    {
+        return $this->group()->getFormattedValue($compoundKey, $postType);
+    }
+
+    protected function fallbackForField(FieldDefinition $field, mixed $fallback): mixed
+    {
+        $value = is_string($fallback) ? sanitize_text_field($fallback) : $fallback;
+
+        return $this->group()->formatFallback($field, $value);
+    }
+
+    private function normalizePostType(mixed $postType): ?string
+    {
+        if (!is_string($postType)) {
+            return null;
+        }
+
+        $postType = trim($postType);
+
+        return $postType === '' ? null : $postType;
+    }
+}

--- a/src/Elementor/bootstrap.php
+++ b/src/Elementor/bootstrap.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gm2\Elementor;
+
+use Elementor\Modules\DynamicTags\Module;
+use Gm2\Elementor\DynamicTags\GM2_Dynamic_Tag_Group;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+add_action(
+    'elementor/dynamic_tags/register',
+    static function ($module): void {
+        if (!$module instanceof Module) {
+            return;
+        }
+
+        GM2_Dynamic_Tag_Group::instance()->register($module);
+    }
+);

--- a/tests/Elementor/DynamicTags/DynamicTagsTest.php
+++ b/tests/Elementor/DynamicTags/DynamicTagsTest.php
@@ -1,0 +1,304 @@
+<?php
+
+declare(strict_types=1);
+
+use Elementor\Modules\DynamicTags\Module;
+use Gm2\Elementor\DynamicTags\GM2_Dynamic_Tag_Group;
+use Gm2\Elementor\DynamicTags\Tag\AddressMapLink;
+use Gm2\Elementor\DynamicTags\Tag\ComputedValue;
+use Gm2\Elementor\DynamicTags\Tag\FieldValue;
+
+class DynamicTagsTest extends WP_UnitTestCase
+{
+    private int $bookId;
+
+    private int $relatedBookId;
+
+    private int $imageId;
+
+    private ?WP_Post $originalPost = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        register_post_type('library_book', [ 'public' => true, 'label' => 'Library Book' ]);
+        update_option('date_format', 'F j, Y');
+        update_option('time_format', 'g:i a');
+        update_option('timezone_string', 'America/New_York');
+        $this->originalPost = $GLOBALS['post'] ?? null;
+
+        $this->registerFieldGroups();
+        $this->createContent();
+    }
+
+    protected function tearDown(): void
+    {
+        unregister_post_type('library_book');
+        delete_option('gm2_field_groups');
+        $GLOBALS['post'] = $this->originalPost;
+        wp_reset_postdata();
+        parent::tearDown();
+    }
+
+    public function test_group_registration_registers_tags(): void
+    {
+        $module = new class extends Module {
+            public array $groups = [];
+            public array $tags   = [];
+
+            public function register_group($name, $args = [])
+            {
+                $this->groups[$name] = $args;
+            }
+
+            public function register_tag($tag)
+            {
+                $this->tags[] = $tag;
+            }
+        };
+
+        do_action('elementor/dynamic_tags/register', $module);
+
+        $groupName = GM2_Dynamic_Tag_Group::instance()->getGroupName();
+        $this->assertArrayHasKey($groupName, $module->groups);
+        $this->assertContains(FieldValue::class, $module->tags);
+        $this->assertContains(ComputedValue::class, $module->tags);
+        $this->assertContains(AddressMapLink::class, $module->tags);
+    }
+
+    public function test_field_value_registers_controls(): void
+    {
+        $tag = new FieldValue();
+        $tag->register_controls();
+        $controls = $tag->get_registered_controls();
+
+        $this->assertArrayHasKey('post_type', $controls);
+        $this->assertArrayHasKey('field_key', $controls);
+        $this->assertArrayHasKey('fallback', $controls);
+        $this->assertArrayHasKey('options', $controls['field_key']);
+        $this->assertArrayHasKey('library_details::price', $controls['field_key']['options']);
+    }
+
+    public function test_field_value_formats_currency_datetime_media_and_relationship(): void
+    {
+        $this->setCurrentPost($this->bookId);
+
+        $priceTag = $this->createFieldTag('library_details::price');
+        $this->assertSame('$123.45', $priceTag->get_value());
+
+        $dateTag = $this->createFieldTag('library_details::launch_date');
+        $expectedDate = wp_date(
+            get_option('date_format') . ' ' . get_option('time_format') . ' T',
+            strtotime('2024-05-01T15:30:00+00:00')
+        );
+        $this->assertSame($expectedDate, $dateTag->get_value());
+
+        $imageTag = $this->createFieldTag('library_details::cover_image');
+        $imageValue = $imageTag->get_value();
+        $this->assertIsArray($imageValue);
+        $this->assertSame($this->imageId, $imageValue['id']);
+        $this->assertSame(wp_get_attachment_url($this->imageId), $imageValue['url']);
+
+        $relationshipTag = $this->createFieldTag('library_details::related_books');
+        $relatedTitle    = wp_strip_all_tags(get_post($this->relatedBookId)->post_title);
+        $this->assertSame($relatedTitle, $relationshipTag->get_value());
+
+        $textTag = $this->createFieldTag('library_details::blurb');
+        $this->assertSame('Exclusive Deals', $textTag->get_value());
+    }
+
+    public function test_field_value_returns_fallback_for_unknown_field(): void
+    {
+        $this->setCurrentPost($this->bookId);
+        $tag = new FieldValue();
+        $tag->set_settings([
+            'post_type' => 'library_book',
+            'field_key' => 'library_details::missing_field',
+            'fallback'  => 'Not Provided',
+        ]);
+
+        $this->assertSame('Not Provided', $tag->get_value());
+    }
+
+    public function test_computed_value_resolves_dependency_graph(): void
+    {
+        $this->setCurrentPost($this->bookId);
+
+        $totalTag = new ComputedValue();
+        $totalTag->set_settings([
+            'post_type' => 'library_book',
+            'field_key' => 'library_details::total',
+            'fallback'  => '0',
+        ]);
+        $this->assertSame('$130.00', $totalTag->get_value());
+
+        $grandTag = new ComputedValue();
+        $grandTag->set_settings([
+            'post_type' => 'library_book',
+            'field_key' => 'library_details::grand_total',
+            'fallback'  => '0',
+        ]);
+        $this->assertSame('$260.00', $grandTag->get_value());
+    }
+
+    public function test_address_map_link_generates_map_url_and_fallback(): void
+    {
+        $this->setCurrentPost($this->bookId);
+
+        $tag = new AddressMapLink();
+        $tag->set_settings([
+            'post_type' => 'library_book',
+            'field_key' => 'library_details::map_coordinates',
+            'fallback'  => 'https://example.com/fallback-map',
+        ]);
+
+        $value = $tag->get_value();
+        $this->assertIsArray($value);
+        $this->assertSame(
+            'https://www.google.com/maps/search/?api=1&query=37.422,-122.0841',
+            $value['url']
+        );
+
+        delete_post_meta($this->bookId, 'map_coordinates');
+        $this->setCurrentPost($this->bookId);
+        $fallbackValue = $tag->get_value();
+        $this->assertSame('https://example.com/fallback-map', $fallbackValue['url']);
+    }
+
+    public function test_field_value_uses_loop_context_in_archive(): void
+    {
+        $query = new WP_Query([
+            'post_type'      => 'library_book',
+            'p'              => $this->bookId,
+            'posts_per_page' => 1,
+        ]);
+
+        $tag = new FieldValue();
+        $tag->set_settings([
+            'post_type' => 'library_book',
+            'field_key' => 'library_details::price',
+            'fallback'  => 'N/A',
+        ]);
+
+        $this->assertTrue($query->have_posts());
+        while ($query->have_posts()) {
+            $query->the_post();
+            $this->assertSame('$123.45', $tag->get_value());
+        }
+        wp_reset_postdata();
+    }
+
+    private function createFieldTag(string $fieldKey): FieldValue
+    {
+        $tag = new FieldValue();
+        $tag->set_settings([
+            'post_type' => 'library_book',
+            'field_key' => $fieldKey,
+            'fallback'  => '',
+        ]);
+
+        return $tag;
+    }
+
+    private function setCurrentPost(int $postId): void
+    {
+        $GLOBALS['post'] = get_post($postId);
+    }
+
+    private function registerFieldGroups(): void
+    {
+        update_option('gm2_field_groups', [
+            'library_details' => [
+                'title'    => 'Library Details',
+                'contexts' => [ 'post' => [ 'library_book' ] ],
+                'fields'   => [
+                    'price' => [
+                        'type'    => 'currency',
+                        'label'   => 'Price',
+                        'symbol'  => '$',
+                        'precision' => 2,
+                    ],
+                    'tax' => [
+                        'type'    => 'currency',
+                        'label'   => 'Tax',
+                        'symbol'  => '$',
+                        'precision' => 2,
+                    ],
+                    'launch_date' => [
+                        'type'  => 'datetime_tz',
+                        'label' => 'Launch Date',
+                    ],
+                    'cover_image' => [
+                        'type'  => 'image',
+                        'label' => 'Cover Image',
+                    ],
+                    'related_books' => [
+                        'type'     => 'relationship_post',
+                        'label'    => 'Related Books',
+                        'multiple' => true,
+                    ],
+                    'map_coordinates' => [
+                        'type'  => 'geopoint',
+                        'label' => 'Map Coordinates',
+                    ],
+                    'blurb' => [
+                        'type'  => 'text',
+                        'label' => 'Blurb',
+                    ],
+                    'total' => [
+                        'type'     => 'computed',
+                        'label'    => 'Total',
+                        'computed' => [
+                            'dependencies' => [ 'price', 'tax' ],
+                            'formula'      => '{price} + {tax}',
+                            'return_type'  => 'number',
+                            'format'       => 'currency',
+                            'symbol'       => '$',
+                            'precision'    => 2,
+                        ],
+                    ],
+                    'grand_total' => [
+                        'type'     => 'computed',
+                        'label'    => 'Grand Total',
+                        'computed' => [
+                            'dependencies' => [ 'total' ],
+                            'formula'      => '{total} * 2',
+                            'return_type'  => 'number',
+                            'format'       => 'currency',
+                            'symbol'       => '$',
+                            'precision'    => 2,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        GM2_Dynamic_Tag_Group::instance()->refresh();
+    }
+
+    private function createContent(): void
+    {
+        $this->relatedBookId = self::factory()->post->create([
+            'post_type'  => 'library_book',
+            'post_title' => 'Related <strong>Book</strong>',
+        ]);
+
+        $this->imageId = self::factory()->attachment->create_upload_object(
+            DIR_TESTDATA . '/images/canola.jpg'
+        );
+
+        $this->bookId = self::factory()->post->create([
+            'post_type'  => 'library_book',
+            'post_title' => 'Primary Book',
+            'meta_input' => [
+                'price'           => '123.45',
+                'tax'             => '6.55',
+                'launch_date'     => '2024-05-01T15:30:00+00:00',
+                'cover_image'     => $this->imageId,
+                'related_books'   => [ $this->relatedBookId ],
+                'map_coordinates' => [ 'lat' => 37.4220, 'lng' => -122.0841 ],
+                'blurb'           => '<strong>Exclusive</strong> Deals',
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add a GM2 dynamic tag group that resolves field metadata, formatting and computed dependencies for Elementor
- provide typed FieldValue, ComputedValue, and AddressMapLink dynamic tags with shared controls and fallbacks
- hook the new bootstrap into the plugin and cover behaviour with PHPUnit tests for formatting, controls, computed chains, and map URLs

## Testing
- `./vendor/bin/phpunit --configuration phpunit.xml --testsuite Unit --filter DynamicTagsTest` *(fails: WordPress test suite is unavailable in the runner environment)*

------
https://chatgpt.com/codex/tasks/task_b_68c9a74c6cbc8330b657afd11b0d94b8