### PR TITLE
Add Elementor widgets and testing harness

### DIFF
--- a/docs/using-with-elementor.md
+++ b/docs/using-with-elementor.md
@@ -42,6 +42,41 @@ controls:
 All CP tags share the **Field Key** selector (with dot notation support) and a
 **Fallback** control so you can handle empty values gracefully.
 
+## Widgets
+
+In addition to dynamic tags, the suite provides Elementor widgets that render
+GM2 data without manual templating.
+
+### GM2 Field widget
+
+The **GM2 Field** widget mirrors the dynamic tag controls so you can drop a
+single field into layouts that expect native widgets. Choose a post type,
+select a field, and optionally override the HTML tag or fallback text. The
+widget formats each field type automatically (images produce `<img>` tags,
+links render anchors, and WYSIWYG content is printed as sanitized HTML).【F:src/Elementor/Widgets/Field.php†L20-L129】【F:src/Elementor/Widgets/AbstractFieldWidget.php†L30-L209】
+
+### GM2 Loop Card widget
+
+Use the **GM2 Loop Card** widget inside Elementor loop templates to assemble a
+complete card from multiple fields. It supports configurable layouts, featured
+images, title/subtitle sources, body text, meta rows, and an optional button
+link. Each value is sanitized and formatted according to its field type so the
+card stays consistent across posts.【F:src/Elementor/Widgets/LoopCard.php†L18-L278】
+
+### GM2 Map widget
+
+The **GM2 Map** widget accepts geopoint or address fields, builds a provider URL
+using `{{lat}}`, `{{lng}}`, or `{{query}}` tokens, and renders either an embed
+iframe or a link. You can change the provider template, tweak the embed height,
+or supply fallback text when no coordinates exist.【F:src/Elementor/Widgets/Map.php†L18-L154】
+
+### GM2 Opening Hours widget
+
+The **GM2 Opening Hours** widget normalizes repeater-based schedules (day,
+start, and end values) or plain text fields into a definition list. Closed days
+use a customizable label and times are formatted with the site time settings
+when possible, falling back to sanitized strings when parsing fails.【F:src/Elementor/Widgets/OpeningHours.php†L18-L192】
+
 ## Query Builder
 
 Elementor Pro's Posts, Loop Grid and Archive Posts widgets gain a **GM2 CP**

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@babel/core": "^7.23.9",
         "@babel/preset-env": "^7.23.9",
+        "@playwright/test": "^1.55.0",
         "@rollup/plugin-babel": "^6.0.4",
         "@rollup/plugin-commonjs": "^28.0.6",
         "@rollup/plugin-node-resolve": "^15.2.1",
@@ -2820,6 +2821,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@puppeteer/browsers": {
@@ -6810,6 +6827,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pngjs": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@babel/core": "^7.23.9",
     "@babel/preset-env": "^7.23.9",
+    "@playwright/test": "^1.55.0",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^28.0.6",
     "@rollup/plugin-node-resolve": "^15.2.1",

--- a/src/Elementor/Widgets/AbstractFieldWidget.php
+++ b/src/Elementor/Widgets/AbstractFieldWidget.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gm2\Elementor\Widgets;
+
+use Elementor\Widget_Base;
+use Gm2\Elementor\DynamicTags\GM2_Dynamic_Tag_Group;
+use Gm2\Fields\FieldDefinition;
+use function __;
+use function esc_attr;
+use function esc_html;
+use function esc_url;
+use function esc_url_raw;
+use function implode;
+use function is_array;
+use function is_bool;
+use function is_numeric;
+use function is_scalar;
+use function is_string;
+use function sanitize_text_field;
+use function trim;
+use function wp_kses_post;
+use function preg_replace;
+
+if (!class_exists(Widget_Base::class)) {
+    return;
+}
+
+abstract class AbstractFieldWidget extends Widget_Base
+{
+    private ?GM2_Dynamic_Tag_Group $group = null;
+
+    protected function group(): GM2_Dynamic_Tag_Group
+    {
+        if ($this->group instanceof GM2_Dynamic_Tag_Group) {
+            return $this->group;
+        }
+
+        $this->group = GM2_Dynamic_Tag_Group::instance();
+
+        return $this->group;
+    }
+
+    protected function fieldOptions(?string $postType, bool $includeComputed = false, array $allowedTypes = []): array
+    {
+        return $this->group()->getFieldOptions($postType, $includeComputed, $allowedTypes);
+    }
+
+    protected function mapFieldOptions(?string $postType = null): array
+    {
+        return $this->group()->getMapFieldOptions($postType);
+    }
+
+    protected function normalizePostType(mixed $postType): ?string
+    {
+        if (!is_string($postType)) {
+            return null;
+        }
+
+        $postType = trim($postType);
+
+        return $postType === '' ? null : $postType;
+    }
+
+    protected function findField(string $compoundKey): ?array
+    {
+        return $this->group()->findField($compoundKey);
+    }
+
+    protected function formattedValue(FieldDefinition $field, string $compoundKey, ?string $postType = null): mixed
+    {
+        return $this->group()->getFormattedValue($compoundKey, $postType);
+    }
+
+    protected function sanitizedValue(FieldDefinition $field, string $compoundKey, ?string $postType = null): mixed
+    {
+        return $this->group()->getSanitizedValue($compoundKey, $postType);
+    }
+
+    protected function valueOrFallback(FieldDefinition $field, mixed $value, mixed $fallback): mixed
+    {
+        if (!$this->group()->isEmptyValue($value)) {
+            return $value;
+        }
+
+        return $this->group()->formatFallback($field, $fallback);
+    }
+
+    protected function renderText(string $content, string $tag = 'div', array $classes = []): void
+    {
+        $tag     = $this->sanitizeTag($tag);
+        $classes = $classes === [] ? '' : ' class="' . esc_attr(implode(' ', $classes)) . '"';
+
+        echo '<' . $tag . $classes . '>' . esc_html($content) . '</' . $tag . '>';
+    }
+
+    protected function sanitizeTag(string $tag): string
+    {
+        $allowed = [ 'div', 'span', 'p', 'h2', 'h3', 'h4', 'h5', 'h6', 'strong' ];
+        if (!in_array($tag, $allowed, true)) {
+            return 'div';
+        }
+
+        return $tag;
+    }
+
+    protected function attachmentHtml(array $value, array $classes = [], string $tag = 'img'): ?string
+    {
+        $url = isset($value['url']) && is_string($value['url']) ? trim($value['url']) : '';
+        if ($url === '') {
+            return null;
+        }
+
+        $url = esc_url($url);
+        if ($tag === 'img') {
+            $classAttr = $classes === [] ? '' : ' class="' . esc_attr(implode(' ', $classes)) . '"';
+
+            return '<img src="' . $url . '" alt="" loading="lazy"' . $classAttr . ' />';
+        }
+
+        $classAttr = $classes === [] ? '' : ' class="' . esc_attr(implode(' ', $classes)) . '"';
+
+        return '<a' . $classAttr . ' href="' . $url . '" target="_blank" rel="noopener noreferrer">' . esc_html($url) . '</a>';
+    }
+
+    protected function stringFromValue(FieldDefinition $field, mixed $value): string
+    {
+        $type = $field->getType()->getName();
+        if ($value === null) {
+            return '';
+        }
+
+        switch ($type) {
+            case 'checkbox':
+            case 'switch':
+                if (is_bool($value)) {
+                    return $value ? __('Yes', 'gm2-wordpress-suite') : __('No', 'gm2-wordpress-suite');
+                }
+
+                return (string) $value;
+            case 'multiselect':
+                if (is_array($value)) {
+                    return implode(', ', array_map('sanitize_text_field', $value));
+                }
+
+                break;
+            case 'address':
+                if (is_array($value)) {
+                    $parts = [];
+                    foreach (['line1', 'line2', 'city', 'state', 'postal_code', 'country'] as $key) {
+                        if (isset($value[$key]) && is_string($value[$key]) && trim($value[$key]) !== '') {
+                            $parts[] = sanitize_text_field($value[$key]);
+                        }
+                    }
+
+                    return implode(', ', $parts);
+                }
+
+                break;
+            case 'geopoint':
+                if (is_array($value)) {
+                    $lat = isset($value['lat']) && is_numeric($value['lat']) ? $this->formatCoordinate((float) $value['lat']) : '';
+                    $lng = isset($value['lng']) && is_numeric($value['lng']) ? $this->formatCoordinate((float) $value['lng']) : '';
+                    $coords = trim($lat . ', ' . $lng);
+                    if ($coords !== ',') {
+                        return $coords;
+                    }
+                }
+
+                break;
+        }
+
+        if (is_scalar($value)) {
+            return sanitize_text_field((string) $value);
+        }
+
+        return '';
+    }
+
+    protected function richTextFromValue(FieldDefinition $field, mixed $value): string
+    {
+        $type = $field->getType()->getName();
+        if ($type === 'wysiwyg' && is_string($value)) {
+            return wp_kses_post($value);
+        }
+
+        return esc_html($this->stringFromValue($field, $value));
+    }
+
+    protected function renderGallery(array $items, array $classes = []): ?string
+    {
+        if ($items === []) {
+            return null;
+        }
+
+        $output = '<div class="' . esc_attr(implode(' ', $classes)) . '">';
+        foreach ($items as $item) {
+            if (!is_array($item)) {
+                continue;
+            }
+            $html = $this->attachmentHtml($item, ['gm2-field-gallery__image']);
+            if ($html === null) {
+                continue;
+            }
+            $output .= '<figure class="gm2-field-gallery__item">' . $html . '</figure>';
+        }
+        $output .= '</div>';
+
+        return $output;
+    }
+
+    protected function buildLink(string $url, ?string $text = null, array $classes = []): ?string
+    {
+        $url = trim($url);
+        if ($url === '') {
+            return null;
+        }
+
+        $text ??= $url;
+
+        return '<a class="' . esc_attr(implode(' ', $classes)) . '" href="' . esc_url($url) . '" target="_blank" rel="noopener noreferrer">' . esc_html($text) . '</a>';
+    }
+
+    protected function telLink(string $number, array $classes = []): ?string
+    {
+        $number = trim($number);
+        if ($number === '') {
+            return null;
+        }
+
+        $display = sanitize_text_field($number);
+        $href    = 'tel:' . preg_replace('/[^0-9+]/', '', $display);
+
+        return '<a class="' . esc_attr(implode(' ', $classes)) . '" href="' . esc_url_raw($href) . '">' . esc_html($display) . '</a>';
+    }
+
+    protected function mailLink(string $email, array $classes = []): ?string
+    {
+        $email = sanitize_text_field(trim($email));
+        if ($email === '') {
+            return null;
+        }
+
+        return '<a class="' . esc_attr(implode(' ', $classes)) . '" href="mailto:' . esc_attr($email) . '">' . esc_html($email) . '</a>';
+    }
+
+    protected function formatCoordinate(float $value): string
+    {
+        $formatted = number_format($value, 6, '.', '');
+
+        return trim(rtrim(rtrim($formatted, '0'), '.'));
+    }
+}

