### PR TITLE
Register SEO meta for REST

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -163,6 +163,7 @@ add_action('init', 'gm2_css_optimizer_init');
 \Gm2\Gm2_Cache_Audit::init();
 \Gm2\Gm2_Script_Attributes::init();
 \Gm2\Gm2_Lazy_Embeds::init();
+\Gm2\SEO\Meta_Registration::init();
 \Gm2\Gm2_Search_Console::init();
 \Gm2\AE_SEO_JS_Detector::init();
 \Gm2\AE_SEO_JS_Manager::init();

--- a/src/SEO/Meta_Registration.php
+++ b/src/SEO/Meta_Registration.php
@@ -1,0 +1,271 @@
+<?php
+
+namespace Gm2\SEO;
+
+class Meta_Registration {
+    public static function init(): void {
+        add_action('init', [__CLASS__, 'register'], 20);
+    }
+
+    public static function get_post_meta_keys(): array {
+        return array_keys(self::get_post_meta_definitions());
+    }
+
+    public static function get_term_meta_keys(): array {
+        return array_keys(self::get_term_meta_definitions());
+    }
+
+    public static function register(): void {
+        foreach (self::get_supported_post_types() as $post_type) {
+            foreach (self::get_post_meta_definitions() as $meta_key => $definition) {
+                register_post_meta(
+                    $post_type,
+                    $meta_key,
+                    self::build_args($definition, $post_type)
+                );
+            }
+        }
+
+        foreach (self::get_supported_taxonomies() as $taxonomy) {
+            foreach (self::get_term_meta_definitions() as $meta_key => $definition) {
+                register_term_meta(
+                    $taxonomy,
+                    $meta_key,
+                    self::build_args($definition, $taxonomy)
+                );
+            }
+        }
+    }
+
+    private static function build_args(array $definition, string $subtype): array {
+        return [
+            'type'              => $definition['schema']['type'],
+            'single'            => true,
+            'show_in_rest'      => [
+                'schema' => $definition['schema'],
+            ],
+            'sanitize_callback' => $definition['sanitize_callback'],
+            'object_subtype'    => $subtype,
+        ];
+    }
+
+    private static function get_post_meta_definitions(): array {
+        return array_merge(
+            self::get_shared_meta_definitions(),
+            [
+                '_gm2_link_rel' => [
+                    'sanitize_callback' => [__CLASS__, 'sanitize_link_rel_map'],
+                    'schema'            => [
+                        'type'        => 'string',
+                        'context'     => ['view', 'edit'],
+                        'description' => 'JSON encoded map of link rel directives keyed by URL.',
+                    ],
+                ],
+                '_aeseo_lcp_override' => [
+                    'sanitize_callback' => [__CLASS__, 'sanitize_lcp_override'],
+                    'schema'            => [
+                        'type'    => 'string',
+                        'context' => ['view', 'edit'],
+                    ],
+                ],
+                '_aeseo_lcp_disable' => self::boolean_definition(),
+            ]
+        );
+    }
+
+    private static function get_term_meta_definitions(): array {
+        return self::get_shared_meta_definitions();
+    }
+
+    private static function get_shared_meta_definitions(): array {
+        return [
+            '_gm2_title'               => self::string_definition('sanitize_text_field'),
+            '_gm2_description'         => self::string_definition('sanitize_textarea_field'),
+            '_gm2_noindex'             => self::boolean_definition(),
+            '_gm2_nofollow'            => self::boolean_definition(),
+            '_gm2_canonical'           => self::string_definition('esc_url_raw', [
+                'format' => 'uri',
+            ]),
+            '_gm2_focus_keywords'      => self::string_definition('sanitize_text_field'),
+            '_gm2_long_tail_keywords'  => self::string_definition('sanitize_text_field'),
+            '_gm2_search_intent'       => self::string_definition('sanitize_text_field'),
+            '_gm2_focus_keyword_limit' => self::integer_definition('absint', [
+                'minimum' => 0,
+            ]),
+            '_gm2_number_of_words'     => self::integer_definition('absint', [
+                'minimum' => 0,
+            ]),
+            '_gm2_improve_readability' => self::boolean_definition(),
+            '_gm2_max_snippet'         => self::string_definition('sanitize_text_field'),
+            '_gm2_max_image_preview'   => self::string_definition('sanitize_text_field'),
+            '_gm2_max_video_preview'   => self::string_definition('sanitize_text_field'),
+            '_gm2_og_image'            => self::integer_definition('absint', [
+                'minimum' => 0,
+            ]),
+            '_gm2_schema_type'         => self::string_definition('sanitize_text_field'),
+            '_gm2_schema_brand'        => self::string_definition('sanitize_text_field'),
+            '_gm2_schema_rating'       => self::string_definition('sanitize_text_field'),
+        ];
+    }
+
+    private static function string_definition(string|array $sanitize, array $schema = []): array {
+        $schema = array_merge(
+            [
+                'type'    => 'string',
+                'context' => ['view', 'edit'],
+            ],
+            $schema
+        );
+
+        return [
+            'sanitize_callback' => $sanitize,
+            'schema'            => $schema,
+        ];
+    }
+
+    private static function integer_definition(string|array $sanitize, array $schema = []): array {
+        $schema = array_merge(
+            [
+                'type'    => 'integer',
+                'context' => ['view', 'edit'],
+            ],
+            $schema
+        );
+
+        return [
+            'sanitize_callback' => $sanitize,
+            'schema'            => $schema,
+        ];
+    }
+
+    private static function boolean_definition(): array {
+        return [
+            'sanitize_callback' => [__CLASS__, 'sanitize_checkbox'],
+            'schema'            => [
+                'type'    => 'boolean',
+                'context' => ['view', 'edit'],
+            ],
+        ];
+    }
+
+    private static function get_supported_post_types(): array {
+        $args = [
+            'public'              => true,
+            'show_ui'             => true,
+            'exclude_from_search' => false,
+        ];
+        $types = get_post_types($args, 'names');
+        unset($types['attachment']);
+        $types = apply_filters('gm2_supported_post_types', array_values($types));
+        return array_values(array_unique($types));
+    }
+
+    private static function get_supported_taxonomies(): array {
+        $taxonomies = ['category'];
+        if (taxonomy_exists('product_cat')) {
+            $taxonomies[] = 'product_cat';
+        }
+        if (taxonomy_exists('brand')) {
+            $taxonomies[] = 'brand';
+        }
+        if (taxonomy_exists('product_brand')) {
+            $taxonomies[] = 'product_brand';
+        }
+        return array_values(array_unique($taxonomies));
+    }
+
+    public static function sanitize_checkbox($value): string {
+        if (is_array($value)) {
+            $value = reset($value);
+        }
+
+        if (is_bool($value)) {
+            return $value ? '1' : '0';
+        }
+
+        if (is_numeric($value)) {
+            return absint($value) > 0 ? '1' : '0';
+        }
+
+        if (is_string($value)) {
+            $value = strtolower(trim($value));
+            if ($value === '') {
+                return '0';
+            }
+            if (in_array($value, ['1', 'true', 'yes', 'on'], true)) {
+                return '1';
+            }
+            if (in_array($value, ['0', 'false', 'no', 'off'], true)) {
+                return '0';
+            }
+        }
+
+        return !empty($value) ? '1' : '0';
+    }
+
+    public static function sanitize_link_rel_map($value): string {
+        if (is_array($value)) {
+            $value = wp_json_encode($value);
+        }
+
+        if (!is_scalar($value)) {
+            return '';
+        }
+
+        $value = trim((string) $value);
+        if ($value === '') {
+            return '';
+        }
+
+        $decoded = json_decode($value, true);
+        if (!is_array($decoded)) {
+            return '';
+        }
+
+        $sanitized = [];
+        foreach ($decoded as $href => $rel) {
+            if (!is_scalar($href)) {
+                continue;
+            }
+
+            $href = esc_url_raw((string) $href);
+            if ($href === '') {
+                continue;
+            }
+
+            if (is_array($rel)) {
+                $rel = implode(' ', array_map('sanitize_text_field', array_map('strval', $rel)));
+            } elseif (is_scalar($rel)) {
+                $rel = sanitize_text_field((string) $rel);
+            } else {
+                $rel = '';
+            }
+
+            $sanitized[$href] = $rel;
+        }
+
+        return wp_json_encode($sanitized);
+    }
+
+    public static function sanitize_lcp_override($value): string {
+        if (is_array($value)) {
+            $value = reset($value);
+        }
+
+        if (is_numeric($value)) {
+            return (string) absint($value);
+        }
+
+        if (!is_scalar($value)) {
+            return '';
+        }
+
+        $value = trim((string) $value);
+        if ($value === '') {
+            return '';
+        }
+
+        $sanitized = esc_url_raw($value);
+        return $sanitized === '' ? '' : $sanitized;
+    }
+}

