### PR TITLE
Add Elementor directory templates for preset

### DIFF
--- a/presets/directory/README.md
+++ b/presets/directory/README.md
@@ -1,0 +1,28 @@
+# Directory Preset Templates
+
+The Directory preset ships with Elementor templates that surface the custom
+fields configured in `blueprint.json` so you can quickly build front-end
+layouts for listings.
+
+## Available templates
+
+- **Listing Single** (`templates/listing-single.json`) &mdash; renders the logo,
+  address, contact methods, gallery, coordinates, and opening hours for the
+  current listing using GM2 widgets.
+- **Listing Archive Loop** (`templates/listing-archive-loop.json`) &mdash; provides a
+  Loop Item card that highlights the logo, city, street, phone number, and price
+  level when used inside Elementor's Loop Grid or Posts widget.
+
+## Import instructions
+
+1. Visit **Elementor → Templates** in the WordPress dashboard.
+2. Click **Import Templates** and upload one of the JSON exports from the
+   `presets/directory/templates/` folder.
+3. For the single template, open **Theme Builder → Single** and assign the
+   imported layout to the **Listing** post type.
+4. For the archive loop card, open **Theme Builder → Loop**, import the loop
+   template, and select it when configuring Loop Grid or Archive Posts widgets
+   on your archive pages.
+
+After importing you can duplicate and customise the templates while retaining
+all of the preset field bindings.

--- a/presets/directory/blueprint.json
+++ b/presets/directory/blueprint.json
@@ -52,7 +52,7 @@
       ],
       "template_lock": "insert",
       "seo": {
-        "meta_title": "{{title}} \u2013 Business Listing",
+        "meta_title": "{{title}} – Business Listing",
         "meta_description": "{{description}}",
         "canonical": "{{permalink}}",
         "open_graph": {
@@ -559,15 +559,6 @@
       ]
     }
   ],
-  "elementor": {
-    "templates": {
-      "single_listing": {
-        "type": "shortcode",
-        "description": "Replace the shortcode placeholder with the ID of a saved Elementor template to render a custom hero.",
-        "file": "elementor/directory-hero.json"
-      }
-    }
-  },
   "seo_mappings": [
     {
       "key": "listing",
@@ -594,42 +585,20 @@
     "listing_single": {
       "post_type": "listing",
       "lock": "insert",
-      "blocks": [
-        [
-          "core/group",
-          {
-            "metadata": {
-              "name": "Listing Layout"
-            },
-            "layout": {
-              "type": "constrained"
-            }
-          },
-          [
-            [
-              "core/heading",
-              {
-                "level": 2,
-                "placeholder": "Business headline or tagline"
-              }
-            ],
-            [
-              "core/paragraph",
-              {
-                "placeholder": "Spotlight the listing or switch to Elementor to customise."
-              }
-            ],
-            [
-              "core/shortcode",
-              {
-                "text": "[elementor-template id=\"\"]"
-              }
-            ]
-          ]
-        ]
-      ],
-      "description": "Block layout bundles a heading, intro, and Elementor shortcode placeholder.",
-      "elementor_placeholder": "[elementor-template id=\"\"]"
+      "builder": "elementor",
+      "file": "templates/listing-single.json",
+      "blocks": [],
+      "description": "Elementor single template featuring listing contact details, gallery, and opening hours.",
+      "notes": "Import via Elementor → Templates → Import Template, then assign it as the single template for listings."
+    },
+    "listing_archive_loop": {
+      "post_type": "listing",
+      "builder": "elementor",
+      "context": "loop",
+      "file": "templates/listing-archive-loop.json",
+      "blocks": [],
+      "description": "Elementor loop card for archive grids showing key listing fields.",
+      "notes": "Import into Elementor's Theme Builder as a Loop Item and select it for Listing archives."
     }
   }
 }