--- a/src/Elementor/Widgets/Field.php
+++ b/src/Elementor/Widgets/Field.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gm2\Elementor\Widgets;
+
+use Elementor\Controls_Manager;
+use Gm2\Fields\FieldDefinition;
+use function esc_attr;
+use function esc_html;
+use function esc_html__;
+use function is_array;
+use function is_string;
+use function trim;
+use function wp_kses_post;
+
+if (!class_exists(AbstractFieldWidget::class)) {
+    return;
+}
+
+final class Field extends AbstractFieldWidget
+{
+    public function get_name(): string
+    {
+        return 'gm2_field';
+    }
+
+    public function get_title(): string
+    {
+        return esc_html__('GM2 Field', 'gm2-wordpress-suite');
+    }
+
+    public function get_icon(): string
+    {
+        return 'eicon-post-info';
+    }
+
+    public function get_categories(): array
+    {
+        return [ 'general' ];
+    }
+
+    public function get_keywords(): array
+    {
+        return [ 'gm2', 'field', 'meta', 'custom' ];
+    }
+
+    protected function register_controls(): void
+    {
+        $this->start_controls_section('section_content', [
+            'label' => esc_html__('Content', 'gm2-wordpress-suite'),
+        ]);
+
+        $this->add_control('post_type', [
+            'label'   => esc_html__('Post Type', 'gm2-wordpress-suite'),
+            'type'    => Controls_Manager::SELECT,
+            'options' => $this->group()->getPostTypeOptions(),
+            'default' => '',
+        ]);
+
+        $this->add_control('field_key', [
+            'label'       => esc_html__('Field', 'gm2-wordpress-suite'),
+            'type'        => Controls_Manager::SELECT2,
+            'label_block' => true,
+            'options'     => $this->fieldOptions(null, false),
+        ]);
+
+        $this->add_control('fallback', [
+            'label'   => esc_html__('Fallback', 'gm2-wordpress-suite'),
+            'type'    => Controls_Manager::TEXT,
+            'dynamic' => [ 'active' => true ],
+        ]);
+
+        $this->add_control('html_tag', [
+            'label'   => esc_html__('HTML Tag', 'gm2-wordpress-suite'),
+            'type'    => Controls_Manager::SELECT,
+            'default' => 'div',
+            'options' => [
+                'div'   => 'div',
+                'span'  => 'span',
+                'p'     => 'p',
+                'h2'    => 'h2',
+                'h3'    => 'h3',
+                'h4'    => 'h4',
+                'strong'=> 'strong',
+            ],
+            'separator' => 'before',
+        ]);
+
+        $this->end_controls_section();
+    }
+
+    protected function render(): void
+    {
+        $settings = $this->get_settings_for_display();
+        $fieldKey = is_string($settings['field_key'] ?? null) ? trim((string) $settings['field_key']) : '';
+        if ($fieldKey === '') {
+            $fallback = is_string($settings['fallback'] ?? null) ? $settings['fallback'] : '';
+            $this->renderText($fallback, $settings['html_tag'] ?? 'div', [ 'gm2-field' ]);
+
+            return;
+        }
+
+        $fieldData = $this->findField($fieldKey);
+        if ($fieldData === null) {
+            $fallback = is_string($settings['fallback'] ?? null) ? $settings['fallback'] : '';
+            $this->renderText($fallback, $settings['html_tag'] ?? 'div', [ 'gm2-field', 'gm2-field--fallback' ]);
+
+            return;
+        }
+
+        /** @var FieldDefinition $field */
+        $field    = $fieldData['field'];
+        $postType = $this->normalizePostType($settings['post_type'] ?? null);
+        $value    = $this->formattedValue($field, $fieldKey, $postType);
+        $value    = $this->valueOrFallback($field, $value, $settings['fallback'] ?? '');
+
+        $output = $this->formatValueForDisplay($field, $value, $settings);
+        if ($output === null) {
+            return;
+        }
+
+        echo $output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+    }
+
+    /**
+     * @param array<string, mixed> $settings
+     */
+    private function formatValueForDisplay(FieldDefinition $field, mixed $value, array $settings): ?string
+    {
+        $tag      = is_string($settings['html_tag'] ?? null) ? $settings['html_tag'] : 'div';
+        $classes  = [ 'gm2-field' ];
+        $type     = $field->getType()->getName();
+
+        switch ($type) {
+            case 'image':
+                if (is_array($value)) {
+                    $html = $this->attachmentHtml($value, [ 'gm2-field__image' ]);
+                    if ($html !== null) {
+                        return '<div class="gm2-field gm2-field--image">' . $html . '</div>';
+                    }
+                }
+
+                break;
+            case 'media':
+            case 'file':
+                if (is_array($value)) {
+                    $html = $this->attachmentHtml($value, [ 'gm2-field__link' ], 'a');
+                    if ($html !== null) {
+                        return '<div class="gm2-field gm2-field--link">' . $html . '</div>';
+                    }
+                }
+
+                break;
+            case 'gallery':
+                if (is_array($value)) {
+                    $gallery = $this->renderGallery($value, [ 'gm2-field__gallery' ]);
+                    if ($gallery !== null) {
+                        return '<div class="gm2-field gm2-field--gallery">' . $gallery . '</div>';
+                    }
+                }
+
+                break;
+            case 'url':
+                if (is_string($value) && $value !== '') {
+                    $link = $this->buildLink($value, null, [ 'gm2-field__link' ]);
+                    if ($link !== null) {
+                        return '<div class="gm2-field gm2-field--link">' . $link . '</div>';
+                    }
+                }
+
+                break;
+            case 'email':
+                if (is_string($value) && $value !== '') {
+                    $link = $this->mailLink($value, [ 'gm2-field__link' ]);
+                    if ($link !== null) {
+                        return '<div class="gm2-field gm2-field--email">' . $link . '</div>';
+                    }
+                }
+
+                break;
+            case 'tel':
+                if (is_string($value) && $value !== '') {
+                    $link = $this->telLink($value, [ 'gm2-field__link' ]);
+                    if ($link !== null) {
+                        return '<div class="gm2-field gm2-field--tel">' . $link . '</div>';
+                    }
+                }
+
+                break;
+            case 'wysiwyg':
+                if (is_string($value)) {
+                    $content = wp_kses_post($value);
+
+                    return '<div class="gm2-field gm2-field--wysiwyg">' . $content . '</div>';
+                }
+
+                break;
+            default:
+                $content = $this->stringFromValue($field, $value);
+                if ($content !== '') {
+                    $classes[] = 'gm2-field--text';
+                    $classAttr = ' class="' . esc_attr(implode(' ', $classes)) . '"';
+
+                    return '<' . $this->sanitizeTag($tag) . $classAttr . '>' . esc_html($content) . '</' . $this->sanitizeTag($tag) . '>';
+                }
+        }
+
+        return null;
+    }
+}

