### PR TITLE
Update event schema mapping for venue and offers

### DIFF
--- a/docs/presets/events.md
+++ b/docs/presets/events.md
@@ -29,7 +29,16 @@
 - **Mappings:**
   - `startDate` ← `start_date`
   - `endDate` ← `end_date`
-  - `location` ← `location`
+  - `eventStatus` ← `status`
+  - `eventAttendanceMode` ← `attendance_mode`
+  - `location.name` ← `location`
+  - `location.address.streetAddress` ← `location`
+  - `virtualLocation.url` ← `virtual_event_url`
+  - `onlineEventUrl` ← `virtual_event_url`
+  - `organizer` ← `organizer`
+  - `offers` ← `ticket_offers`
+
+The `location` text feeds the `Place` name and street address, while linking an organizer post fills the `Organization` node. Adding rows to the `ticket_offers` repeater produces `Offer` objects with price, currency, and optional purchase URLs, and supplying a virtual event link populates a `VirtualLocation` alongside `onlineEventUrl` for all-online or hybrid sessions.
 
 ## Elementor Notes
 

--- a/includes/seo/class-gm2-cp-schema.php
+++ b/includes/seo/class-gm2-cp-schema.php
@@ -182,6 +182,7 @@ class Gm2_CP_Schema {
             'offers' => 'Offer',
             'openingHoursSpecification' => 'OpeningHoursSpecification',
             'organizer' => 'Organization',
+            'virtualLocation' => 'VirtualLocation',
             default => null,
         };
     }

--- a/presets/events/blueprint.json
+++ b/presets/events/blueprint.json
@@ -797,7 +797,14 @@
       "map": {
         "startDate": "start_date",
         "endDate": "end_date",
-        "location": "location"
+        "eventStatus": "status",
+        "eventAttendanceMode": "attendance_mode",
+        "location.name": "location",
+        "location.address.streetAddress": "location",
+        "virtualLocation.url": "virtual_event_url",
+        "onlineEventUrl": "virtual_event_url",
+        "organizer": "organizer",
+        "offers": "ticket_offers"
       }
     }
   ],


### PR DESCRIPTION
## Summary
- expand the event preset SEO mapping to cover status, attendance mode, venue/place, organizer, virtual link, and ticket offers
- document how each Event schema property is sourced in the preset notes
- teach the schema emitter to label mapped virtual locations as VirtualLocation

## Testing
- `vendor/bin/phpunit` *(fails: WordPress test library missing in container)*

------
https://chatgpt.com/codex/tasks/task_b_68cb04cf74ec8330b84decb69a191bb3