### PR TITLE
Add blueprint IO utilities and CLI field-group support

### DIFF
--- a/admin/Gm2_Custom_Posts_Admin.php
+++ b/admin/Gm2_Custom_Posts_Admin.php
@@ -2202,42 +2202,16 @@ class Gm2_Custom_Posts_Admin {
                 'message' => __('Select at least one field group to export.', 'gm2-wordpress-suite'),
             ]);
         }
-        $export = \gm2_model_export('array');
+        $export = \gm2_field_groups_export('json', $slugs);
         if (is_wp_error($export)) {
             wp_send_json_error([
                 'code'    => 'export_failed',
                 'message' => $export->get_error_message(),
             ]);
         }
-        $groups = $export['field_groups'] ?? [];
-        $selected = [];
-        foreach ($slugs as $slug) {
-            if (isset($groups[$slug])) {
-                $selected[$slug] = $groups[$slug];
-            }
-        }
-        if (!$selected) {
-            wp_send_json_error([
-                'code'    => 'not_found',
-                'message' => __('The selected field groups could not be found.', 'gm2-wordpress-suite'),
-            ]);
-        }
-        $data = [
-            'post_types'      => [],
-            'taxonomies'      => [],
-            'field_groups'    => $selected,
-            'schema_mappings' => [],
-        ];
-        $json = wp_json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
-        if (false === $json) {
-            wp_send_json_error([
-                'code'    => 'json_encode_failed',
-                'message' => __('Could not encode field groups to JSON.', 'gm2-wordpress-suite'),
-            ]);
-        }
         $filename = 'gm2-field-groups-' . gmdate('Y-m-d') . '.json';
         wp_send_json_success([
-            'content'  => $json,
+            'content'  => $export,
             'filename' => $filename,
         ]);
     }

--- a/includes/cli/class-gm2-blueprint-cli.php
+++ b/includes/cli/class-gm2-blueprint-cli.php
@@ -1,6 +1,8 @@
 <?php
 namespace Gm2;
 
+use Gm2\Presets\BlueprintIO;
+
 if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
     return;
 }
