### PR TITLE
Add Elementor query filters for GM2 presets

### DIFF
--- a/src/Elementor/Query/Filters.php
+++ b/src/Elementor/Query/Filters.php
@@ -1,0 +1,347 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gm2\Elementor\Query;
+
+use WP_Query;
+
+use function add_action;
+use function current_time;
+use function deg2rad;
+use function cos;
+use function sanitize_text_field;
+
+/**
+ * Registers Elementor query filters for GM2 content types.
+ */
+class Filters
+{
+    private const DEFAULT_EVENTS_PER_PAGE     = 6;
+    private const DEFAULT_JOBS_PER_PAGE       = 10;
+    private const DEFAULT_PROPERTIES_PER_PAGE = 12;
+    private const DEFAULT_DIRECTORY_PER_PAGE  = 12;
+    private const DEFAULT_COURSES_PER_PAGE    = 9;
+
+    /**
+     * Bootstrap the filter callbacks.
+     */
+    public static function register(): void
+    {
+        add_action('elementor/query/gm2_upcoming_events', [self::class, 'handleUpcomingEvents'], 10, 2);
+        add_action('elementor/query/gm2_past_events', [self::class, 'handlePastEvents'], 10, 2);
+        add_action('elementor/query/gm2_open_jobs', [self::class, 'handleOpenJobs'], 10, 2);
+        add_action('elementor/query/gm2_properties_sale', [self::class, 'handlePropertiesForSale'], 10, 2);
+        add_action('elementor/query/gm2_properties_rent', [self::class, 'handlePropertiesForRent'], 10, 2);
+        add_action('elementor/query/gm2_directory_nearby', [self::class, 'handleDirectoryNearby'], 10, 2);
+        add_action('elementor/query/gm2_courses_active', [self::class, 'handleActiveCourses'], 10, 2);
+    }
+
+    /**
+     * Upcoming events are ordered by start date and limited to future events.
+     */
+    public static function handleUpcomingEvents($query, $widget = null): void
+    {
+        if (!$query instanceof WP_Query) {
+            return;
+        }
+
+        self::ensurePostType($query, 'event');
+        self::ensureStatus($query, 'publish');
+        self::ensurePagination($query, self::DEFAULT_EVENTS_PER_PAGE);
+        self::applySearch($query, ['gm2_event_search', 'gm2_search']);
+
+        $now = current_time('mysql');
+        self::appendMetaQuery($query, [
+            'key'     => 'start_date',
+            'value'   => $now,
+            'compare' => '>=',
+            'type'    => 'DATETIME',
+        ]);
+
+        self::ensureMetaOrdering($query, 'start_date', 'meta_value', 'ASC');
+    }
+
+    /**
+     * Past events are sorted by most recent first and limited to dates before today.
+     */
+    public static function handlePastEvents($query, $widget = null): void
+    {
+        if (!$query instanceof WP_Query) {
+            return;
+        }
+
+        self::ensurePostType($query, 'event');
+        self::ensureStatus($query, 'publish');
+        self::ensurePagination($query, self::DEFAULT_EVENTS_PER_PAGE);
+        self::applySearch($query, ['gm2_event_search', 'gm2_search']);
+
+        $now = current_time('mysql');
+        self::appendMetaQuery($query, [
+            'key'     => 'start_date',
+            'value'   => $now,
+            'compare' => '<',
+            'type'    => 'DATETIME',
+        ]);
+
+        self::ensureMetaOrdering($query, 'start_date', 'meta_value', 'DESC');
+    }
+
+    /**
+     * Open jobs default to the current listings in descending publish order.
+     */
+    public static function handleOpenJobs($query, $widget = null): void
+    {
+        if (!$query instanceof WP_Query) {
+            return;
+        }
+
+        self::ensurePostType($query, 'job');
+        self::ensureStatus($query, 'publish');
+        self::ensurePagination($query, self::DEFAULT_JOBS_PER_PAGE);
+        self::applySearch($query, ['gm2_job_search', 'gm2_search']);
+
+        self::appendMetaQuery($query, [
+            'key'   => 'status',
+            'value' => 'open',
+        ]);
+
+        self::ensureOrdering($query, 'date', 'DESC');
+    }
+
+    /**
+     * Properties for sale filter by taxonomy and price order.
+     */
+    public static function handlePropertiesForSale($query, $widget = null): void
+    {
+        if (!$query instanceof WP_Query) {
+            return;
+        }
+
+        self::preparePropertyQuery($query, 'for-sale');
+    }
+
+    /**
+     * Properties for rent filter by taxonomy and price order.
+     */
+    public static function handlePropertiesForRent($query, $widget = null): void
+    {
+        if (!$query instanceof WP_Query) {
+            return;
+        }
+
+        self::preparePropertyQuery($query, 'for-rent');
+    }
+
+    /**
+     * Nearby directory listings use a geo bounding box to limit results.
+     */
+    public static function handleDirectoryNearby($query, $widget = null): void
+    {
+        if (!$query instanceof WP_Query) {
+            return;
+        }
+
+        self::ensurePostType($query, 'listing');
+        self::ensureStatus($query, 'publish');
+        self::ensurePagination($query, self::DEFAULT_DIRECTORY_PER_PAGE);
+        self::applySearch($query, ['gm2_directory_search', 'gm2_search']);
+
+        $lat    = self::floatQueryVar($query, 'gm2_lat');
+        $lng    = self::floatQueryVar($query, 'gm2_lng');
+        $radius = self::floatQueryVar($query, 'gm2_radius');
+
+        if ($lat !== null && $lng !== null && $radius !== null && $radius > 0) {
+            $latRange = $radius / 111.045;
+            $lngRange = $radius / (111.045 * max(cos(deg2rad($lat)), 0.00001));
+
+            self::appendMetaQuery($query, [
+                'key'     => 'latitude',
+                'value'   => [$lat - $latRange, $lat + $latRange],
+                'compare' => 'BETWEEN',
+                'type'    => 'DECIMAL',
+            ]);
+
+            self::appendMetaQuery($query, [
+                'key'     => 'longitude',
+                'value'   => [$lng - $lngRange, $lng + $lngRange],
+                'compare' => 'BETWEEN',
+                'type'    => 'DECIMAL',
+            ]);
+        }
+
+        self::ensureOrdering($query, 'title', 'ASC');
+    }
+
+    /**
+     * Active courses are published entries with an "active" status flag.
+     */
+    public static function handleActiveCourses($query, $widget = null): void
+    {
+        if (!$query instanceof WP_Query) {
+            return;
+        }
+
+        self::ensurePostType($query, 'course');
+        self::ensureStatus($query, 'publish');
+        self::ensurePagination($query, self::DEFAULT_COURSES_PER_PAGE);
+        self::applySearch($query, ['gm2_course_search', 'gm2_search']);
+
+        self::appendMetaQuery($query, [
+            'key'   => 'status',
+            'value' => 'active',
+        ]);
+
+        self::ensureOrdering($query, 'date', 'DESC');
+    }
+
+    /**
+     * Apply shared property filtering logic.
+     */
+    private static function preparePropertyQuery(WP_Query $query, string $statusSlug): void
+    {
+        self::ensurePostType($query, 'property');
+        self::ensureStatus($query, 'publish');
+        self::ensurePagination($query, self::DEFAULT_PROPERTIES_PER_PAGE);
+        self::applySearch($query, ['gm2_property_search', 'gm2_search']);
+
+        self::appendTaxQuery($query, [
+            'taxonomy' => 'property_status',
+            'field'    => 'slug',
+            'terms'    => [$statusSlug],
+        ]);
+
+        self::ensureMetaOrdering($query, 'price', 'meta_value_num', 'ASC');
+    }
+
+    /**
+     * Ensure a post type when one has not been explicitly set.
+     */
+    private static function ensurePostType(WP_Query $query, string $postType): void
+    {
+        $current = $query->get('post_type');
+        if (empty($current) || $current === 'any') {
+            $query->set('post_type', $postType);
+        }
+    }
+
+    /**
+     * Ensure a post status when one has not been explicitly set.
+     */
+    private static function ensureStatus(WP_Query $query, string $status): void
+    {
+        if (!$query->get('post_status')) {
+            $query->set('post_status', $status);
+        }
+    }
+
+    /**
+     * Ensure pagination defaults to a sensible amount.
+     */
+    private static function ensurePagination(WP_Query $query, int $default): void
+    {
+        $perPage = (int) $query->get('posts_per_page');
+        if ($perPage <= 0) {
+            $query->set('posts_per_page', $default);
+        }
+    }
+
+    /**
+     * Append a meta query clause.
+     */
+    private static function appendMetaQuery(WP_Query $query, array $clause): void
+    {
+        $metaQuery = $query->get('meta_query');
+        if (!is_array($metaQuery)) {
+            $metaQuery = [];
+        }
+
+        $metaQuery[] = $clause;
+
+        if (count($metaQuery) > 1 && !isset($metaQuery['relation'])) {
+            $metaQuery['relation'] = 'AND';
+        }
+
+        $query->set('meta_query', $metaQuery);
+    }
+
+    /**
+     * Append a taxonomy query clause.
+     */
+    private static function appendTaxQuery(WP_Query $query, array $clause): void
+    {
+        $taxQuery = $query->get('tax_query');
+        if (!is_array($taxQuery)) {
+            $taxQuery = [];
+        }
+
+        $taxQuery[] = $clause;
+
+        if (count($taxQuery) > 1 && !isset($taxQuery['relation'])) {
+            $taxQuery['relation'] = 'AND';
+        }
+
+        $query->set('tax_query', $taxQuery);
+    }
+
+    /**
+     * Ensure ordering using a standard post field.
+     */
+    private static function ensureOrdering(WP_Query $query, $orderby, string $order): void
+    {
+        if (!$query->get('orderby')) {
+            $query->set('orderby', $orderby);
+        }
+
+        if (!$query->get('order')) {
+            $query->set('order', $order);
+        }
+    }
+
+    /**
+     * Ensure ordering using a specific meta key.
+     */
+    private static function ensureMetaOrdering(WP_Query $query, string $metaKey, $orderby, string $order): void
+    {
+        if (!$query->get('meta_key')) {
+            $query->set('meta_key', $metaKey);
+        }
+
+        self::ensureOrdering($query, $orderby, $order);
+    }
+
+    /**
+     * Apply a search term if the query has been given a custom key.
+     */
+    private static function applySearch(WP_Query $query, array $keys): void
+    {
+        if ($query->get('s')) {
+            return;
+        }
+
+        foreach ($keys as $key) {
+            $value = $query->get($key);
+            if (is_string($value) && $value !== '') {
+                $query->set('s', sanitize_text_field($value));
+                break;
+            }
+        }
+    }
+
+    /**
+     * Pull a float value out of the query vars.
+     */
+    private static function floatQueryVar(WP_Query $query, string $key): ?float
+    {
+        $value = $query->get($key);
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (is_numeric($value)) {
+            return (float) $value;
+        }
+
+        return null;
+    }
+}

