### PR TITLE
Add core sitemap provider integration

### DIFF
--- a/docs/seo-sitemaps.md
+++ b/docs/seo-sitemaps.md
@@ -1,0 +1,27 @@
+# Core XML Sitemap Integration
+
+GM2 now relies on the WordPress 5.5+ [core XML sitemap API](https://make.wordpress.org/core/2020/07/22/wordpress-5-5-introduces-xml-sitemaps/) instead of maintaining a custom renderer. The `Gm2\SEO\Sitemaps\CoreProvider` class registers lightweight providers with core during `init` and augments the default post and taxonomy providers with GM2-specific content.
+
+## Filters
+
+The provider exposes several filters to adjust sitemap behaviour:
+
+| Filter | Description |
+| ------ | ----------- |
+| `gm2_supported_post_types` | Append custom post types that should appear in the sitemap. |
+| `gm2_supported_taxonomies` | Append custom taxonomies that should appear in the sitemap. |
+| `gm2_sitemaps_skip_statuses` | Modify the list of post statuses excluded from sitemap queries. Useful for removing drafts, private content, or other custom statuses. |
+| `gm2_sitemaps_split_taxonomies` | Provide a map of taxonomy names to term counts per sitemap page to further split large term archives. |
+
+## Images and Last Modified Dates
+
+For GM2 post types the provider enriches sitemap entries with:
+
+- A `lastmod` timestamp sourced from `get_post_modified_time()`.
+- Image metadata populated from the post thumbnail. When address fields are available the caption/title is derived from existing GM2 field helpers.
+
+When GM2 taxonomy metadata contains `gm2_last_modified` or `gm2_updated_at` values, those timestamps are surfaced as `lastmod` entries. The provider also attempts to resolve representative term images via GM2 field helpers or the `_thumbnail_id` meta value.
+
+## Disabling Sitemaps
+
+All filters short-circuit when the `gm2_sitemap_enabled` option is set to `0`, allowing sites to disable sitemap output entirely while still retaining the legacy manual sitemap generator.

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -303,8 +303,6 @@ function gm2_add_ac_schedule($schedules) {
 add_filter('cron_schedules', 'gm2_add_ac_schedule');
 
 function gm2_activate_plugin() {
-    $public = new Gm2_SEO_Public();
-    $public->add_sitemap_rewrite();
     flush_rewrite_rules();
     $result = gm2_generate_sitemap();
     if (is_wp_error($result) && defined('WP_DEBUG') && WP_DEBUG) {

--- a/public/Gm2_SEO_Public.php
+++ b/public/Gm2_SEO_Public.php
@@ -441,10 +441,7 @@ class Gm2_SEO_Public {
     }
 
     public function run() {
-        add_action('init', [$this, 'add_sitemap_rewrite']);
-        add_filter('query_vars', [$this, 'add_query_vars']);
         add_action('template_redirect', [$this, 'maybe_apply_redirects'], 0);
-        add_action('template_redirect', [$this, 'maybe_output_sitemap']);
         add_action('template_redirect', [$this, 'log_404_url'], 99);
         add_action('wp_head', [$this, 'output_canonical_url'], 5);
         add_action('wp_head', [$this, 'output_hreflang_links'], 5);
@@ -472,22 +469,6 @@ class Gm2_SEO_Public {
         add_action('shutdown', [$this, 'maybe_flush_buffer'], 0);
         add_action('send_headers', [$this, 'send_cache_headers']);
         add_filter('robots_txt', [$this, 'filter_robots_txt'], 10, 2);
-    }
-
-    public function add_sitemap_rewrite() {
-        add_rewrite_rule('sitemap\\.xml$', 'index.php?gm2_sitemap=1', 'top');
-    }
-
-    public function add_query_vars($vars) {
-        $vars[] = 'gm2_sitemap';
-        return $vars;
-    }
-
-    public function maybe_output_sitemap() {
-        if (get_query_var('gm2_sitemap')) {
-            $s = new Gm2_Sitemap();
-            $s->output();
-        }
     }
 
     public function maybe_apply_redirects() {

--- a/src/SEO/Sitemaps/CoreProvider.php
+++ b/src/SEO/Sitemaps/CoreProvider.php
@@ -1,0 +1,520 @@
+<?php
+
+namespace Gm2\SEO\Sitemaps;
+
+use WP_Post;
+use WP_Sitemaps_Provider;
+use WP_Term;
+
+if (!defined('ABSPATH')) {
+    return;
+}
+
+/**
+ * Integrates GM2 content with the core XML sitemaps API introduced in WordPress 5.5.
+ *
+ * @see https://make.wordpress.org/core/2020/07/22/wordpress-5-5-introduces-xml-sitemaps/
+ * @see https://developer.wordpress.org/reference/classes/wp_sitemaps_provider/
+ */
+final class CoreProvider
+{
+    /**
+     * Tracks whether the provider has already registered its hooks.
+     */
+    private static bool $registered = false;
+
+    /**
+     * Bootstrap the provider by scheduling registration on {@see init}.
+     */
+    public static function bootstrap(): void
+    {
+        add_action('init', [__CLASS__, 'register'], 20);
+    }
+
+    /**
+     * Register GM2 specific providers and filters with the sitemap server.
+     */
+    public static function register(): void
+    {
+        if (self::$registered || !self::isSitemapsAvailable() || !self::isEnabled()) {
+            return;
+        }
+
+        self::$registered = true;
+
+        self::registerProviders();
+        self::hookFilters();
+    }
+
+    /**
+     * Determine if the core sitemap server is available.
+     */
+    private static function isSitemapsAvailable(): bool
+    {
+        return function_exists('wp_sitemaps_get_server') && class_exists('\\WP_Sitemaps_Provider');
+    }
+
+    /**
+     * Determine if sitemap output is enabled for the site.
+     */
+    private static function isEnabled(): bool
+    {
+        return get_option('gm2_sitemap_enabled', '1') === '1';
+    }
+
+    /**
+     * Register lightweight providers to signal GM2 sitemap support to core.
+     */
+    private static function registerProviders(): void
+    {
+        $postProvider = new NullProvider('gm2-posts', 'post');
+        $taxProvider  = new NullProvider('gm2-taxonomies', 'term');
+
+        self::registerProvider('gm2-posts', $postProvider);
+        self::registerProvider('gm2-taxonomies', $taxProvider);
+    }
+
+    /**
+     * Register a provider with the core sitemap registry.
+     */
+    private static function registerProvider(string $name, WP_Sitemaps_Provider $provider): void
+    {
+        if (function_exists('wp_sitemaps_register_provider')) {
+            wp_sitemaps_register_provider($name, $provider);
+            return;
+        }
+
+        if (function_exists('wp_register_sitemap_provider')) {
+            wp_register_sitemap_provider($name, $provider);
+        }
+    }
+
+    /**
+     * Hook core sitemap filters so GM2 content is exposed by the default providers.
+     */
+    private static function hookFilters(): void
+    {
+        add_filter('wp_sitemaps_post_types', [__CLASS__, 'filterPostTypes']);
+        add_filter('wp_sitemaps_taxonomies', [__CLASS__, 'filterTaxonomies']);
+        add_filter('wp_sitemaps_posts_entry', [__CLASS__, 'filterPostEntry'], 10, 3);
+        add_filter('wp_sitemaps_posts_query_args', [__CLASS__, 'filterPostQueryArgs'], 10, 2);
+        add_filter('wp_sitemaps_taxonomies_entry', [__CLASS__, 'filterTaxonomyEntry'], 10, 4);
+        add_filter('wp_sitemaps_taxonomies_query_args', [__CLASS__, 'filterTaxonomyQueryArgs'], 10, 2);
+        add_filter('wp_sitemaps_taxonomies_pre_max_num_pages', [__CLASS__, 'filterTaxonomyMaxPages'], 10, 2);
+    }
+
+    /**
+     * Append GM2 post types to the default posts provider.
+     *
+     * @param array<string, \WP_Post_Type> $postTypes
+     * @return array<string, \WP_Post_Type>
+     */
+    public static function filterPostTypes(array $postTypes): array
+    {
+        if (!self::isEnabled()) {
+            return $postTypes;
+        }
+
+        foreach (self::getSupportedPostTypes() as $postType) {
+            if (isset($postTypes[$postType])) {
+                continue;
+            }
+
+            $object = get_post_type_object($postType);
+            if (!$object || !is_post_type_viewable($object)) {
+                continue;
+            }
+
+            $postTypes[$postType] = $object;
+        }
+
+        return $postTypes;
+    }
+
+    /**
+     * Append GM2 taxonomies to the default taxonomy provider.
+     *
+     * @param array<string, \WP_Taxonomy> $taxonomies
+     * @return array<string, \WP_Taxonomy>
+     */
+    public static function filterTaxonomies(array $taxonomies): array
+    {
+        if (!self::isEnabled()) {
+            return $taxonomies;
+        }
+
+        foreach (self::getSupportedTaxonomies() as $taxonomy) {
+            if (isset($taxonomies[$taxonomy])) {
+                continue;
+            }
+
+            $object = get_taxonomy($taxonomy);
+            if (!$object || !is_taxonomy_viewable($object)) {
+                continue;
+            }
+
+            $taxonomies[$taxonomy] = $object;
+        }
+
+        return $taxonomies;
+    }
+
+    /**
+     * Ensure sitemap queries skip unwanted statuses while remaining filterable.
+     *
+     * @param array  $args     Query args supplied to {@see WP_Query}.
+     * @param string $postType Current post type being queried.
+     * @return array
+     */
+    public static function filterPostQueryArgs(array $args, string $postType): array
+    {
+        if (!self::isEnabled() || !in_array($postType, self::getSupportedPostTypes(), true)) {
+            return $args;
+        }
+
+        $statuses = isset($args['post_status']) ? (array) $args['post_status'] : ['publish'];
+
+        if (in_array('any', $statuses, true)) {
+            $statuses = get_post_stati(['internal' => false]);
+        }
+
+        /**
+         * Filter the list of post statuses that should be skipped when building sitemap queries.
+         *
+         * @param string[] $statuses_to_skip Statuses that must be removed from the sitemap query.
+         * @param string   $postType        The current post type name.
+         */
+        $skip = apply_filters('gm2_sitemaps_skip_statuses', ['draft', 'pending', 'future', 'private'], $postType);
+        $skip = array_map('sanitize_key', array_filter((array) $skip));
+
+        if (!empty($skip)) {
+            $statuses = array_values(array_diff($statuses, $skip));
+        }
+
+        if (empty($statuses)) {
+            $statuses = ['publish'];
+        }
+
+        $args['post_status'] = $statuses;
+
+        return $args;
+    }
+
+    /**
+     * Populate last modified and image data for GM2 posts.
+     *
+     * @param array   $entry    Sitemap entry data.
+     * @param WP_Post $post     The current post object.
+     * @param string  $postType Current post type name.
+     * @return array
+     */
+    public static function filterPostEntry(array $entry, WP_Post $post, string $postType): array
+    {
+        if (!self::isEnabled() || !in_array($postType, self::getSupportedPostTypes(), true)) {
+            return $entry;
+        }
+
+        $entry['lastmod'] = get_post_modified_time('c', true, $post);
+
+        $image = get_the_post_thumbnail_url($post, 'full');
+        if ($image) {
+            $imageEntry = [
+                'loc' => $image,
+            ];
+
+            $caption = self::resolveAddress($post->ID);
+            if ($caption !== '') {
+                $imageEntry['caption'] = $caption;
+                $imageEntry['title']   = $caption;
+            }
+
+            $entry['images']   = isset($entry['images']) && is_array($entry['images']) ? $entry['images'] : [];
+            $entry['images'][] = $imageEntry;
+        }
+
+        return $entry;
+    }
+
+    /**
+     * Populate last modified data for GM2 terms and provide a hook for term images.
+     *
+     * @param array        $entry    Sitemap entry data.
+     * @param int          $termId   Term ID.
+     * @param string       $taxonomy Taxonomy name.
+     * @param WP_Term|null $term     Optional term object (added in WordPress 6.0).
+     * @return array
+     */
+    public static function filterTaxonomyEntry(array $entry, int $termId, string $taxonomy, ?WP_Term $term = null): array
+    {
+        if (!self::isEnabled() || !in_array($taxonomy, self::getSupportedTaxonomies(), true)) {
+            return $entry;
+        }
+
+        $lastModified = self::getTermLastModified($termId, $taxonomy);
+        if ($lastModified !== '') {
+            $entry['lastmod'] = $lastModified;
+        }
+
+        $image = self::getTermImageUrl($termId);
+        if ($image) {
+            $entry['images']   = isset($entry['images']) && is_array($entry['images']) ? $entry['images'] : [];
+            $entry['images'][] = ['loc' => $image];
+        }
+
+        return $entry;
+    }
+
+    /**
+     * Adjust taxonomy queries when large term sets need additional pagination.
+     *
+     * @param array  $args     Query args supplied to {@see WP_Term_Query}.
+     * @param string $taxonomy The taxonomy name currently being queried.
+     * @return array
+     */
+    public static function filterTaxonomyQueryArgs(array $args, string $taxonomy): array
+    {
+        if (!self::isEnabled()) {
+            return $args;
+        }
+
+        $map = self::getTaxonomySplitSizes();
+        if (!isset($map[$taxonomy])) {
+            return $args;
+        }
+
+        $chunk = $map[$taxonomy];
+        if ($chunk > 0) {
+            $args['number'] = min($chunk, (int) wp_sitemaps_get_max_urls('term'));
+        }
+
+        return $args;
+    }
+
+    /**
+     * Ensure taxonomy pagination honours the configured split sizes.
+     *
+     * @param int|null $maxPages Existing value supplied by core.
+     * @param string   $taxonomy Taxonomy name.
+     * @return int|null
+     */
+    public static function filterTaxonomyMaxPages($maxPages, string $taxonomy)
+    {
+        if (!self::isEnabled()) {
+            return $maxPages;
+        }
+
+        $map = self::getTaxonomySplitSizes();
+        if (!isset($map[$taxonomy]) || $map[$taxonomy] <= 0) {
+            return $maxPages;
+        }
+
+        $chunkSize = (int) $map[$taxonomy];
+
+        $count = wp_count_terms([
+            'taxonomy'   => $taxonomy,
+            'hide_empty' => true,
+        ]);
+
+        if (is_wp_error($count)) {
+            return $maxPages;
+        }
+
+        return (int) ceil((int) $count / max(1, $chunkSize));
+    }
+
+    /**
+     * Retrieve the GM2-supported post types.
+     *
+     * @return string[]
+     */
+    private static function getSupportedPostTypes(): array
+    {
+        $args  = [
+            'public'              => true,
+            'show_ui'             => true,
+            'exclude_from_search' => false,
+        ];
+        $types = get_post_types($args, 'names');
+        unset($types['attachment']);
+
+        /**
+         * Filter the list of GM2 supported post types.
+         *
+         * @param string[] $postTypes List of supported post type names.
+         */
+        $types = apply_filters('gm2_supported_post_types', array_values($types));
+
+        return array_values(array_unique(array_map('sanitize_key', (array) $types)));
+    }
+
+    /**
+     * Retrieve the GM2-supported taxonomies.
+     *
+     * @return string[]
+     */
+    private static function getSupportedTaxonomies(): array
+    {
+        $taxonomies = ['category'];
+        if (taxonomy_exists('product_cat')) {
+            $taxonomies[] = 'product_cat';
+        }
+        if (taxonomy_exists('brand')) {
+            $taxonomies[] = 'brand';
+        }
+        if (taxonomy_exists('product_brand')) {
+            $taxonomies[] = 'product_brand';
+        }
+
+        /**
+         * Filter the list of GM2 supported taxonomies.
+         *
+         * @param string[] $taxonomies List of supported taxonomy names.
+         */
+        $taxonomies = apply_filters('gm2_supported_taxonomies', $taxonomies);
+
+        return array_values(array_unique(array_map('sanitize_key', (array) $taxonomies)));
+    }
+
+    /**
+     * Resolve an address string for the given post using existing helpers.
+     */
+    private static function resolveAddress(int $postId): string
+    {
+        $value = \gm2_field('address', '', $postId);
+
+        if (is_array($value)) {
+            if (isset($value['address']) && is_array($value['address']) && class_exists('\\GM2_Field_Geospatial')) {
+                $formatted = \GM2_Field_Geospatial::format_address($value['address']);
+                if ($formatted !== '') {
+                    return $formatted;
+                }
+            }
+
+            $parts = array_filter(array_map('trim', $value));
+            if (!empty($parts)) {
+                return implode(', ', $parts);
+            }
+        }
+
+        $parts = [];
+        foreach (['address', 'city', 'region', 'state', 'province', 'postal_code', 'zip', 'country'] as $key) {
+            $field = \gm2_field($key, '', $postId);
+            if (is_string($field) && trim($field) !== '') {
+                $parts[] = trim($field);
+            }
+        }
+
+        $parts = array_values(array_unique(array_filter($parts)));
+
+        return $parts ? implode(', ', $parts) : '';
+    }
+
+    /**
+     * Retrieve a formatted last modified time for the supplied term.
+     */
+    private static function getTermLastModified(int $termId, string $taxonomy): string
+    {
+        $metaKeys = ['gm2_last_modified', '_gm2_last_modified', 'gm2_updated_at', '_gm2_updated_at'];
+        foreach ($metaKeys as $key) {
+            $value = get_term_meta($termId, $key, true);
+            if (is_string($value) && $value !== '') {
+                $timestamp = strtotime($value);
+                if ($timestamp) {
+                    return gmdate('c', $timestamp);
+                }
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Attempt to locate a representative image URL for the supplied term.
+     */
+    private static function getTermImageUrl(int $termId): string
+    {
+        $image = \gm2_field('image', '', $termId, 'term');
+        if (is_numeric($image)) {
+            $src = wp_get_attachment_url((int) $image);
+            if (is_string($src)) {
+                return $src;
+            }
+        }
+
+        if (is_string($image) && filter_var($image, FILTER_VALIDATE_URL)) {
+            return $image;
+        }
+
+        $thumbnailId = get_term_meta($termId, '_thumbnail_id', true);
+        if (is_numeric($thumbnailId)) {
+            $src = wp_get_attachment_url((int) $thumbnailId);
+            if (is_string($src)) {
+                return $src;
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Retrieve sanitized taxonomy split sizes configured via {@see gm2_sitemaps_split_taxonomies}.
+     *
+     * @return array<string, int>
+     */
+    private static function getTaxonomySplitSizes(): array
+    {
+        /**
+         * Filter the number of taxonomy terms displayed per sitemap page.
+         *
+         * Returning an associative array keyed by taxonomy name allows large datasets to be split
+         * across multiple sitemap pages.
+         *
+         * @param array<string,int> $splits Mapping of taxonomy name to the desired chunk size.
+         */
+        $map = apply_filters('gm2_sitemaps_split_taxonomies', []);
+        if (!is_array($map)) {
+            return [];
+        }
+
+        $sanitized = [];
+        foreach ($map as $taxonomy => $size) {
+            $taxonomy = sanitize_key((string) $taxonomy);
+            $size     = (int) $size;
+            if ($taxonomy !== '' && $size > 0) {
+                $sanitized[$taxonomy] = $size;
+            }
+        }
+
+        return $sanitized;
+    }
+}
+
+/**
+ * Minimal provider used to announce GM2 sitemap participation to the core registry.
+ */
+final class NullProvider extends WP_Sitemaps_Provider
+{
+    public function __construct(string $name, string $objectType)
+    {
+        $this->name        = $name;
+        $this->object_type = $objectType;
+    }
+
+    /** @inheritDoc */
+    public function get_url_list($page_num, $object_subtype = ''): array
+    {
+        return [];
+    }
+
+    /** @inheritDoc */
+    public function get_max_num_pages($object_subtype = ''): int
+    {
+        return 0;
+    }
+
+    /** @inheritDoc */
+    public function get_object_subtypes(): array
+    {
+        return [];
+    }
+}

--- a/src/SEO/bootstrap.php
+++ b/src/SEO/bootstrap.php
@@ -8,6 +8,7 @@ use Gm2\SEO\Schema\Mapper\DirectoryMapper;
 use Gm2\SEO\Schema\Mapper\EventMapper;
 use Gm2\SEO\Schema\Mapper\JobMapper;
 use Gm2\SEO\Schema\Mapper\RealEstateMapper;
+use Gm2\SEO\Sitemaps\CoreProvider;
 
 if (!defined('ABSPATH')) {
     return;
@@ -33,3 +34,4 @@ function bootstrap_schema_manager(): Manager
 }
 
 bootstrap_schema_manager();
+CoreProvider::bootstrap();

--- a/tests/SEO/Sitemaps/CoreProviderTest.php
+++ b/tests/SEO/Sitemaps/CoreProviderTest.php
@@ -1,0 +1,102 @@
+<?php
+
+use Gm2\SEO\Sitemaps\CoreProvider;
+
+class CoreProviderTest extends WP_UnitTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        update_option('gm2_sitemap_enabled', '1');
+        CoreProvider::register();
+    }
+
+    protected function tearDown(): void
+    {
+        remove_filter('gm2_supported_post_types', [$this, 'includeListingPostType']);
+        parent::tearDown();
+    }
+
+    public function test_provider_registration(): void
+    {
+        $providers = wp_get_sitemap_providers();
+
+        $this->assertArrayHasKey('gm2-posts', $providers, 'GM2 posts provider not registered.');
+        $this->assertArrayHasKey('gm2-taxonomies', $providers, 'GM2 taxonomy provider not registered.');
+        $this->assertInstanceOf(WP_Sitemaps_Provider::class, $providers['gm2-posts']);
+    }
+
+    public function test_query_args_filter_respects_skip_statuses(): void
+    {
+        $this->registerListingPostType();
+
+        $args = [
+            'post_status' => ['publish', 'draft', 'private', 'pending'],
+        ];
+
+        $filtered = apply_filters('wp_sitemaps_posts_query_args', $args, 'listing');
+
+        $this->assertSame(['publish'], $filtered['post_status']);
+
+        unregister_post_type('listing');
+    }
+
+    public function test_lastmod_and_image_are_populated(): void
+    {
+        $this->registerListingPostType();
+
+        $attachment_id = self::factory()->attachment->create_upload_object(DIR_TESTDATA . '/images/canola.jpg');
+
+        $post_id = self::factory()->post->create([
+            'post_type'   => 'listing',
+            'post_status' => 'publish',
+            'post_date'   => '2023-01-01 12:00:00',
+        ]);
+
+        set_post_thumbnail($post_id, $attachment_id);
+        update_post_meta($post_id, 'address', '123 Main St');
+        update_post_meta($post_id, 'city', 'Springfield');
+        update_post_meta($post_id, 'region', 'IL');
+
+        $provider = new WP_Sitemaps_Posts();
+        $entries  = $provider->get_url_list(1, 'listing');
+
+        $this->assertNotEmpty($entries, 'Sitemap entries should include listing content.');
+        $entry = $entries[0];
+
+        $expected_lastmod = get_post_modified_time('c', true, $post_id);
+        $this->assertSame($expected_lastmod, $entry['lastmod']);
+
+        $this->assertArrayHasKey('images', $entry);
+        $this->assertNotEmpty($entry['images']);
+
+        $image_entry = $entry['images'][0];
+        $this->assertSame(wp_get_attachment_url($attachment_id), $image_entry['loc']);
+        $this->assertStringContainsString('Springfield', $image_entry['caption']);
+
+        wp_delete_post($post_id, true);
+        wp_delete_attachment($attachment_id, true);
+        unregister_post_type('listing');
+    }
+
+    private function registerListingPostType(): void
+    {
+        register_post_type('listing', [
+            'label'               => 'Listing',
+            'public'              => true,
+            'show_ui'             => true,
+            'exclude_from_search' => false,
+            'supports'            => ['title', 'editor', 'thumbnail'],
+        ]);
+
+        add_filter('gm2_supported_post_types', [$this, 'includeListingPostType']);
+    }
+
+    public function includeListingPostType(array $types): array
+    {
+        $types[] = 'listing';
+
+        return array_values(array_unique($types));
+    }
+
+}


### PR DESCRIPTION
## Summary
- introduce a `CoreProvider` that augments WordPress core XML sitemaps with GM2 post types, taxonomies, images, and last-modified data while exposing new filters for query control
- bootstrap the new provider from the SEO bootstrap and retire the legacy front-end rewrite handler so requests fall back to WordPress core
- document the available sitemap filters and add PHPUnit coverage for provider registration, query filtering, and entry enrichment

## Testing
- `MYSQL_PWD=rootpass vendor/bin/phpunit` *(fails: existing schema mapper property initialiser triggers a PHP fatal before the suite runs)*

------
https://chatgpt.com/codex/tasks/task_b_68cac5dd5a40833094838bb96084e943