### PR TITLE
Add company post type and relationship for jobs

### DIFF
--- a/presets/jobs/blueprint.json
+++ b/presets/jobs/blueprint.json
@@ -65,6 +65,24 @@
           "image": "{{image}}"
         }
       }
+    },
+    "company": {
+      "labels": {
+        "name": "Companies",
+        "singular_name": "Company"
+      },
+      "supports": [
+        "title",
+        "editor",
+        "thumbnail"
+      ],
+      "has_archive": true,
+      "rewrite": {
+        "slug": "companies"
+      },
+      "menu_icon": "dashicons-building",
+      "show_in_rest": true,
+      "rest_base": "companies"
     }
   },
   "taxonomies": {
@@ -107,7 +125,14 @@
           "key": "field_company",
           "label": "Company",
           "name": "company",
-          "type": "text",
+          "type": "relationship",
+          "relationship_type": "post",
+          "post_types": [
+            "company"
+          ],
+          "max": 1,
+          "sync": "two-way",
+          "instructions": "Select the company offering this position.",
           "required": true,
           "expose_in_rest": true
         },
@@ -160,7 +185,14 @@
             "key": "field_company",
             "label": "Company",
             "name": "company",
-            "type": "text",
+            "type": "relationship",
+            "relationship_type": "post",
+            "post_types": [
+              "company"
+            ],
+            "max": 1,
+            "sync": "two-way",
+            "instructions": "Select the company offering this position.",
             "required": true,
             "expose_in_rest": true
           },
@@ -175,7 +207,17 @@
       }
     ]
   },
-  "relationships": [],
+  "relationships": [
+    {
+      "from": "job",
+      "to": "company",
+      "type": "job_to_company",
+      "direction": "job_to_company",
+      "label": "Company",
+      "reverse_label": "Open Roles",
+      "cardinality": "many-to-one"
+    }
+  ],
   "default_terms": {
     "job_category": [
       {


### PR DESCRIPTION
## Summary
- add a company custom post type with REST support for the jobs preset
- convert job company field to a post relationship and sync it with company entries
- register a job-to-company relationship for associating listings with employers

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68cc0fd82a9c8330a3b8fd02de448186