--- a/src/Elementor/bootstrap.php
+++ b/src/Elementor/bootstrap.php
@@ -6,10 +6,13 @@ namespace Gm2\Elementor;
 
 use Elementor\Modules\DynamicTags\Module;
 use Gm2\Elementor\DynamicTags\GM2_Dynamic_Tag_Group;
+use Gm2\Elementor\Query\Filters;
 
 if (!defined('ABSPATH')) {
     exit;
 }
+
+require_once __DIR__ . '/Query/Filters.php';
 
 add_action(
     'elementor/dynamic_tags/register',
@@ -21,3 +24,5 @@ add_action(
         GM2_Dynamic_Tag_Group::instance()->register($module);
     }
 );
+
+Filters::register();

--- a/tests/Elementor/Query/FiltersTest.php
+++ b/tests/Elementor/Query/FiltersTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+class FiltersTest extends WP_UnitTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        register_post_type('event', ['public' => true]);
+        register_post_type('job', ['public' => true]);
+        register_post_type('property', ['public' => true]);
+        register_taxonomy('property_status', 'property', ['public' => true]);
+        register_post_type('listing', ['public' => true]);
+        register_post_type('course', ['public' => true]);
+    }
+
+    protected function tearDown(): void
+    {
+        unregister_post_type('event');
+        unregister_post_type('job');
+        unregister_post_type('property');
+        unregister_taxonomy('property_status');
+        unregister_post_type('listing');
+        unregister_post_type('course');
+        parent::tearDown();
+    }
+
+    public function test_upcoming_events_enforces_future_dates(): void
+    {
+        $query = new WP_Query();
+        $query->set('posts_per_page', 0);
+
+        do_action('elementor/query/gm2_upcoming_events', $query);
+
+        $this->assertSame('event', $query->get('post_type'));
+        $this->assertSame('publish', $query->get('post_status'));
+        $this->assertSame(6, $query->get('posts_per_page'));
+        $this->assertSame('start_date', $query->get('meta_key'));
+        $this->assertSame('meta_value', $query->get('orderby'));
+        $this->assertSame('ASC', $query->get('order'));
+
+        $metaQuery = $query->get('meta_query');
+        $this->assertIsArray($metaQuery);
+        $this->assertArrayHasKey(0, $metaQuery);
+        $clause = $metaQuery[0];
+        $this->assertSame('start_date', $clause['key']);
+        $this->assertSame('>=', $clause['compare']);
+        $this->assertSame('DATETIME', $clause['type']);
+        $this->assertGreaterThanOrEqual(current_time('timestamp') - 60, strtotime($clause['value']));
+    }
+
+    public function test_past_events_use_descending_order(): void
+    {
+        $query = new WP_Query();
+
+        do_action('elementor/query/gm2_past_events', $query);
+
+        $this->assertSame('event', $query->get('post_type'));
+        $this->assertSame('publish', $query->get('post_status'));
+        $this->assertSame(6, $query->get('posts_per_page'));
+        $this->assertSame('start_date', $query->get('meta_key'));
+        $this->assertSame('meta_value', $query->get('orderby'));
+        $this->assertSame('DESC', $query->get('order'));
+
+        $metaQuery = $query->get('meta_query');
+        $this->assertSame('<', $metaQuery[0]['compare']);
+    }
+
+    public function test_open_jobs_apply_status_and_search(): void
+    {
+        $query = new WP_Query();
+        $query->set('gm2_job_search', 'Engineer');
+
+        do_action('elementor/query/gm2_open_jobs', $query);
+
+        $this->assertSame('job', $query->get('post_type'));
+        $this->assertSame('publish', $query->get('post_status'));
+        $this->assertSame(10, $query->get('posts_per_page'));
+        $this->assertSame('date', $query->get('orderby'));
+        $this->assertSame('DESC', $query->get('order'));
+        $this->assertSame('Engineer', $query->get('s'));
+
+        $metaQuery = $query->get('meta_query');
+        $this->assertSame('status', $metaQuery[0]['key']);
+        $this->assertSame('open', $metaQuery[0]['value']);
+    }
+
+    public function test_properties_for_sale_filter_by_status_taxonomy(): void
+    {
+        $query = new WP_Query();
+
+        do_action('elementor/query/gm2_properties_sale', $query);
+
+        $this->assertSame('property', $query->get('post_type'));
+        $this->assertSame('publish', $query->get('post_status'));
+        $this->assertSame(12, $query->get('posts_per_page'));
+        $this->assertSame('price', $query->get('meta_key'));
+        $this->assertSame('meta_value_num', $query->get('orderby'));
+        $this->assertSame('ASC', $query->get('order'));
+
+        $taxQuery = $query->get('tax_query');
+        $this->assertIsArray($taxQuery);
+        $this->assertSame('property_status', $taxQuery[0]['taxonomy']);
+        $this->assertSame(['for-sale'], $taxQuery[0]['terms']);
+    }
+
+    public function test_directory_nearby_adds_geo_bounding_box(): void
+    {
+        $query = new WP_Query();
+        $query->set('gm2_lat', '51.5');
+        $query->set('gm2_lng', '-0.1');
+        $query->set('gm2_radius', '10');
+
+        do_action('elementor/query/gm2_directory_nearby', $query);
+
+        $this->assertSame('listing', $query->get('post_type'));
+        $this->assertSame('publish', $query->get('post_status'));
+        $this->assertSame(12, $query->get('posts_per_page'));
+        $this->assertSame('title', $query->get('orderby'));
+        $this->assertSame('ASC', $query->get('order'));
+
+        $metaQuery = $query->get('meta_query');
+        $this->assertCount(2, array_filter($metaQuery, 'is_array'));
+        $latClause = $metaQuery[0];
+        $lngClause = $metaQuery[1];
+
+        $this->assertSame('latitude', $latClause['key']);
+        $this->assertSame('BETWEEN', $latClause['compare']);
+        $this->assertCount(2, $latClause['value']);
+        $this->assertLessThan($latClause['value'][1], 52);
+        $this->assertGreaterThan($latClause['value'][0], 51);
+
+        $this->assertSame('longitude', $lngClause['key']);
+        $this->assertSame('BETWEEN', $lngClause['compare']);
+        $this->assertCount(2, $lngClause['value']);
+        $this->assertLessThan($lngClause['value'][1], 0.2);
+        $this->assertGreaterThan($lngClause['value'][0], -0.3);
+    }
+
+    public function test_courses_active_apply_status_and_search_default(): void
+    {
+        $query = new WP_Query();
+        $query->set('gm2_search', 'Design');
+
+        do_action('elementor/query/gm2_courses_active', $query);
+
+        $this->assertSame('course', $query->get('post_type'));
+        $this->assertSame('publish', $query->get('post_status'));
+        $this->assertSame(9, $query->get('posts_per_page'));
+        $this->assertSame('date', $query->get('orderby'));
+        $this->assertSame('DESC', $query->get('order'));
+        $this->assertSame('Design', $query->get('s'));
+
+        $metaQuery = $query->get('meta_query');
+        $this->assertSame('status', $metaQuery[0]['key']);
+        $this->assertSame('active', $metaQuery[0]['value']);
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated Elementor query filter bootstrap that wires gm2_* presets to tailored query logic
- update the Elementor bootstrap to load the new filters alongside dynamic tag registration
- cover the query filters with PHPUnit tests to verify search, meta, taxonomy, and geo defaults

## Testing
- `vendor/bin/phpunit tests/Elementor/Query/FiltersTest.php` *(fails: WordPress test library is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_b_68c9adfb41f88330951847f41e751cbd