--- a/tests/test-seo-meta-registration.php
+++ b/tests/test-seo-meta-registration.php
@@ -1,0 +1,188 @@
+<?php
+
+use Gm2\SEO\Meta_Registration;
+
+class Seo_Meta_Registration_Test extends WP_UnitTestCase {
+    /**
+     * @var WP_REST_Server
+     */
+    private $server;
+
+    public function set_up(): void {
+        parent::set_up();
+
+        if (!did_action('init')) {
+            do_action('init');
+        }
+
+        global $wp_rest_server;
+        $wp_rest_server = new WP_REST_Server();
+        $this->server   = $wp_rest_server;
+
+        do_action('rest_api_init');
+    }
+
+    public function tear_down(): void {
+        global $wp_rest_server;
+        $wp_rest_server = null;
+
+        parent::tear_down();
+    }
+
+    private function get_supported_post_types(): array {
+        $args = [
+            'public'              => true,
+            'show_ui'             => true,
+            'exclude_from_search' => false,
+        ];
+        $types = get_post_types($args, 'names');
+        unset($types['attachment']);
+        $types = apply_filters('gm2_supported_post_types', array_values($types));
+        return array_values(array_unique($types));
+    }
+
+    private function get_supported_taxonomies(): array {
+        $taxonomies = ['category'];
+        if (taxonomy_exists('product_cat')) {
+            $taxonomies[] = 'product_cat';
+        }
+        if (taxonomy_exists('brand')) {
+            $taxonomies[] = 'brand';
+        }
+        if (taxonomy_exists('product_brand')) {
+            $taxonomies[] = 'product_brand';
+        }
+        return array_values(array_unique($taxonomies));
+    }
+
+    public function test_post_meta_keys_registered(): void {
+        foreach ($this->get_supported_post_types() as $post_type) {
+            $registered = get_registered_meta_keys('post', $post_type);
+            foreach (Meta_Registration::get_post_meta_keys() as $meta_key) {
+                $this->assertArrayHasKey(
+                    $meta_key,
+                    $registered,
+                    sprintf('Meta key %s was not registered for post type %s', $meta_key, $post_type)
+                );
+                $args = $registered[$meta_key];
+                $this->assertTrue($args['single']);
+                $this->assertSame($post_type, $args['object_subtype']);
+                $this->assertIsArray($args['show_in_rest']);
+                $this->assertArrayHasKey('schema', $args['show_in_rest']);
+            }
+        }
+    }
+
+    public function test_term_meta_keys_registered(): void {
+        foreach ($this->get_supported_taxonomies() as $taxonomy) {
+            $registered = get_registered_meta_keys('term', $taxonomy);
+            foreach (Meta_Registration::get_term_meta_keys() as $meta_key) {
+                $this->assertArrayHasKey(
+                    $meta_key,
+                    $registered,
+                    sprintf('Meta key %s was not registered for taxonomy %s', $meta_key, $taxonomy)
+                );
+                $args = $registered[$meta_key];
+                $this->assertTrue($args['single']);
+                $this->assertSame($taxonomy, $args['object_subtype']);
+                $this->assertIsArray($args['show_in_rest']);
+                $this->assertArrayHasKey('schema', $args['show_in_rest']);
+            }
+        }
+    }
+
+    public function test_rest_sanitizes_post_meta(): void {
+        wp_set_current_user(self::factory()->user->create(['role' => 'administrator']));
+
+        $request = new WP_REST_Request('POST', '/wp/v2/posts');
+        $request->set_param('title', 'SEO Post');
+        $request->set_param('status', 'draft');
+        $request->set_param('meta', [
+            '_gm2_title' => ' <b>Headline</b> ',
+            '_gm2_description' => "Line<script>alert('x')</script>",
+            '_gm2_noindex' => 'true',
+            '_gm2_focus_keyword_limit' => '9words',
+            '_gm2_link_rel' => '{"https://example.com/":"nofollow<script>"}',
+            '_aeseo_lcp_override' => 'https://example.com/override<script>',
+            '_aeseo_lcp_disable' => 'no',
+        ]);
+
+        $response = $this->server->dispatch($request);
+        $this->assertSame(201, $response->get_status());
+        $post_id = $response->get_data()['id'];
+
+        $this->assertSame('Headline', get_post_meta($post_id, '_gm2_title', true));
+        $this->assertSame("Linealert('x')", get_post_meta($post_id, '_gm2_description', true));
+        $this->assertSame('1', get_post_meta($post_id, '_gm2_noindex', true));
+        $this->assertSame('9', get_post_meta($post_id, '_gm2_focus_keyword_limit', true));
+
+        $link_rel = get_post_meta($post_id, '_gm2_link_rel', true);
+        $this->assertIsString($link_rel);
+        $this->assertNotSame('', $link_rel);
+        $this->assertSame(
+            ['https://example.com/' => 'nofollowscript'],
+            json_decode($link_rel, true)
+        );
+
+        $expected_override = esc_url_raw('https://example.com/override<script>');
+        $this->assertSame($expected_override, get_post_meta($post_id, '_aeseo_lcp_override', true));
+        $this->assertSame('0', get_post_meta($post_id, '_aeseo_lcp_disable', true));
+
+        $update = new WP_REST_Request('POST', sprintf('/wp/v2/posts/%d', $post_id));
+        $update->set_param('meta', [
+            '_gm2_noindex' => false,
+            '_gm2_focus_keyword_limit' => 'not-a-number',
+            '_aeseo_lcp_override' => 42,
+            '_gm2_link_rel' => '{"https://example.org/":["nofollow","noopener"]}',
+        ]);
+
+        $update_response = $this->server->dispatch($update);
+        $this->assertSame(200, $update_response->get_status());
+
+        $this->assertSame('0', get_post_meta($post_id, '_gm2_noindex', true));
+        $this->assertSame('0', get_post_meta($post_id, '_gm2_focus_keyword_limit', true));
+        $this->assertSame('42', get_post_meta($post_id, '_aeseo_lcp_override', true));
+        $this->assertSame(
+            ['https://example.org/' => 'nofollow noopener'],
+            json_decode(get_post_meta($post_id, '_gm2_link_rel', true), true)
+        );
+    }
+
+    public function test_rest_sanitizes_term_meta(): void {
+        wp_set_current_user(self::factory()->user->create(['role' => 'administrator']));
+
+        $request = new WP_REST_Request('POST', '/wp/v2/categories');
+        $request->set_param('name', 'SEO Category');
+        $request->set_param('slug', 'seo-category');
+        $request->set_param('meta', [
+            '_gm2_description' => " Term<script>alert('y')</script> ",
+            '_gm2_improve_readability' => 'yes',
+            '_gm2_number_of_words' => '15 words',
+            '_gm2_canonical' => 'https://example.com/category<script>',
+        ]);
+
+        $response = $this->server->dispatch($request);
+        $this->assertSame(201, $response->get_status());
+        $term_id = $response->get_data()['id'];
+
+        $this->assertSame("Termalert('y')", get_term_meta($term_id, '_gm2_description', true));
+        $this->assertSame('1', get_term_meta($term_id, '_gm2_improve_readability', true));
+        $this->assertSame('15', get_term_meta($term_id, '_gm2_number_of_words', true));
+        $this->assertSame(
+            esc_url_raw('https://example.com/category<script>'),
+            get_term_meta($term_id, '_gm2_canonical', true)
+        );
+
+        $update = new WP_REST_Request('POST', sprintf('/wp/v2/categories/%d', $term_id));
+        $update->set_param('meta', [
+            '_gm2_improve_readability' => '',
+            '_gm2_number_of_words' => 'words only',
+        ]);
+
+        $update_response = $this->server->dispatch($update);
+        $this->assertSame(200, $update_response->get_status());
+
+        $this->assertSame('0', get_term_meta($term_id, '_gm2_improve_readability', true));
+        $this->assertSame('0', get_term_meta($term_id, '_gm2_number_of_words', true));
+    }
+}


### PR DESCRIPTION
## Summary
- register GM2 SEO post and term meta keys on init with REST schema, sanitization, and subtype coverage
- expose helper sanitizers for JSON link rel maps and LCP overrides to match save_post_meta logic
- add PHPUnit coverage verifying meta registration and REST sanitization for posts and taxonomies

## Testing
- `vendor/bin/phpunit` *(fails: WordPress test library is not installed in the environment; mysql client/server unavailable for bootstrap)*

------
https://chatgpt.com/codex/tasks/task_b_68ca113808bc8330bfa2f6637dff169e