### PR TITLE
Add preset wizard admin experience

### DIFF
--- a/admin/Gm2_Custom_Posts_Admin.php
+++ b/admin/Gm2_Custom_Posts_Admin.php
@@ -21,7 +21,6 @@ class Gm2_Custom_Posts_Admin {
         add_action('wp_ajax_gm2_save_tax_args', [ $this, 'ajax_save_tax_args' ]);
         add_action('wp_ajax_gm2_save_query', [ $this, 'ajax_save_query' ]);
         add_action('wp_ajax_gm2_save_cpt_model', [ $this, 'ajax_save_cpt_model' ]);
-        add_action('wp_ajax_gm2_import_preset', [ $this, 'ajax_import_preset' ]);
         add_action('wp_ajax_gm2_save_field_group', [ $this, 'ajax_save_field_group' ]);
         add_action('wp_ajax_gm2_delete_field_group', [ $this, 'ajax_delete_field_group' ]);
         add_action('wp_ajax_gm2_rename_field_group', [ $this, 'ajax_rename_field_group' ]);
@@ -44,11 +43,11 @@ class Gm2_Custom_Posts_Admin {
 
     private function init_help() {
         $this->register_help('toplevel_page_gm2-custom-posts',
-            '<p>' . esc_html__( 'Manage custom post types and taxonomies. Use the preset control to import example models.', 'gm2-wordpress-suite' ) . '</p>',
+            '<p>' . esc_html__( 'Manage custom post types and taxonomies. Use the preset wizard to import example models.', 'gm2-wordpress-suite' ) . '</p>',
             [
                 'input[name="pt_slug"]'  => esc_html__( 'Unique identifier for the post type.', 'gm2-wordpress-suite' ),
                 'input[name="tax_slug"]' => esc_html__( 'Unique identifier for the taxonomy.', 'gm2-wordpress-suite' ),
-                '#gm2-import-preset'       => esc_html__( 'Import a predefined blueprint preset.', 'gm2-wordpress-suite' ),
+                '#gm2-preset-wizard-root'  => esc_html__( 'Launch the preset wizard to preview and import bundled models.', 'gm2-wordpress-suite' ),
             ]
         );
 
@@ -1505,12 +1504,6 @@ class Gm2_Custom_Posts_Admin {
                 file_exists($admin_js) ? filemtime($admin_js) : GM2_VERSION,
                 true
             );
-            wp_localize_script('gm2-custom-posts-admin', 'gm2CPTImport', [
-                'ajax'    => admin_url('admin-ajax.php'),
-                'nonce'   => wp_create_nonce('gm2_import_preset'),
-                'success' => esc_html__('Preset imported.', 'gm2-wordpress-suite'),
-                'error'   => esc_html__('Failed to import preset.', 'gm2-wordpress-suite'),
-            ]);
             return;
         }
 
@@ -2083,68 +2076,6 @@ class Gm2_Custom_Posts_Admin {
         update_option('gm2_custom_posts_config', $config);
         wp_send_json_success([
             'post_type' => $config['post_types'][$slug],
-        ]);
-    }
-
-    public function ajax_import_preset() {
-        if (!$this->can_manage()) {
-            wp_send_json_error([
-                'code'    => 'permission',
-                'message' => __( 'You do not have permission to import presets.', 'gm2-wordpress-suite' ),
-            ]);
-        }
-        $nonce = $_POST['nonce'] ?? '';
-        if (!wp_verify_nonce($nonce, 'gm2_import_preset')) {
-            wp_send_json_error([
-                'code'    => 'nonce',
-                'message' => __( 'Security check failed. Please refresh and try again.', 'gm2-wordpress-suite' ),
-            ]);
-        }
-        $raw  = isset($_POST['preset']) ? $_POST['preset'] : ($_POST['file'] ?? '');
-        $slug = sanitize_key(str_replace('.json', '', (string) $raw));
-        if (!$slug) {
-            wp_send_json_error([
-                'code'    => 'file',
-                'message' => __( 'No preset selected.', 'gm2-wordpress-suite' ),
-            ]);
-        }
-        $blueprint = null;
-        $manager   = apply_filters('gm2/presets/manager', null);
-        if ($manager instanceof \Gm2\Presets\PresetManager) {
-            $blueprint = $manager->get($slug);
-        }
-        if ($blueprint !== null) {
-            $json = wp_json_encode($blueprint);
-        } else {
-            $path = GM2_PLUGIN_DIR . 'presets/' . $slug . '/blueprint.json';
-            if (!file_exists($path)) {
-                wp_send_json_error([
-                    'code'    => 'missing',
-                    'message' => __( 'Preset not found.', 'gm2-wordpress-suite' ),
-                ]);
-            }
-            $json = file_get_contents($path);
-            if ($json === false) {
-                wp_send_json_error([
-                    'code'    => 'missing',
-                    'message' => __( 'Preset not found.', 'gm2-wordpress-suite' ),
-                ]);
-            }
-            $decoded = json_decode($json, true);
-            if (is_array($decoded)) {
-                $blueprint = $decoded;
-            }
-        }
-        $result = \gm2_model_import($json);
-        if (is_wp_error($result)) {
-            wp_send_json_error([
-                'code'    => 'import',
-                'message' => $result->get_error_message(),
-            ]);
-        }
-        wp_send_json_success([
-            'blueprint' => $blueprint,
-            'message'   => __( 'Preset imported.', 'gm2-wordpress-suite' ),
         ]);
     }
 

--- a/admin/Presets/Wizard.php
+++ b/admin/Presets/Wizard.php
@@ -1,0 +1,551 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gm2\Presets;
+
+use WP_Error;
+
+use function __;
+use function add_action;
+use function admin_url;
+use function apply_filters;
+use function array_filter;
+use function array_values;
+use function current_user_can;
+use function file_exists;
+use function file_get_contents;
+use function filemtime;
+use function get_option;
+use function in_array;
+use function is_array;
+use function is_string;
+use function is_wp_error;
+use function post_type_exists;
+use function sanitize_key;
+use function str_contains;
+use function str_replace;
+use function trailingslashit;
+use function ucwords;
+use function update_post_meta;
+use function wp_create_nonce;
+use function wp_enqueue_script;
+use function wp_insert_post;
+use function wp_json_encode;
+use function wp_localize_script;
+use function wp_send_json_error;
+use function wp_send_json_success;
+use function wp_set_object_terms;
+use function wp_slash;
+use function wp_unslash;
+use function wp_verify_nonce;
+use function taxonomy_exists;
+
+class Wizard
+{
+    public function run(): void
+    {
+        add_action('admin_enqueue_scripts', [$this, 'enqueueAssets']);
+        add_action('wp_ajax_gm2_presets_apply', [$this, 'ajaxApply']);
+        add_action('wp_ajax_gm2_presets_import_elementor', [$this, 'ajaxImportElementor']);
+    }
+
+    public function enqueueAssets(string $hook): void
+    {
+        $screens = [
+            'toplevel_page_gm2-custom-posts',
+            'gm2-custom-posts_page_gm2_cpt_overview',
+        ];
+        if (!in_array($hook, $screens, true)) {
+            return;
+        }
+
+        $manager = $this->getManager();
+        if ($manager === null) {
+            return;
+        }
+
+        $script = GM2_PLUGIN_DIR . 'admin/js/preset-wizard.js';
+        wp_enqueue_script(
+            'gm2-preset-wizard',
+            GM2_PLUGIN_URL . 'admin/js/preset-wizard.js',
+            ['wp-element', 'wp-components', 'wp-i18n', 'wp-api-fetch'],
+            file_exists($script) ? filemtime($script) : GM2_VERSION,
+            true
+        );
+
+        wp_localize_script('gm2-preset-wizard', 'gm2PresetWizard', [
+            'ajaxUrl'         => admin_url('admin-ajax.php'),
+            'applyNonce'      => wp_create_nonce('gm2_presets_apply'),
+            'importNonce'     => wp_create_nonce('gm2_presets_import_elementor'),
+            'locked'          => $this->isModelLocked(),
+            'hasExisting'     => $this->hasExistingDefinitions(),
+            'capable'         => $this->canManage(),
+            'elementorActive' => post_type_exists('elementor_library'),
+            'presets'         => $this->preparePresetSummaries($manager),
+            'i18n'            => [
+                'heading'               => __('Blueprint Preset Wizard', 'gm2-wordpress-suite'),
+                'selectPreset'          => __('Select a preset', 'gm2-wordpress-suite'),
+                'descriptionHeading'    => __('Overview', 'gm2-wordpress-suite'),
+                'postTypesHeading'      => __('Post types', 'gm2-wordpress-suite'),
+                'taxonomiesHeading'     => __('Taxonomies', 'gm2-wordpress-suite'),
+                'fieldGroupsHeading'    => __('Field groups', 'gm2-wordpress-suite'),
+                'blockTemplatesHeading' => __('Block templates', 'gm2-wordpress-suite'),
+                'elementorHeading'      => __('Elementor templates', 'gm2-wordpress-suite'),
+                'defaultTermsHeading'   => __('Default terms', 'gm2-wordpress-suite'),
+                'applyPreset'           => __('Apply preset', 'gm2-wordpress-suite'),
+                'applyPresetAnyway'     => __('Apply preset anyway', 'gm2-wordpress-suite'),
+                'cancel'                => __('Cancel', 'gm2-wordpress-suite'),
+                'lockedMessage'         => __('Content model editing is locked for this environment.', 'gm2-wordpress-suite'),
+                'missingCapability'     => __('You do not have permission to apply presets.', 'gm2-wordpress-suite'),
+                'applySuccess'          => __('Preset applied.', 'gm2-wordpress-suite'),
+                'applyError'            => __('Failed to apply the preset.', 'gm2-wordpress-suite'),
+                'confirmTitle'          => __('Overwrite existing definitions?', 'gm2-wordpress-suite'),
+                'confirmBody'           => __('Applying a preset will replace existing custom post types, taxonomies, field groups, and schema mappings.', 'gm2-wordpress-suite'),
+                'importSuccess'         => __('Elementor templates imported.', 'gm2-wordpress-suite'),
+                'importPartial'         => __('Some Elementor templates failed to import.', 'gm2-wordpress-suite'),
+                'importError'           => __('Failed to import Elementor templates.', 'gm2-wordpress-suite'),
+                'noTemplates'           => __('Preset does not bundle Elementor templates.', 'gm2-wordpress-suite'),
+                'elementorInactive'     => __('Elementor must be active to import templates.', 'gm2-wordpress-suite'),
+                'noPresets'             => __('No presets are currently available.', 'gm2-wordpress-suite'),
+                'templateUnavailable'   => __('Template bundle is not included with this preset.', 'gm2-wordpress-suite'),
+            ],
+        ]);
+    }
+
+    public function ajaxApply(): void
+    {
+        if (!$this->canManage()) {
+            wp_send_json_error([
+                'code'    => 'permission',
+                'message' => __('You do not have permission to apply presets.', 'gm2-wordpress-suite'),
+            ]);
+        }
+
+        $nonce = $_POST['nonce'] ?? '';
+        if (!wp_verify_nonce($nonce, 'gm2_presets_apply')) {
+            wp_send_json_error([
+                'code'    => 'nonce',
+                'message' => __('Security check failed. Please refresh and try again.', 'gm2-wordpress-suite'),
+            ]);
+        }
+
+        $slug = sanitize_key($_POST['preset'] ?? '');
+        if ($slug === '') {
+            wp_send_json_error([
+                'code'    => 'preset_missing',
+                'message' => __('No preset selected.', 'gm2-wordpress-suite'),
+            ]);
+        }
+
+        $manager = $this->getManager();
+        if ($manager === null) {
+            wp_send_json_error([
+                'code'    => 'manager_missing',
+                'message' => __('Preset manager is unavailable.', 'gm2-wordpress-suite'),
+            ]);
+        }
+
+        $force = !empty($_POST['force']);
+
+        $result = $manager->apply($slug, $force);
+        if (is_wp_error($result)) {
+            wp_send_json_error([
+                'code'    => $result->get_error_code(),
+                'message' => $result->get_error_message(),
+            ]);
+        }
+
+        wp_send_json_success([
+            'message' => __('Preset applied.', 'gm2-wordpress-suite'),
+        ]);
+    }
+
+    public function ajaxImportElementor(): void
+    {
+        if (!$this->canManage()) {
+            wp_send_json_error([
+                'code'    => 'permission',
+                'message' => __('You do not have permission to import templates.', 'gm2-wordpress-suite'),
+            ]);
+        }
+
+        $nonce = $_POST['nonce'] ?? '';
+        if (!wp_verify_nonce($nonce, 'gm2_presets_import_elementor')) {
+            wp_send_json_error([
+                'code'    => 'nonce',
+                'message' => __('Security check failed. Please refresh and try again.', 'gm2-wordpress-suite'),
+            ]);
+        }
+
+        $slug = sanitize_key($_POST['preset'] ?? '');
+        if ($slug === '') {
+            wp_send_json_error([
+                'code'    => 'preset_missing',
+                'message' => __('No preset selected.', 'gm2-wordpress-suite'),
+            ]);
+        }
+
+        $requested = $_POST['templates'] ?? [];
+        if (!is_array($requested)) {
+            $requested = [];
+        } else {
+            $requested = array_values(array_filter(array_map('sanitize_key', wp_unslash($requested))));
+        }
+
+        if (!$requested) {
+            wp_send_json_success([
+                'message' => __('No Elementor templates selected.', 'gm2-wordpress-suite'),
+                'results' => [],
+            ]);
+        }
+
+        $manager = $this->getManager();
+        if ($manager === null) {
+            wp_send_json_error([
+                'code'    => 'manager_missing',
+                'message' => __('Preset manager is unavailable.', 'gm2-wordpress-suite'),
+            ]);
+        }
+
+        $blueprint = $manager->get($slug);
+        if (!is_array($blueprint)) {
+            wp_send_json_error([
+                'code'    => 'preset_missing',
+                'message' => __('Preset not found.', 'gm2-wordpress-suite'),
+            ]);
+        }
+
+        $basePath = $manager->getPath($slug);
+        if ($basePath === null) {
+            wp_send_json_error([
+                'code'    => 'preset_path_missing',
+                'message' => __('Preset path could not be resolved.', 'gm2-wordpress-suite'),
+            ]);
+        }
+
+        $results = [];
+        $errors = false;
+
+        foreach ($requested as $templateKey) {
+            $import = $this->importTemplate($blueprint, $basePath, $templateKey);
+            if (is_wp_error($import)) {
+                $results[] = [
+                    'key'     => $templateKey,
+                    'status'  => 'error',
+                    'message' => $import->get_error_message(),
+                ];
+                $errors = true;
+            } else {
+                $results[] = [
+                    'key'    => $templateKey,
+                    'status' => 'success',
+                    'id'     => $import,
+                ];
+            }
+        }
+
+        $response = [
+            'message' => $errors
+                ? __('Some Elementor templates failed to import.', 'gm2-wordpress-suite')
+                : __('Elementor templates imported.', 'gm2-wordpress-suite'),
+            'results' => $results,
+        ];
+
+        if ($errors) {
+            wp_send_json_error($response);
+        }
+
+        wp_send_json_success($response);
+    }
+
+    private function preparePresetSummaries(PresetManager $manager): array
+    {
+        $summaries = [];
+        foreach ($manager->all() as $slug => $blueprint) {
+            if (!is_array($blueprint)) {
+                continue;
+            }
+            $label = isset($blueprint['label']) && is_string($blueprint['label']) ? $blueprint['label'] : $this->toLabel($slug);
+            $description = isset($blueprint['description']) && is_string($blueprint['description']) ? $blueprint['description'] : '';
+
+            $postTypes = [];
+            foreach ($blueprint['post_types'] ?? [] as $ptSlug => $config) {
+                if (!is_array($config)) {
+                    continue;
+                }
+                $ptLabel = '';
+                if (isset($config['labels']['name']) && is_string($config['labels']['name'])) {
+                    $ptLabel = $config['labels']['name'];
+                } elseif (isset($config['label']) && is_string($config['label'])) {
+                    $ptLabel = $config['label'];
+                }
+                if ($ptLabel === '') {
+                    $ptLabel = $this->toLabel($ptSlug);
+                }
+                $postTypes[] = [
+                    'slug'   => $ptSlug,
+                    'label'  => $ptLabel,
+                    'fields' => isset($config['fields']) && is_array($config['fields']) ? count($config['fields']) : 0,
+                ];
+            }
+
+            $taxonomies = [];
+            foreach ($blueprint['taxonomies'] ?? [] as $taxSlug => $config) {
+                if (!is_array($config)) {
+                    continue;
+                }
+                $taxLabel = '';
+                if (isset($config['labels']['name']) && is_string($config['labels']['name'])) {
+                    $taxLabel = $config['labels']['name'];
+                } elseif (isset($config['label']) && is_string($config['label'])) {
+                    $taxLabel = $config['label'];
+                }
+                if ($taxLabel === '') {
+                    $taxLabel = $this->toLabel($taxSlug);
+                }
+                $taxonomies[] = [
+                    'slug'  => $taxSlug,
+                    'label' => $taxLabel,
+                ];
+            }
+
+            $fieldGroups = [];
+            $groups = $blueprint['field_groups'] ?? [];
+            if (!$groups && isset($blueprint['fields']['groups']) && is_array($blueprint['fields']['groups'])) {
+                $groups = $blueprint['fields']['groups'];
+            }
+            if (is_array($groups)) {
+                foreach ($groups as $group) {
+                    if (!is_array($group)) {
+                        continue;
+                    }
+                    $title = isset($group['title']) && is_string($group['title']) ? $group['title'] : '';
+                    if ($title === '' && isset($group['key']) && is_string($group['key'])) {
+                        $title = $this->toLabel($group['key']);
+                    }
+                    $fieldGroups[] = [
+                        'title' => $title,
+                        'count' => isset($group['fields']) && is_array($group['fields']) ? count($group['fields']) : 0,
+                    ];
+                }
+            }
+
+            $defaultTerms = [];
+            foreach ($blueprint['default_terms'] ?? [] as $tax => $terms) {
+                $defaultTerms[] = [
+                    'taxonomy' => $tax,
+                    'count'    => is_array($terms) ? count($terms) : 0,
+                ];
+            }
+
+            $blockTemplates = [];
+            foreach ($blueprint['templates'] ?? [] as $templateKey => $templateData) {
+                if (!is_array($templateData)) {
+                    continue;
+                }
+                $blockTemplates[] = [
+                    'key'         => $templateKey,
+                    'description' => isset($templateData['description']) && is_string($templateData['description'])
+                        ? $templateData['description']
+                        : '',
+                ];
+            }
+
+            $elementorTemplates = $this->mapElementorTemplates($manager, $slug, $blueprint);
+
+            $summaries[] = [
+                'slug'               => $slug,
+                'label'              => $label,
+                'description'        => $description,
+                'postTypes'          => $postTypes,
+                'taxonomies'         => $taxonomies,
+                'fieldGroups'        => $fieldGroups,
+                'defaultTerms'       => $defaultTerms,
+                'blockTemplates'     => $blockTemplates,
+                'elementorTemplates' => $elementorTemplates,
+            ];
+        }
+
+        return $summaries;
+    }
+
+    private function mapElementorTemplates(PresetManager $manager, string $slug, array $blueprint): array
+    {
+        $templates = $blueprint['elementor']['templates'] ?? [];
+        if (!is_array($templates)) {
+            return [];
+        }
+        $result = [];
+        foreach ($templates as $key => $template) {
+            if (!is_array($template)) {
+                continue;
+            }
+            $description = isset($template['description']) && is_string($template['description'])
+                ? $template['description']
+                : '';
+            $type = isset($template['type']) && is_string($template['type']) ? $template['type'] : '';
+            $file = isset($template['file']) && is_string($template['file']) ? $template['file'] : '';
+            $result[] = [
+                'key'      => $key,
+                'label'    => isset($template['label']) && is_string($template['label'])
+                    ? $template['label']
+                    : $this->toLabel($key),
+                'description' => $description,
+                'type'     => $type,
+                'hasFile'  => $file !== '' && $this->templateFileExists($manager, $slug, $file),
+            ];
+        }
+        return $result;
+    }
+
+    private function templateFileExists(PresetManager $manager, string $slug, string $file): bool
+    {
+        if ($file === '' || str_contains($file, '..')) {
+            return false;
+        }
+        $base = $manager->getPath($slug);
+        if ($base === null) {
+            return false;
+        }
+        $path = trailingslashit($base) . ltrim($file, '/');
+        return file_exists($path);
+    }
+
+    private function importTemplate(array $blueprint, string $basePath, string $templateKey)
+    {
+        if (!post_type_exists('elementor_library')) {
+            return new WP_Error(
+                'gm2_elementor_inactive',
+                __('Elementor templates require the Elementor plugin to be active.', 'gm2-wordpress-suite')
+            );
+        }
+
+        $template = $blueprint['elementor']['templates'][$templateKey] ?? null;
+        if (!is_array($template)) {
+            return new WP_Error(
+                'gm2_template_missing',
+                __('The requested Elementor template is not defined in the preset.', 'gm2-wordpress-suite')
+            );
+        }
+
+        $file = $template['file'] ?? '';
+        if (!is_string($file) || $file === '' || str_contains($file, '..')) {
+            return new WP_Error(
+                'gm2_template_file_missing',
+                __('The Elementor template bundle could not be located.', 'gm2-wordpress-suite')
+            );
+        }
+
+        $path = trailingslashit($basePath) . ltrim($file, '/');
+        if (!file_exists($path)) {
+            return new WP_Error(
+                'gm2_template_file_missing',
+                __('The Elementor template bundle could not be located.', 'gm2-wordpress-suite')
+            );
+        }
+
+        $contents = file_get_contents($path);
+        if ($contents === false) {
+            return new WP_Error(
+                'gm2_template_unreadable',
+                __('Unable to read the Elementor template bundle.', 'gm2-wordpress-suite')
+            );
+        }
+
+        $data = json_decode($contents, true);
+        if (!is_array($data)) {
+            return new WP_Error(
+                'gm2_template_invalid',
+                __('The Elementor template bundle contains invalid JSON.', 'gm2-wordpress-suite')
+            );
+        }
+
+        $title = isset($data['title']) && is_string($data['title']) ? $data['title'] : $this->toLabel($templateKey);
+        $type = isset($data['type']) && is_string($data['type']) ? $data['type'] : ($template['type'] ?? 'section');
+        if (!is_string($type)) {
+            $type = 'section';
+        }
+
+        $postId = wp_insert_post([
+            'post_title'  => $title,
+            'post_type'   => 'elementor_library',
+            'post_status' => 'publish',
+        ], true);
+
+        if (is_wp_error($postId)) {
+            return $postId;
+        }
+        if (!$postId) {
+            return new WP_Error(
+                'gm2_template_insert_failed',
+                __('Failed to save the Elementor template.', 'gm2-wordpress-suite')
+            );
+        }
+
+        $content = $data['content'] ?? [];
+        if (!is_array($content)) {
+            $content = [];
+        }
+
+        update_post_meta($postId, '_elementor_edit_mode', 'builder');
+        update_post_meta($postId, '_elementor_template_type', $type);
+        if (isset($data['version']) && is_string($data['version'])) {
+            update_post_meta($postId, '_elementor_version', $data['version']);
+        }
+        update_post_meta($postId, '_elementor_data', wp_slash(wp_json_encode($content)));
+
+        if (taxonomy_exists('elementor_library_type') && $type !== '') {
+            wp_set_object_terms($postId, $type, 'elementor_library_type', false);
+        }
+
+        return (int) $postId;
+    }
+
+    private function canManage(): bool
+    {
+        if ($this->isModelLocked()) {
+            return false;
+        }
+
+        return current_user_can('manage_options') || current_user_can('gm2_manage_cpts');
+    }
+
+    private function isModelLocked(): bool
+    {
+        return (bool) get_option('gm2_model_locked');
+    }
+
+    private function hasExistingDefinitions(): bool
+    {
+        $config = get_option('gm2_custom_posts_config', []);
+        if (is_array($config)) {
+            if (!empty($config['post_types']) || !empty($config['taxonomies'])) {
+                return true;
+            }
+        }
+
+        $fieldGroups = get_option('gm2_field_groups', []);
+        if (is_array($fieldGroups) && !empty($fieldGroups)) {
+            return true;
+        }
+
+        $schemaMappings = get_option('gm2_cp_schema_map', []);
+        if (is_array($schemaMappings) && !empty($schemaMappings)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private function getManager(): ?PresetManager
+    {
+        $manager = apply_filters('gm2/presets/manager', null);
+        return $manager instanceof PresetManager ? $manager : null;
+    }
+
+    private function toLabel(string $slug): string
+    {
+        return ucwords(str_replace(['-', '_'], ' ', $slug));
+    }
+}

--- a/admin/js/gm2-custom-posts-admin.js
+++ b/admin/js/gm2-custom-posts-admin.js
@@ -84,26 +84,6 @@ jQuery(function($){
         });
     }
 
-    $('#gm2-import-preset').on('click', function(){
-        var preset = $('#gm2-preset-select').val();
-        if(!preset){ return; }
-        $.post(gm2CPTImport.ajax, {
-            action: 'gm2_import_preset',
-            preset: preset,
-            nonce: gm2CPTImport.nonce
-        }, function(resp){
-            $('.gm2-import-notice').remove();
-            if(resp && resp.success){
-                $('<div class="notice notice-success gm2-import-notice"><p>'+esc(gm2CPTImport.success)+'</p></div>').insertBefore('#gm2-post-type-form');
-                window.scrollTo(0,0);
-            }else{
-                var msg = resp && resp.data && resp.data.message ? resp.data.message : gm2CPTImport.error;
-                $('<div class="notice notice-error gm2-import-notice"><p>'+esc(msg)+'</p></div>').insertBefore('#gm2-post-type-form');
-                window.scrollTo(0,0);
-            }
-        });
-    });
-
     function toggleFieldOptions(type){
         $('#gm2-field-date-options').toggle(type === 'date');
         $('#gm2-field-wysiwyg-options').toggle(type === 'wysiwyg');

--- a/admin/js/preset-wizard.js
+++ b/admin/js/preset-wizard.js
@@ -1,0 +1,456 @@
+(function () {
+    const wizardData = window.gm2PresetWizard || {};
+    const presets = Array.isArray(wizardData.presets) ? wizardData.presets : [];
+
+    if (!window.wp || !window.wp.element || !document.getElementById('gm2-preset-wizard-root')) {
+        return;
+    }
+
+    const { createElement: el, useState, useMemo, useEffect } = window.wp.element;
+    const { render } = window.wp.element;
+    const { __ } = window.wp.i18n;
+    const {
+        Button,
+        Card,
+        CardBody,
+        CardHeader,
+        CheckboxControl,
+        Notice,
+        PanelBody,
+        SelectControl,
+        Spinner,
+        Modal,
+    } = window.wp.components;
+
+    const strings = wizardData.i18n || {};
+
+    const sendRequest = async (action, payload) => {
+        const body = new window.FormData();
+        body.append('action', action);
+        Object.keys(payload).forEach((key) => {
+            const value = payload[key];
+            if (Array.isArray(value)) {
+                const formKey = key.endsWith('[]') ? key : `${key}[]`;
+                value.forEach((item) => body.append(formKey, String(item)));
+            } else if (value !== undefined && value !== null) {
+                body.append(key, String(value));
+            }
+        });
+
+        const response = await window.fetch(wizardData.ajaxUrl, {
+            method: 'POST',
+            credentials: 'same-origin',
+            body,
+        });
+
+        if (!response.ok) {
+            throw new Error('request_failed');
+        }
+
+        return response.json();
+    };
+
+    const PresetDetails = ({ preset, elementorActive, selection, onToggle }) => {
+        if (!preset) {
+            return null;
+        }
+
+        const description = preset.description || '';
+        const postTypes = Array.isArray(preset.postTypes) ? preset.postTypes : [];
+        const taxonomies = Array.isArray(preset.taxonomies) ? preset.taxonomies : [];
+        const fieldGroups = Array.isArray(preset.fieldGroups) ? preset.fieldGroups : [];
+        const defaultTerms = Array.isArray(preset.defaultTerms) ? preset.defaultTerms : [];
+        const blockTemplates = Array.isArray(preset.blockTemplates) ? preset.blockTemplates : [];
+        const elementorTemplates = Array.isArray(preset.elementorTemplates) ? preset.elementorTemplates : [];
+
+        return el(
+            'div',
+            { className: 'gm2-preset-wizard-details' },
+            description
+                ? el('p', { className: 'gm2-preset-wizard-description' }, description)
+                : null,
+            el(
+                PanelBody,
+                { title: strings.postTypesHeading || __('Post types', 'gm2-wordpress-suite'), initialOpen: true },
+                postTypes.length
+                    ? el(
+                        'ul',
+                        null,
+                        postTypes.map((pt) =>
+                            el(
+                                'li',
+                                { key: pt.slug },
+                                el('strong', null, pt.label || pt.slug),
+                                pt.fields ? el('span', { className: 'gm2-preset-wizard-count' }, ` · ${pt.fields}`) : null
+                            )
+                        )
+                    )
+                    : el('p', null, __('No post types defined.', 'gm2-wordpress-suite'))
+            ),
+            el(
+                PanelBody,
+                { title: strings.taxonomiesHeading || __('Taxonomies', 'gm2-wordpress-suite'), initialOpen: false },
+                taxonomies.length
+                    ? el(
+                        'ul',
+                        null,
+                        taxonomies.map((tax) =>
+                            el('li', { key: tax.slug }, el('strong', null, tax.label || tax.slug))
+                        )
+                    )
+                    : el('p', null, __('No taxonomies defined.', 'gm2-wordpress-suite'))
+            ),
+            el(
+                PanelBody,
+                { title: strings.fieldGroupsHeading || __('Field groups', 'gm2-wordpress-suite'), initialOpen: false },
+                fieldGroups.length
+                    ? el(
+                        'ul',
+                        null,
+                        fieldGroups.map((group, index) =>
+                            el(
+                                'li',
+                                { key: `${group.title || index}` },
+                                el('strong', null, group.title || __('Field group', 'gm2-wordpress-suite')),
+                                group.count
+                                    ? el('span', { className: 'gm2-preset-wizard-count' }, ` · ${group.count}`)
+                                    : null
+                            )
+                        )
+                    )
+                    : el('p', null, __('No field groups defined.', 'gm2-wordpress-suite'))
+            ),
+            el(
+                PanelBody,
+                { title: strings.defaultTermsHeading || __('Default terms', 'gm2-wordpress-suite'), initialOpen: false },
+                defaultTerms.length
+                    ? el(
+                        'ul',
+                        null,
+                        defaultTerms.map((term) =>
+                            el(
+                                'li',
+                                { key: term.taxonomy },
+                                el('strong', null, term.taxonomy),
+                                term.count
+                                    ? el('span', { className: 'gm2-preset-wizard-count' }, ` · ${term.count}`)
+                                    : null
+                            )
+                        )
+                    )
+                    : el('p', null, __('No default terms provided.', 'gm2-wordpress-suite'))
+            ),
+            el(
+                PanelBody,
+                { title: strings.blockTemplatesHeading || __('Block templates', 'gm2-wordpress-suite'), initialOpen: false },
+                blockTemplates.length
+                    ? el(
+                        'ul',
+                        null,
+                        blockTemplates.map((tpl) =>
+                            el(
+                                'li',
+                                { key: tpl.key },
+                                el('strong', null, tpl.key),
+                                tpl.description ? ` – ${tpl.description}` : null
+                            )
+                        )
+                    )
+                    : el('p', null, __('No block templates bundled.', 'gm2-wordpress-suite'))
+            ),
+            el(
+                PanelBody,
+                { title: strings.elementorHeading || __('Elementor templates', 'gm2-wordpress-suite'), initialOpen: false },
+                elementorTemplates.length
+                    ? elementorTemplates.map((tpl) =>
+                        el(CheckboxControl, {
+                            key: tpl.key,
+                            label: tpl.label,
+                            help:
+                                tpl.hasFile
+                                    ? tpl.description || ''
+                                    : strings.templateUnavailable || __('Template bundle is not included with this preset.', 'gm2-wordpress-suite'),
+                            checked: !!selection[tpl.key],
+                            onChange: (checked) => onToggle(tpl.key, checked),
+                            disabled: !tpl.hasFile,
+                        })
+                    )
+                    : el('p', null, strings.noTemplates || __('Preset does not bundle Elementor templates.', 'gm2-wordpress-suite'))
+            ),
+            !elementorActive && elementorTemplates.length
+                ? el(
+                    Notice,
+                    { status: 'warning', isDismissible: false },
+                    strings.elementorInactive || __('Elementor must be active to import templates.', 'gm2-wordpress-suite')
+                )
+                : null
+        );
+    };
+
+    const App = () => {
+        const initialSlug = presets.length ? presets[0].slug : '';
+        const [selectedSlug, setSelectedSlug] = useState(initialSlug);
+        const [templateSelection, setTemplateSelection] = useState({});
+        const [notice, setNotice] = useState(null);
+        const [isApplying, setIsApplying] = useState(false);
+        const [confirmVisible, setConfirmVisible] = useState(false);
+        const [needsConfirmation, setNeedsConfirmation] = useState(Boolean(wizardData.hasExisting));
+
+        const selectedPreset = useMemo(
+            () => presets.find((preset) => preset.slug === selectedSlug) || null,
+            [presets, selectedSlug]
+        );
+
+        useEffect(() => {
+            setTemplateSelection({});
+        }, [selectedSlug]);
+
+        useEffect(() => {
+            if (!selectedSlug && presets.length) {
+                setSelectedSlug(presets[0].slug);
+            }
+        }, [presets, selectedSlug]);
+
+        const selectedTemplates = useMemo(
+            () => Object.keys(templateSelection).filter((key) => templateSelection[key]),
+            [templateSelection]
+        );
+
+        const applyDisabled = !wizardData.capable || wizardData.locked || !selectedPreset || isApplying;
+
+        const handleToggleTemplate = (key, checked) => {
+            setTemplateSelection((prev) => ({
+                ...prev,
+                [key]: checked,
+            }));
+        };
+
+        const handleApply = async (force = false) => {
+            if (!selectedPreset) {
+                return;
+            }
+            if (!force && needsConfirmation) {
+                setConfirmVisible(true);
+                return;
+            }
+
+            setConfirmVisible(false);
+            setIsApplying(true);
+            setNotice(null);
+
+            try {
+                const applyResponse = await sendRequest('gm2_presets_apply', {
+                    nonce: wizardData.applyNonce,
+                    preset: selectedPreset.slug,
+                    force: force ? '1' : '0',
+                });
+
+                if (!applyResponse || !applyResponse.success) {
+                    const data = applyResponse && applyResponse.data ? applyResponse.data : {};
+                    if (!force && data.code === 'gm2_preset_conflict') {
+                        setNeedsConfirmation(true);
+                        setConfirmVisible(true);
+                        return;
+                    }
+                    setNotice({
+                        status: 'error',
+                        text: data.message || strings.applyError || __('Failed to apply the preset.', 'gm2-wordpress-suite'),
+                    });
+                    return;
+                }
+
+                const messages = [];
+                if (applyResponse.data && applyResponse.data.message) {
+                    messages.push(applyResponse.data.message);
+                } else {
+                    messages.push(strings.applySuccess || __('Preset applied.', 'gm2-wordpress-suite'));
+                }
+
+                let status = 'success';
+
+                if (selectedTemplates.length) {
+                    try {
+                        const importResponse = await sendRequest('gm2_presets_import_elementor', {
+                            nonce: wizardData.importNonce,
+                            preset: selectedPreset.slug,
+                            templates: selectedTemplates,
+                        });
+                        if (importResponse && importResponse.success) {
+                            if (importResponse.data && importResponse.data.message) {
+                                messages.push(importResponse.data.message);
+                            } else {
+                                messages.push(strings.importSuccess || __('Elementor templates imported.', 'gm2-wordpress-suite'));
+                            }
+                        } else if (importResponse && importResponse.data) {
+                            status = 'warning';
+                            messages.push(
+                                importResponse.data.message ||
+                                    strings.importPartial ||
+                                    __('Some Elementor templates failed to import.', 'gm2-wordpress-suite')
+                            );
+                        }
+                    } catch (error) {
+                        status = 'warning';
+                        messages.push(strings.importError || __('Failed to import Elementor templates.', 'gm2-wordpress-suite'));
+                    }
+                } else if (!selectedPreset.elementorTemplates || !selectedPreset.elementorTemplates.length) {
+                    messages.push(strings.noTemplates || __('Preset does not bundle Elementor templates.', 'gm2-wordpress-suite'));
+                }
+
+                setNotice({ status, text: messages.join(' ') });
+                setNeedsConfirmation(true);
+            } catch (error) {
+                setNotice({
+                    status: 'error',
+                    text: strings.applyError || __('Failed to apply the preset.', 'gm2-wordpress-suite'),
+                });
+            } finally {
+                setIsApplying(false);
+            }
+        };
+
+        const noticeElement = notice
+            ? el(
+                  Notice,
+                  {
+                      status: notice.status || 'info',
+                      isDismissible: true,
+                      onRemove: () => setNotice(null),
+                  },
+                  notice.text
+              )
+            : null;
+
+        const options = [
+            {
+                label: strings.selectPreset || __('Select a preset', 'gm2-wordpress-suite'),
+                value: '',
+            },
+            ...presets.map((preset) => ({
+                label: preset.label || preset.slug,
+                value: preset.slug,
+            })),
+        ];
+
+        const bodyChildren = [];
+
+        if (wizardData.locked) {
+            bodyChildren.push(
+                el(
+                    Notice,
+                    { key: 'locked', status: 'warning', isDismissible: false },
+                    strings.lockedMessage || __('Content model editing is locked for this environment.', 'gm2-wordpress-suite')
+                )
+            );
+        }
+
+        if (!wizardData.capable) {
+            bodyChildren.push(
+                el(
+                    Notice,
+                    { key: 'cap', status: 'warning', isDismissible: false },
+                    strings.missingCapability || __('You do not have permission to apply presets.', 'gm2-wordpress-suite')
+                )
+            );
+        }
+
+        if (noticeElement) {
+            bodyChildren.push(el('div', { key: 'notice' }, noticeElement));
+        }
+
+        if (!presets.length) {
+            bodyChildren.push(
+                el(
+                    'p',
+                    { key: 'empty' },
+                    strings.noPresets || __('No presets are currently available.', 'gm2-wordpress-suite')
+                )
+            );
+        } else {
+            bodyChildren.push(
+                el(SelectControl, {
+                    key: 'select',
+                    label: strings.selectPreset || __('Select a preset', 'gm2-wordpress-suite'),
+                    value: selectedSlug,
+                    options,
+                    onChange: (value) => setSelectedSlug(value),
+                })
+            );
+
+            bodyChildren.push(
+                el(PresetDetails, {
+                    key: 'details',
+                    preset: selectedPreset,
+                    elementorActive: !!wizardData.elementorActive,
+                    selection: templateSelection,
+                    onToggle: handleToggleTemplate,
+                })
+            );
+
+            bodyChildren.push(
+                el(
+                    'div',
+                    { key: 'actions', className: 'gm2-preset-wizard-actions' },
+                    el(
+                        Button,
+                        {
+                            variant: 'primary',
+                            onClick: () => handleApply(false),
+                            disabled: applyDisabled,
+                        },
+                        isApplying
+                            ? el(Spinner, { key: 'spinner', className: 'gm2-preset-wizard-spinner' })
+                            : strings.applyPreset || __('Apply preset', 'gm2-wordpress-suite')
+                    )
+                )
+            );
+        }
+
+        return el(
+            'div',
+            { className: 'gm2-preset-wizard' },
+            el(
+                Card,
+                null,
+                el(CardHeader, null, strings.heading || __('Blueprint Preset Wizard', 'gm2-wordpress-suite')),
+                el(CardBody, null, bodyChildren)
+            ),
+            confirmVisible
+                ? el(
+                      Modal,
+                      {
+                          title: strings.confirmTitle || __('Overwrite existing definitions?', 'gm2-wordpress-suite'),
+                          onRequestClose: () => setConfirmVisible(false),
+                      },
+                      el('p', null, strings.confirmBody || __('Applying a preset will replace existing custom post types, taxonomies, field groups, and schema mappings.', 'gm2-wordpress-suite')),
+                      el(
+                          'div',
+                          { className: 'gm2-preset-wizard-confirm' },
+                          el(
+                              Button,
+                              {
+                                  variant: 'primary',
+                                  onClick: () => handleApply(true),
+                                  disabled: isApplying,
+                              },
+                              strings.applyPresetAnyway || __('Apply preset anyway', 'gm2-wordpress-suite')
+                          ),
+                          el(
+                              Button,
+                              {
+                                  variant: 'secondary',
+                                  onClick: () => setConfirmVisible(false),
+                              },
+                              strings.cancel || __('Cancel', 'gm2-wordpress-suite')
+                          )
+                      )
+                  )
+                : null
+        );
+    };
+
+    const root = document.getElementById('gm2-preset-wizard-root');
+    if (root) {
+        render(el(App), root);
+    }
+})();

--- a/admin/pages/post-types.php
+++ b/admin/pages/post-types.php
@@ -189,24 +189,9 @@
 
         echo '<hr />';
 
-        $preset_files = apply_filters('gm2/presets/list', []);
-        echo '<h2>' . esc_html__( 'Add / Edit Post Type', 'gm2-wordpress-suite' );
-        if ($preset_files) {
-            echo ' <select id="gm2-preset-select"><option value="">' . esc_html__( 'Select Preset', 'gm2-wordpress-suite' ) . '</option>';
-            foreach ($preset_files as $slug => $meta) {
-                if (is_array($meta)) {
-                    $label = $meta['label'] ?? ucwords(str_replace(['-', '_'], ' ', (string) $slug));
-                } else {
-                    $label = (string) $meta;
-                }
-                if ($label === '') {
-                    $label = ucwords(str_replace(['-', '_'], ' ', (string) $slug));
-                }
-                echo '<option value="' . esc_attr($slug) . '">' . esc_html($label) . '</option>';
-            }
-            echo '</select> <button type="button" class="button" id="gm2-import-preset">' . esc_html__( 'Import Preset', 'gm2-wordpress-suite' ) . '</button>';
-        }
-        echo '</h2>';
+        echo '<h2>' . esc_html__( 'Add / Edit Post Type', 'gm2-wordpress-suite' ) . '</h2>';
+        echo '<div id="gm2-preset-wizard-root"></div>';
+        echo '<noscript><p>' . esc_html__( 'The preset wizard requires JavaScript. Enable it to import bundled models.', 'gm2-wordpress-suite' ) . '</p></noscript>';
         echo '<form method="post" action="' . esc_url(admin_url('admin-post.php')) . '" id="gm2-post-type-form">';
         wp_nonce_field('gm2_edit_post_type');
         echo '<input type="hidden" name="action" value="gm2_edit_post_type" />';

--- a/docs/presets/README.md
+++ b/docs/presets/README.md
@@ -7,3 +7,14 @@ Detailed breakdowns of the bundled blueprint presets, including custom post type
 - [Real Estate](real-estate.md)
 - [Jobs](jobs.md)
 - [Courses](courses.md)
+
+## Applying presets in the admin
+
+The **Blueprint Preset Wizard** is available from **Gm2 Custom Posts → Overview**. It replaces the legacy preset dropdown and provides a richer preview and confirmation flow:
+
+1. Open the wizard and select a preset to review its post types, taxonomies, field groups, default terms, block templates and bundled Elementor layouts.
+2. Check the Elementor templates you want to import. Templates are disabled when the preset does not ship a bundle; a warning appears when Elementor is not active.
+3. Click **Apply preset**. If existing definitions are detected you will be prompted to confirm the overwrite before the blueprint is applied via the `PresetManager`.
+4. When Elementor templates are selected the wizard imports the JSON bundles into the `elementor_library` post type after the blueprint is installed.
+
+The wizard is powered by `admin/Presets/Wizard.php` and the React implementation in `admin/js/preset-wizard.js`. It uses AJAX nonces and capability checks to ensure only authorised users can run blueprints or import Elementor assets.

--- a/includes/Gm2_Loader.php
+++ b/includes/Gm2_Loader.php
@@ -2,6 +2,8 @@
 
 namespace Gm2;
 
+use Gm2\Presets\Wizard as PresetWizard;
+
 if (!defined('ABSPATH')) {
     exit;
 }
@@ -89,6 +91,8 @@ class Gm2_Loader {
                 $cp_admin->run();
                 $model_export = new Gm2_Model_Export_Admin();
                 $model_export->run();
+                $preset_wizard = new PresetWizard();
+                $preset_wizard->run();
             }
             $cp_public = new Gm2_Custom_Posts_Public();
             $cp_public->run();

--- a/presets/courses/blueprint.json
+++ b/presets/courses/blueprint.json
@@ -187,7 +187,8 @@
     "templates": {
       "single_course": {
         "type": "shortcode",
-        "description": "Insert a saved Elementor template ID to enhance the course hero."
+        "description": "Insert a saved Elementor template ID to enhance the course hero.",
+        "file": "elementor/course-hero.json"
       }
     }
   },

--- a/presets/courses/elementor/course-hero.json
+++ b/presets/courses/elementor/course-hero.json
@@ -1,0 +1,48 @@
+{
+  "version": "0.4",
+  "title": "Course Hero Section",
+  "type": "section",
+  "content": [
+    {
+      "id": "course-section",
+      "elType": "section",
+      "isInner": false,
+      "settings": {
+        "layout": "full_width"
+      },
+      "elements": [
+        {
+          "id": "course-column",
+          "elType": "column",
+          "isInner": false,
+          "settings": {
+            "_column_size": 100
+          },
+          "elements": [
+            {
+              "id": "course-heading",
+              "elType": "widget",
+              "widgetType": "heading",
+              "settings": {
+                "title": "Course Overview",
+                "tag": "h2"
+              },
+              "elements": [],
+              "isInner": false
+            },
+            {
+              "id": "course-text",
+              "elType": "widget",
+              "widgetType": "text-editor",
+              "settings": {
+                "editor": "<p>Highlight what learners gain from this course.</p>"
+              },
+              "elements": [],
+              "isInner": false
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/presets/directory/blueprint.json
+++ b/presets/directory/blueprint.json
@@ -213,7 +213,8 @@
     "templates": {
       "single_listing": {
         "type": "shortcode",
-        "description": "Replace the shortcode placeholder with the ID of a saved Elementor template to render a custom hero."
+        "description": "Replace the shortcode placeholder with the ID of a saved Elementor template to render a custom hero.",
+        "file": "elementor/directory-hero.json"
       }
     }
   },

--- a/presets/directory/elementor/directory-hero.json
+++ b/presets/directory/elementor/directory-hero.json
@@ -1,0 +1,48 @@
+{
+  "version": "0.4",
+  "title": "Directory Spotlight",
+  "type": "section",
+  "content": [
+    {
+      "id": "directory-section",
+      "elType": "section",
+      "isInner": false,
+      "settings": {
+        "layout": "full_width"
+      },
+      "elements": [
+        {
+          "id": "directory-column",
+          "elType": "column",
+          "isInner": false,
+          "settings": {
+            "_column_size": 100
+          },
+          "elements": [
+            {
+              "id": "directory-heading",
+              "elType": "widget",
+              "widgetType": "heading",
+              "settings": {
+                "title": "Featured Directory Listing",
+                "tag": "h2"
+              },
+              "elements": [],
+              "isInner": false
+            },
+            {
+              "id": "directory-text",
+              "elType": "widget",
+              "widgetType": "text-editor",
+              "settings": {
+                "editor": "<p>Introduce the business and encourage visitors to explore the listing.</p>"
+              },
+              "elements": [],
+              "isInner": false
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/presets/events/blueprint.json
+++ b/presets/events/blueprint.json
@@ -195,7 +195,8 @@
     "templates": {
       "single_event": {
         "type": "shortcode",
-        "description": "Populate the shortcode with a saved Elementor template for the event hero."
+        "description": "Populate the shortcode with a saved Elementor template for the event hero.",
+        "file": "elementor/event-hero.json"
       }
     }
   },

--- a/presets/events/elementor/event-hero.json
+++ b/presets/events/elementor/event-hero.json
@@ -1,0 +1,48 @@
+{
+  "version": "0.4",
+  "title": "Event Spotlight",
+  "type": "section",
+  "content": [
+    {
+      "id": "event-section",
+      "elType": "section",
+      "isInner": false,
+      "settings": {
+        "layout": "full_width"
+      },
+      "elements": [
+        {
+          "id": "event-column",
+          "elType": "column",
+          "isInner": false,
+          "settings": {
+            "_column_size": 100
+          },
+          "elements": [
+            {
+              "id": "event-heading",
+              "elType": "widget",
+              "widgetType": "heading",
+              "settings": {
+                "title": "Upcoming Event",
+                "tag": "h2"
+              },
+              "elements": [],
+              "isInner": false
+            },
+            {
+              "id": "event-text",
+              "elType": "widget",
+              "widgetType": "text-editor",
+              "settings": {
+                "editor": "<p>Share the headline details to entice visitors to register.</p>"
+              },
+              "elements": [],
+              "isInner": false
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/presets/jobs/blueprint.json
+++ b/presets/jobs/blueprint.json
@@ -201,7 +201,8 @@
     "templates": {
       "single_job": {
         "type": "shortcode",
-        "description": "Use a saved Elementor template ID in the shortcode for a tailored hero."
+        "description": "Use a saved Elementor template ID in the shortcode for a tailored hero.",
+        "file": "elementor/job-hero.json"
       }
     }
   },

--- a/presets/jobs/elementor/job-hero.json
+++ b/presets/jobs/elementor/job-hero.json
@@ -1,0 +1,48 @@
+{
+  "version": "0.4",
+  "title": "Job Overview",
+  "type": "section",
+  "content": [
+    {
+      "id": "job-section",
+      "elType": "section",
+      "isInner": false,
+      "settings": {
+        "layout": "full_width"
+      },
+      "elements": [
+        {
+          "id": "job-column",
+          "elType": "column",
+          "isInner": false,
+          "settings": {
+            "_column_size": 100
+          },
+          "elements": [
+            {
+              "id": "job-heading",
+              "elType": "widget",
+              "widgetType": "heading",
+              "settings": {
+                "title": "Role at a Glance",
+                "tag": "h2"
+              },
+              "elements": [],
+              "isInner": false
+            },
+            {
+              "id": "job-text",
+              "elType": "widget",
+              "widgetType": "text-editor",
+              "settings": {
+                "editor": "<p>Summarize the role and invite candidates to apply.</p>"
+              },
+              "elements": [],
+              "isInner": false
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/presets/real-estate/blueprint.json
+++ b/presets/real-estate/blueprint.json
@@ -223,7 +223,8 @@
     "templates": {
       "single_property": {
         "type": "shortcode",
-        "description": "Replace the shortcode with a gallery-centric Elementor template ID."
+        "description": "Replace the shortcode with a gallery-centric Elementor template ID.",
+        "file": "elementor/property-hero.json"
       }
     }
   },

--- a/presets/real-estate/elementor/property-hero.json
+++ b/presets/real-estate/elementor/property-hero.json
@@ -1,0 +1,48 @@
+{
+  "version": "0.4",
+  "title": "Property Highlight",
+  "type": "section",
+  "content": [
+    {
+      "id": "property-section",
+      "elType": "section",
+      "isInner": false,
+      "settings": {
+        "layout": "full_width"
+      },
+      "elements": [
+        {
+          "id": "property-column",
+          "elType": "column",
+          "isInner": false,
+          "settings": {
+            "_column_size": 100
+          },
+          "elements": [
+            {
+              "id": "property-heading",
+              "elType": "widget",
+              "widgetType": "heading",
+              "settings": {
+                "title": "Featured Property",
+                "tag": "h2"
+              },
+              "elements": [],
+              "isInner": false
+            },
+            {
+              "id": "property-text",
+              "elType": "widget",
+              "widgetType": "text-editor",
+              "settings": {
+                "editor": "<p>Share the selling points for this listing.</p>"
+              },
+              "elements": [],
+              "isInner": false
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/e2e/preset-wizard.spec.ts
+++ b/tests/e2e/preset-wizard.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost';
+const AUTH = process.env.WP_AUTH || 'admin:password';
+const [username, password] = AUTH.split(':');
+
+test('preset wizard applies a blueprint', async ({ page }) => {
+  await page.goto(`${BASE_URL}/wp-login.php`);
+  await page.fill('#user_login', username);
+  await page.fill('#user_pass', password);
+  await page.click('#wp-submit');
+  await page.waitForURL(`${BASE_URL}/wp-admin/**`);
+
+  await page.goto(`${BASE_URL}/wp-admin/admin.php?page=gm2-custom-posts`);
+  await page.waitForSelector('#gm2-preset-wizard-root select');
+
+  const presetSelect = page.locator('#gm2-preset-wizard-root select');
+  await presetSelect.selectOption({ value: 'courses' });
+
+  const applyButton = page.getByRole('button', { name: /Apply preset/i });
+  await applyButton.click();
+
+  const confirmButton = page.getByRole('button', { name: /Apply preset anyway/i });
+  try {
+    await confirmButton.waitFor({ state: 'visible', timeout: 2000 });
+    await confirmButton.click();
+  } catch (error) {
+    // Confirmation modal did not appear.
+  }
+
+  const notice = page.locator('#gm2-preset-wizard-root .components-notice__content');
+  await expect(notice).toContainText('Preset applied');
+
+  await page.goto(`${BASE_URL}/wp-admin/admin.php?page=gm2-custom-posts`);
+  const slugCells = page.locator('table.wp-list-table tbody td.column-slug');
+  await expect(slugCells).toContainText('course');
+});


### PR DESCRIPTION
## Summary
- add an admin Preset\Wizard controller that surfaces preset metadata, applies blueprints and imports Elementor bundles
- replace the legacy select/button with a React-powered wizard that previews presets and handles overwrite confirmation
- package Elementor template JSON for each preset, document the workflow, and add end-to-end coverage for applying a preset

## Testing
- `npx playwright test tests/e2e/preset-wizard.spec.ts` *(fails: missing system dependencies required by Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_b_68cadb0326048330be71be8b75cbeb93