### PR TITLE
Add custom Elementor controls with AJAX and update query integration

### DIFF
--- a/public/js/gm2-elementor-controls.js
+++ b/public/js/gm2-elementor-controls.js
@@ -1,0 +1,187 @@
+(function ($) {
+  'use strict';
+
+  const config = window.gm2ElementorControls || {};
+  if (!config.ajaxUrl) {
+    return;
+  }
+
+  const cache = {};
+
+  function fetchOptions(action, payload) {
+    const data = Object.assign({ action, nonce: config.nonce }, payload);
+    const key = JSON.stringify(data);
+    if (!cache[key]) {
+      cache[key] = $.post(config.ajaxUrl, data)
+        .then((response) => {
+          if (!response || !response.success || !Array.isArray(response.data)) {
+            return [];
+          }
+          return response.data;
+        })
+        .catch(() => []);
+    }
+    return cache[key];
+  }
+
+  function parseSelected($select) {
+    const attr = $select.attr('data-selected');
+    if (attr) {
+      try {
+        const parsed = JSON.parse(attr);
+        if (Array.isArray(parsed)) {
+          return parsed.map(String);
+        }
+        if (parsed === null || parsed === undefined || parsed === '') {
+          return [];
+        }
+        return [String(parsed)];
+      } catch (e) {
+        // Ignore malformed JSON and fall through.
+      }
+    }
+    const value = $select.val();
+    if (Array.isArray(value)) {
+      return value.map(String);
+    }
+    if (value === null || value === undefined || value === '') {
+      return [];
+    }
+    return [String(value)];
+  }
+
+  function setSelected($select, selected) {
+    if (!Array.isArray(selected)) {
+      selected = selected === undefined ? [] : [selected];
+    }
+
+    if ($select.prop('multiple')) {
+      $select.val(selected);
+    } else {
+      $select.val(selected.length ? selected[0] : '');
+    }
+
+    const stored = $select.prop('multiple') ? $select.val() || [] : $select.val() || '';
+    $select.attr('data-selected', JSON.stringify(stored));
+  }
+
+  function findControlValue(name, $select) {
+    if (!name) {
+      return null;
+    }
+    const $container = $select.closest('.elementor-control').parent();
+    const $inputs = $container.find('[data-setting="' + name + '"]');
+    if (!$inputs.length) {
+      return null;
+    }
+    const $input = $inputs.first();
+    const value = $input.val();
+    if ($input.prop('multiple')) {
+      return value || [];
+    }
+    return value;
+  }
+
+  function refreshSelect($select) {
+    const action = $select.data('action');
+    if (!action) {
+      return;
+    }
+
+    const payload = {};
+    const mode = $select.data('mode');
+    if (mode) {
+      payload.mode = mode;
+    }
+
+    const taxonomyControl = $select.data('taxonomyControl');
+    if (taxonomyControl) {
+      const taxonomyValue = findControlValue(taxonomyControl, $select);
+      if (taxonomyValue) {
+        payload.taxonomy = taxonomyValue;
+      }
+    }
+
+    const postTypeControl = $select.data('postTypeControl');
+    if (postTypeControl) {
+      let postTypes = findControlValue(postTypeControl, $select);
+      if (postTypes) {
+        if (!Array.isArray(postTypes)) {
+          postTypes = [postTypes];
+        }
+        payload.post_types = postTypes.filter((item) => item !== '');
+      }
+    }
+
+    const selected = parseSelected($select);
+
+    fetchOptions(action, payload).then((options) => {
+      const normalizedSelected = selected.map(String);
+      const preserve = normalizedSelected.length ? normalizedSelected : parseSelected($select);
+      $select.empty();
+      options.forEach((option) => {
+        const value = option.value !== undefined ? option.value : option.id;
+        const label = option.label !== undefined ? option.label : option.text;
+        const $option = $('<option></option>').attr('value', value).text(label);
+        if (preserve.indexOf(String(value)) !== -1) {
+          $option.prop('selected', true);
+        }
+        $select.append($option);
+      });
+      setSelected($select, preserve);
+      $select.trigger('change');
+    });
+  }
+
+  function bindSelect($select) {
+    if ($select.data('gm2Bound')) {
+      return;
+    }
+    $select.data('gm2Bound', true);
+
+    const taxonomyControl = $select.data('taxonomyControl');
+    if (taxonomyControl) {
+      const $container = $select.closest('.elementor-control').parent();
+      $container.on('change', '[data-setting="' + taxonomyControl + '"]', () => {
+        refreshSelect($select);
+      });
+    }
+
+    const postTypeControl = $select.data('postTypeControl');
+    if (postTypeControl) {
+      const $container = $select.closest('.elementor-control').parent();
+      $container.on('change', '[data-setting="' + postTypeControl + '"]', () => {
+        refreshSelect($select);
+      });
+    }
+
+    refreshSelect($select);
+  }
+
+  function scan(node) {
+    $(node)
+      .find('.gm2-ajax-select')
+      .addBack('.gm2-ajax-select')
+      .each(function () {
+        bindSelect($(this));
+      });
+  }
+
+  $(function () {
+    scan(document.body);
+  });
+
+  const observer = new MutationObserver((mutations) => {
+    mutations.forEach((mutation) => {
+      if (mutation.type === 'childList') {
+        mutation.addedNodes.forEach((node) => {
+          if (node.nodeType === 1) {
+            scan(node);
+          }
+        });
+      }
+    });
+  });
+
+  observer.observe(document.body, { childList: true, subtree: true });
+})(jQuery);