--- a/src/Elementor/Widgets/LoopCard.php
+++ b/src/Elementor/Widgets/LoopCard.php
@@ -1,0 +1,462 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gm2\Elementor\Widgets;
+
+use Elementor\Controls_Manager;
+use Elementor\Repeater;
+use Gm2\Fields\FieldDefinition;
+use function esc_attr;
+use function esc_html;
+use function esc_html__;
+use function esc_url;
+use function get_the_title;
+use function is_array;
+use function is_string;
+use function trim;
+use function wp_kses_post;
+
+if (!class_exists(AbstractFieldWidget::class)) {
+    return;
+}
+
+final class LoopCard extends AbstractFieldWidget
+{
+    private const LAYOUTS = [ 'stacked', 'horizontal' ];
+    private const CARD_TAGS = [ 'article', 'div', 'section' ];
+    private const TITLE_TAGS = [ 'h2', 'h3', 'h4', 'p', 'div' ];
+
+    public function get_name(): string
+    {
+        return 'gm2_loop_card';
+    }
+
+    public function get_title(): string
+    {
+        return esc_html__('GM2 Loop Card', 'gm2-wordpress-suite');
+    }
+
+    public function get_icon(): string
+    {
+        return 'eicon-post-list';
+    }
+
+    public function get_categories(): array
+    {
+        return [ 'general' ];
+    }
+
+    public function get_keywords(): array
+    {
+        return [ 'gm2', 'loop', 'card', 'meta' ];
+    }
+
+    protected function register_controls(): void
+    {
+        $this->start_controls_section('section_content', [
+            'label' => esc_html__('Card', 'gm2-wordpress-suite'),
+        ]);
+
+        $this->add_control('post_type', [
+            'label'   => esc_html__('Post Type', 'gm2-wordpress-suite'),
+            'type'    => Controls_Manager::SELECT,
+            'options' => $this->group()->getPostTypeOptions(),
+            'default' => '',
+        ]);
+
+        $this->add_control('layout', [
+            'label'   => esc_html__('Layout', 'gm2-wordpress-suite'),
+            'type'    => Controls_Manager::SELECT,
+            'options' => [
+                'stacked'    => esc_html__('Stacked', 'gm2-wordpress-suite'),
+                'horizontal' => esc_html__('Horizontal', 'gm2-wordpress-suite'),
+            ],
+            'default' => 'stacked',
+        ]);
+
+        $this->add_control('card_tag', [
+            'label'   => esc_html__('Wrapper Tag', 'gm2-wordpress-suite'),
+            'type'    => Controls_Manager::SELECT,
+            'options' => [ 'article' => 'article', 'div' => 'div', 'section' => 'section' ],
+            'default' => 'article',
+        ]);
+
+        $this->add_control('image_field', [
+            'label'       => esc_html__('Image Field', 'gm2-wordpress-suite'),
+            'type'        => Controls_Manager::SELECT2,
+            'label_block' => true,
+            'options'     => $this->fieldOptions(null, false, [ 'image' ]),
+        ]);
+
+        $this->add_control('image_fallback', [
+            'label'       => esc_html__('Image Fallback URL', 'gm2-wordpress-suite'),
+            'type'        => Controls_Manager::TEXT,
+            'dynamic'     => [ 'active' => true ],
+            'placeholder' => 'https://example.com/fallback.jpg',
+        ]);
+
+        $this->add_control('title_field', [
+            'label'       => esc_html__('Title Field', 'gm2-wordpress-suite'),
+            'type'        => Controls_Manager::SELECT2,
+            'label_block' => true,
+            'options'     => $this->fieldOptions(null, false, $this->titleFieldTypes()),
+        ]);
+
+        $this->add_control('title_tag', [
+            'label'   => esc_html__('Title Tag', 'gm2-wordpress-suite'),
+            'type'    => Controls_Manager::SELECT,
+            'options' => [ 'h2' => 'h2', 'h3' => 'h3', 'h4' => 'h4', 'p' => 'p', 'div' => 'div' ],
+            'default' => 'h3',
+        ]);
+
+        $this->add_control('title_fallback', [
+            'label'   => esc_html__('Title Fallback', 'gm2-wordpress-suite'),
+            'type'    => Controls_Manager::TEXT,
+            'dynamic' => [ 'active' => true ],
+        ]);
+
+        $this->add_control('subtitle_field', [
+            'label'       => esc_html__('Subtitle Field', 'gm2-wordpress-suite'),
+            'type'        => Controls_Manager::SELECT2,
+            'label_block' => true,
+            'options'     => $this->fieldOptions(null, false, $this->subtitleFieldTypes()),
+        ]);
+
+        $this->add_control('subtitle_tag', [
+            'label'   => esc_html__('Subtitle Tag', 'gm2-wordpress-suite'),
+            'type'    => Controls_Manager::SELECT,
+            'options' => [ 'p' => 'p', 'div' => 'div', 'span' => 'span' ],
+            'default' => 'p',
+        ]);
+
+        $this->add_control('subtitle_fallback', [
+            'label'   => esc_html__('Subtitle Fallback', 'gm2-wordpress-suite'),
+            'type'    => Controls_Manager::TEXT,
+            'dynamic' => [ 'active' => true ],
+        ]);
+
+        $this->add_control('body_field', [
+            'label'       => esc_html__('Body Field', 'gm2-wordpress-suite'),
+            'type'        => Controls_Manager::SELECT2,
+            'label_block' => true,
+            'options'     => $this->fieldOptions(null, false, $this->bodyFieldTypes()),
+        ]);
+
+        $this->add_control('body_fallback', [
+            'label'   => esc_html__('Body Fallback', 'gm2-wordpress-suite'),
+            'type'    => Controls_Manager::TEXTAREA,
+            'dynamic' => [ 'active' => true ],
+        ]);
+
+        $repeater = new Repeater();
+        $repeater->add_control('label', [
+            'label'   => esc_html__('Label', 'gm2-wordpress-suite'),
+            'type'    => Controls_Manager::TEXT,
+            'dynamic' => [ 'active' => true ],
+        ]);
+        $repeater->add_control('field_key', [
+            'label'       => esc_html__('Field', 'gm2-wordpress-suite'),
+            'type'        => Controls_Manager::SELECT2,
+            'label_block' => true,
+            'options'     => $this->fieldOptions(null, false, $this->metaFieldTypes()),
+        ]);
+        $repeater->add_control('fallback', [
+            'label'   => esc_html__('Fallback', 'gm2-wordpress-suite'),
+            'type'    => Controls_Manager::TEXT,
+            'dynamic' => [ 'active' => true ],
+        ]);
+
+        $this->add_control('meta_fields', [
+            'label'       => esc_html__('Meta Fields', 'gm2-wordpress-suite'),
+            'type'        => Controls_Manager::REPEATER,
+            'fields'      => $repeater->get_controls(),
+            'title_field' => '{{{ label }}}',
+        ]);
+
+        $this->add_control('button_text', [
+            'label'       => esc_html__('Button Text', 'gm2-wordpress-suite'),
+            'type'        => Controls_Manager::TEXT,
+            'dynamic'     => [ 'active' => true ],
+            'default'     => esc_html__('View Details', 'gm2-wordpress-suite'),
+        ]);
+
+        $this->add_control('button_url_field', [
+            'label'       => esc_html__('Button URL Field', 'gm2-wordpress-suite'),
+            'type'        => Controls_Manager::SELECT2,
+            'label_block' => true,
+            'options'     => $this->fieldOptions(null, false, [ 'url' ]),
+        ]);
+
+        $this->add_control('button_fallback_url', [
+            'label'   => esc_html__('Button Fallback URL', 'gm2-wordpress-suite'),
+            'type'    => Controls_Manager::TEXT,
+            'dynamic' => [ 'active' => true ],
+        ]);
+
+        $this->end_controls_section();
+    }
+
+    protected function render(): void
+    {
+        $settings = $this->get_settings_for_display();
+        $postType = $this->normalizePostType($settings['post_type'] ?? null);
+        $layout   = $this->sanitizeChoice($settings['layout'] ?? 'stacked', self::LAYOUTS, 'stacked');
+        $tag      = $this->sanitizeChoice($settings['card_tag'] ?? 'article', self::CARD_TAGS, 'article');
+
+        $classes = [ 'gm2-loop-card', 'gm2-loop-card--' . $layout ];
+        echo '<' . $tag . ' class="' . esc_attr(implode(' ', $classes)) . '">';
+
+        $this->renderMedia($settings, $postType);
+        echo '<div class="gm2-loop-card__content">';
+        $this->renderHeading($settings, $postType);
+        $this->renderSubtitle($settings, $postType);
+        $this->renderBody($settings, $postType);
+        $this->renderMetaList($settings, $postType);
+        $this->renderButton($settings, $postType);
+        echo '</div>';
+        echo '</' . $tag . '>';
+    }
+
+    private function renderMedia(array $settings, ?string $postType): void
+    {
+        $imageData = $this->loadFieldValue($settings['image_field'] ?? null, $postType, $settings['image_fallback'] ?? '');
+        if ($imageData === null) {
+            return;
+        }
+
+        $value = $imageData['value'];
+        if (!is_array($value)) {
+            return;
+        }
+
+        $html = $this->attachmentHtml($value, [ 'gm2-loop-card__image' ]);
+        if ($html === null) {
+            return;
+        }
+
+        echo '<figure class="gm2-loop-card__media">' . $html . '</figure>';
+    }
+
+    private function renderHeading(array $settings, ?string $postType): void
+    {
+        $data = $this->loadFieldValue($settings['title_field'] ?? null, $postType, $settings['title_fallback'] ?? '');
+        $title = '';
+        if ($data !== null) {
+            $title = $this->stringFromValue($data['field'], $data['value']);
+        }
+
+        if ($title === '') {
+            $title = get_the_title() ?: '';
+        }
+
+        if ($title === '') {
+            return;
+        }
+
+        $tag = $this->sanitizeChoice($settings['title_tag'] ?? 'h3', self::TITLE_TAGS, 'h3');
+        echo '<' . $tag . ' class="gm2-loop-card__title">' . esc_html($title) . '</' . $tag . '>';
+    }
+
+    private function renderSubtitle(array $settings, ?string $postType): void
+    {
+        $data = $this->loadFieldValue($settings['subtitle_field'] ?? null, $postType, $settings['subtitle_fallback'] ?? '');
+        if ($data === null) {
+            return;
+        }
+
+        $subtitle = $this->stringFromValue($data['field'], $data['value']);
+        if ($subtitle === '') {
+            return;
+        }
+
+        $tag = $this->sanitizeChoice($settings['subtitle_tag'] ?? 'p', [ 'p', 'div', 'span' ], 'p');
+        echo '<' . $tag . ' class="gm2-loop-card__subtitle">' . esc_html($subtitle) . '</' . $tag . '>';
+    }
+
+    private function renderBody(array $settings, ?string $postType): void
+    {
+        $data = $this->loadFieldValue($settings['body_field'] ?? null, $postType, $settings['body_fallback'] ?? '');
+        if ($data === null) {
+            return;
+        }
+
+        $field = $data['field'];
+        $value = $data['value'];
+
+        if ($field->getType()->getName() === 'wysiwyg' && is_string($value)) {
+            $content = wp_kses_post($value);
+            if ($content !== '') {
+                echo '<div class="gm2-loop-card__body">' . $content . '</div>';
+            }
+
+            return;
+        }
+
+        $text = $this->stringFromValue($field, $value);
+        if ($text !== '') {
+            echo '<div class="gm2-loop-card__body">' . esc_html($text) . '</div>';
+        }
+    }
+
+    private function renderMetaList(array $settings, ?string $postType): void
+    {
+        $items = $settings['meta_fields'] ?? [];
+        if (!is_array($items) || $items === []) {
+            return;
+        }
+
+        $output = '';
+        foreach ($items as $item) {
+            if (!is_array($item)) {
+                continue;
+            }
+            $fieldData = $this->loadFieldValue($item['field_key'] ?? null, $postType, $item['fallback'] ?? '');
+            if ($fieldData === null) {
+                continue;
+            }
+
+            $valueHtml = $this->renderMetaValue($fieldData['field'], $fieldData['value']);
+            if ($valueHtml === null || trim($valueHtml) === '') {
+                continue;
+            }
+
+            $label = is_string($item['label'] ?? null) && $item['label'] !== ''
+                ? $item['label']
+                : $fieldData['field']->getLabel();
+
+            $output .= '<div class="gm2-loop-card__meta-item">'
+                . '<dt class="gm2-loop-card__meta-label">' . esc_html($label) . '</dt>'
+                . '<dd class="gm2-loop-card__meta-value">' . $valueHtml . '</dd>'
+                . '</div>';
+        }
+
+        if ($output === '') {
+            return;
+        }
+
+        echo '<dl class="gm2-loop-card__meta">' . $output . '</dl>';
+    }
+
+    private function renderButton(array $settings, ?string $postType): void
+    {
+        $fieldData = $this->loadFieldValue($settings['button_url_field'] ?? null, $postType, $settings['button_fallback_url'] ?? '');
+        if ($fieldData === null) {
+            return;
+        }
+
+        $urlValue = $fieldData['value'];
+        if (!is_string($urlValue) || trim($urlValue) === '') {
+            return;
+        }
+
+        $text = is_string($settings['button_text'] ?? null) && trim((string) $settings['button_text']) !== ''
+            ? $settings['button_text']
+            : esc_html__('Read more', 'gm2-wordpress-suite');
+
+        echo '<a class="gm2-loop-card__button" href="' . esc_url($urlValue) . '">' . esc_html($text) . '</a>';
+    }
+
+    /**
+     * @return array<string>
+     */
+    private function titleFieldTypes(): array
+    {
+        return [ 'text', 'textarea', 'number', 'currency', 'select', 'radio', 'multiselect', 'computed', 'relationship_post', 'relationship_term', 'relationship_user', 'date', 'datetime_tz', 'time' ];
+    }
+
+    /**
+     * @return array<string>
+     */
+    private function subtitleFieldTypes(): array
+    {
+        return [ 'text', 'textarea', 'number', 'currency', 'select', 'radio', 'multiselect', 'computed', 'date', 'datetime_tz', 'time', 'relationship_post', 'relationship_term', 'relationship_user' ];
+    }
+
+    /**
+     * @return array<string>
+     */
+    private function bodyFieldTypes(): array
+    {
+        return [ 'text', 'textarea', 'wysiwyg', 'computed' ];
+    }
+
+    /**
+     * @return array<string>
+     */
+    private function metaFieldTypes(): array
+    {
+        return [
+            'text', 'textarea', 'number', 'currency', 'select', 'radio', 'multiselect',
+            'checkbox', 'switch', 'computed', 'date', 'time', 'datetime_tz', 'relationship_post',
+            'relationship_term', 'relationship_user', 'url', 'email', 'tel', 'address', 'geopoint',
+        ];
+    }
+
+    /**
+     * @param array<string, mixed>|null $field
+     *
+     * @return array{field: FieldDefinition, value: mixed}|null
+     */
+    private function loadFieldValue(mixed $fieldKey, ?string $postType, mixed $fallback): ?array
+    {
+        if (!is_string($fieldKey)) {
+            return null;
+        }
+
+        $fieldKey = trim($fieldKey);
+        if ($fieldKey === '') {
+            return null;
+        }
+
+        $fieldData = $this->findField($fieldKey);
+        if ($fieldData === null) {
+            return null;
+        }
+
+        $field = $fieldData['field'];
+        $value = $this->formattedValue($field, $fieldKey, $postType);
+        $value = $this->valueOrFallback($field, $value, $fallback);
+
+        return [ 'field' => $field, 'value' => $value ];
+    }
+
+    private function renderMetaValue(FieldDefinition $field, mixed $value): ?string
+    {
+        $type = $field->getType()->getName();
+        if ($type === 'url' && is_string($value) && $value !== '') {
+            $link = $this->buildLink($value, null, [ 'gm2-loop-card__meta-link' ]);
+
+            return $link;
+        }
+
+        if ($type === 'email' && is_string($value) && $value !== '') {
+            return $this->mailLink($value, [ 'gm2-loop-card__meta-link' ]);
+        }
+
+        if ($type === 'tel' && is_string($value) && $value !== '') {
+            return $this->telLink($value, [ 'gm2-loop-card__meta-link' ]);
+        }
+
+        $text = $this->stringFromValue($field, $value);
+        if ($text === '') {
+            return null;
+        }
+
+        return esc_html($text);
+    }
+
+    private function sanitizeChoice(mixed $value, array $allowed, string $default): string
+    {
+        if (!is_string($value)) {
+            return $default;
+        }
+
+        $value = trim($value);
+        if ($value === '') {
+            return $default;
+        }
+
+        return in_array($value, $allowed, true) ? $value : $default;
+    }
+}

