### PR TITLE
Add schema manager with typed mappers and admin toggles

### DIFF
--- a/admin/Gm2_SEO_Admin.php
+++ b/admin/Gm2_SEO_Admin.php
@@ -2,6 +2,14 @@
 
 namespace Gm2;
 
+use Gm2\SEO\Schema\Manager as SchemaManager;
+use Gm2\SEO\Schema\Mapper\CourseMapper;
+use Gm2\SEO\Schema\Mapper\DirectoryMapper;
+use Gm2\SEO\Schema\Mapper\EventMapper;
+use Gm2\SEO\Schema\Mapper\JobMapper;
+use Gm2\SEO\Schema\Mapper\MapperInterface;
+use Gm2\SEO\Schema\Mapper\RealEstateMapper;
+
 
 if (!defined('ABSPATH')) {
     exit;
@@ -10,6 +18,7 @@ if (!defined('ABSPATH')) {
 class Gm2_SEO_Admin {
     private $elementor_initialized = false;
     private static $notices = [];
+    private bool $schema_notice_scanned = false;
     const AI_CRON_HOOK = 'gm2_ai_batch_process';
     const AI_QUEUE_OPTION = 'gm2_ai_batch_queue';
     const AI_TAX_CRON_HOOK = 'gm2_ai_tax_batch_process';
@@ -108,6 +117,11 @@ class Gm2_SEO_Admin {
         add_option('ae_perf_dom_audit', '0');
         add_option('gm2_title_templates', []);
         add_option('gm2_description_templates', []);
+        add_option('gm2_schema_directory', '1');
+        add_option('gm2_schema_event', '1');
+        add_option('gm2_schema_job', '1');
+        add_option('gm2_schema_course', '1');
+        add_option('gm2_schema_real_estate', '1');
 
         $this->migrate_js_option_names();
 
@@ -1062,6 +1076,11 @@ class Gm2_SEO_Admin {
             $taxonomy_list = get_option('gm2_schema_taxonomy', '1');
             $article       = get_option('gm2_schema_article', '1');
             $review        = get_option('gm2_schema_review', '1');
+            $directory     = get_option('gm2_schema_directory', '1');
+            $event         = get_option('gm2_schema_event', '1');
+            $job           = get_option('gm2_schema_job', '1');
+            $course        = get_option('gm2_schema_course', '1');
+            $real_estate   = get_option('gm2_schema_real_estate', '1');
             $footer_bc     = get_option('gm2_show_footer_breadcrumbs', '1');
             if (!empty($_GET['updated'])) {
                 echo '<div class="updated notice"><p>' . esc_html__('Settings saved.', 'gm2-wordpress-suite') . '</p></div>';
@@ -1076,6 +1095,11 @@ class Gm2_SEO_Admin {
             echo '<tr><th scope="row">' . esc_html__( 'Breadcrumb Schema', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="gm2_schema_breadcrumbs" value="1" ' . checked($breadcrumbs, '1', false) . '></td></tr>';
             echo '<tr><th scope="row">' . esc_html__( 'Taxonomy ItemList Schema', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="gm2_schema_taxonomy" value="1" ' . checked($taxonomy_list, '1', false) . '></td></tr>';
             echo '<tr><th scope="row">' . esc_html__( 'Article Schema', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="gm2_schema_article" value="1" ' . checked($article, '1', false) . '></td></tr>';
+            echo '<tr><th scope="row">' . esc_html__( 'Directory Schema', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="gm2_schema_directory" value="1" ' . checked($directory, '1', false) . '></td></tr>';
+            echo '<tr><th scope="row">' . esc_html__( 'Event Schema', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="gm2_schema_event" value="1" ' . checked($event, '1', false) . '></td></tr>';
+            echo '<tr><th scope="row">' . esc_html__( 'Job Schema', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="gm2_schema_job" value="1" ' . checked($job, '1', false) . '></td></tr>';
+            echo '<tr><th scope="row">' . esc_html__( 'Course Schema', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="gm2_schema_course" value="1" ' . checked($course, '1', false) . '></td></tr>';
+            echo '<tr><th scope="row">' . esc_html__( 'Real Estate Schema', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="gm2_schema_real_estate" value="1" ' . checked($real_estate, '1', false) . '></td></tr>';
             echo '<tr><th scope="row">' . esc_html__( 'Show Breadcrumbs in Footer', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="gm2_show_footer_breadcrumbs" value="1" ' . checked($footer_bc, '1', false) . '></td></tr>';
             echo '<tr><th scope="row">' . esc_html__( 'Review Schema', 'gm2-wordpress-suite' ) . '</th><td><input type="checkbox" name="gm2_schema_review" value="1" ' . checked($review, '1', false) . '></td></tr>';
             echo '</tbody></table>';
@@ -3042,6 +3066,21 @@ class Gm2_SEO_Admin {
 
         $article = isset($_POST['gm2_schema_article']) ? '1' : '0';
         update_option('gm2_schema_article', $article);
+
+        $directory = isset($_POST['gm2_schema_directory']) ? '1' : '0';
+        update_option('gm2_schema_directory', $directory);
+
+        $event = isset($_POST['gm2_schema_event']) ? '1' : '0';
+        update_option('gm2_schema_event', $event);
+
+        $job = isset($_POST['gm2_schema_job']) ? '1' : '0';
+        update_option('gm2_schema_job', $job);
+
+        $course = isset($_POST['gm2_schema_course']) ? '1' : '0';
+        update_option('gm2_schema_course', $course);
+
+        $real_estate = isset($_POST['gm2_schema_real_estate']) ? '1' : '0';
+        update_option('gm2_schema_real_estate', $real_estate);
 
         $footer_bc = isset($_POST['gm2_show_footer_breadcrumbs']) ? '1' : '0';
         update_option('gm2_show_footer_breadcrumbs', $footer_bc);
@@ -6863,7 +6902,88 @@ class Gm2_SEO_Admin {
         self::$notices[] = [ 'message' => $msg, 'type' => $type ];
     }
 
+    /**
+     * Surface notices when required schema fields are missing.
+     */
+    private function maybe_add_schema_mapping_notices(): void
+    {
+        if ($this->schema_notice_scanned) {
+            return;
+        }
+
+        $this->schema_notice_scanned = true;
+
+        if (!function_exists('get_current_screen')) {
+            return;
+        }
+
+        $screen = get_current_screen();
+        if (!$screen || $screen->id !== 'toplevel_page_gm2-seo') {
+            return;
+        }
+
+        $tab = isset($_GET['tab']) ? sanitize_key(wp_unslash((string) $_GET['tab'])) : '';
+        if ($tab !== 'schema') {
+            return;
+        }
+
+        foreach ($this->getSchemaMappersForValidation() as $mapper) {
+            if (!$mapper instanceof MapperInterface) {
+                continue;
+            }
+
+            if (get_option($mapper->getOptionName(), '1') !== '1') {
+                continue;
+            }
+
+            if (!post_type_exists($mapper->getPostType())) {
+                continue;
+            }
+
+            $missing = [];
+            foreach ($mapper->getRequiredFieldMap() as $key => $label) {
+                if (!gm2_find_field_definition($key)) {
+                    $missing[] = sprintf('%s (%s)', $label, $key);
+                }
+            }
+
+            if ($missing) {
+                self::add_notice(
+                    sprintf(
+                        /* translators: 1: schema label, 2: comma separated list of missing fields */
+                        __('%1$s schema requires field mappings for: %2$s', 'gm2-wordpress-suite'),
+                        $mapper->getLabel(),
+                        implode(', ', $missing)
+                    )
+                );
+            }
+        }
+    }
+
+    /**
+     * Retrieve the schema mappers available for validation.
+     *
+     * @return MapperInterface[]
+     */
+    private function getSchemaMappersForValidation(): array
+    {
+        $manager = SchemaManager::instance();
+        $mappers = $manager->getMappers();
+        if (!empty($mappers)) {
+            return $mappers;
+        }
+
+        return [
+            new DirectoryMapper(),
+            new EventMapper(),
+            new JobMapper(),
+            new CourseMapper(),
+            new RealEstateMapper(),
+        ];
+    }
+
     public function admin_notices() {
+        $this->maybe_add_schema_mapping_notices();
         foreach (self::$notices as $n) {
             echo '<div class="notice notice-' . esc_attr($n['type']) . '"><p>' . esc_html($n['message']) . '</p></div>';
         }

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -92,6 +92,7 @@ require_once GM2_PLUGIN_DIR . 'includes/gm2-open-in-code.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-field-renderers.php';
 require_once GM2_PLUGIN_DIR . 'includes/elementor/class-gm2-field-key-control.php';
 require_once GM2_PLUGIN_DIR . 'src/Elementor/bootstrap.php';
+require_once GM2_PLUGIN_DIR . 'src/SEO/bootstrap.php';
 require_once GM2_PLUGIN_DIR . 'integrations/elementor/class-gm2-cp-elementor-tags.php';
 require_once GM2_PLUGIN_DIR . 'integrations/elementor/class-gm2-cp-elementor-query.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-schema-tooltips.php';

--- a/src/SEO/Schema/Manager.php
+++ b/src/SEO/Schema/Manager.php
@@ -1,0 +1,299 @@
+<?php
+
+namespace Gm2\SEO\Schema;
+
+use Gm2\SEO\Schema\Mapper\MapperInterface;
+use WP_Post;
+use WP_Query;
+
+class Manager
+{
+    private static ?self $instance = null;
+
+    /** @var array<string,MapperInterface> */
+    private array $mappers = [];
+
+    private bool $printed = false;
+
+    private bool $suppressed = false;
+
+    private bool $registered = false;
+
+    public function __construct(array $mappers = [])
+    {
+        $this->setMappers($mappers);
+    }
+
+    public static function instance(): self
+    {
+        if (!self::$instance instanceof self) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    public static function bootstrap(array $mappers): self
+    {
+        $instance = self::instance();
+        $instance->setMappers($mappers);
+        $instance->register();
+
+        return $instance;
+    }
+
+    public static function reset(): void
+    {
+        if (self::$instance instanceof self) {
+            self::$instance->unregister();
+        }
+
+        self::$instance = null;
+    }
+
+    public function register(): void
+    {
+        if ($this->registered) {
+            return;
+        }
+
+        add_action('wp_head', [$this, 'handleHead'], 1);
+        add_action('wp_footer', [$this, 'handleFooter'], 1);
+        add_filter('gm2_seo_cp_schema', [$this, 'maybeBlockLegacySchema'], 10, 3);
+        $this->registered = true;
+    }
+
+    public function unregister(): void
+    {
+        if (!$this->registered) {
+            return;
+        }
+
+        remove_action('wp_head', [$this, 'handleHead'], 1);
+        remove_action('wp_footer', [$this, 'handleFooter'], 1);
+        remove_filter('gm2_seo_cp_schema', [$this, 'maybeBlockLegacySchema'], 10);
+        $this->registered = false;
+        $this->printed = false;
+        $this->suppressed = false;
+    }
+
+    public function setMappers(array $mappers): void
+    {
+        $this->mappers = [];
+        foreach ($mappers as $mapper) {
+            if ($mapper instanceof MapperInterface) {
+                $this->mappers[$mapper->getPostType()] = $mapper;
+            }
+        }
+    }
+
+    /**
+     * @return array<string,MapperInterface>
+     */
+    public function getMappers(): array
+    {
+        return $this->mappers;
+    }
+
+    public function handleHead(): void
+    {
+        $this->render('wp_head');
+    }
+
+    public function handleFooter(): void
+    {
+        $this->render('wp_footer');
+    }
+
+    public function render(string $hook = ''): void
+    {
+        if ($this->printed || $this->suppressed) {
+            return;
+        }
+
+        if (is_admin() || is_feed() || is_404()) {
+            return;
+        }
+
+        if ($this->shouldBailForThirdParty()) {
+            $this->suppressed = true;
+            return;
+        }
+
+        if (is_singular()) {
+            $object = get_queried_object();
+            if ($object instanceof WP_Post) {
+                $this->renderSingular($object, $hook);
+            }
+
+            return;
+        }
+
+        if (is_post_type_archive()) {
+            $postType = get_query_var('post_type');
+            if (is_array($postType)) {
+                $postType = reset($postType) ?: '';
+            }
+
+            if (!$postType && get_post_type()) {
+                $postType = get_post_type();
+            }
+
+            if (is_string($postType) && $postType !== '') {
+                $this->renderArchive($postType, $hook);
+            }
+        }
+    }
+
+    private function renderSingular(WP_Post $post, string $hook): void
+    {
+        $mapper = $this->mappers[$post->post_type] ?? null;
+        if (!$mapper instanceof MapperInterface) {
+            return;
+        }
+
+        if (!$this->isEnabled($mapper)) {
+            return;
+        }
+
+        $result = $mapper->map($post);
+        if (is_wp_error($result)) {
+            do_action('gm2_seo_schema_validation_error', $result, $post, $mapper);
+            return;
+        }
+
+        $payload = $result;
+        if (!isset($payload['@context'])) {
+            $payload['@context'] = 'https://schema.org';
+        }
+
+        $payload = apply_filters(
+            'gm2_seo_schema_payload',
+            $payload,
+            [
+                'context'   => 'singular',
+                'post_id'   => $post->ID,
+                'post_type' => $post->post_type,
+                'mapper'    => $mapper,
+                'hook'      => $hook,
+            ]
+        );
+
+        if (empty($payload)) {
+            return;
+        }
+
+        $this->output($payload);
+    }
+
+    private function renderArchive(string $postType, string $hook): void
+    {
+        $mapper = $this->mappers[$postType] ?? null;
+        if (!$mapper instanceof MapperInterface) {
+            return;
+        }
+
+        if (!$this->isEnabled($mapper)) {
+            return;
+        }
+
+        global $wp_query;
+        if (!$wp_query instanceof WP_Query) {
+            return;
+        }
+
+        $items = [];
+        foreach ($wp_query->posts as $index => $post) {
+            $postObject = get_post($post);
+            if (!$postObject instanceof WP_Post) {
+                continue;
+            }
+
+            $mapped = $mapper->map($postObject);
+            if (is_wp_error($mapped)) {
+                do_action('gm2_seo_schema_validation_error', $mapped, $postObject, $mapper);
+                continue;
+            }
+
+            $items[] = [
+                '@type'    => 'ListItem',
+                'position' => $index + 1,
+                'url'      => get_permalink($postObject),
+                'item'     => $mapped,
+            ];
+        }
+
+        if (!$items) {
+            return;
+        }
+
+        $payload = [
+            '@context'        => 'https://schema.org',
+            '@type'           => 'ItemList',
+            'url'             => get_post_type_archive_link($postType) ?: '',
+            'itemListElement' => $items,
+        ];
+
+        $payload = apply_filters(
+            'gm2_seo_schema_payload',
+            $payload,
+            [
+                'context'   => 'archive',
+                'post_type' => $postType,
+                'mapper'    => $mapper,
+                'hook'      => $hook,
+            ]
+        );
+
+        if (empty($payload)) {
+            return;
+        }
+
+        $this->output($payload);
+    }
+
+    private function output(array $payload): void
+    {
+        echo '<script type="application/ld+json">' . wp_json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . '</script>' . "\n";
+        $this->printed = true;
+    }
+
+    private function isEnabled(MapperInterface $mapper): bool
+    {
+        return get_option($mapper->getOptionName(), '1') === '1';
+    }
+
+    private function shouldBailForThirdParty(): bool
+    {
+        if (did_action('wpseo_json_ld_output') > 0 || defined('WPSEO_VERSION') || class_exists('WPSEO_Frontend')) {
+            return true;
+        }
+
+        if (did_action('rank_math/json_ld') > 0 || defined('RANK_MATH_VERSION') || class_exists('RankMath')) {
+            return true;
+        }
+
+        if (did_action('aioseo_schema_graph') > 0 || defined('AIOSEO_VERSION') || class_exists('AIOSEO\\Plugin')) {
+            return true;
+        }
+
+        if (did_action('seopress/jsonld/print') > 0 || defined('SEOPRESS_VERSION') || class_exists('SEOPRESS_Core')) {
+            return true;
+        }
+
+        if (did_action('the_seo_framework_front_schema') > 0 || defined('THE_SEO_FRAMEWORK_VERSION')) {
+            return true;
+        }
+
+        return (bool) apply_filters('gm2_seo_schema_third_party', false);
+    }
+
+    public function maybeBlockLegacySchema($skip, $schema, $context)
+    {
+        if ($skip) {
+            return $skip;
+        }
+
+        return $this->printed;
+    }
+}

--- a/src/SEO/Schema/Mapper/AbstractMapper.php
+++ b/src/SEO/Schema/Mapper/AbstractMapper.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace Gm2\SEO\Schema\Mapper;
+
+use WP_Error;
+use WP_Post;
+
+abstract class AbstractMapper implements MapperInterface
+{
+    protected array $requiredFields = [];
+
+    public function __construct(
+        protected string $postType,
+        protected string $schemaType,
+        protected string $optionName,
+        protected string $label
+    ) {
+    }
+
+    public function getPostType(): string
+    {
+        return $this->postType;
+    }
+
+    public function getSchemaType(): string
+    {
+        return $this->schemaType;
+    }
+
+    public function getOptionName(): string
+    {
+        return $this->optionName;
+    }
+
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+
+    public function map(WP_Post $post)
+    {
+        $missing = $this->missingFields($post);
+        if (!empty($missing)) {
+            return new WP_Error(
+                'gm2_schema_missing_fields',
+                sprintf(
+                    /* translators: %s: comma separated field labels */
+                    __('Missing required schema fields: %s', 'gm2-wordpress-suite'),
+                    implode(', ', $missing)
+                ),
+                [
+                    'fields'  => array_keys($missing),
+                    'post_id' => $post->ID,
+                    'schema'  => $this->schemaType,
+                ]
+            );
+        }
+
+        $data = $this->filterEmpty($this->mapData($post));
+        if (!isset($data['@type'])) {
+            $data['@type'] = $this->schemaType;
+        }
+
+        return $data;
+    }
+
+    public function getRequiredFieldMap(): array
+    {
+        return $this->requiredFields;
+    }
+
+    protected function missingFields(WP_Post $post): array
+    {
+        $missing = [];
+        foreach ($this->requiredFields as $key => $label) {
+            $value = $this->getField($post, $key);
+            if ($this->isEmpty($value)) {
+                $missing[$key] = $label;
+            }
+        }
+
+        return $missing;
+    }
+
+    protected function getField(WP_Post $post, string $key, mixed $default = ''): mixed
+    {
+        return gm2_field($key, $default, $post->ID);
+    }
+
+    protected function sanitizeText(?string $value): string
+    {
+        if ($value === null) {
+            return '';
+        }
+
+        return trim(wp_strip_all_tags($value));
+    }
+
+    protected function toFloat(mixed $value): ?float
+    {
+        if ($this->isEmpty($value)) {
+            return null;
+        }
+
+        if (is_numeric($value)) {
+            return (float) $value;
+        }
+
+        if (is_string($value)) {
+            $filtered = preg_replace('/[^0-9.+-]/', '', $value);
+            if ($filtered === '' || $filtered === null) {
+                return null;
+            }
+
+            return is_numeric($filtered) ? (float) $filtered : null;
+        }
+
+        return null;
+    }
+
+    protected function toInt(mixed $value): ?int
+    {
+        $float = $this->toFloat($value);
+        if ($float === null) {
+            return null;
+        }
+
+        return (int) round($float);
+    }
+
+    protected function filterEmpty(array $data): array
+    {
+        foreach ($data as $key => $value) {
+            if (is_array($value)) {
+                $value = $this->filterEmpty($value);
+                if ($value === []) {
+                    unset($data[$key]);
+                    continue;
+                }
+
+                $data[$key] = $value;
+                continue;
+            }
+
+            if ($value === null) {
+                unset($data[$key]);
+                continue;
+            }
+
+            if (is_string($value) && trim($value) === '') {
+                unset($data[$key]);
+            }
+        }
+
+        return $data;
+    }
+
+    protected function buildAddress(array $parts): array
+    {
+        $address = ['@type' => 'PostalAddress'];
+        foreach ($parts as $schemaKey => $value) {
+            if ($value !== null && $value !== '') {
+                $address[$schemaKey] = $value;
+            }
+        }
+
+        $address = $this->filterEmpty($address);
+
+        if (count($address) === 1 && isset($address['@type'])) {
+            return [];
+        }
+
+        return $address;
+    }
+
+    protected function buildGeo(?float $latitude, ?float $longitude): array
+    {
+        if ($latitude === null || $longitude === null) {
+            return [];
+        }
+
+        return [
+            '@type'     => 'GeoCoordinates',
+            'latitude'  => $latitude,
+            'longitude' => $longitude,
+        ];
+    }
+
+    protected function hasAny(array $values): bool
+    {
+        foreach ($values as $value) {
+            if (!$this->isEmpty($value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected function isEmpty(mixed $value): bool
+    {
+        if (is_array($value)) {
+            foreach ($value as $item) {
+                if (!$this->isEmpty($item)) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        return $value === null || $value === '';
+    }
+
+    abstract protected function mapData(WP_Post $post): array;
+}

--- a/src/SEO/Schema/Mapper/CourseMapper.php
+++ b/src/SEO/Schema/Mapper/CourseMapper.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Gm2\SEO\Schema\Mapper;
+
+use WP_Post;
+
+class CourseMapper extends AbstractMapper
+{
+    protected array $requiredFields = [
+        'provider'    => __('Provider', 'gm2-wordpress-suite'),
+        'course_code' => __('Course code', 'gm2-wordpress-suite'),
+    ];
+
+    public function __construct()
+    {
+        parent::__construct(
+            'course',
+            'Course',
+            'gm2_schema_course',
+            __('Course', 'gm2-wordpress-suite')
+        );
+    }
+
+    protected function mapData(WP_Post $post): array
+    {
+        $provider = $this->filterEmpty([
+            '@type' => 'Organization',
+            'name'  => $this->sanitizeText($this->getField($post, 'provider')),
+            'sameAs'=> $this->normalizeSameAs($this->getField($post, 'provider_same_as', [])),
+            'url'   => esc_url_raw((string) $this->getField($post, 'provider_url')),
+        ]);
+
+        $courseUrl = $this->getField($post, 'course_url');
+
+        return [
+            '@id'           => trailingslashit(get_permalink($post)) . '#course',
+            'name'          => get_the_title($post),
+            'description'   => $this->sanitizeText($post->post_excerpt ?: $post->post_content),
+            'provider'      => $provider,
+            'courseCode'    => $this->sanitizeText($this->getField($post, 'course_code')),
+            'url'           => $courseUrl ? esc_url_raw((string) $courseUrl) : esc_url_raw(get_permalink($post)),
+            'inLanguage'    => $this->getField($post, 'course_language'),
+            'educationalLevel' => $this->getField($post, 'course_level'),
+            'coursePrerequisites' => $this->getField($post, 'course_prerequisites'),
+            'courseInstance' => $this->buildCourseInstance($post),
+        ];
+    }
+
+    private function buildCourseInstance(WP_Post $post): array
+    {
+        $name  = $this->getField($post, 'course_instance_name');
+        $start = $this->getField($post, 'course_instance_start');
+        $end   = $this->getField($post, 'course_instance_end');
+        $url   = $this->getField($post, 'course_instance_url');
+
+        if ($this->isEmpty($name) && $this->isEmpty($start) && $this->isEmpty($end) && $this->isEmpty($url)) {
+            return [];
+        }
+
+        $location = [
+            '@type'   => 'Place',
+            'name'    => $this->sanitizeText($this->getField($post, 'course_location_name')),
+            'address' => $this->buildAddress([
+                'streetAddress'   => $this->getField($post, 'course_location_address'),
+                'addressLocality' => $this->getField($post, 'course_location_city'),
+                'addressRegion'   => $this->getField($post, 'course_location_region'),
+                'postalCode'      => $this->getField($post, 'course_location_postal_code'),
+                'addressCountry'  => $this->getField($post, 'course_location_country'),
+            ]),
+        ];
+
+        $location = $this->filterEmpty($location);
+
+        return $this->filterEmpty([
+            '@type'     => 'CourseInstance',
+            'name'      => $this->sanitizeText((string) $name),
+            'startDate' => $start ?: null,
+            'endDate'   => $end ?: null,
+            'location'  => $location,
+            'url'       => $url ? esc_url_raw((string) $url) : null,
+            'courseMode'=> $this->getField($post, 'course_mode'),
+            'instructor'=> $this->buildInstructor($post),
+        ]);
+    }
+
+    private function buildInstructor(WP_Post $post): array
+    {
+        $name = $this->getField($post, 'course_instructor');
+        if ($this->isEmpty($name)) {
+            return [];
+        }
+
+        return $this->filterEmpty([
+            '@type' => 'Person',
+            'name'  => $this->sanitizeText((string) $name),
+            'url'   => esc_url_raw((string) $this->getField($post, 'course_instructor_url')),
+        ]);
+    }
+
+    private function normalizeSameAs(mixed $value): array
+    {
+        if ($this->isEmpty($value)) {
+            return [];
+        }
+
+        if (is_string($value)) {
+            $value = preg_split('/[\r\n]+/', $value);
+        }
+
+        if (!is_array($value)) {
+            return [];
+        }
+
+        $links = [];
+        foreach ($value as $link) {
+            if (!is_string($link)) {
+                continue;
+            }
+
+            $link = trim($link);
+            if ($link === '') {
+                continue;
+            }
+
+            $links[] = esc_url_raw($link);
+        }
+
+        return array_values(array_unique(array_filter($links)));
+    }
+}

--- a/src/SEO/Schema/Mapper/DirectoryMapper.php
+++ b/src/SEO/Schema/Mapper/DirectoryMapper.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Gm2\SEO\Schema\Mapper;
+
+use WP_Post;
+
+class DirectoryMapper extends AbstractMapper
+{
+    protected array $requiredFields = [
+        'address' => __('Address', 'gm2-wordpress-suite'),
+    ];
+
+    public function __construct()
+    {
+        parent::__construct(
+            'listing',
+            'LocalBusiness',
+            'gm2_schema_directory',
+            __('Local Business', 'gm2-wordpress-suite')
+        );
+    }
+
+    protected function mapData(WP_Post $post): array
+    {
+        $address = $this->buildAddress([
+            'streetAddress'   => $this->getField($post, 'address'),
+            'addressLocality' => $this->getField($post, 'city'),
+            'addressRegion'   => $this->getField($post, 'region'),
+            'postalCode'      => $this->getField($post, 'postal_code'),
+            'addressCountry'  => $this->getField($post, 'country'),
+        ]);
+
+        $geo = $this->buildGeo(
+            $this->toFloat($this->getField($post, 'latitude')),
+            $this->toFloat($this->getField($post, 'longitude'))
+        );
+
+        $url = $this->getField($post, 'website');
+        if (!$url) {
+            $url = get_permalink($post);
+        }
+
+        $image = get_the_post_thumbnail_url($post, 'full');
+
+        return [
+            '@id'                       => trailingslashit(get_permalink($post)) . '#local-business',
+            'name'                      => get_the_title($post),
+            'description'               => $this->sanitizeText($post->post_excerpt ?: $post->post_content),
+            'url'                       => esc_url_raw($url),
+            'image'                     => $image ?: null,
+            'telephone'                 => $this->formatTelephone($this->getField($post, 'phone')),
+            'address'                   => $address,
+            'geo'                       => $geo,
+            'openingHoursSpecification' => $this->normalizeOpeningHours($this->getField($post, 'opening_hours', [])),
+            'sameAs'                    => $this->normalizeSameAs($this->getField($post, 'same_as', [])),
+        ];
+    }
+
+    private function formatTelephone(mixed $value): ?string
+    {
+        if ($this->isEmpty($value)) {
+            return null;
+        }
+
+        return preg_replace('/[^0-9+\-().\s]/', '', (string) $value);
+    }
+
+    private function normalizeOpeningHours(mixed $hours): array
+    {
+        if (!is_array($hours)) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach ($hours as $row) {
+            if (!is_array($row)) {
+                continue;
+            }
+
+            $entry = [
+                '@type'     => 'OpeningHoursSpecification',
+                'dayOfWeek' => $row['dayOfWeek'] ?? $row['day'] ?? null,
+                'opens'     => $row['opens'] ?? null,
+                'closes'    => $row['closes'] ?? null,
+            ];
+
+            $entry = $this->filterEmpty($entry);
+            if ($entry) {
+                $normalized[] = $entry;
+            }
+        }
+
+        return $normalized;
+    }
+
+    private function normalizeSameAs(mixed $value): array
+    {
+        if ($this->isEmpty($value)) {
+            return [];
+        }
+
+        if (is_string($value)) {
+            $value = preg_split('/[\r\n]+/', $value);
+        }
+
+        if (!is_array($value)) {
+            return [];
+        }
+
+        $links = [];
+        foreach ($value as $link) {
+            if (!is_string($link)) {
+                continue;
+            }
+
+            $link = trim($link);
+            if ($link === '') {
+                continue;
+            }
+
+            $links[] = esc_url_raw($link);
+        }
+
+        return array_values(array_unique(array_filter($links)));
+    }
+}

--- a/src/SEO/Schema/Mapper/EventMapper.php
+++ b/src/SEO/Schema/Mapper/EventMapper.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Gm2\SEO\Schema\Mapper;
+
+use WP_Post;
+
+class EventMapper extends AbstractMapper
+{
+    protected array $requiredFields = [
+        'start_date' => __('Start date', 'gm2-wordpress-suite'),
+        'end_date'   => __('End date', 'gm2-wordpress-suite'),
+        'location'   => __('Location', 'gm2-wordpress-suite'),
+    ];
+
+    public function __construct()
+    {
+        parent::__construct(
+            'event',
+            'Event',
+            'gm2_schema_event',
+            __('Event', 'gm2-wordpress-suite')
+        );
+    }
+
+    protected function mapData(WP_Post $post): array
+    {
+        $location = [
+            '@type' => 'Place',
+            'name'  => $this->sanitizeText($this->getField($post, 'location')),
+        ];
+
+        $address = $this->buildAddress([
+            'streetAddress'   => $this->getField($post, 'location_address'),
+            'addressLocality' => $this->getField($post, 'location_city'),
+            'addressRegion'   => $this->getField($post, 'location_region'),
+            'postalCode'      => $this->getField($post, 'location_postal_code'),
+            'addressCountry'  => $this->getField($post, 'location_country'),
+        ]);
+        if (!empty($address)) {
+            $location['address'] = $address;
+        }
+
+        return [
+            '@id'                 => trailingslashit(get_permalink($post)) . '#event',
+            'name'                => get_the_title($post),
+            'description'         => $this->sanitizeText($post->post_excerpt ?: $post->post_content),
+            'startDate'           => $this->getField($post, 'start_date'),
+            'endDate'             => $this->getField($post, 'end_date'),
+            'eventAttendanceMode' => $this->getField($post, 'attendance_mode'),
+            'eventStatus'         => $this->getField($post, 'event_status'),
+            'location'            => $this->filterEmpty($location),
+            'organizer'           => $this->buildOrganizer($post),
+            'offers'              => $this->buildOffers($post),
+        ];
+    }
+
+    private function buildOrganizer(WP_Post $post): array
+    {
+        $name = $this->getField($post, 'organizer_name');
+        if ($this->isEmpty($name)) {
+            return [];
+        }
+
+        return $this->filterEmpty([
+            '@type' => 'Organization',
+            'name'  => $this->sanitizeText((string) $name),
+            'url'   => esc_url_raw((string) $this->getField($post, 'organizer_url')),
+        ]);
+    }
+
+    private function buildOffers(WP_Post $post): array
+    {
+        $price    = $this->toFloat($this->getField($post, 'ticket_price'));
+        $currency = $this->getField($post, 'ticket_currency');
+        $url      = $this->getField($post, 'ticket_url');
+
+        if ($price === null && $this->isEmpty($currency) && $this->isEmpty($url)) {
+            return [];
+        }
+
+        return $this->filterEmpty([
+            '@type'         => 'Offer',
+            'price'         => $price,
+            'priceCurrency' => $currency ?: null,
+            'availability'  => $this->getField($post, 'ticket_availability'),
+            'validFrom'     => $this->getField($post, 'ticket_valid_from'),
+            'url'           => $url ? esc_url_raw((string) $url) : esc_url_raw(get_permalink($post)),
+        ]);
+    }
+}

--- a/src/SEO/Schema/Mapper/JobMapper.php
+++ b/src/SEO/Schema/Mapper/JobMapper.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace Gm2\SEO\Schema\Mapper;
+
+use WP_Post;
+
+class JobMapper extends AbstractMapper
+{
+    protected array $requiredFields = [
+        'date_posted'      => __('Date posted', 'gm2-wordpress-suite'),
+        'employment_type'  => __('Employment type', 'gm2-wordpress-suite'),
+        'company'          => __('Company name', 'gm2-wordpress-suite'),
+    ];
+
+    public function __construct()
+    {
+        parent::__construct(
+            'job',
+            'JobPosting',
+            'gm2_schema_job',
+            __('Job Posting', 'gm2-wordpress-suite')
+        );
+    }
+
+    protected function mapData(WP_Post $post): array
+    {
+        $location = $this->buildJobLocation($post);
+        $salary   = $this->buildSalary($post);
+        $hiring   = $this->buildHiringOrganization($post);
+
+        $applyUrl = $this->getField($post, 'apply_url');
+
+        return [
+            '@id'             => trailingslashit(get_permalink($post)) . '#job',
+            'title'           => get_the_title($post),
+            'description'     => $this->sanitizeText($post->post_excerpt ?: $post->post_content),
+            'datePosted'      => $this->getField($post, 'date_posted'),
+            'employmentType'  => $this->sanitizeText($this->getField($post, 'employment_type')),
+            'hiringOrganization' => $hiring,
+            'jobLocation'     => $location,
+            'baseSalary'      => $salary,
+            'industry'        => $this->getField($post, 'industry'),
+            'validThrough'    => $this->getField($post, 'valid_through'),
+            'applicantLocationRequirements' => $this->buildApplicantLocation($post),
+            'directApply'     => $this->normalizeBool($this->getField($post, 'direct_apply')),
+            'url'             => $applyUrl ? esc_url_raw((string) $applyUrl) : esc_url_raw(get_permalink($post)),
+        ];
+    }
+
+    private function buildJobLocation(WP_Post $post): array
+    {
+        $place = [
+            '@type'  => 'Place',
+            'name'   => $this->sanitizeText($this->getField($post, 'job_location_name')),
+            'address'=> $this->buildAddress([
+                'streetAddress'   => $this->getField($post, 'job_street'),
+                'addressLocality' => $this->getField($post, 'job_city'),
+                'addressRegion'   => $this->getField($post, 'job_region'),
+                'postalCode'      => $this->getField($post, 'job_postal_code'),
+                'addressCountry'  => $this->getField($post, 'job_country'),
+            ]),
+        ];
+
+        $place = $this->filterEmpty($place);
+        if (empty($place)) {
+            return [];
+        }
+
+        return $place;
+    }
+
+    private function buildHiringOrganization(WP_Post $post): array
+    {
+        $name = $this->getField($post, 'company');
+        if ($this->isEmpty($name)) {
+            return [];
+        }
+
+        return $this->filterEmpty([
+            '@type' => 'Organization',
+            'name'  => $this->sanitizeText((string) $name),
+            'sameAs'=> $this->normalizeSameAs($this->getField($post, 'company_same_as', [])),
+            'url'   => esc_url_raw((string) $this->getField($post, 'company_url')),
+        ]);
+    }
+
+    private function buildSalary(WP_Post $post): array
+    {
+        $currency = $this->getField($post, 'salary_currency');
+        $value    = $this->toFloat($this->getField($post, 'salary_value'));
+        $min      = $this->toFloat($this->getField($post, 'salary_min'));
+        $max      = $this->toFloat($this->getField($post, 'salary_max'));
+        $unit     = $this->getField($post, 'salary_unit_text');
+
+        if ($value === null && $min === null && $max === null && $this->isEmpty($currency)) {
+            return [];
+        }
+
+        $quantitative = $this->filterEmpty([
+            '@type'     => 'QuantitativeValue',
+            'value'     => $value,
+            'minValue'  => $min,
+            'maxValue'  => $max,
+            'unitText'  => $unit ?: null,
+        ]);
+
+        return $this->filterEmpty([
+            '@type'     => 'MonetaryAmount',
+            'currency'  => $currency ?: null,
+            'value'     => $quantitative,
+        ]);
+    }
+
+    private function buildApplicantLocation(WP_Post $post): array
+    {
+        $allowed = $this->getField($post, 'applicant_region');
+        if ($this->isEmpty($allowed)) {
+            return [];
+        }
+
+        return $this->filterEmpty([
+            '@type'          => 'Country',
+            'name'           => $this->sanitizeText((string) $allowed),
+        ]);
+    }
+
+    private function normalizeSameAs(mixed $value): array
+    {
+        if ($this->isEmpty($value)) {
+            return [];
+        }
+
+        if (is_string($value)) {
+            $value = preg_split('/[\r\n]+/', $value);
+        }
+
+        if (!is_array($value)) {
+            return [];
+        }
+
+        $links = [];
+        foreach ($value as $link) {
+            if (!is_string($link)) {
+                continue;
+            }
+
+            $link = trim($link);
+            if ($link === '') {
+                continue;
+            }
+
+            $links[] = esc_url_raw($link);
+        }
+
+        return array_values(array_unique(array_filter($links)));
+    }
+
+    private function normalizeBool(mixed $value): ?bool
+    {
+        if ($this->isEmpty($value)) {
+            return null;
+        }
+
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_numeric($value)) {
+            return (bool) (int) $value;
+        }
+
+        $value = strtolower(trim((string) $value));
+        if (in_array($value, ['1', 'true', 'yes'], true)) {
+            return true;
+        }
+        if (in_array($value, ['0', 'false', 'no'], true)) {
+            return false;
+        }
+
+        return null;
+    }
+}

--- a/src/SEO/Schema/Mapper/MapperInterface.php
+++ b/src/SEO/Schema/Mapper/MapperInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Gm2\SEO\Schema\Mapper;
+
+use WP_Error;
+use WP_Post;
+
+interface MapperInterface
+{
+    public function getPostType(): string;
+
+    public function getSchemaType(): string;
+
+    public function getOptionName(): string;
+
+    public function getLabel(): string;
+
+    /**
+     * Build schema data for a singular post.
+     *
+     * @param WP_Post $post Post to map.
+     * @return array|WP_Error
+     */
+    public function map(WP_Post $post);
+
+    /**
+     * Retrieve a map of required field keys to human readable labels.
+     *
+     * @return array<string,string>
+     */
+    public function getRequiredFieldMap(): array;
+}

--- a/src/SEO/Schema/Mapper/RealEstateMapper.php
+++ b/src/SEO/Schema/Mapper/RealEstateMapper.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Gm2\SEO\Schema\Mapper;
+
+use WP_Post;
+
+class RealEstateMapper extends AbstractMapper
+{
+    protected array $requiredFields = [
+        'price'   => __('Price', 'gm2-wordpress-suite'),
+        'address' => __('Address', 'gm2-wordpress-suite'),
+    ];
+
+    public function __construct()
+    {
+        parent::__construct(
+            'property',
+            'RealEstateListing',
+            'gm2_schema_real_estate',
+            __('Real Estate Listing', 'gm2-wordpress-suite')
+        );
+    }
+
+    protected function mapData(WP_Post $post): array
+    {
+        $address = $this->buildAddress([
+            'streetAddress'   => $this->getField($post, 'address'),
+            'addressLocality' => $this->getField($post, 'city'),
+            'addressRegion'   => $this->getField($post, 'region'),
+            'postalCode'      => $this->getField($post, 'postal_code'),
+            'addressCountry'  => $this->getField($post, 'country'),
+        ]);
+
+        $geo = $this->buildGeo(
+            $this->toFloat($this->getField($post, 'latitude')),
+            $this->toFloat($this->getField($post, 'longitude'))
+        );
+
+        return [
+            '@id'          => trailingslashit(get_permalink($post)) . '#listing',
+            'name'         => get_the_title($post),
+            'description'  => $this->sanitizeText($post->post_excerpt ?: $post->post_content),
+            'url'          => esc_url_raw(get_permalink($post)),
+            'address'      => $address,
+            'geo'          => $geo,
+            'numberOfRooms'=> $this->toInt($this->getField($post, 'bedrooms')),
+            'numberOfBathroomsTotal' => $this->toInt($this->getField($post, 'bathrooms')),
+            'floorSize'    => $this->buildFloorSize($post),
+            'propertyType' => $this->getField($post, 'property_type'),
+            'offers'       => $this->buildOffers($post, $address),
+        ];
+    }
+
+    private function buildOffers(WP_Post $post, array $address): array
+    {
+        $price    = $this->toFloat($this->getField($post, 'price'));
+        $currency = $this->getField($post, 'price_currency');
+        $status   = $this->getField($post, 'availability');
+
+        $itemOffered = $this->filterEmpty([
+            '@type'             => $this->getField($post, 'residence_type') ?: 'Residence',
+            'name'              => get_the_title($post),
+            'numberOfRooms'     => $this->toInt($this->getField($post, 'bedrooms')),
+            'numberOfBathroomsTotal' => $this->toInt($this->getField($post, 'bathrooms')),
+            'address'           => $address,
+            'floorSize'         => $this->buildFloorSize($post),
+        ]);
+
+        return $this->filterEmpty([
+            '@type'         => 'Offer',
+            'price'         => $price,
+            'priceCurrency' => $currency ?: null,
+            'availability'  => $status ?: null,
+            'url'           => esc_url_raw(get_permalink($post)),
+            'itemOffered'   => $itemOffered,
+            'seller'        => $this->buildSeller($post),
+        ]);
+    }
+
+    private function buildSeller(WP_Post $post): array
+    {
+        $name = $this->getField($post, 'seller_name');
+        if ($this->isEmpty($name)) {
+            return [];
+        }
+
+        return $this->filterEmpty([
+            '@type' => 'RealEstateAgent',
+            'name'  => $this->sanitizeText((string) $name),
+            'url'   => esc_url_raw((string) $this->getField($post, 'seller_url')),
+            'telephone' => $this->formatTelephone($this->getField($post, 'seller_phone')),
+        ]);
+    }
+
+    private function buildFloorSize(WP_Post $post): array
+    {
+        $value = $this->toFloat($this->getField($post, 'floor_size'));
+        $unit  = $this->getField($post, 'floor_size_unit');
+
+        if ($value === null && $this->isEmpty($unit)) {
+            return [];
+        }
+
+        return $this->filterEmpty([
+            '@type'    => 'QuantitativeValue',
+            'value'    => $value,
+            'unitText' => $unit ?: null,
+        ]);
+    }
+
+    private function formatTelephone(mixed $value): ?string
+    {
+        if ($this->isEmpty($value)) {
+            return null;
+        }
+
+        return preg_replace('/[^0-9+\-().\s]/', '', (string) $value);
+    }
+}

--- a/src/SEO/bootstrap.php
+++ b/src/SEO/bootstrap.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Gm2\SEO;
+
+use Gm2\SEO\Schema\Manager;
+use Gm2\SEO\Schema\Mapper\CourseMapper;
+use Gm2\SEO\Schema\Mapper\DirectoryMapper;
+use Gm2\SEO\Schema\Mapper\EventMapper;
+use Gm2\SEO\Schema\Mapper\JobMapper;
+use Gm2\SEO\Schema\Mapper\RealEstateMapper;
+
+if (!defined('ABSPATH')) {
+    return;
+}
+
+/**
+ * Bootstrap the schema manager with default mappers.
+ */
+function bootstrap_schema_manager(): Manager
+{
+    $mappers = [
+        new DirectoryMapper(),
+        new EventMapper(),
+        new JobMapper(),
+        new CourseMapper(),
+        new RealEstateMapper(),
+    ];
+
+    /** @var array<int, \Gm2\SEO\Schema\Mapper\MapperInterface> $mappers */
+    $mappers = apply_filters('gm2_seo_schema_mappers', $mappers);
+
+    return Manager::bootstrap($mappers);
+}
+
+bootstrap_schema_manager();

--- a/tests/SEO/Schema/ManagerTest.php
+++ b/tests/SEO/Schema/ManagerTest.php
@@ -1,0 +1,157 @@
+<?php
+
+use Gm2\SEO\Schema\Manager;
+use Gm2\SEO\Schema\Mapper\DirectoryMapper;
+
+class SchemaManagerTest extends WP_UnitTestCase
+{
+    private array $registered = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->registered = [];
+        Manager::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->registered as $slug) {
+            if (post_type_exists($slug)) {
+                unregister_post_type($slug);
+            }
+        }
+
+        Manager::reset();
+        update_option('gm2_schema_directory', '1');
+        \Gm2\SEO\bootstrap_schema_manager();
+        parent::tearDown();
+    }
+
+    private function registerPostType(string $slug): void
+    {
+        if (!post_type_exists($slug)) {
+            register_post_type($slug, ['public' => true, 'has_archive' => true]);
+            $this->registered[] = $slug;
+        }
+    }
+
+    private function buildDirectoryPost(): int
+    {
+        $this->registerPostType('listing');
+        $post_id = self::factory()->post->create([
+            'post_type' => 'listing',
+            'post_title' => 'Test Listing',
+            'post_content' => 'Sample description.',
+        ]);
+
+        update_post_meta($post_id, 'address', '123 Main St');
+        update_post_meta($post_id, 'city', 'Metropolis');
+
+        return $post_id;
+    }
+
+    public function test_manager_respects_option_toggle(): void
+    {
+        $post_id = $this->buildDirectoryPost();
+        update_option('gm2_schema_directory', '1');
+
+        $manager = new Manager([ new DirectoryMapper() ]);
+        $manager->register();
+
+        $this->go_to(get_permalink($post_id));
+        ob_start();
+        $manager->render('wp_head');
+        $output = ob_get_clean();
+        $this->assertStringContainsString('LocalBusiness', $output);
+
+        $manager->unregister();
+        update_option('gm2_schema_directory', '0');
+
+        $manager = new Manager([ new DirectoryMapper() ]);
+        $manager->register();
+
+        $this->go_to(get_permalink($post_id));
+        ob_start();
+        $manager->render('wp_head');
+        $output = ob_get_clean();
+        $this->assertSame('', $output);
+    }
+
+    public function test_manager_detects_third_party_schema(): void
+    {
+        $post_id = $this->buildDirectoryPost();
+        update_option('gm2_schema_directory', '1');
+
+        $manager = new Manager([ new DirectoryMapper() ]);
+        $manager->register();
+
+        $this->go_to(get_permalink($post_id));
+        do_action('wpseo_json_ld_output');
+
+        ob_start();
+        $manager->render('wp_head');
+        $output = ob_get_clean();
+        $this->assertSame('', $output);
+    }
+
+    public function test_manager_outputs_once_for_head_and_footer(): void
+    {
+        $post_id = $this->buildDirectoryPost();
+        update_option('gm2_schema_directory', '1');
+
+        $manager = new Manager([ new DirectoryMapper() ]);
+        $manager->register();
+
+        $this->go_to(get_permalink($post_id));
+
+        ob_start();
+        $manager->render('wp_head');
+        $head = ob_get_clean();
+
+        ob_start();
+        $manager->render('wp_footer');
+        $footer = ob_get_clean();
+
+        $combined = $head . $footer;
+        $this->assertSame(1, substr_count($combined, '<script type="application/ld+json">'));
+    }
+
+    public function test_archive_output_emits_single_script(): void
+    {
+        $this->registerPostType('listing');
+        $ids = [];
+        $ids[] = self::factory()->post->create([
+            'post_type' => 'listing',
+            'post_title' => 'Listing One',
+        ]);
+        $ids[] = self::factory()->post->create([
+            'post_type' => 'listing',
+            'post_title' => 'Listing Two',
+        ]);
+
+        foreach ($ids as $id) {
+            update_post_meta($id, 'address', '123 Main');
+        }
+
+        update_option('gm2_schema_directory', '1');
+        $manager = new Manager([ new DirectoryMapper() ]);
+        $manager->register();
+
+        $this->go_to(home_url('/?post_type=listing'));
+
+        ob_start();
+        $manager->render('wp_head');
+        $head = ob_get_clean();
+
+        ob_start();
+        $manager->render('wp_footer');
+        $footer = ob_get_clean();
+
+        $combined = $head . $footer;
+        $this->assertSame(1, substr_count($combined, '<script type="application/ld+json">'));
+        $this->assertStringContainsString('"ItemList"', $combined);
+        $this->assertStringContainsString('Listing One', $combined);
+        $this->assertStringContainsString('Listing Two', $combined);
+    }
+}

--- a/tests/SEO/Schema/MapperTest.php
+++ b/tests/SEO/Schema/MapperTest.php
@@ -1,0 +1,203 @@
+<?php
+
+use Gm2\SEO\Schema\Mapper\CourseMapper;
+use Gm2\SEO\Schema\Mapper\DirectoryMapper;
+use Gm2\SEO\Schema\Mapper\EventMapper;
+use Gm2\SEO\Schema\Mapper\JobMapper;
+use Gm2\SEO\Schema\Mapper\RealEstateMapper;
+use WP_Error;
+
+class SchemaMapperTest extends WP_UnitTestCase
+{
+    private array $registered = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->registered = [];
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->registered as $slug) {
+            if (post_type_exists($slug)) {
+                unregister_post_type($slug);
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    private function registerPostType(string $slug): void
+    {
+        if (!post_type_exists($slug)) {
+            register_post_type($slug, ['public' => true]);
+            $this->registered[] = $slug;
+        }
+    }
+
+    public function test_directory_mapper_requires_address(): void
+    {
+        $this->registerPostType('listing');
+        $post_id = self::factory()->post->create([
+            'post_type' => 'listing',
+            'post_title' => 'Sample Listing',
+        ]);
+
+        $mapper = new DirectoryMapper();
+        $result = $mapper->map(get_post($post_id));
+        $this->assertInstanceOf(WP_Error::class, $result);
+    }
+
+    public function test_directory_mapper_builds_schema(): void
+    {
+        $this->registerPostType('listing');
+        $post_id = self::factory()->post->create([
+            'post_type' => 'listing',
+            'post_title' => 'Cafe 123',
+            'post_content' => 'Great coffee and pastries.',
+        ]);
+
+        update_post_meta($post_id, 'address', '123 Main St');
+        update_post_meta($post_id, 'city', 'Metropolis');
+        update_post_meta($post_id, 'region', 'CA');
+        update_post_meta($post_id, 'postal_code', '90001');
+        update_post_meta($post_id, 'country', 'US');
+        update_post_meta($post_id, 'phone', '(555) 555-0100');
+        update_post_meta($post_id, 'website', 'https://example.com/cafe');
+        update_post_meta($post_id, 'latitude', '34.05');
+        update_post_meta($post_id, 'longitude', '-118.25');
+        update_post_meta($post_id, 'opening_hours', [
+            ['dayOfWeek' => 'Monday', 'opens' => '09:00', 'closes' => '17:00'],
+        ]);
+
+        $mapper = new DirectoryMapper();
+        $result = $mapper->map(get_post($post_id));
+
+        $this->assertIsArray($result);
+        $this->assertSame('LocalBusiness', $result['@type']);
+        $this->assertSame('123 Main St', $result['address']['streetAddress']);
+        $this->assertSame('Metropolis', $result['address']['addressLocality']);
+        $this->assertSame('CA', $result['address']['addressRegion']);
+        $this->assertSame('(555) 555-0100', $result['telephone']);
+        $this->assertSame('https://example.com/cafe', $result['url']);
+        $this->assertSame(34.05, $result['geo']['latitude']);
+        $this->assertSame(-118.25, $result['geo']['longitude']);
+        $this->assertSame('OpeningHoursSpecification', $result['openingHoursSpecification'][0]['@type']);
+    }
+
+    public function test_event_mapper_requires_fields(): void
+    {
+        $this->registerPostType('event');
+        $post_id = self::factory()->post->create([
+            'post_type' => 'event',
+            'post_title' => 'Conf',
+        ]);
+
+        $mapper = new EventMapper();
+        $result = $mapper->map(get_post($post_id));
+        $this->assertInstanceOf(WP_Error::class, $result);
+    }
+
+    public function test_event_mapper_builds_schema(): void
+    {
+        $this->registerPostType('event');
+        $post_id = self::factory()->post->create([
+            'post_type' => 'event',
+            'post_title' => 'Product Launch',
+        ]);
+
+        update_post_meta($post_id, 'start_date', '2024-07-01T09:00:00-05:00');
+        update_post_meta($post_id, 'end_date', '2024-07-01T11:00:00-05:00');
+        update_post_meta($post_id, 'location', 'Downtown HQ');
+        update_post_meta($post_id, 'location_city', 'Springfield');
+        update_post_meta($post_id, 'ticket_price', '25');
+        update_post_meta($post_id, 'ticket_currency', 'USD');
+
+        $mapper = new EventMapper();
+        $result = $mapper->map(get_post($post_id));
+
+        $this->assertIsArray($result);
+        $this->assertSame('Event', $result['@type']);
+        $this->assertSame('2024-07-01T09:00:00-05:00', $result['startDate']);
+        $this->assertSame('Downtown HQ', $result['location']['name']);
+        $this->assertSame('USD', $result['offers']['priceCurrency']);
+    }
+
+    public function test_job_mapper_includes_salary(): void
+    {
+        $this->registerPostType('job');
+        $post_id = self::factory()->post->create([
+            'post_type' => 'job',
+            'post_title' => 'Developer',
+            'post_content' => 'Build systems.',
+        ]);
+
+        update_post_meta($post_id, 'date_posted', '2024-03-01');
+        update_post_meta($post_id, 'employment_type', 'Full-time');
+        update_post_meta($post_id, 'company', 'Example Inc');
+        update_post_meta($post_id, 'salary_currency', 'USD');
+        update_post_meta($post_id, 'salary_value', '90000');
+        update_post_meta($post_id, 'job_city', 'Gotham');
+
+        $mapper = new JobMapper();
+        $result = $mapper->map(get_post($post_id));
+
+        $this->assertIsArray($result);
+        $this->assertSame('JobPosting', $result['@type']);
+        $this->assertSame('USD', $result['baseSalary']['currency']);
+        $this->assertSame(90000.0, $result['baseSalary']['value']['value']);
+        $this->assertSame('Example Inc', $result['hiringOrganization']['name']);
+    }
+
+    public function test_course_mapper_builds_instance(): void
+    {
+        $this->registerPostType('course');
+        $post_id = self::factory()->post->create([
+            'post_type' => 'course',
+            'post_title' => 'Robotics 101',
+        ]);
+
+        update_post_meta($post_id, 'provider', 'Robotics Academy');
+        update_post_meta($post_id, 'course_code', 'ROB101');
+        update_post_meta($post_id, 'course_instance_name', 'Spring Session');
+        update_post_meta($post_id, 'course_instance_start', '2024-04-01');
+        update_post_meta($post_id, 'course_instance_end', '2024-06-01');
+        update_post_meta($post_id, 'course_location_region', 'CA');
+
+        $mapper = new CourseMapper();
+        $result = $mapper->map(get_post($post_id));
+
+        $this->assertIsArray($result);
+        $this->assertSame('Course', $result['@type']);
+        $this->assertSame('ROB101', $result['courseCode']);
+        $this->assertSame('CourseInstance', $result['courseInstance']['@type']);
+        $this->assertSame('Spring Session', $result['courseInstance']['name']);
+        $this->assertSame('CA', $result['courseInstance']['location']['address']['addressRegion']);
+    }
+
+    public function test_real_estate_mapper_builds_offer(): void
+    {
+        $this->registerPostType('property');
+        $post_id = self::factory()->post->create([
+            'post_type' => 'property',
+            'post_title' => 'Luxury Condo',
+        ]);
+
+        update_post_meta($post_id, 'address', '200 Market Street');
+        update_post_meta($post_id, 'city', 'Metropolis');
+        update_post_meta($post_id, 'price', '750000');
+        update_post_meta($post_id, 'price_currency', 'USD');
+        update_post_meta($post_id, 'bedrooms', '3');
+
+        $mapper = new RealEstateMapper();
+        $result = $mapper->map(get_post($post_id));
+
+        $this->assertIsArray($result);
+        $this->assertSame('RealEstateListing', $result['@type']);
+        $this->assertSame(3, $result['numberOfRooms']);
+        $this->assertSame(750000.0, $result['offers']['price']);
+        $this->assertSame('USD', $result['offers']['priceCurrency']);
+        $this->assertSame('Residence', $result['offers']['itemOffered']['@type']);
+    }
+}


### PR DESCRIPTION
## Summary
- add a schema manager that renders JSON-LD once per request with third-party suppression hooks and register it during bootstrap
- implement typed mappers for directory, event, job, course, and real estate schemas so required fields are validated and mapped
- extend the SEO admin settings with toggles and mapping notices for the new schema types and cover the behaviour with unit tests

## Testing
- `vendor/bin/phpunit tests/SEO/Schema/MapperTest.php tests/SEO/Schema/ManagerTest.php` *(fails: WordPress test suite requires mysqladmin which is unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cabd9bc2e8833094107c81596aef44