--- a/src/Elementor/Controls/AbstractAjaxSelectControl.php
+++ b/src/Elementor/Controls/AbstractAjaxSelectControl.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gm2\Elementor\Controls;
+
+use Elementor\Base_Data_Control;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Base class for Elementor select controls that fetch options via AJAX.
+ */
+abstract class AbstractAjaxSelectControl extends Base_Data_Control
+{
+    /** Script handle shared by all GM2 Elementor controls. */
+    protected const SCRIPT_HANDLE = 'gm2-elementor-controls';
+
+    /** Nonce action used for AJAX security checks. */
+    protected const NONCE_ACTION = 'gm2_elementor_controls';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function enqueue(): void
+    {
+        if (!wp_script_is(self::SCRIPT_HANDLE, 'registered')) {
+            wp_register_script(
+                self::SCRIPT_HANDLE,
+                GM2_PLUGIN_URL . 'public/js/gm2-elementor-controls.js',
+                ['jquery'],
+                defined('GM2_VERSION') ? GM2_VERSION : false,
+                true
+            );
+        }
+
+        wp_enqueue_script(self::SCRIPT_HANDLE);
+
+        static $localized = false;
+        if (!$localized) {
+            wp_localize_script(
+                self::SCRIPT_HANDLE,
+                'gm2ElementorControls',
+                [
+                    'ajaxUrl' => admin_url('admin-ajax.php'),
+                    'nonce'   => wp_create_nonce(self::NONCE_ACTION),
+                ]
+            );
+            $localized = true;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function get_default_settings(): array
+    {
+        return [
+            'label_block' => true,
+            'multiple'    => false,
+            'placeholder' => '',
+            'options'     => [],
+        ];
+    }
+}

--- a/src/Elementor/Controls/MetaKeySelect.php
+++ b/src/Elementor/Controls/MetaKeySelect.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gm2\Elementor\Controls;
+
+use Elementor\Controls_Manager;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Elementor control for selecting meta keys via AJAX.
+ */
+class MetaKeySelect extends AbstractAjaxSelectControl
+{
+    public const TYPE = 'gm2-meta-key-select';
+
+    private const AJAX_ACTION = 'gm2_elementor_meta_keys';
+
+    /**
+     * Register Elementor hooks for the control.
+     */
+    public static function register(): void
+    {
+        add_action('elementor/controls/register', [static::class, 'register_control']);
+        add_action('wp_ajax_' . self::AJAX_ACTION, [static::class, 'ajax_meta_keys']);
+    }
+
+    /**
+     * Register the control with Elementor.
+     */
+    public static function register_control(Controls_Manager $controls_manager): void
+    {
+        $controls_manager->register_control(self::TYPE, new self());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function get_type(): string
+    {
+        return self::TYPE;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function get_default_settings(): array
+    {
+        $defaults = parent::get_default_settings();
+        $defaults['post_type_control'] = '';
+        return $defaults;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function content_template(): void
+    {
+        ?>
+        <div class="gm2-control gm2-control--meta-key">
+            <select class="gm2-ajax-select" data-action="<?php echo esc_attr(self::AJAX_ACTION); ?>" data-post-type-control="{{ data.post_type_control }}" data-setting="{{ data.name }}" data-selected='{{{ JSON.stringify( data.controlValue || "" ) }}}'>
+                <# if ( data.options ) { #>
+                    <# _.each( data.options, function( label, value ) { #>
+                        <option value="{{ value }}">{{ label }}</option>
+                    <# } ); #>
+                <# } #>
+            </select>
+        </div>
+        <?php
+    }
+
+    /**
+     * Handle AJAX request to retrieve distinct meta keys.
+     */
+    public static function ajax_meta_keys(): void
+    {
+        check_ajax_referer(self::NONCE_ACTION, 'nonce');
+
+        if (!current_user_can('edit_posts')) {
+            wp_send_json_error(__('Access denied', 'gm2-wordpress-suite'), 403);
+        }
+
+        global $wpdb;
+
+        $post_types = array_filter(array_map('sanitize_key', (array) ($_POST['post_types'] ?? [])));
+        $search     = sanitize_text_field($_POST['search'] ?? '');
+
+        $limit = 50;
+        if ($post_types) {
+            $placeholders = implode(', ', array_fill(0, count($post_types), '%s'));
+            $sql          = $wpdb->prepare(
+                "SELECT DISTINCT pm.meta_key
+                FROM {$wpdb->postmeta} pm
+                INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
+                WHERE pm.meta_key <> ''
+                  AND p.post_type IN ($placeholders)
+                ORDER BY pm.meta_key ASC
+                LIMIT %d",
+                array_merge($post_types, [$limit])
+            );
+        } else {
+            $sql = $wpdb->prepare(
+                "SELECT DISTINCT meta_key
+                FROM {$wpdb->postmeta}
+                WHERE meta_key <> ''
+                ORDER BY meta_key ASC
+                LIMIT %d",
+                $limit
+            );
+        }
+
+        $keys = (array) $wpdb->get_col($sql);
+
+        $options = [];
+        foreach ($keys as $key) {
+            $label = sanitize_text_field($key);
+            if ($search !== '' && stripos($label, $search) === false && stripos($key, $search) === false) {
+                continue;
+            }
+            $options[] = [
+                'value' => $key,
+                'label' => $label,
+            ];
+        }
+
+        wp_send_json_success($options);
+    }
+}

--- a/src/Elementor/Controls/PostTypeSelect.php
+++ b/src/Elementor/Controls/PostTypeSelect.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gm2\Elementor\Controls;
+
+use Elementor\Controls_Manager;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Elementor control for selecting one or more post types.
+ */
+class PostTypeSelect extends AbstractAjaxSelectControl
+{
+    public const TYPE = 'gm2-post-type-select';
+
+    private const AJAX_ACTION = 'gm2_elementor_post_types';
+
+    /**
+     * Register Elementor hooks for the control.
+     */
+    public static function register(): void
+    {
+        add_action('elementor/controls/register', [static::class, 'register_control']);
+        add_action('wp_ajax_' . self::AJAX_ACTION, [static::class, 'ajax_post_types']);
+    }
+
+    /**
+     * Register the control with Elementor.
+     */
+    public static function register_control(Controls_Manager $controls_manager): void
+    {
+        $controls_manager->register_control(self::TYPE, new self());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function get_type(): string
+    {
+        return self::TYPE;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function content_template(): void
+    {
+        ?>
+        <div class="gm2-control gm2-control--post-type">
+            <select class="gm2-ajax-select" data-action="<?php echo esc_attr(self::AJAX_ACTION); ?>" data-setting="{{ data.name }}" data-selected='{{{ JSON.stringify( data.controlValue || ( data.multiple ? [] : "" ) ) }}}' <# if ( data.multiple ) { #>multiple="multiple"<# } #>>
+                <# if ( data.options ) { #>
+                    <# _.each( data.options, function( label, value ) { #>
+                        <option value="{{ value }}">{{ label }}</option>
+                    <# } ); #>
+                <# } #>
+            </select>
+        </div>
+        <?php
+    }
+
+    /**
+     * Handle AJAX request to fetch available post types.
+     */
+    public static function ajax_post_types(): void
+    {
+        check_ajax_referer(self::NONCE_ACTION, 'nonce');
+
+        if (!current_user_can('edit_posts')) {
+            wp_send_json_error(__('Access denied', 'gm2-wordpress-suite'), 403);
+        }
+
+        $search = sanitize_text_field($_POST['search'] ?? '');
+
+        $options = [];
+        $post_types = get_post_types(['public' => true], 'objects');
+        foreach ($post_types as $slug => $object) {
+            $label = $object->labels->singular_name ?? $object->labels->name ?? $slug;
+            if ($search !== '' && stripos($label, $search) === false && stripos($slug, $search) === false) {
+                continue;
+            }
+            $options[] = [
+                'value' => $slug,
+                'label' => $label,
+            ];
+        }
+
+        wp_send_json_success($options);
+    }
+}

--- a/src/Elementor/Controls/Price.php
+++ b/src/Elementor/Controls/Price.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gm2\Elementor\Controls;
+
+use Elementor\Base_Data_Control;
+use Elementor\Controls_Manager;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Elementor control capturing a price range and associated meta key.
+ */
+class Price extends Base_Data_Control
+{
+    public const TYPE = 'gm2-price';
+
+    /**
+     * Register Elementor hooks for the control.
+     */
+    public static function register(): void
+    {
+        add_action('elementor/controls/register', [static::class, 'register_control']);
+    }
+
+    /**
+     * Register the control type with Elementor.
+     */
+    public static function register_control(Controls_Manager $controls_manager): void
+    {
+        $controls_manager->register_control(self::TYPE, new self());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function get_type(): string
+    {
+        return self::TYPE;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function get_default_settings(): array
+    {
+        return [
+            'label_block'  => true,
+            'show_key'     => true,
+            'placeholders' => [
+                'key' => __('Meta key (default: _price)', 'gm2-wordpress-suite'),
+                'min' => __('Minimum price', 'gm2-wordpress-suite'),
+                'max' => __('Maximum price', 'gm2-wordpress-suite'),
+            ],
+            'default'      => [
+                'key' => '_price',
+                'min' => '',
+                'max' => '',
+            ],
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function content_template(): void
+    {
+        ?>
+        <#
+        var current = data.controlValue || {};
+        var defaults = data.default || {};
+        var placeholders = data.placeholders || {};
+        var key = (typeof current.key !== 'undefined') ? current.key : (defaults.key || '');
+        var min = (typeof current.min !== 'undefined') ? current.min : (defaults.min || '');
+        var max = (typeof current.max !== 'undefined') ? current.max : (defaults.max || '');
+        #>
+        <div class="gm2-control gm2-control--price">
+            <# if ( data.show_key ) { #>
+                <input type="text" class="gm2-price-control__key" data-setting="{{ data.name }}[key]" placeholder="{{ placeholders.key }}" value="{{ key }}" />
+            <# } #>
+            <div class="gm2-price-control__range">
+                <input type="number" step="any" class="gm2-price-control__min" data-setting="{{ data.name }}[min]" placeholder="{{ placeholders.min }}" value="{{ min }}" />
+                <input type="number" step="any" class="gm2-price-control__max" data-setting="{{ data.name }}[max]" placeholder="{{ placeholders.max }}" value="{{ max }}" />
+            </div>
+        </div>
+        <?php
+    }
+}

--- a/src/Elementor/Controls/TaxonomyTermMulti.php
+++ b/src/Elementor/Controls/TaxonomyTermMulti.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gm2\Elementor\Controls;
+
+use Elementor\Controls_Manager;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Elementor control for selecting taxonomies or their terms via AJAX.
+ */
+class TaxonomyTermMulti extends AbstractAjaxSelectControl
+{
+    public const TYPE = 'gm2-taxonomy-term-multi';
+
+    private const AJAX_ACTION = 'gm2_elementor_taxonomy_terms';
+
+    /**
+     * Register Elementor hooks for the control.
+     */
+    public static function register(): void
+    {
+        add_action('elementor/controls/register', [static::class, 'register_control']);
+        add_action('wp_ajax_' . self::AJAX_ACTION, [static::class, 'ajax_taxonomy_terms']);
+    }
+
+    /**
+     * Register the control type with Elementor.
+     */
+    public static function register_control(Controls_Manager $controls_manager): void
+    {
+        $controls_manager->register_control(self::TYPE, new self());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function get_type(): string
+    {
+        return self::TYPE;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function get_default_settings(): array
+    {
+        $defaults = parent::get_default_settings();
+        $defaults['mode'] = 'terms';
+        $defaults['taxonomy_control'] = '';
+        return $defaults;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function content_template(): void
+    {
+        ?>
+        <div class="gm2-control gm2-control--taxonomy">
+            <select class="gm2-ajax-select" data-action="<?php echo esc_attr(self::AJAX_ACTION); ?>" data-mode="{{ data.mode }}" data-taxonomy-control="{{ data.taxonomy_control }}" data-setting="{{ data.name }}" data-selected='{{{ JSON.stringify( data.controlValue || ( data.multiple ? [] : "" ) ) }}}' <# if ( data.multiple ) { #>multiple="multiple"<# } #>>
+                <# if ( data.options ) { #>
+                    <# _.each( data.options, function( label, value ) { #>
+                        <option value="{{ value }}">{{ label }}</option>
+                    <# } ); #>
+                <# } #>
+            </select>
+        </div>
+        <?php
+    }
+
+    /**
+     * Handle AJAX request for taxonomies or terms depending on the provided mode.
+     */
+    public static function ajax_taxonomy_terms(): void
+    {
+        check_ajax_referer(self::NONCE_ACTION, 'nonce');
+
+        if (!current_user_can('edit_posts')) {
+            wp_send_json_error(__('Access denied', 'gm2-wordpress-suite'), 403);
+        }
+
+        $mode   = sanitize_key($_POST['mode'] ?? 'terms');
+        $search = sanitize_text_field($_POST['search'] ?? '');
+
+        if ($mode === 'taxonomy') {
+            $options = [];
+            $taxonomies = get_taxonomies(['public' => true], 'objects');
+            foreach ($taxonomies as $slug => $object) {
+                $label = $object->labels->singular_name ?? $object->labels->name ?? $slug;
+                if ($search !== '' && stripos($label, $search) === false && stripos($slug, $search) === false) {
+                    continue;
+                }
+                $options[] = [
+                    'value' => $slug,
+                    'label' => $label,
+                ];
+            }
+            wp_send_json_success($options);
+        }
+
+        $taxonomy = sanitize_key($_POST['taxonomy'] ?? '');
+        if ($taxonomy === '') {
+            wp_send_json_success([]);
+        }
+
+        $terms = get_terms([
+            'taxonomy'   => $taxonomy,
+            'hide_empty' => false,
+            'search'     => $search,
+        ]);
+
+        if (is_wp_error($terms)) {
+            wp_send_json_success([]);
+        }
+
+        $options = [];
+        foreach ($terms as $term) {
+            $options[] = [
+                'value' => (string) $term->term_id,
+                'label' => $term->name,
+            ];
+        }
+
+        wp_send_json_success($options);
+    }
+}

--- a/src/Elementor/Controls/Unit.php
+++ b/src/Elementor/Controls/Unit.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gm2\Elementor\Controls;
+
+use Elementor\Base_Data_Control;
+use Elementor\Controls_Manager;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Elementor control that captures a numeric value alongside a selectable unit.
+ */
+class Unit extends Base_Data_Control
+{
+    public const TYPE = 'gm2-unit';
+
+    /**
+     * Register Elementor hooks for the control.
+     */
+    public static function register(): void
+    {
+        add_action('elementor/controls/register', [static::class, 'register_control']);
+    }
+
+    /**
+     * Register the control type with Elementor.
+     */
+    public static function register_control(Controls_Manager $controls_manager): void
+    {
+        $controls_manager->register_control(self::TYPE, new self());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function get_type(): string
+    {
+        return self::TYPE;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function get_default_settings(): array
+    {
+        return [
+            'label_block' => true,
+            'placeholder' => '',
+            'units'       => [
+                'km' => __('Kilometers', 'gm2-wordpress-suite'),
+                'mi' => __('Miles', 'gm2-wordpress-suite'),
+            ],
+            'default'     => [
+                'value' => '',
+                'unit'  => 'km',
+            ],
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function content_template(): void
+    {
+        ?>
+        <#
+        var current = data.controlValue || {};
+        var defaults = data.default || {};
+        var value = (typeof current.value !== 'undefined') ? current.value : (defaults.value || '');
+        var unit = current.unit || defaults.unit || '';
+        #>
+        <div class="gm2-control gm2-control--unit">
+            <input type="number" step="any" class="gm2-unit-control__value" placeholder="{{ data.placeholder }}" data-setting="{{ data.name }}[value]" value="{{ value }}" />
+            <select class="gm2-unit-control__unit" data-setting="{{ data.name }}[unit]">
+                <# _.each( data.units, function( label, key ) { #>
+                    <option value="{{ key }}" <# if ( key === unit ) { #>selected<# } #>>{{ label }}</option>
+                <# } ); #>
+            </select>
+        </div>
+        <?php
+    }
+}

--- a/src/Elementor/bootstrap.php
+++ b/src/Elementor/bootstrap.php
@@ -5,6 +5,11 @@ declare(strict_types=1);
 namespace Gm2\Elementor;
 
 use Elementor\Modules\DynamicTags\Module;
+use Gm2\Elementor\Controls\MetaKeySelect;
+use Gm2\Elementor\Controls\PostTypeSelect;
+use Gm2\Elementor\Controls\Price;
+use Gm2\Elementor\Controls\TaxonomyTermMulti;
+use Gm2\Elementor\Controls\Unit;
 use Gm2\Elementor\DynamicTags\GM2_Dynamic_Tag_Group;
 use Gm2\Elementor\Query\Filters;
 
@@ -26,3 +31,9 @@ add_action(
 );
 
 Filters::register();
+
+PostTypeSelect::register();
+TaxonomyTermMulti::register();
+MetaKeySelect::register();
+Unit::register();
+Price::register();

--- a/tests/Elementor/Controls/ControlsAjaxTest.php
+++ b/tests/Elementor/Controls/ControlsAjaxTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+use Gm2\Elementor\Controls\MetaKeySelect;
+use Gm2\Elementor\Controls\PostTypeSelect;
+use Gm2\Elementor\Controls\TaxonomyTermMulti;
+
+class ControlsAjaxTest extends WP_Ajax_UnitTestCase
+{
+    public static function wpSetUpBeforeClass($factory): void
+    {
+        register_post_type('book', ['public' => true]);
+        register_post_type('movie', ['public' => true]);
+        register_post_type('private_item', ['public' => false]);
+        register_taxonomy('genre', ['book'], ['public' => true]);
+
+        PostTypeSelect::register();
+        TaxonomyTermMulti::register();
+        MetaKeySelect::register();
+    }
+
+    public static function wpTearDownAfterClass(): void
+    {
+        unregister_taxonomy('genre');
+        unregister_post_type('book');
+        unregister_post_type('movie');
+        unregister_post_type('private_item');
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->_setRole('administrator');
+    }
+
+    public function test_post_type_ajax_returns_public_types(): void
+    {
+        $_POST['nonce'] = wp_create_nonce('gm2_elementor_controls');
+        $_REQUEST['nonce'] = $_POST['nonce'];
+
+        try {
+            $this->_handleAjax('gm2_elementor_post_types');
+        } catch (WPAjaxDieContinueException $e) {
+            // Expected due to wp_send_json_* terminating execution.
+        }
+
+        $response = json_decode($this->_last_response, true);
+        $this->assertTrue($response['success']);
+        $values = wp_list_pluck($response['data'], 'value');
+        $this->assertContains('book', $values);
+        $this->assertContains('movie', $values);
+        $this->assertNotContains('private_item', $values);
+    }
+
+    public function test_taxonomy_mode_lists_taxonomies(): void
+    {
+        $_POST['nonce'] = wp_create_nonce('gm2_elementor_controls');
+        $_REQUEST['nonce'] = $_POST['nonce'];
+        $_POST['mode'] = 'taxonomy';
+
+        try {
+            $this->_handleAjax('gm2_elementor_taxonomy_terms');
+        } catch (WPAjaxDieContinueException $e) {
+        }
+
+        $response = json_decode($this->_last_response, true);
+        $this->assertTrue($response['success']);
+        $values = wp_list_pluck($response['data'], 'value');
+        $this->assertContains('genre', $values);
+    }
+
+    public function test_terms_mode_lists_requested_terms(): void
+    {
+        $term_one = wp_insert_term('Fiction', 'genre');
+        $term_two = wp_insert_term('Non Fiction', 'genre');
+
+        $_POST['nonce'] = wp_create_nonce('gm2_elementor_controls');
+        $_REQUEST['nonce'] = $_POST['nonce'];
+        $_POST['mode'] = 'terms';
+        $_POST['taxonomy'] = 'genre';
+
+        try {
+            $this->_handleAjax('gm2_elementor_taxonomy_terms');
+        } catch (WPAjaxDieContinueException $e) {
+        }
+
+        $response = json_decode($this->_last_response, true);
+        $this->assertTrue($response['success']);
+        $values = wp_list_pluck($response['data'], 'value');
+        $this->assertContains((string) $term_one['term_id'], $values);
+        $this->assertContains((string) $term_two['term_id'], $values);
+    }
+
+    public function test_meta_key_ajax_respects_post_type_filter(): void
+    {
+        $book = self::factory()->post->create(['post_type' => 'book']);
+        $movie = self::factory()->post->create(['post_type' => 'movie']);
+        update_post_meta($book, 'rating', '5');
+        update_post_meta($book, 'pages', '120');
+        update_post_meta($movie, 'rating', '4');
+        update_post_meta($movie, 'duration', '90');
+
+        $_POST['nonce'] = wp_create_nonce('gm2_elementor_controls');
+        $_REQUEST['nonce'] = $_POST['nonce'];
+        $_POST['post_types'] = ['book'];
+
+        try {
+            $this->_handleAjax('gm2_elementor_meta_keys');
+        } catch (WPAjaxDieContinueException $e) {
+        }
+
+        $response = json_decode($this->_last_response, true);
+        $this->assertTrue($response['success']);
+        $values = wp_list_pluck($response['data'], 'value');
+        $this->assertContains('rating', $values);
+        $this->assertContains('pages', $values);
+        $this->assertNotContains('duration', $values);
+    }
+}

--- a/tests/Elementor/Controls/ControlsTemplateTest.php
+++ b/tests/Elementor/Controls/ControlsTemplateTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use Gm2\Elementor\Controls\MetaKeySelect;
+use Gm2\Elementor\Controls\PostTypeSelect;
+use Gm2\Elementor\Controls\Price;
+use Gm2\Elementor\Controls\TaxonomyTermMulti;
+use Gm2\Elementor\Controls\Unit;
+
+class ControlsTemplateTest extends WP_UnitTestCase
+{
+    public function test_post_type_control_template_contains_ajax_action(): void
+    {
+        $control = new PostTypeSelect();
+        ob_start();
+        $control->content_template();
+        $template = ob_get_clean();
+
+        $this->assertStringContainsString('data-action="gm2_elementor_post_types"', $template);
+        $this->assertStringContainsString('data-selected', $template);
+    }
+
+    public function test_taxonomy_control_marks_taxonomy_dependency(): void
+    {
+        $control = new TaxonomyTermMulti();
+        ob_start();
+        $control->content_template();
+        $template = ob_get_clean();
+
+        $this->assertStringContainsString('data-taxonomy-control', $template);
+        $this->assertStringContainsString('gm2_elementor_taxonomy_terms', $template);
+    }
+
+    public function test_meta_key_control_includes_post_type_reference(): void
+    {
+        $control = new MetaKeySelect();
+        ob_start();
+        $control->content_template();
+        $template = ob_get_clean();
+
+        $this->assertStringContainsString('data-post-type-control', $template);
+        $this->assertStringContainsString('gm2_elementor_meta_keys', $template);
+    }
+
+    public function test_unit_control_uses_nested_settings(): void
+    {
+        $control = new Unit();
+        ob_start();
+        $control->content_template();
+        $template = ob_get_clean();
+
+        $this->assertStringContainsString('[value]', $template);
+        $this->assertStringContainsString('[unit]', $template);
+    }
+
+    public function test_price_control_outputs_key_and_range_inputs(): void
+    {
+        $control = new Price();
+        ob_start();
+        $control->content_template();
+        $template = ob_get_clean();
+
+        $this->assertStringContainsString('[key]', $template);
+        $this->assertStringContainsString('[min]', $template);
+        $this->assertStringContainsString('[max]', $template);
+    }
+}

--- a/tests/Elementor/Query/Gm2CpQueryControlTest.php
+++ b/tests/Elementor/Query/Gm2CpQueryControlTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+use Gm2\Integrations\Elementor\GM2_CP_Elementor_Query;
+
+class Gm2CpQueryControlTest extends WP_UnitTestCase
+{
+    public function test_apply_query_sanitizes_new_control_values(): void
+    {
+        $settings = [
+            'gm2_cp_post_type'   => [' job ', 'event<script>'],
+            'gm2_cp_taxonomy'    => 'genre<script>',
+            'gm2_cp_terms'       => ['5', '8<script>'],
+            'gm2_cp_meta_key'    => ' total_sales ',
+            'gm2_cp_meta_value'  => ' 100 ',
+            'gm2_cp_meta_compare'=> '>=',
+            'gm2_cp_meta_type'   => 'NUMERIC',
+            'gm2_cp_price'       => [
+                'key' => ' price-key ',
+                'min' => '10.5',
+                'max' => '25.5',
+            ],
+            'gm2_cp_geo_lat'     => '45.00',
+            'gm2_cp_geo_lng'     => '-93.00',
+            'gm2_cp_geo_radius'  => [
+                'value' => '5',
+                'unit'  => 'mi',
+            ],
+            'gm2_cp_geo_lat_key' => ' latitude_meta ',
+            'gm2_cp_geo_lng_key' => ' longitude_meta ',
+        ];
+
+        $widget = new class($settings) {
+            private $settings;
+
+            public function __construct(array $settings)
+            {
+                $this->settings = $settings;
+            }
+
+            public function get_settings(): array
+            {
+                return $this->settings;
+            }
+        };
+
+        $query = new WP_Query();
+        GM2_CP_Elementor_Query::apply_query($query, $widget);
+
+        $this->assertSame(['job', 'eventscript'], $query->get('post_type'));
+
+        $tax_query = $query->get('tax_query');
+        $this->assertCount(1, $tax_query);
+        $this->assertSame('genrescript', $tax_query[0]['taxonomy']);
+        $this->assertSame([5, 8], $tax_query[0]['terms']);
+
+        $meta_query = $query->get('meta_query');
+        $this->assertNotEmpty($meta_query);
+
+        $meta_keys = wp_list_pluck($meta_query, 'key');
+        $this->assertContains('total_sales', $meta_keys);
+        $this->assertContains('price-key', $meta_keys);
+        $this->assertContains('latitude_meta', $meta_keys);
+        $this->assertContains('longitude_meta', $meta_keys);
+
+        $price_clause = $meta_query[array_search('price-key', $meta_keys, true)];
+        $this->assertSame('NUMERIC', $price_clause['type']);
+        $this->assertSame('BETWEEN', $price_clause['compare']);
+        $this->assertEquals([10.5, 25.5], array_values($price_clause['value']));
+
+        $lat_clause = $meta_query[array_search('latitude_meta', $meta_keys, true)];
+        $lng_clause = $meta_query[array_search('longitude_meta', $meta_keys, true)];
+        $this->assertSame('BETWEEN', $lat_clause['compare']);
+        $this->assertCount(2, $lat_clause['value']);
+        $this->assertSame('BETWEEN', $lng_clause['compare']);
+        $this->assertCount(2, $lng_clause['value']);
+
+        // 5 miles is approximately 8.04672 kilometres.
+        $radius_km = 5 * 1.609344;
+        $expected_lat_delta = $radius_km / 111.045;
+        $this->assertEqualsWithDelta($expected_lat_delta, $lat_clause['value'][1] - 45.0, 0.0001);
+        $this->assertEqualsWithDelta($expected_lat_delta, 45.0 - $lat_clause['value'][0], 0.0001);
+    }
+}

--- a/tests/js/gm2-elementor-controls.test.js
+++ b/tests/js/gm2-elementor-controls.test.js
@@ -1,0 +1,104 @@
+const { JSDOM } = require('jsdom');
+const jqueryFactory = require('jquery');
+
+describe('gm2-elementor-controls script', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    delete global.window;
+    delete global.document;
+    delete global.jQuery;
+    delete global.$;
+    delete global.MutationObserver;
+  });
+
+  test('populates a select with AJAX data', async () => {
+    const dom = new JSDOM('<div class="elementor-controls-stack"></div>', { url: 'http://localhost' });
+    const $ = jqueryFactory(dom.window);
+    Object.assign(global, { window: dom.window, document: dom.window.document, jQuery: $, $ });
+    global.MutationObserver = dom.window.MutationObserver;
+
+    window.gm2ElementorControls = { ajaxUrl: '/ajax', nonce: 'abc' };
+
+    const postMock = jest.fn(() =>
+      Promise.resolve({ success: true, data: [{ value: 'book', label: 'Book' }] })
+    );
+    $.post = postMock;
+
+    require('../../public/js/gm2-elementor-controls.js');
+
+    const control = dom.window.document.createElement('div');
+    control.className = 'elementor-control';
+    const select = dom.window.document.createElement('select');
+    select.className = 'gm2-ajax-select';
+    select.setAttribute('data-action', 'gm2_elementor_post_types');
+    select.setAttribute('data-setting', 'gm2_cp_post_type');
+    select.setAttribute('data-selected', '[]');
+    select.setAttribute('multiple', 'multiple');
+    control.appendChild(select);
+    dom.window.document.querySelector('.elementor-controls-stack').appendChild(control);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(postMock).toHaveBeenCalledWith('/ajax', expect.objectContaining({ action: 'gm2_elementor_post_types', nonce: 'abc' }));
+    const options = dom.window.document.querySelectorAll('option');
+    expect(options).toHaveLength(1);
+    expect(options[0].value).toBe('book');
+  });
+
+  test('terms control requests terms for selected taxonomy', async () => {
+    const dom = new JSDOM('<div class="elementor-controls-stack"></div>', { url: 'http://localhost' });
+    const $ = jqueryFactory(dom.window);
+    Object.assign(global, { window: dom.window, document: dom.window.document, jQuery: $, $ });
+    global.MutationObserver = dom.window.MutationObserver;
+
+    window.gm2ElementorControls = { ajaxUrl: '/ajax', nonce: 'nonce' };
+
+    const responses = [
+      Promise.resolve({ success: true, data: [{ value: 'genre', label: 'Genre' }] }),
+      Promise.resolve({ success: true, data: [{ value: '12', label: 'Mystery' }] }),
+      Promise.resolve({ success: true, data: [{ value: '12', label: 'Mystery' }] }),
+    ];
+    const postMock = jest.fn(() => responses.shift() || Promise.resolve({ success: true, data: [] }));
+    $.post = postMock;
+
+    require('../../public/js/gm2-elementor-controls.js');
+
+    const controlsStack = dom.window.document.querySelector('.elementor-controls-stack');
+    const taxonomyWrapper = dom.window.document.createElement('div');
+    taxonomyWrapper.className = 'elementor-control';
+    const taxonomySelect = dom.window.document.createElement('select');
+    taxonomySelect.className = 'gm2-ajax-select';
+    taxonomySelect.setAttribute('data-action', 'gm2_elementor_taxonomy_terms');
+    taxonomySelect.setAttribute('data-setting', 'gm2_cp_taxonomy');
+    taxonomySelect.setAttribute('data-mode', 'taxonomy');
+    taxonomySelect.setAttribute('data-selected', '"genre"');
+    taxonomySelect.value = 'genre';
+    taxonomyWrapper.appendChild(taxonomySelect);
+    controlsStack.appendChild(taxonomyWrapper);
+
+    const termsWrapper = dom.window.document.createElement('div');
+    termsWrapper.className = 'elementor-control';
+    const termsSelect = dom.window.document.createElement('select');
+    termsSelect.className = 'gm2-ajax-select';
+    termsSelect.setAttribute('data-action', 'gm2_elementor_taxonomy_terms');
+    termsSelect.setAttribute('data-setting', 'gm2_cp_terms');
+    termsSelect.setAttribute('data-mode', 'terms');
+    termsSelect.setAttribute('data-taxonomy-control', 'gm2_cp_taxonomy');
+    termsSelect.setAttribute('data-selected', '[]');
+    termsWrapper.appendChild(termsSelect);
+    controlsStack.appendChild(termsWrapper);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(postMock).toHaveBeenCalled();
+    const termCalls = postMock.mock.calls.filter((call) => call[1] && call[1].mode === 'terms');
+    expect(termCalls.length).toBeGreaterThan(0);
+    expect(termCalls[termCalls.length - 1][1].taxonomy).toBe('genre');
+
+    const termOptions = dom.window.document.querySelectorAll('[data-setting="gm2_cp_terms"] option');
+    expect(termOptions.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable Elementor control classes for post types, taxonomies, meta keys, units, and price ranges
- register the new controls and move GM2 CP query widgets to the bespoke control types with updated sanitization
- cover the controls with PHPUnit AJAX/query tests and a Jest suite for the shared control script

## Testing
- `npm test -- tests/js/gm2-elementor-controls.test.js`
- `./vendor/bin/phpunit tests/Elementor/Controls/ControlsTemplateTest.php tests/Elementor/Controls/ControlsAjaxTest.php tests/Elementor/Query/Gm2CpQueryControlTest.php` *(fails: WordPress test library requires MySQL tooling in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68c9b3aaa2b48330a9407e2404c5b40c