--- a/src/Elementor/Widgets/Map.php
+++ b/src/Elementor/Widgets/Map.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gm2\Elementor\Widgets;
+
+use Elementor\Controls_Manager;
+use Gm2\Fields\FieldDefinition;
+use function esc_attr;
+use function esc_html;
+use function esc_html__;
+use function esc_url;
+use function esc_url_raw;
+use function implode;
+use function is_array;
+use function is_numeric;
+use function is_string;
+use function sanitize_text_field;
+use function trim;
+
+if (!class_exists(AbstractFieldWidget::class)) {
+    return;
+}
+
+final class Map extends AbstractFieldWidget
+{
+    public function get_name(): string
+    {
+        return 'gm2_map';
+    }
+
+    public function get_title(): string
+    {
+        return esc_html__('GM2 Map', 'gm2-wordpress-suite');
+    }
+
+    public function get_icon(): string
+    {
+        return 'eicon-google-maps';
+    }
+
+    public function get_categories(): array
+    {
+        return [ 'general' ];
+    }
+
+    public function get_keywords(): array
+    {
+        return [ 'gm2', 'map', 'address', 'geolocation' ];
+    }
+
+    protected function register_controls(): void
+    {
+        $this->start_controls_section('section_map', [
+            'label' => esc_html__('Map', 'gm2-wordpress-suite'),
+        ]);
+
+        $this->add_control('post_type', [
+            'label'   => esc_html__('Post Type', 'gm2-wordpress-suite'),
+            'type'    => Controls_Manager::SELECT,
+            'options' => $this->group()->getPostTypeOptions(),
+            'default' => '',
+        ]);
+
+        $this->add_control('field_key', [
+            'label'       => esc_html__('Location Field', 'gm2-wordpress-suite'),
+            'type'        => Controls_Manager::SELECT2,
+            'label_block' => true,
+            'options'     => $this->mapFieldOptions(null),
+        ]);
+
+        $this->add_control('display', [
+            'label'   => esc_html__('Display', 'gm2-wordpress-suite'),
+            'type'    => Controls_Manager::SELECT,
+            'options' => [
+                'embed' => esc_html__('Embed', 'gm2-wordpress-suite'),
+                'link'  => esc_html__('Link', 'gm2-wordpress-suite'),
+            ],
+            'default' => 'embed',
+        ]);
+
+        $this->add_control('provider_url', [
+            'label'       => esc_html__('Provider URL', 'gm2-wordpress-suite'),
+            'type'        => Controls_Manager::TEXT,
+            'dynamic'     => [ 'active' => true ],
+            'default'     => 'https://www.google.com/maps/search/?api=1&query={{query}}',
+            'description' => esc_html__('Use {{query}}, {{lat}}, and {{lng}} tokens to build the URL.', 'gm2-wordpress-suite'),
+        ]);
+
+        $this->add_control('link_text', [
+            'label'       => esc_html__('Link Text', 'gm2-wordpress-suite'),
+            'type'        => Controls_Manager::TEXT,
+            'dynamic'     => [ 'active' => true ],
+            'default'     => esc_html__('View on map', 'gm2-wordpress-suite'),
+            'condition'   => [ 'display' => 'link' ],
+        ]);
+
+        $this->add_control('height', [
+            'label'       => esc_html__('Embed Height (px)', 'gm2-wordpress-suite'),
+            'type'        => Controls_Manager::NUMBER,
+            'default'     => 320,
+            'condition'   => [ 'display' => 'embed' ],
+        ]);
+
+        $this->add_control('fallback_text', [
+            'label'   => esc_html__('Fallback Text', 'gm2-wordpress-suite'),
+            'type'    => Controls_Manager::TEXT,
+            'dynamic' => [ 'active' => true ],
+        ]);
+
+        $this->end_controls_section();
+    }
+
+    protected function render(): void
+    {
+        $settings = $this->get_settings_for_display();
+        $fieldKey = is_string($settings['field_key'] ?? null) ? trim($settings['field_key']) : '';
+        if ($fieldKey === '') {
+            $this->renderFallback($settings);
+
+            return;
+        }
+
+        $fieldData = $this->findField($fieldKey);
+        if ($fieldData === null) {
+            $this->renderFallback($settings);
+
+            return;
+        }
+
+        /** @var FieldDefinition $field */
+        $field    = $fieldData['field'];
+        $postType = $this->normalizePostType($settings['post_type'] ?? null);
+        $rawValue = $this->sanitizedValue($field, $fieldKey, $postType);
+
+        $url = $this->buildProviderUrl($field, $rawValue, $settings, $fieldKey, $postType);
+        if ($url === null) {
+            $this->renderFallback($settings);
+
+            return;
+        }
+
+        $display = is_string($settings['display'] ?? null) ? $settings['display'] : 'embed';
+        if ($display === 'link') {
+            $text = is_string($settings['link_text'] ?? null) && trim($settings['link_text']) !== ''
+                ? $settings['link_text']
+                : esc_html__('View on map', 'gm2-wordpress-suite');
+            echo '<a class="gm2-map gm2-map--link" href="' . esc_url($url) . '" target="_blank" rel="noopener noreferrer">' . esc_html($text) . '</a>';
+
+            return;
+        }
+
+        $height = isset($settings['height']) && is_numeric($settings['height']) ? max(120, (int) $settings['height']) : 320;
+        echo '<div class="gm2-map gm2-map--embed">'
+            . '<iframe src="' . esc_url($url) . '" loading="lazy" allowfullscreen style="width:100%;border:0;height:' . esc_attr((string) $height) . 'px"></iframe>'
+            . '</div>';
+    }
+
+    private function renderFallback(array $settings): void
+    {
+        $fallback = is_string($settings['fallback_text'] ?? null) ? trim($settings['fallback_text']) : '';
+        if ($fallback === '') {
+            return;
+        }
+
+        echo '<div class="gm2-map gm2-map--fallback">' . esc_html($fallback) . '</div>';
+    }
+
+    private function buildProviderUrl(FieldDefinition $field, mixed $value, array $settings, string $compoundKey, ?string $postType): ?string
+    {
+        $template = is_string($settings['provider_url'] ?? null) ? trim($settings['provider_url']) : '';
+
+        if ($template === '') {
+            $default = $this->group()->buildMapUrl($compoundKey, $postType);
+
+            return $default === null ? null : $default;
+        }
+
+        $lat = null;
+        $lng = null;
+        $query = '';
+
+        if (is_array($value)) {
+            if (isset($value['lat'], $value['lng']) && is_numeric($value['lat']) && is_numeric($value['lng'])) {
+                $lat = $this->formatCoordinate((float) $value['lat']);
+                $lng = $this->formatCoordinate((float) $value['lng']);
+            }
+
+            $parts = [];
+            foreach (['line1', 'line2', 'city', 'state', 'postal_code', 'country'] as $key) {
+                if (isset($value[$key]) && is_string($value[$key]) && trim($value[$key]) !== '') {
+                    $parts[] = sanitize_text_field($value[$key]);
+                }
+            }
+
+            if ($parts !== []) {
+                $query = implode(' ', $parts);
+            }
+        } elseif (is_string($value)) {
+            $query = trim($value);
+        }
+
+        if (($query === '' || $query === null) && $lat !== null && $lng !== null) {
+            $query = $lat . ',' . $lng;
+        }
+
+        $replacements = [
+            '{{lat}}'   => $lat ?? '',
+            '{{lng}}'   => $lng ?? '',
+            '{{query}}' => $query,
+        ];
+
+        $url = strtr($template, $replacements);
+        $url = esc_url_raw($url);
+        if ($url === '' && $query !== '') {
+            $url = 'https://www.google.com/maps/search/?api=1&query=' . rawurlencode($query);
+        }
+
+        return $url !== '' ? $url : null;
+    }
+}