--- a/presets/directory/templates/listing-archive-loop.json
+++ b/presets/directory/templates/listing-archive-loop.json
@@ -1,0 +1,75 @@
+{
+  "version": "0.4",
+  "title": "Directory Listing Card",
+  "type": "loop-item",
+  "content": [
+    {
+      "id": "directory-loop-section",
+      "elType": "section",
+      "isInner": false,
+      "settings": {
+        "layout": "boxed"
+      },
+      "elements": [
+        {
+          "id": "directory-loop-column",
+          "elType": "column",
+          "isInner": false,
+          "settings": {
+            "_column_size": 100
+          },
+          "elements": [
+            {
+              "id": "directory-loop-card",
+              "elType": "widget",
+              "widgetType": "gm2_loop_card",
+              "settings": {
+                "post_type": "listing",
+                "layout": "stacked",
+                "card_tag": "article",
+                "image_field": "group_listing_details::logo",
+                "image_fallback": "",
+                "title_tag": "h3",
+                "subtitle_field": "group_listing_details::city",
+                "subtitle_tag": "p",
+                "body_field": "",
+                "body_fallback": "",
+                "meta_fields": [
+                  {
+                    "_id": "meta-address",
+                    "label": "Street",
+                    "field_key": "group_listing_details::address",
+                    "fallback": ""
+                  },
+                  {
+                    "_id": "meta-region",
+                    "label": "Region",
+                    "field_key": "group_listing_details::region",
+                    "fallback": ""
+                  },
+                  {
+                    "_id": "meta-phone",
+                    "label": "Phone",
+                    "field_key": "group_listing_details::phone",
+                    "fallback": ""
+                  },
+                  {
+                    "_id": "meta-price",
+                    "label": "Price Level",
+                    "field_key": "group_listing_details::price_level",
+                    "fallback": ""
+                  }
+                ],
+                "button_text": "View Listing",
+                "button_url_field": "group_listing_details::website",
+                "button_fallback_url": ""
+              },
+              "elements": [],
+              "isInner": false
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/presets/directory/templates/listing-single.json
+++ b/presets/directory/templates/listing-single.json
@@ -1,0 +1,314 @@
+{
+  "version": "0.4",
+  "title": "Directory Listing Single",
+  "type": "page",
+  "content": [
+    {
+      "id": "directory-single-hero",
+      "elType": "section",
+      "isInner": false,
+      "settings": {
+        "layout": "full_width"
+      },
+      "elements": [
+        {
+          "id": "directory-hero-column-left",
+          "elType": "column",
+          "isInner": false,
+          "settings": {
+            "_column_size": 60
+          },
+          "elements": [
+            {
+              "id": "directory-title",
+              "elType": "widget",
+              "widgetType": "heading",
+              "settings": {
+                "title": "Listing Title",
+                "header_size": "h1",
+                "dynamic": {
+                  "title": {
+                    "active": true,
+                    "tag": "post-title"
+                  }
+                }
+              },
+              "elements": [],
+              "isInner": false
+            },
+            {
+              "id": "directory-price-level",
+              "elType": "widget",
+              "widgetType": "gm2_field",
+              "settings": {
+                "post_type": "listing",
+                "field_key": "group_listing_details::price_level",
+                "html_tag": "p",
+                "fallback": "Price level"
+              },
+              "elements": [],
+              "isInner": false
+            },
+            {
+              "id": "directory-claimed",
+              "elType": "widget",
+              "widgetType": "gm2_field",
+              "settings": {
+                "post_type": "listing",
+                "field_key": "group_listing_details::claimed",
+                "html_tag": "p",
+                "fallback": "Claimed listing status"
+              },
+              "elements": [],
+              "isInner": false
+            }
+          ]
+        },
+        {
+          "id": "directory-hero-column-right",
+          "elType": "column",
+          "isInner": false,
+          "settings": {
+            "_column_size": 40
+          },
+          "elements": [
+            {
+              "id": "directory-logo",
+              "elType": "widget",
+              "widgetType": "gm2_field",
+              "settings": {
+                "post_type": "listing",
+                "field_key": "group_listing_details::logo",
+                "html_tag": "div",
+                "fallback": ""
+              },
+              "elements": [],
+              "isInner": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "directory-single-details",
+      "elType": "section",
+      "isInner": false,
+      "settings": {
+        "layout": "boxed"
+      },
+      "elements": [
+        {
+          "id": "directory-details-column-left",
+          "elType": "column",
+          "isInner": false,
+          "settings": {
+            "_column_size": 50
+          },
+          "elements": [
+            {
+              "id": "directory-contact-heading",
+              "elType": "widget",
+              "widgetType": "heading",
+              "settings": {
+                "title": "Contact",
+                "header_size": "h2"
+              },
+              "elements": [],
+              "isInner": false
+            },
+            {
+              "id": "directory-address",
+              "elType": "widget",
+              "widgetType": "gm2_field",
+              "settings": {
+                "post_type": "listing",
+                "field_key": "group_listing_details::address",
+                "html_tag": "p",
+                "fallback": "Street address"
+              },
+              "elements": [],
+              "isInner": false
+            },
+            {
+              "id": "directory-city",
+              "elType": "widget",
+              "widgetType": "gm2_field",
+              "settings": {
+                "post_type": "listing",
+                "field_key": "group_listing_details::city",
+                "html_tag": "p",
+                "fallback": "City"
+              },
+              "elements": [],
+              "isInner": false
+            },
+            {
+              "id": "directory-region",
+              "elType": "widget",
+              "widgetType": "gm2_field",
+              "settings": {
+                "post_type": "listing",
+                "field_key": "group_listing_details::region",
+                "html_tag": "p",
+                "fallback": "Region"
+              },
+              "elements": [],
+              "isInner": false
+            },
+            {
+              "id": "directory-postal-code",
+              "elType": "widget",
+              "widgetType": "gm2_field",
+              "settings": {
+                "post_type": "listing",
+                "field_key": "group_listing_details::postal_code",
+                "html_tag": "p",
+                "fallback": "Postal code"
+              },
+              "elements": [],
+              "isInner": false
+            },
+            {
+              "id": "directory-country",
+              "elType": "widget",
+              "widgetType": "gm2_field",
+              "settings": {
+                "post_type": "listing",
+                "field_key": "group_listing_details::country",
+                "html_tag": "p",
+                "fallback": "Country"
+              },
+              "elements": [],
+              "isInner": false
+            },
+            {
+              "id": "directory-phone",
+              "elType": "widget",
+              "widgetType": "gm2_field",
+              "settings": {
+                "post_type": "listing",
+                "field_key": "group_listing_details::phone",
+                "html_tag": "p",
+                "fallback": "Phone number"
+              },
+              "elements": [],
+              "isInner": false
+            },
+            {
+              "id": "directory-email",
+              "elType": "widget",
+              "widgetType": "gm2_field",
+              "settings": {
+                "post_type": "listing",
+                "field_key": "group_listing_details::email",
+                "html_tag": "p",
+                "fallback": "Email address"
+              },
+              "elements": [],
+              "isInner": false
+            },
+            {
+              "id": "directory-website",
+              "elType": "widget",
+              "widgetType": "gm2_field",
+              "settings": {
+                "post_type": "listing",
+                "field_key": "group_listing_details::website",
+                "html_tag": "p",
+                "fallback": "Website"
+              },
+              "elements": [],
+              "isInner": false
+            },
+            {
+              "id": "directory-same-as",
+              "elType": "widget",
+              "widgetType": "gm2_field",
+              "settings": {
+                "post_type": "listing",
+                "field_key": "group_listing_details::same_as",
+                "html_tag": "div",
+                "fallback": "Social profiles"
+              },
+              "elements": [],
+              "isInner": false
+            },
+            {
+              "id": "directory-opening-hours",
+              "elType": "widget",
+              "widgetType": "gm2_opening_hours",
+              "settings": {
+                "post_type": "listing",
+                "field_key": "group_listing_details::opening_hours",
+                "closed_label": "Closed",
+                "fallback_text": "Opening hours coming soon"
+              },
+              "elements": [],
+              "isInner": false
+            }
+          ]
+        },
+        {
+          "id": "directory-details-column-right",
+          "elType": "column",
+          "isInner": false,
+          "settings": {
+            "_column_size": 50
+          },
+          "elements": [
+            {
+              "id": "directory-gallery",
+              "elType": "widget",
+              "widgetType": "gm2_field",
+              "settings": {
+                "post_type": "listing",
+                "field_key": "group_listing_details::gallery",
+                "html_tag": "div",
+                "fallback": "Gallery"
+              },
+              "elements": [],
+              "isInner": false
+            },
+            {
+              "id": "directory-location-heading",
+              "elType": "widget",
+              "widgetType": "heading",
+              "settings": {
+                "title": "Location Coordinates",
+                "header_size": "h3"
+              },
+              "elements": [],
+              "isInner": false
+            },
+            {
+              "id": "directory-latitude",
+              "elType": "widget",
+              "widgetType": "gm2_field",
+              "settings": {
+                "post_type": "listing",
+                "field_key": "group_listing_details::latitude",
+                "html_tag": "p",
+                "fallback": "Latitude"
+              },
+              "elements": [],
+              "isInner": false
+            },
+            {
+              "id": "directory-longitude",
+              "elType": "widget",
+              "widgetType": "gm2_field",
+              "settings": {
+                "post_type": "listing",
+                "field_key": "group_listing_details::longitude",
+                "html_tag": "p",
+                "fallback": "Longitude"
+              },
+              "elements": [],
+              "isInner": false
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Elementor JSON exports for listing single and archive loop layouts that surface directory fields
- update the directory preset blueprint to reference the new template files and include usage guidance
- document how to import the templates for the directory preset

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68caf82b520883309735b33cb9a6ac48