@@ -16,18 +18,36 @@ class Gm2_Blueprint_CLI extends \WP_CLI_Command {
      *
      * <file>
      * : Destination file path.
+     *
+     * [--format=<format>]
+     * : Output format: json or yaml. Defaults to json.
+     *
+     * [--field-groups]
+     * : Export only field group definitions.
      */
-    public function export( $args ) {
+    public function export( $args, $assoc_args ) {
         $file = $args[0] ?? '';
         if ( ! $file ) {
             \WP_CLI::error( __( 'Missing file argument.', 'gm2-wordpress-suite' ) );
         }
-        $data = \gm2_model_export( 'json' );
+        $format = strtolower( $assoc_args['format'] ?? 'json' );
+        $fields_only = ! empty( $assoc_args['field-groups'] );
+
+        if ( $fields_only ) {
+            $data = \gm2_field_groups_export( $format );
+        } else {
+            $data = \gm2_model_export( $format );
+        }
+
         if ( is_wp_error( $data ) ) {
             \WP_CLI::error( $data->get_error_message() );
         }
+
         file_put_contents( $file, $data );
-        \WP_CLI::success( sprintf( __( 'Blueprint exported to %s', 'gm2-wordpress-suite' ), $file ) );
+        $message = $fields_only
+            ? sprintf( __( 'Field groups exported to %s', 'gm2-wordpress-suite' ), $file )
+            : sprintf( __( 'Blueprint exported to %s', 'gm2-wordpress-suite' ), $file );
+        \WP_CLI::success( $message );
     }
 
     /**
@@ -37,29 +57,71 @@ class Gm2_Blueprint_CLI extends \WP_CLI_Command {
      *
      * <files>...
      * : One or more blueprint file paths.
+     *
+     * [--format=<format>]
+     * : File format: json or yaml. Defaults to json.
+     *
+     * [--field-groups]
+     * : Import field group definitions instead of full blueprints.
+     *
+     * [--replace]
+     * : Replace existing field groups instead of merging (only used with --field-groups).
      */
-    public function import( $args ) {
+    public function import( $args, $assoc_args ) {
         if ( empty( $args ) ) {
             \WP_CLI::error( __( 'Missing file argument.', 'gm2-wordpress-suite' ) );
         }
+        $format = strtolower( $assoc_args['format'] ?? 'json' );
+        $fields_only = ! empty( $assoc_args['field-groups'] );
+        $replace = ! empty( $assoc_args['replace'] );
+
+        if ( $fields_only ) {
+            $first = true;
+            foreach ( $args as $file ) {
+                if ( ! file_exists( $file ) ) {
+                    \WP_CLI::error( sprintf( __( 'File not found: %s', 'gm2-wordpress-suite' ), $file ) );
+                }
+                $contents = file_get_contents( $file );
+                $merge    = $replace ? ! $first : true;
+                $result   = \gm2_field_groups_import( $contents, $format, $merge );
+                if ( is_wp_error( $result ) ) {
+                    \WP_CLI::error( $result->get_error_message() );
+                }
+                $first = false;
+            }
+            \WP_CLI::success( __( 'Field groups imported.', 'gm2-wordpress-suite' ) );
+            return;
+        }
+
         $merged = [
-            'post_types'   => [],
-            'taxonomies'   => [],
-            'field_groups' => [],
+            'post_types'      => [],
+            'taxonomies'      => [],
+            'field_groups'    => [],
+            'schema_mappings' => [],
         ];
+
         foreach ( $args as $file ) {
             if ( ! file_exists( $file ) ) {
                 \WP_CLI::error( sprintf( __( 'File not found: %s', 'gm2-wordpress-suite' ), $file ) );
             }
             $contents = file_get_contents( $file );
-            $data     = json_decode( $contents, true );
-            if ( ! is_array( $data ) ) {
-                \WP_CLI::error( sprintf( __( 'Invalid JSON in %s', 'gm2-wordpress-suite' ), $file ) );
+            $data     = BlueprintIO::decode( $contents, $format );
+            if ( is_wp_error( $data ) ) {
+                \WP_CLI::error( $data->get_error_message() );
             }
+
             $merged['post_types']   = array_merge( $merged['post_types'], $data['post_types'] ?? [] );
             $merged['taxonomies']   = array_merge( $merged['taxonomies'], $data['taxonomies'] ?? [] );
-            $merged['field_groups'] = array_merge( $merged['field_groups'], $data['field_groups'] ?? [] );
+            $groups                 = $data['field_groups'] ?? ( $data['fields']['groups'] ?? [] );
+            if ( is_array( $groups ) ) {
+                $merged['field_groups'] = array_merge( $merged['field_groups'], $groups );
+            }
+            $maps = $data['schema_mappings'] ?? ( $data['seo']['mappings'] ?? [] );
+            if ( is_array( $maps ) ) {
+                $merged['schema_mappings'] = array_merge( $merged['schema_mappings'], $maps );
+            }
         }
+
         $result = \gm2_model_import( $merged, 'array' );
         if ( is_wp_error( $result ) ) {
             \WP_CLI::error( $result->get_error_message() );

--- a/presets/schema.json
+++ b/presets/schema.json
@@ -18,7 +18,6 @@
     "description": { "type": "string" },
     "post_types": {
       "type": "object",
-      "minProperties": 1,
       "additionalProperties": { "$ref": "#/definitions/postType" }
     },
     "taxonomies": {

--- a/src/Presets/BlueprintIO.php
+++ b/src/Presets/BlueprintIO.php
@@ -1,0 +1,652 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gm2\Presets;
+
+use WP_Error;
+
+use function array_values;
+use function function_exists;
+use function get_option;
+use function is_array;
+use function is_string;
+use function json_decode;
+use function sanitize_key;
+use function update_option;
+use function wp_json_encode;
+use function is_wp_error;
+
+/**
+ * Handles serialization and deserialization of blueprint data.
+ */
+class BlueprintIO
+{
+    private const OPTION_CONFIG = 'gm2_custom_posts_config';
+    private const OPTION_FIELD_GROUPS = 'gm2_field_groups';
+    private const OPTION_SCHEMA_MAP = 'gm2_cp_schema_map';
+    private const OPTION_META = 'gm2_model_blueprint_meta';
+
+    /**
+     * Paths that should always be encoded as objects.
+     *
+     * @var array<int, array<int, string>>
+     */
+    private const FORCE_OBJECT_PATHS = [
+        ['post_types'],
+        ['taxonomies'],
+        ['default_terms'],
+        ['schema_mappings'],
+        ['templates'],
+        ['fields'],
+        ['fields', 'groups', '*'],
+        ['elementor'],
+        ['elementor', 'queries'],
+        ['elementor', 'templates'],
+        ['seo'],
+        ['seo', 'mappings'],
+    ];
+
+    /**
+     * Export the complete blueprint definition.
+     */
+    public static function exportBlueprint(): array
+    {
+        $config = self::getOptionArray(self::OPTION_CONFIG);
+        $postTypes = self::deepConvert($config['post_types'] ?? []);
+        $taxonomies = self::deepConvert($config['taxonomies'] ?? []);
+
+        $fieldGroups = self::buildFieldGroupList();
+
+        $defaultTerms = [];
+        foreach ($taxonomies as $slug => $definition) {
+            if (is_array($definition) && !empty($definition['default_terms']) && is_array($definition['default_terms'])) {
+                $defaultTerms[$slug] = self::deepConvert($definition['default_terms']);
+            }
+        }
+
+        $meta = self::getMeta();
+        $relationships = array_values(array_map([self::class, 'deepConvert'], $meta['relationships'] ?? []));
+        $templates = self::deepConvert($meta['templates'] ?? []);
+        $elementor = self::normalizeElementor($meta['elementor'] ?? []);
+
+        $schemaMappings = self::getOptionArray(self::OPTION_SCHEMA_MAP);
+
+        $seo = [
+            'mappings' => $schemaMappings,
+        ];
+
+        return [
+            'post_types'      => $postTypes,
+            'taxonomies'      => $taxonomies,
+            'field_groups'    => $fieldGroups,
+            'fields'          => [
+                'groups' => $fieldGroups,
+            ],
+            'relationships'   => $relationships,
+            'default_terms'   => $defaultTerms,
+            'elementor'       => $elementor,
+            'seo'             => $seo,
+            'templates'       => $templates,
+            'schema_mappings' => $schemaMappings,
+        ];
+    }
+
+    /**
+     * Export only field groups, leaving other blueprint sections empty.
+     *
+     * @param array<int, string>|null $slugs Optional list of group slugs to export.
+     */
+    public static function exportFieldGroups(?array $slugs = null): array
+    {
+        $groups = self::buildFieldGroupList($slugs);
+
+        return [
+            'post_types'      => [],
+            'taxonomies'      => [],
+            'field_groups'    => $groups,
+            'fields'          => [
+                'groups' => $groups,
+            ],
+            'relationships'   => [],
+            'default_terms'   => [],
+            'elementor'       => [
+                'queries'   => [],
+                'templates' => [],
+            ],
+            'seo'             => [
+                'mappings' => [],
+            ],
+            'templates'       => [],
+            'schema_mappings' => [],
+        ];
+    }
+
+    /**
+     * Import a full blueprint definition, replacing stored options.
+     */
+    public static function importBlueprint(array $data): true|WP_Error
+    {
+        $data = self::deepConvert($data);
+
+        $postTypes = is_array($data['post_types'] ?? null) ? $data['post_types'] : [];
+        $taxonomies = is_array($data['taxonomies'] ?? null) ? $data['taxonomies'] : [];
+
+        $config = self::getOptionArray(self::OPTION_CONFIG);
+        $config['post_types'] = $postTypes;
+        $config['taxonomies'] = $taxonomies;
+        update_option(self::OPTION_CONFIG, $config);
+
+        $fieldGroups = self::prepareFieldGroupsForStorage($data);
+        update_option(self::OPTION_FIELD_GROUPS, $fieldGroups);
+
+        $schemaMappings = self::resolveSchemaMappings($data);
+        update_option(self::OPTION_SCHEMA_MAP, $schemaMappings);
+
+        $meta = self::getMeta();
+        $meta['relationships'] = array_values(array_map([self::class, 'deepConvert'], $data['relationships'] ?? []));
+        $meta['templates'] = self::deepConvert($data['templates'] ?? []);
+        $meta['elementor'] = self::normalizeElementor($data['elementor'] ?? []);
+        update_option(self::OPTION_META, $meta);
+
+        return true;
+    }
+
+    /**
+     * Import field groups, optionally merging with existing groups.
+     */
+    public static function importFieldGroups(array $data, bool $merge = true): true|WP_Error
+    {
+        $groups = self::extractFieldGroupList($data);
+        if (empty($groups)) {
+            return new WP_Error('gm2_field_groups_empty', 'No field groups were provided.');
+        }
+
+        $validationBlueprint = self::exportFieldGroups();
+        $validationBlueprint['field_groups'] = $groups;
+        $validationBlueprint['fields']['groups'] = $groups;
+        $validationResult = \gm2_validate_blueprint($validationBlueprint);
+        if (is_wp_error($validationResult)) {
+            return $validationResult;
+        }
+
+        $prepared = self::fieldGroupListToOptionMap($groups);
+
+        if ($merge) {
+            $current = self::getOptionArray(self::OPTION_FIELD_GROUPS);
+            $prepared = $current + $prepared;
+        }
+
+        update_option(self::OPTION_FIELD_GROUPS, $prepared);
+
+        return true;
+    }
+
+    /**
+     * Convert a blueprint field group definition to the stored option format.
+     */
+    public static function prepareFieldGroupsForStorage(array $data): array
+    {
+        $groups = self::extractFieldGroupList($data);
+        return self::fieldGroupListToOptionMap($groups);
+    }
+
+    /**
+     * Encode blueprint data to JSON or YAML.
+     */
+    public static function encode(array $data, string $format)
+    {
+        $prepared = self::prepareForEncoding($data);
+
+        switch ($format) {
+            case 'yaml':
+                if (!function_exists('yaml_emit')) {
+                    return new WP_Error('yaml_unavailable', 'YAML support is not available.');
+                }
+                return yaml_emit($prepared);
+            case 'json':
+            default:
+                $encoder = function_exists('wp_json_encode') ? 'wp_json_encode' : 'json_encode';
+                $encoded = $encoder($prepared, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+                if ($encoded === false) {
+                    return new WP_Error('json_encode_failed', 'Could not encode blueprint to JSON.');
+                }
+                return $encoded;
+        }
+    }
+
+    /**
+     * Decode blueprint data from the given format.
+     *
+     * @param array|string $input Raw input or decoded array.
+     */
+    public static function decode($input, string $format)
+    {
+        if ($format === 'array') {
+            if (!is_array($input)) {
+                return new WP_Error('invalid_data', 'Invalid blueprint data.');
+            }
+            return self::deepConvert($input);
+        }
+
+        if (!is_string($input)) {
+            return new WP_Error('invalid_data', 'Invalid blueprint data.');
+        }
+
+        if ($format === 'yaml') {
+            if (!function_exists('yaml_parse')) {
+                return new WP_Error('yaml_unavailable', 'YAML support is not available.');
+            }
+            $parsed = yaml_parse($input);
+        } else {
+            $parsed = json_decode($input, true);
+        }
+
+        if (!is_array($parsed)) {
+            return new WP_Error('invalid_data', 'Invalid blueprint data.');
+        }
+
+        return self::deepConvert($parsed);
+    }
+
+    /**
+     * Prepare blueprint data for schema validation.
+     */
+    public static function prepareForSchema(array $data)
+    {
+        $encoded = wp_json_encode(self::prepareForEncoding($data));
+        if (!is_string($encoded)) {
+            return $data;
+        }
+
+        $decoded = json_decode($encoded);
+        return $decoded ?? $data;
+    }
+
+    /**
+     * Retrieve blueprint meta storage.
+     */
+    private static function getMeta(): array
+    {
+        $meta = get_option(self::OPTION_META, []);
+        return is_array($meta) ? self::deepConvert($meta) : [];
+    }
+
+    /**
+     * Build the list of field groups for export.
+     *
+     * @param array<int, string>|null $slugs
+     * @return array<int, array<string, mixed>>
+     */
+    private static function buildFieldGroupList(?array $slugs = null): array
+    {
+        $groups = self::getOptionArray(self::OPTION_FIELD_GROUPS);
+
+        $allowed = null;
+        if ($slugs !== null) {
+            $allowed = [];
+            foreach ($slugs as $slug) {
+                if (is_string($slug) && $slug !== '') {
+                    $allowed[sanitize_key($slug)] = true;
+                }
+            }
+        }
+
+        $result = [];
+        foreach ($groups as $slug => $group) {
+            if (!is_array($group)) {
+                continue;
+            }
+            if ($allowed !== null && !isset($allowed[sanitize_key((string) $slug)])) {
+                continue;
+            }
+            $slugString = is_string($slug) ? $slug : (string) $slug;
+            $result[] = self::convertGroupForBlueprint($slugString, $group);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Convert a stored field group to blueprint format.
+     */
+    private static function convertGroupForBlueprint(string $slug, array $group): array
+    {
+        $fields = [];
+        foreach (($group['fields'] ?? []) as $metaKey => $field) {
+            if (!is_array($field)) {
+                continue;
+            }
+            $meta = is_string($metaKey) ? $metaKey : (string) $metaKey;
+            $fieldData = self::deepConvert($field);
+            $fieldData['name'] = is_string($fieldData['name'] ?? '') && $fieldData['name'] !== ''
+                ? $fieldData['name']
+                : $meta;
+            if (empty($fieldData['key']) || !is_string($fieldData['key'])) {
+                $fieldData['key'] = self::generateFieldKey($slug, $meta);
+            }
+            $fields[] = $fieldData;
+        }
+
+        return [
+            'key'      => is_string($group['key'] ?? '') ? $group['key'] : $slug,
+            'title'    => is_string($group['title'] ?? '') ? $group['title'] : $slug,
+            'scope'    => is_string($group['scope'] ?? '') ? $group['scope'] : 'post_type',
+            'objects'  => self::sanitizeStringArray($group['objects'] ?? []),
+            'location' => self::deepConvert($group['location'] ?? []),
+            'fields'   => $fields,
+        ];
+    }
+
+    /**
+     * Extract field groups from blueprint data.
+     *
+     * @param array<string, mixed>|array<int, mixed> $data
+     * @return array<int, array<string, mixed>>
+     */
+    private static function extractFieldGroupList(array $data): array
+    {
+        if (isset($data['field_groups'])) {
+            $groups = $data['field_groups'];
+        } elseif (isset($data['fields']['groups'])) {
+            $groups = $data['fields']['groups'];
+        } else {
+            $groups = $data;
+        }
+
+        if (!is_array($groups)) {
+            return [];
+        }
+
+        if (self::isAssoc($groups)) {
+            $list = [];
+            foreach ($groups as $key => $group) {
+                if (!is_array($group)) {
+                    continue;
+                }
+                $group['key'] = $group['key'] ?? (is_string($key) ? $key : (string) $key);
+                $list[] = self::deepConvert($group);
+            }
+            return $list;
+        }
+
+        $result = [];
+        foreach ($groups as $group) {
+            if (is_array($group)) {
+                $result[] = self::deepConvert($group);
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * Convert a field group list to the option map format.
+     *
+     * @param array<int, array<string, mixed>> $groups
+     */
+    private static function fieldGroupListToOptionMap(array $groups): array
+    {
+        $result = [];
+        foreach ($groups as $group) {
+            if (!is_array($group)) {
+                continue;
+            }
+            $slug = self::determineGroupSlug($group);
+            if ($slug === '') {
+                continue;
+            }
+            $title = is_string($group['title'] ?? '') ? $group['title'] : $slug;
+            $scope = is_string($group['scope'] ?? '') ? $group['scope'] : 'post_type';
+            $objects = self::sanitizeStringArray($group['objects'] ?? []);
+            $location = is_array($group['location'] ?? null) ? self::deepConvert($group['location']) : [];
+
+            $fields = [];
+            foreach (($group['fields'] ?? []) as $field) {
+                if (!is_array($field)) {
+                    continue;
+                }
+                $field = self::deepConvert($field);
+                $metaKey = self::determineFieldMetaKey($field);
+                if ($metaKey === '') {
+                    continue;
+                }
+                unset($field['key'], $field['name']);
+                $fields[$metaKey] = $field;
+            }
+
+            $result[$slug] = [
+                'title'    => $title,
+                'scope'    => $scope,
+                'objects'  => $objects,
+                'location' => $location,
+                'fields'   => $fields,
+            ];
+        }
+        return $result;
+    }
+
+    /**
+     * Determine the slug for a field group import.
+     */
+    private static function determineGroupSlug(array $group): string
+    {
+        $candidates = [];
+        if (isset($group['slug']) && is_string($group['slug'])) {
+            $candidates[] = $group['slug'];
+        }
+        if (isset($group['key']) && is_string($group['key'])) {
+            $candidates[] = $group['key'];
+        }
+
+        foreach ($candidates as $candidate) {
+            $slug = sanitize_key($candidate);
+            if ($slug !== '') {
+                return $slug;
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Determine the meta key for a field import.
+     */
+    private static function determineFieldMetaKey(array $field): string
+    {
+        $candidates = [];
+        if (isset($field['name']) && is_string($field['name'])) {
+            $candidates[] = $field['name'];
+        }
+        if (isset($field['key']) && is_string($field['key'])) {
+            $candidates[] = $field['key'];
+        }
+
+        foreach ($candidates as $candidate) {
+            $key = sanitize_key($candidate);
+            if ($key !== '') {
+                return $key;
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Generate a fallback field key when missing from stored data.
+     */
+    private static function generateFieldKey(string $groupSlug, string $fieldSlug): string
+    {
+        $group = sanitize_key($groupSlug);
+        $field = sanitize_key($fieldSlug);
+        if ($group === '') {
+            return 'field_' . $field;
+        }
+        if ($field === '') {
+            return 'field_' . $group;
+        }
+        return 'field_' . $group . '_' . $field;
+    }
+
+    /**
+     * Resolve schema mappings from blueprint data.
+     */
+    private static function resolveSchemaMappings(array $data): array
+    {
+        if (!empty($data['schema_mappings']) && is_array($data['schema_mappings'])) {
+            return self::deepConvert($data['schema_mappings']);
+        }
+        if (!empty($data['seo']['mappings']) && is_array($data['seo']['mappings'])) {
+            return self::deepConvert($data['seo']['mappings']);
+        }
+        return [];
+    }
+
+    /**
+     * Normalize Elementor metadata to an array structure.
+     */
+    private static function normalizeElementor(array $elementor): array
+    {
+        $queries = [];
+        if (!empty($elementor['queries']) && is_array($elementor['queries'])) {
+            foreach ($elementor['queries'] as $key => $query) {
+                if (is_string($key) && is_array($query)) {
+                    $queries[$key] = self::deepConvert($query);
+                }
+            }
+        }
+
+        $templates = [];
+        if (!empty($elementor['templates']) && is_array($elementor['templates'])) {
+            foreach ($elementor['templates'] as $key => $template) {
+                if (is_string($key) && is_array($template)) {
+                    $templates[$key] = self::deepConvert($template);
+                }
+            }
+        }
+
+        return [
+            'queries'   => $queries,
+            'templates' => $templates,
+        ];
+    }
+
+    /**
+     * Retrieve an option value as an array.
+     */
+    private static function getOptionArray(string $option): array
+    {
+        $value = get_option($option, []);
+        return is_array($value) ? self::deepConvert($value) : [];
+    }
+
+    /**
+     * Recursively convert objects to arrays.
+     */
+    private static function deepConvert(mixed $value): mixed
+    {
+        if ($value instanceof \stdClass) {
+            $value = (array) $value;
+        }
+        if (is_array($value)) {
+            $result = [];
+            foreach ($value as $key => $item) {
+                $result[$key] = self::deepConvert($item);
+            }
+            return $result;
+        }
+        return $value;
+    }
+
+    /**
+     * Determine whether the provided array is associative.
+     */
+    private static function isAssoc(array $array): bool
+    {
+        return array_keys($array) !== array_keys(array_values($array));
+    }
+
+    /**
+     * Prepare data for encoding, converting associative arrays to objects.
+     */
+    private static function prepareForEncoding(mixed $value, array $path = [])
+    {
+        if (!is_array($value)) {
+            return $value;
+        }
+
+        $isAssoc = self::isAssoc($value);
+        $result = [];
+        foreach ($value as $key => $item) {
+            $nextPath = $path;
+            if (is_string($key)) {
+                $nextPath[] = $key;
+            } else {
+                $nextPath[] = '*';
+            }
+            $result[$key] = self::prepareForEncoding($item, $nextPath);
+        }
+
+        if (self::shouldRepresentAsObject($path, $isAssoc)) {
+            return (object) $result;
+        }
+
+        if ($isAssoc) {
+            return (object) $result;
+        }
+
+        return array_values($result);
+    }
+
+    /**
+     * Determine whether the current path should be encoded as an object.
+     */
+    private static function shouldRepresentAsObject(array $path, bool $isAssoc): bool
+    {
+        foreach (self::FORCE_OBJECT_PATHS as $objectPath) {
+            if (self::pathMatches($path, $objectPath)) {
+                return true;
+            }
+        }
+        return $isAssoc;
+    }
+
+    /**
+     * Check whether the current path matches a forced-object rule.
+     */
+    private static function pathMatches(array $path, array $rule): bool
+    {
+        if (count($path) === 0 && count($rule) === 0) {
+            return true;
+        }
+        if (count($path) < count($rule)) {
+            return false;
+        }
+        $pathSlice = array_slice($path, 0, count($rule));
+        foreach ($rule as $index => $segment) {
+            if ($segment === '*') {
+                continue;
+            }
+            if (!isset($pathSlice[$index]) || $pathSlice[$index] !== $segment) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Normalize an array of mixed values to a string array.
+     */
+    private static function sanitizeStringArray(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+        $result = [];
+        foreach ($value as $item) {
+            if (is_string($item) && $item !== '') {
+                $result[] = $item;
+            }
+        }
+        return array_values(array_unique($result));
+    }
+}

--- a/tests/Presets/BlueprintIOTest.php
+++ b/tests/Presets/BlueprintIOTest.php
@@ -1,0 +1,134 @@
+<?php
+
+class BlueprintIOTest extends WP_UnitTestCase {
+    protected function tearDown(): void {
+        delete_option('gm2_custom_posts_config');
+        delete_option('gm2_field_groups');
+        delete_option('gm2_cp_schema_map');
+        delete_option('gm2_model_blueprint_meta');
+        parent::tearDown();
+    }
+
+    public function test_full_blueprint_round_trip(): void {
+        $config = [
+            'post_types' => [
+                'book' => [
+                    'label' => 'Book',
+                    'args'  => [ 'public' => [ 'value' => true ] ],
+                ],
+            ],
+            'taxonomies' => [
+                'genre' => [
+                    'label'       => 'Genre',
+                    'post_types'  => [ 'book' ],
+                    'default_terms' => [
+                        [ 'slug' => 'fiction', 'name' => 'Fiction' ],
+                    ],
+                ],
+            ],
+        ];
+        update_option('gm2_custom_posts_config', $config);
+
+        $field_groups = [
+            'book_details' => [
+                'title'   => 'Book Details',
+                'scope'   => 'post_type',
+                'objects' => [ 'book' ],
+                'location'=> [],
+                'fields'  => [
+                    'isbn' => [
+                        'label'    => 'ISBN',
+                        'type'     => 'text',
+                        'required' => true,
+                    ],
+                ],
+            ],
+        ];
+        update_option('gm2_field_groups', $field_groups);
+
+        $schema_map = [
+            'book' => [
+                'type' => 'Book',
+                'map'  => [ 'name' => 'post_title' ],
+            ],
+        ];
+        update_option('gm2_cp_schema_map', $schema_map);
+
+        $meta = [
+            'relationships' => [
+                [
+                    'from' => 'book',
+                    'to'   => 'genre',
+                    'type' => 'taxonomy',
+                ],
+            ],
+            'templates' => [
+                'book_single' => [
+                    'post_type' => 'book',
+                    'blocks'    => [],
+                ],
+            ],
+            'elementor' => [
+                'queries' => [
+                    'books_recent' => [
+                        'id'   => 'gm2_books_recent',
+                        'post_types' => [ 'book' ],
+                    ],
+                ],
+                'templates' => [
+                    'book_card' => [
+                        'type' => 'shortcode',
+                        'file' => 'elementor/book-card.json',
+                    ],
+                ],
+            ],
+        ];
+        update_option('gm2_model_blueprint_meta', $meta);
+
+        $export = \gm2_model_export('array');
+        $this->assertIsArray($export);
+
+        delete_option('gm2_custom_posts_config');
+        delete_option('gm2_field_groups');
+        delete_option('gm2_cp_schema_map');
+        delete_option('gm2_model_blueprint_meta');
+
+        $result = \gm2_model_import($export, 'array');
+        $this->assertTrue($result);
+
+        $this->assertEquals($config, get_option('gm2_custom_posts_config'));
+        $this->assertEquals($field_groups, get_option('gm2_field_groups'));
+        $this->assertEquals($schema_map, get_option('gm2_cp_schema_map'));
+        $this->assertEquals($meta, get_option('gm2_model_blueprint_meta'));
+    }
+
+    public function test_field_group_round_trip(): void {
+        $field_groups = [
+            'library_info' => [
+                'title'   => 'Library Info',
+                'scope'   => 'post_type',
+                'objects' => [ 'library' ],
+                'location'=> [],
+                'fields'  => [
+                    'address' => [ 'label' => 'Address', 'type' => 'text' ],
+                ],
+            ],
+        ];
+        update_option('gm2_field_groups', $field_groups);
+
+        $export = \gm2_field_groups_export('array');
+        $this->assertIsArray($export);
+        $this->assertArrayHasKey('field_groups', $export);
+
+        delete_option('gm2_field_groups');
+        $result = \gm2_field_groups_import($export, 'array');
+        $this->assertTrue($result);
+        $this->assertEquals($field_groups, get_option('gm2_field_groups'));
+    }
+
+    public function test_import_validation_failure(): void {
+        $invalid = [ 'post_types' => 'invalid' ];
+        $result  = \gm2_model_import($invalid, 'array');
+        $this->assertInstanceOf(WP_Error::class, $result);
+    }
+}


### PR DESCRIPTION
## Summary
- add the new `BlueprintIO` helper to serialize, validate, and import blueprint data including field-groups, relationships, Elementor data, and templates
- update model export/import helpers, AJAX handlers, and CLI commands to support field-group only operations and to use the expanded blueprint structure
- refresh the bundled JSON schema and add PHPUnit coverage for blueprint and field-group round trips

## Testing
- `vendor/bin/phpunit --testsuite Presets` *(fails: WordPress test library is unavailable in this environment; mysqladmin not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68cae304fb6c833081a9dc236eb4891b