--- a/src/Elementor/Widgets/OpeningHours.php
+++ b/src/Elementor/Widgets/OpeningHours.php
@@ -1,0 +1,282 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gm2\Elementor\Widgets;
+
+use Elementor\Controls_Manager;
+use Gm2\Fields\FieldDefinition;
+use function esc_html;
+use function esc_html__;
+use function get_option;
+use function in_array;
+use function is_array;
+use function is_bool;
+use function is_string;
+use function sanitize_text_field;
+use function strtotime;
+use function trim;
+use function wp_date;
+
+if (!class_exists(AbstractFieldWidget::class)) {
+    return;
+}
+
+final class OpeningHours extends AbstractFieldWidget
+{
+    public function get_name(): string
+    {
+        return 'gm2_opening_hours';
+    }
+
+    public function get_title(): string
+    {
+        return esc_html__('GM2 Opening Hours', 'gm2-wordpress-suite');
+    }
+
+    public function get_icon(): string
+    {
+        return 'eicon-time-line';
+    }
+
+    public function get_categories(): array
+    {
+        return [ 'general' ];
+    }
+
+    public function get_keywords(): array
+    {
+        return [ 'gm2', 'hours', 'schedule', 'opening' ];
+    }
+
+    protected function register_controls(): void
+    {
+        $this->start_controls_section('section_hours', [
+            'label' => esc_html__('Opening Hours', 'gm2-wordpress-suite'),
+        ]);
+
+        $this->add_control('post_type', [
+            'label'   => esc_html__('Post Type', 'gm2-wordpress-suite'),
+            'type'    => Controls_Manager::SELECT,
+            'options' => $this->group()->getPostTypeOptions(),
+            'default' => '',
+        ]);
+
+        $this->add_control('field_key', [
+            'label'       => esc_html__('Hours Field', 'gm2-wordpress-suite'),
+            'type'        => Controls_Manager::SELECT2,
+            'label_block' => true,
+            'options'     => $this->fieldOptions(null, false, [ 'repeater', 'text', 'textarea' ]),
+        ]);
+
+        $this->add_control('closed_label', [
+            'label'       => esc_html__('Closed Label', 'gm2-wordpress-suite'),
+            'type'        => Controls_Manager::TEXT,
+            'default'     => esc_html__('Closed', 'gm2-wordpress-suite'),
+        ]);
+
+        $this->add_control('fallback_text', [
+            'label'   => esc_html__('Fallback Text', 'gm2-wordpress-suite'),
+            'type'    => Controls_Manager::TEXT,
+            'dynamic' => [ 'active' => true ],
+        ]);
+
+        $this->end_controls_section();
+    }
+
+    protected function render(): void
+    {
+        $settings = $this->get_settings_for_display();
+        $fieldKey = is_string($settings['field_key'] ?? null) ? trim($settings['field_key']) : '';
+        if ($fieldKey === '') {
+            $this->renderFallback($settings);
+
+            return;
+        }
+
+        $fieldData = $this->findField($fieldKey);
+        if ($fieldData === null) {
+            $this->renderFallback($settings);
+
+            return;
+        }
+
+        /** @var FieldDefinition $field */
+        $field    = $fieldData['field'];
+        $postType = $this->normalizePostType($settings['post_type'] ?? null);
+        $value    = $this->sanitizedValue($field, $fieldKey, $postType);
+
+        if (is_string($value) && trim($value) !== '') {
+            echo '<div class="gm2-opening-hours gm2-opening-hours--text">' . esc_html($value) . '</div>';
+
+            return;
+        }
+
+        if (!is_array($value) || $value === []) {
+            $this->renderFallback($settings);
+
+            return;
+        }
+
+        $hours = $this->normalizeHours($value);
+        if ($hours === []) {
+            $this->renderFallback($settings);
+
+            return;
+        }
+
+        $closed = is_string($settings['closed_label'] ?? null) && trim($settings['closed_label']) !== ''
+            ? $settings['closed_label']
+            : esc_html__('Closed', 'gm2-wordpress-suite');
+
+        $output = '';
+        foreach ($hours as $row) {
+            $display = $row['closed']
+                ? $closed
+                : $this->formatTimeRange($row['open'], $row['close']);
+
+            if ($display === '') {
+                continue;
+            }
+
+            $output .= '<div class="gm2-opening-hours__row">'
+                . '<dt class="gm2-opening-hours__day">' . esc_html($row['day']) . '</dt>'
+                . '<dd class="gm2-opening-hours__time">' . esc_html($display) . '</dd>'
+                . '</div>';
+        }
+
+        if ($output === '') {
+            $this->renderFallback($settings);
+
+            return;
+        }
+
+        echo '<div class="gm2-opening-hours"><dl class="gm2-opening-hours__list">' . $output . '</dl></div>';
+    }
+
+    /**
+     * @param array<int, mixed> $rows
+     *
+     * @return array<int, array{day: string, open: string, close: string, closed: bool}>
+     */
+    private function normalizeHours(array $rows): array
+    {
+        $normalized = [];
+        foreach ($rows as $row) {
+            if (!is_array($row)) {
+                continue;
+            }
+
+            $day = isset($row['day']) && is_string($row['day']) ? sanitize_text_field($row['day']) : '';
+            if ($day === '') {
+                continue;
+            }
+
+            $open  = $this->extractTime($row, ['start', 'opens', 'open']);
+            $close = $this->extractTime($row, ['end', 'closes', 'close']);
+
+            $closed = false;
+            if (($open === '' && $close === '') || $this->isMarkedClosed($row)) {
+                $closed = true;
+            }
+
+            $normalized[] = [
+                'day'    => $day,
+                'open'   => $open,
+                'close'  => $close,
+                'closed' => $closed,
+            ];
+        }
+
+        return $normalized;
+    }
+
+    private function extractTime(array $row, array $keys): string
+    {
+        foreach ($keys as $key) {
+            if (!isset($row[$key])) {
+                continue;
+            }
+
+            if (is_string($row[$key])) {
+                return trim($row[$key]);
+            }
+        }
+
+        return '';
+    }
+
+    private function isMarkedClosed(array $row): bool
+    {
+        foreach (['closed', 'is_closed', 'status'] as $key) {
+            if (!isset($row[$key])) {
+                continue;
+            }
+
+            $value = $row[$key];
+            if (is_bool($value)) {
+                return $value;
+            }
+
+            if (is_string($value)) {
+                $value = strtolower(trim($value));
+                if (in_array($value, ['closed', 'yes', 'true', '1'], true)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function formatTimeRange(string $open, string $close): string
+    {
+        if ($open === '' && $close === '') {
+            return '';
+        }
+
+        $formattedOpen  = $this->formatTime($open);
+        $formattedClose = $this->formatTime($close);
+
+        if ($formattedOpen === '' && $formattedClose === '') {
+            return '';
+        }
+
+        if ($formattedOpen === '') {
+            return $formattedClose;
+        }
+
+        if ($formattedClose === '') {
+            return $formattedOpen;
+        }
+
+        return $formattedOpen . ' – ' . $formattedClose;
+    }
+
+    private function formatTime(string $value): string
+    {
+        $value = trim($value);
+        if ($value === '') {
+            return '';
+        }
+
+        $timestamp = strtotime($value);
+        if ($timestamp === false) {
+            return sanitize_text_field($value);
+        }
+
+        $format = get_option('time_format');
+
+        return wp_date($format ?: 'g:i a', $timestamp);
+    }
+
+    private function renderFallback(array $settings): void
+    {
+        $fallback = is_string($settings['fallback_text'] ?? null) ? trim($settings['fallback_text']) : '';
+        if ($fallback === '') {
+            return;
+        }
+
+        echo '<div class="gm2-opening-hours gm2-opening-hours--fallback">' . esc_html($fallback) . '</div>';
+    }
+}

--- a/src/Elementor/bootstrap.php
+++ b/src/Elementor/bootstrap.php
@@ -12,6 +12,20 @@ use Gm2\Elementor\Controls\TaxonomyTermMulti;
 use Gm2\Elementor\Controls\Unit;
 use Gm2\Elementor\DynamicTags\GM2_Dynamic_Tag_Group;
 use Gm2\Elementor\Query\Filters;
+use ReflectionMethod;
+use WP_Error;
+use WP_REST_Request;
+use function __;
+use function class_exists;
+use function get_post;
+use function is_array;
+use function sanitize_text_field;
+use function trim;
+use function update_option;
+use function update_post_meta;
+use function wp_delete_post;
+use function wp_insert_post;
+use function wp_reset_postdata;
 
 if (!defined('ABSPATH')) {
     exit;
@@ -30,6 +44,93 @@ add_action(
     }
 );
 
+if (defined('GM2_TESTING') && GM2_TESTING) {
+    add_action('rest_api_init', static function (): void {
+        register_rest_route('gm2-test/v1', '/widget-preview', [
+            'methods'             => 'POST',
+            'permission_callback' => '__return_true',
+            'callback'            => static function (WP_REST_Request $request) {
+                if (!class_exists('Elementor\\Widget_Base')) {
+                    eval('namespace Elementor; abstract class Widget_Base { protected array $settings = []; public function __construct($data = [], $args = null) {} abstract public function get_name(); abstract public function get_title(); abstract public function get_icon(); public function get_categories(){ return []; } public function get_keywords(){ return []; } protected function register_controls(): void {} protected function start_controls_section($id, $args = []){} protected function end_controls_section(){} protected function add_control($id, $args = []){} protected function add_inline_editing_attributes($key, $args = []){} public function set_settings(array $settings): void { $this->settings = $settings; } public function get_settings($key = null){ if ($key === null) { return $this->settings; } return $this->settings[$key] ?? null; } public function get_settings_for_display($key = null){ return $this->get_settings($key); } }');
+                }
+
+                $fieldGroups = $request->get_param('field_groups');
+                if (is_array($fieldGroups)) {
+                    update_option('gm2_field_groups', $fieldGroups);
+                    GM2_Dynamic_Tag_Group::instance()->refresh();
+                }
+
+                $widgetName = sanitize_text_field((string) $request->get_param('widget'));
+                $map = [
+                    'gm2_field'         => [ 'class' => 'Gm2\\Elementor\\Widgets\\Field', 'file' => __DIR__ . '/Widgets/Field.php' ],
+                    'gm2_loop_card'     => [ 'class' => 'Gm2\\Elementor\\Widgets\\LoopCard', 'file' => __DIR__ . '/Widgets/LoopCard.php' ],
+                    'gm2_map'           => [ 'class' => 'Gm2\\Elementor\\Widgets\\Map', 'file' => __DIR__ . '/Widgets/Map.php' ],
+                    'gm2_opening_hours' => [ 'class' => 'Gm2\\Elementor\\Widgets\\OpeningHours', 'file' => __DIR__ . '/Widgets/OpeningHours.php' ],
+                ];
+
+                if (!isset($map[$widgetName])) {
+                    return new WP_Error('gm2_invalid_widget', __('Unknown widget.', 'gm2-wordpress-suite'), [ 'status' => 400 ]);
+                }
+
+                $definition = $map[$widgetName];
+                if (!class_exists($definition['class'])) {
+                    require_once $definition['file'];
+                }
+
+                if (!class_exists($definition['class'])) {
+                    return new WP_Error('gm2_widget_unavailable', __('Widget unavailable.', 'gm2-wordpress-suite'), [ 'status' => 400 ]);
+                }
+
+                $settings = $request->get_param('settings');
+                $widget   = new $definition['class']();
+                if (method_exists($widget, 'set_settings') && is_array($settings)) {
+                    $widget->set_settings($settings);
+                }
+
+                $postConfig = $request->get_param('post');
+                $postId     = 0;
+                if (is_array($postConfig)) {
+                    $postType = sanitize_text_field($postConfig['post_type'] ?? 'post');
+                    $postId   = wp_insert_post([
+                        'post_type'   => $postType,
+                        'post_title'  => 'GM2 Widget Preview',
+                        'post_status' => 'publish',
+                    ]);
+
+                    if ($postId > 0 && isset($postConfig['meta']) && is_array($postConfig['meta'])) {
+                        foreach ($postConfig['meta'] as $key => $value) {
+                            if (!is_string($key)) {
+                                continue;
+                            }
+                            update_post_meta($postId, $key, $value);
+                        }
+                    }
+                }
+
+                $original = $GLOBALS['post'] ?? null;
+                if ($postId > 0) {
+                    $GLOBALS['post'] = get_post($postId);
+                }
+
+                $method = new ReflectionMethod($widget, 'render');
+                $method->setAccessible(true);
+                ob_start();
+                $method->invoke($widget);
+                $html = (string) ob_get_clean();
+
+                if ($postId > 0) {
+                    wp_delete_post($postId, true);
+                }
+
+                $GLOBALS['post'] = $original;
+                wp_reset_postdata();
+
+                return [ 'html' => $html ];
+            },
+        ]);
+    });
+}
+
 Filters::register();
 
 PostTypeSelect::register();
@@ -37,3 +138,40 @@ TaxonomyTermMulti::register();
 MetaKeySelect::register();
 Unit::register();
 Price::register();
+
+add_action(
+    'elementor/widgets/register',
+    static function ($manager): void {
+        if (!class_exists('Elementor\\Widget_Base')) {
+            return;
+        }
+
+        $widgets = [
+            'Gm2\\Elementor\\Widgets\\Field'         => __DIR__ . '/Widgets/Field.php',
+            'Gm2\\Elementor\\Widgets\\LoopCard'      => __DIR__ . '/Widgets/LoopCard.php',
+            'Gm2\\Elementor\\Widgets\\Map'           => __DIR__ . '/Widgets/Map.php',
+            'Gm2\\Elementor\\Widgets\\OpeningHours' => __DIR__ . '/Widgets/OpeningHours.php',
+        ];
+
+        foreach ($widgets as $class => $path) {
+            if (!class_exists($class)) {
+                require_once $path;
+            }
+
+            if (!class_exists($class)) {
+                continue;
+            }
+
+            $widget = new $class();
+
+            if (method_exists($manager, 'register')) {
+                $manager->register($widget);
+                continue;
+            }
+
+            if (method_exists($manager, 'register_widget_type')) {
+                $manager->register_widget_type($widget);
+            }
+        }
+    }
+);

--- a/tests/Elementor/Widgets/WidgetsTest.php
+++ b/tests/Elementor/Widgets/WidgetsTest.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+use Gm2\Elementor\DynamicTags\GM2_Dynamic_Tag_Group;
+use Gm2\Elementor\Widgets\Field;
+use Gm2\Elementor\Widgets\LoopCard;
+use Gm2\Elementor\Widgets\Map;
+use Gm2\Elementor\Widgets\OpeningHours;
+use ReflectionMethod;
+
+class WidgetsTest extends WP_UnitTestCase
+{
+    private int $postId;
+
+    private int $relatedId;
+
+    private int $imageId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        register_post_type('library_book', [ 'public' => true ]);
+        update_option('date_format', 'F j, Y');
+        update_option('time_format', 'g:i a');
+        $this->registerFieldGroups();
+        $this->createContent();
+        GM2_Dynamic_Tag_Group::instance()->refresh();
+    }
+
+    protected function tearDown(): void
+    {
+        unregister_post_type('library_book');
+        delete_option('gm2_field_groups');
+        wp_reset_postdata();
+        parent::tearDown();
+    }
+
+    public function test_widgets_register_with_manager(): void
+    {
+        $manager = new class {
+            public array $registered = [];
+            public function register($widget): void
+            {
+                $this->registered[] = $widget;
+            }
+            public function register_widget_type($widget): void
+            {
+                $this->registered[] = $widget;
+            }
+        };
+
+        do_action('elementor/widgets/register', $manager);
+
+        $names = array_map(static fn ($widget) => $widget->get_name(), $manager->registered);
+        $this->assertContains('gm2_field', $names);
+        $this->assertContains('gm2_loop_card', $names);
+        $this->assertContains('gm2_map', $names);
+        $this->assertContains('gm2_opening_hours', $names);
+    }
+
+    public function test_field_widget_outputs_formatted_value(): void
+    {
+        $widget = new Field();
+        $widget->set_settings([
+            'post_type' => 'library_book',
+            'field_key' => 'library_details::blurb',
+            'fallback'  => 'N/A',
+            'html_tag'  => 'p',
+        ]);
+
+        $this->setCurrentPost($this->postId);
+
+        $html = $this->renderWidget($widget);
+        $this->assertStringContainsString('Exclusive Deals', $html);
+        $this->assertStringContainsString('gm2-field--text', $html);
+    }
+
+    public function test_map_widget_builds_custom_provider_link(): void
+    {
+        $widget = new Map();
+        $widget->set_settings([
+            'post_type'    => 'library_book',
+            'field_key'    => 'library_details::map_coordinates',
+            'display'      => 'link',
+            'provider_url' => 'https://maps.example.com/?lat={{lat}}&lng={{lng}}',
+            'link_text'    => 'Open Map',
+        ]);
+
+        $this->setCurrentPost($this->postId);
+
+        $html = $this->renderWidget($widget);
+        $this->assertStringContainsString('https://maps.example.com/?lat=37.422&amp;lng=-122.0841', $html);
+        $this->assertStringContainsString('Open Map', $html);
+    }
+
+    public function test_opening_hours_widget_formats_schedule(): void
+    {
+        $widget = new OpeningHours();
+        $widget->set_settings([
+            'post_type'    => 'library_book',
+            'field_key'    => 'library_details::opening_hours',
+            'closed_label' => 'Closed',
+            'fallback_text'=> 'Call for hours',
+        ]);
+
+        $this->setCurrentPost($this->postId);
+
+        $html = $this->renderWidget($widget);
+        $this->assertStringContainsString('Monday', $html);
+        $this->assertStringContainsString('9:00 am', $html);
+        $this->assertStringContainsString('Closed', $html);
+    }
+
+    public function test_loop_card_widget_renders_meta_and_button(): void
+    {
+        $widget = new LoopCard();
+        $widget->set_settings([
+            'post_type'        => 'library_book',
+            'layout'           => 'stacked',
+            'image_field'      => 'library_details::cover_image',
+            'title_field'      => 'library_details::title',
+            'subtitle_field'   => 'library_details::price',
+            'body_field'       => 'library_details::blurb',
+            'meta_fields'      => [
+                [
+                    'label'     => 'Launch',
+                    'field_key' => 'library_details::launch_date',
+                    'fallback'  => '',
+                ],
+            ],
+            'button_text'      => 'Buy now',
+            'button_url_field' => 'library_details::purchase_url',
+        ]);
+
+        $this->setCurrentPost($this->postId);
+
+        $html = $this->renderWidget($widget);
+        $this->assertStringContainsString('gm2-loop-card__title', $html);
+        $this->assertStringContainsString('Launch', $html);
+        $this->assertStringContainsString('Buy now', $html);
+        $this->assertStringContainsString('https://example.com/purchase', $html);
+    }
+
+    private function renderWidget(object $widget): string
+    {
+        $method = new ReflectionMethod($widget, 'render');
+        $method->setAccessible(true);
+        ob_start();
+        $method->invoke($widget);
+
+        return (string) ob_get_clean();
+    }
+
+    private function setCurrentPost(int $postId): void
+    {
+        $GLOBALS['post'] = get_post($postId);
+    }
+
+    private function registerFieldGroups(): void
+    {
+        update_option('gm2_field_groups', [
+            'library_details' => [
+                'title'    => 'Library Details',
+                'contexts' => [ 'post' => [ 'library_book' ] ],
+                'fields'   => [
+                    'title' => [ 'type' => 'text', 'label' => 'Title' ],
+                    'price' => [
+                        'type'      => 'currency',
+                        'label'     => 'Price',
+                        'symbol'    => '$',
+                        'precision' => 2,
+                    ],
+                    'launch_date' => [
+                        'type'  => 'datetime_tz',
+                        'label' => 'Launch Date',
+                    ],
+                    'cover_image' => [ 'type' => 'image', 'label' => 'Cover Image' ],
+                    'map_coordinates' => [ 'type' => 'geopoint', 'label' => 'Map Coordinates' ],
+                    'purchase_url' => [ 'type' => 'url', 'label' => 'Purchase URL' ],
+                    'blurb' => [ 'type' => 'text', 'label' => 'Blurb' ],
+                    'opening_hours' => [ 'type' => 'repeater', 'label' => 'Opening Hours' ],
+                ],
+            ],
+        ]);
+    }
+
+    private function createContent(): void
+    {
+        $this->relatedId = self::factory()->post->create([
+            'post_type'  => 'library_book',
+            'post_title' => 'Related Book',
+        ]);
+
+        $this->imageId = self::factory()->attachment->create_upload_object(
+            DIR_TESTDATA . '/images/canola.jpg'
+        );
+
+        $this->postId = self::factory()->post->create([
+            'post_type'  => 'library_book',
+            'post_title' => 'Primary Book',
+            'meta_input' => [
+                'title'           => 'Primary Book',
+                'price'           => '123.45',
+                'launch_date'     => '2024-05-01T15:30:00+00:00',
+                'cover_image'     => $this->imageId,
+                'map_coordinates' => [ 'lat' => 37.4220, 'lng' => -122.0841 ],
+                'purchase_url'    => 'https://example.com/purchase',
+                'blurb'           => 'Exclusive Deals',
+                'opening_hours'   => [
+                    [ 'day' => 'Monday', 'start' => '09:00', 'end' => '17:00' ],
+                    [ 'day' => 'Tuesday', 'status' => 'closed' ],
+                ],
+            ],
+        ]);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -37,8 +37,11 @@ function _manually_load_plugin() {
     if (!class_exists('Elementor\\Repeater')) {
         eval('namespace Elementor; class Repeater { private $controls = []; public function add_control($id, $args = []) { $this->controls[$id] = $args; } public function get_controls() { return $this->controls; } }');
     }
+    if (!class_exists('Elementor\\Widget_Base')) {
+        eval('namespace Elementor; abstract class Widget_Base { protected array $settings = []; public function __construct($data = [], $args = null) {} abstract public function get_name(); abstract public function get_title(); abstract public function get_icon(); public function get_categories(){ return []; } public function get_keywords(){ return []; } protected function register_controls(): void {} protected function start_controls_section($id, $args = []){} protected function end_controls_section(){} protected function add_control($id, $args = []){} protected function add_inline_editing_attributes($key, $args = []){} public function set_settings(array $settings): void { $this->settings = $settings; } public function get_settings($key = null){ if ($key === null) { return $this->settings; } return $this->settings[$key] ?? null; } public function get_settings_for_display($key = null){ return $this->get_settings($key); } }');
+    }
     if (!class_exists('Elementor\\Plugin')) {
-        eval('namespace Elementor; class Plugin { public static $instance; public $widgets_manager; public function __construct(){ self::$instance=$this; $this->widgets_manager=new class { public function register_control($id,$ctrl){} public function register_tag($tag){} public function register_group($n,$a=[]){} }; } }');
+        eval('namespace Elementor; class Plugin { public static $instance; public $widgets_manager; public function __construct(){ self::$instance=$this; $this->widgets_manager=new class { public function register_control($id,$ctrl){} public function register_tag($tag){} public function register_group($n,$a=[]){} public function register($widget){} public function register_widget_type($widget){} }; } }');
         new \Elementor\Plugin();
     }
     if (!class_exists('Elementor\\Core\\DynamicTags\\Tag')) {

--- a/tests/e2e/elementor-widgets.spec.ts
+++ b/tests/e2e/elementor-widgets.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost';
+const AUTH = 'Basic ' + Buffer.from(process.env.WP_AUTH || 'admin:password').toString('base64');
+
+const headers = {
+  Authorization: AUTH,
+  'Content-Type': 'application/json',
+};
+
+test('gm2 widget preview renders field, map and hours', async ({ request }) => {
+  const fieldGroups = {
+    test_details: {
+      title: 'Test Details',
+      contexts: { post: ['post'] },
+      fields: {
+        blurb: { type: 'text', label: 'Blurb' },
+        map: { type: 'geopoint', label: 'Map' },
+        hours: { type: 'repeater', label: 'Hours' },
+      },
+    },
+  };
+
+  const fieldResponse = await request.post(
+    `${BASE_URL}/wp-json/gm2-test/v1/widget-preview`,
+    {
+      headers,
+      data: {
+        field_groups: fieldGroups,
+        widget: 'gm2_field',
+        settings: {
+          post_type: 'post',
+          field_key: 'test_details::blurb',
+          fallback: 'Missing',
+          html_tag: 'p',
+        },
+        post: {
+          post_type: 'post',
+          meta: { blurb: 'Sanitized <strong>text</strong>' },
+        },
+      },
+    }
+  );
+  expect(fieldResponse.ok()).toBeTruthy();
+  const fieldJson = await fieldResponse.json();
+  expect(fieldJson.html).toContain('Sanitized text');
+
+  const mapResponse = await request.post(
+    `${BASE_URL}/wp-json/gm2-test/v1/widget-preview`,
+    {
+      headers,
+      data: {
+        widget: 'gm2_map',
+        settings: {
+          post_type: 'post',
+          field_key: 'test_details::map',
+          display: 'link',
+          provider_url: 'https://maps.example.com/?lat={{lat}}&lng={{lng}}',
+          link_text: 'Map link',
+        },
+        post: {
+          post_type: 'post',
+          meta: { map: { lat: 51.5, lng: -0.1 } },
+        },
+      },
+    }
+  );
+  expect(mapResponse.ok()).toBeTruthy();
+  const mapJson = await mapResponse.json();
+  expect(mapJson.html).toContain('maps.example.com');
+  expect(mapJson.html).toContain('Map link');
+
+  const hoursResponse = await request.post(
+    `${BASE_URL}/wp-json/gm2-test/v1/widget-preview`,
+    {
+      headers,
+      data: {
+        widget: 'gm2_opening_hours',
+        settings: {
+          post_type: 'post',
+          field_key: 'test_details::hours',
+          closed_label: 'Closed',
+        },
+        post: {
+          post_type: 'post',
+          meta: {
+            hours: [
+              { day: 'Monday', start: '08:00', end: '17:30' },
+              { day: 'Tuesday', status: 'closed' },
+            ],
+          },
+        },
+      },
+    }
+  );
+  expect(hoursResponse.ok()).toBeTruthy();
+  const hoursJson = await hoursResponse.json();
+  expect(hoursJson.html).toContain('Monday');
+  expect(hoursJson.html).toMatch(/8:00\s*(am|AM)/);
+  expect(hoursJson.html).toContain('Closed');
+});


### PR DESCRIPTION
## Summary
- add Elementor Field, Loop Card, Map, and Opening Hours widgets backed by the GM2 dynamic tag group utilities and register them for Elementor managers
- expose a GM2 testing REST route to preview widget output under GM2_TESTING and document the new widgets in the Elementor guide
- expand automated coverage with PHPUnit widget tests and a Playwright spec driving the widget preview endpoint

## Testing
- `./vendor/bin/phpunit tests/Elementor/Widgets/WidgetsTest.php` *(fails: WordPress test library missing in environment)*
- `npx playwright test tests/e2e/elementor-widgets.spec.ts` *(fails: no WordPress instance listening at WP_BASE_URL)*

------
https://chatgpt.com/codex/tasks/task_b_68c9c4931fd88330b525e53d8c515d5e