### PR TITLE
Update event preset taxonomies

### DIFF
--- a/docs/presets/events.md
+++ b/docs/presets/events.md
@@ -10,7 +10,8 @@
 
 | Taxonomy | Hierarchical | Purpose |
 | --- | --- | --- |
-| `event_type` | No | Labels events by type (e.g., workshop, webinar) for filtering and archive navigation. |
+| `event_category` | Yes | Hierarchical categories organize events in archives (e.g., Workshop, Webinar). |
+| `event_tag` | No | Flexible tagging surfaces keywords like `Networking` or `Virtual` for filtering. |
 
 ## Field Groups
 

--- a/presets/events/blueprint.json
+++ b/presets/events/blueprint.json
@@ -108,17 +108,30 @@
     }
   },
   "taxonomies": {
-    "event_type": {
+    "event_category": {
       "object_type": [
         "event"
       ],
       "labels": {
-        "name": "Event Types",
-        "singular_name": "Event Type"
+        "name": "Event Categories",
+        "singular_name": "Event Category"
+      },
+      "hierarchical": true,
+      "rewrite": {
+        "slug": "event-category"
+      }
+    },
+    "event_tag": {
+      "object_type": [
+        "event"
+      ],
+      "labels": {
+        "name": "Event Tags",
+        "singular_name": "Event Tag"
       },
       "hierarchical": false,
       "rewrite": {
-        "slug": "event-type"
+        "slug": "event-tag"
       }
     }
   },
@@ -257,7 +270,7 @@
     }
   ],
   "default_terms": {
-    "event_type": [
+    "event_category": [
       {
         "name": "Workshop",
         "slug": "workshop"
@@ -265,6 +278,16 @@
       {
         "name": "Webinar",
         "slug": "webinar"
+      }
+    ],
+    "event_tag": [
+      {
+        "name": "Networking",
+        "slug": "networking"
+      },
+      {
+        "name": "Virtual",
+        "slug": "virtual"
       }
     ]
   },


### PR DESCRIPTION
## Summary
- replace the single event_type taxonomy with new event_category and event_tag definitions in the events preset
- add default term seeds for both event taxonomies to maintain sample content
- document the taxonomy changes in the events preset guide

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68cafea58a888330a4c614b3bdfb8219