### PR TITLE
Add job status meta to open job preset

### DIFF
--- a/assets/blueprints/samples/jobs.json
+++ b/assets/blueprints/samples/jobs.json
@@ -101,7 +101,7 @@
     "queries": {
       "open_positions": {
         "id": "gm2_open_jobs",
-        "description": "Published job posts flagged as open.",
+        "description": "Published job posts where the job_status meta is set to open.",
         "post_types": [
           "job"
         ]

--- a/docs/elementor-query-presets.md
+++ b/docs/elementor-query-presets.md
@@ -44,11 +44,11 @@ The Gm2 WordPress Suite registers preset query IDs for Elementor's Posts, Loop G
 
 ### Open jobs (`gm2_open_jobs`)
 
-**What it does:** Returns published `job` posts tagged with a `status` meta value of `open`, limits the loop to ten entries, and sorts by the publish date descending so the most recent listing appears first.【F:src/Elementor/Query/Filters.php†L96-L112】
+**What it does:** Returns published `job` posts tagged with a `job_status` meta value of `open`, limits the loop to ten entries, and sorts by the publish date descending so the most recent listing appears first.【F:src/Elementor/Query/Filters.php†L96-L112】
 
 **Required data:**
 
-- Custom post type `job` with a `status` text field that stores `open` for active roles so the preset knows which listings to display.【F:src/Elementor/Query/Filters.php†L96-L112】
+- Custom post type `job` with a `job_status` select field that stores `open` for active roles so the preset knows which listings to display.【F:src/Elementor/Query/Filters.php†L96-L112】【F:presets/jobs/blueprint.json†L170-L199】
 - Fields like `date_posted`, `employment_type`, and `company` from the Jobs preset help populate the loop output.【F:docs/presets/jobs.md†L5-L24】
 
 **Elementor setup:**

--- a/docs/presets/jobs.md
+++ b/docs/presets/jobs.md
@@ -19,6 +19,7 @@
 | Field | Type | Validation & Notes |
 | --- | --- | --- |
 | `date_posted` | Date | Required posting date exposed in REST feeds. |
+| `job_status` | Select | Required open/closed flag exposed in REST so queries can hide filled roles. |
 | `employment_type` | Text | Required employment type (full-time, contract, etc.) exposed in REST. |
 | `company` | Text | Required hiring organisation name available through REST. |
 | `apply_url` | URL | Optional application link exposed in REST. |

--- a/presets/jobs/blueprint.json
+++ b/presets/jobs/blueprint.json
@@ -165,6 +165,29 @@
           }
         },
         {
+          "key": "field_job_status",
+          "label": "Job Status",
+          "name": "job_status",
+          "type": "select",
+          "default": "open",
+          "options": {
+            "open": "Open",
+            "closed": "Closed"
+          },
+          "required": true,
+          "instructions": "Mark roles as open or closed to drive Elementor presets and REST responses.",
+          "expose_in_rest": true,
+          "rest": {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "open",
+                "closed"
+              ]
+            }
+          }
+        },
+        {
           "key": "field_employment_type",
           "label": "Employment Type",
           "name": "employment_type",
@@ -647,6 +670,29 @@
               "schema": {
                 "type": "string",
                 "format": "date"
+              }
+            }
+          },
+          {
+            "key": "field_job_status",
+            "label": "Job Status",
+            "name": "job_status",
+            "type": "select",
+            "default": "open",
+            "options": {
+              "open": "Open",
+              "closed": "Closed"
+            },
+            "required": true,
+            "instructions": "Mark roles as open or closed to drive Elementor presets and REST responses.",
+            "expose_in_rest": true,
+            "rest": {
+              "schema": {
+                "type": "string",
+                "enum": [
+                  "open",
+                  "closed"
+                ]
               }
             }
           },
@@ -1138,7 +1184,7 @@
     {
       "key": "open_positions",
       "id": "gm2_open_jobs",
-      "description": "Published job posts flagged as open.",
+      "description": "Published job posts where the job_status meta is set to open.",
       "post_types": [
         "job"
       ]

--- a/src/Elementor/Query/Filters.php
+++ b/src/Elementor/Query/Filters.php
@@ -105,7 +105,7 @@ class Filters
         self::applySearch($query, ['gm2_job_search', 'gm2_search']);
 
         self::appendMetaQuery($query, [
-            'key'   => 'status',
+            'key'   => 'job_status',
             'value' => 'open',
         ]);
 

--- a/tests/Elementor/Query/FiltersTest.php
+++ b/tests/Elementor/Query/FiltersTest.php
@@ -84,8 +84,38 @@ class FiltersTest extends WP_UnitTestCase
         $this->assertSame('Engineer', $query->get('s'));
 
         $metaQuery = $query->get('meta_query');
-        $this->assertSame('status', $metaQuery[0]['key']);
+        $this->assertSame('job_status', $metaQuery[0]['key']);
         $this->assertSame('open', $metaQuery[0]['value']);
+    }
+
+    public function test_open_jobs_returns_only_open_posts(): void
+    {
+        $openId = self::factory()->post->create([
+            'post_type'   => 'job',
+            'post_status' => 'publish',
+            'post_title'  => 'Open Role',
+        ]);
+        add_post_meta($openId, 'job_status', 'open');
+
+        $closedId = self::factory()->post->create([
+            'post_type'   => 'job',
+            'post_status' => 'publish',
+            'post_title'  => 'Closed Role',
+        ]);
+        add_post_meta($closedId, 'job_status', 'closed');
+
+        $query = new WP_Query();
+
+        do_action('elementor/query/gm2_open_jobs', $query);
+
+        $query->query($query->query_vars);
+
+        $postIds = wp_list_pluck($query->posts, 'ID');
+
+        $this->assertContains($openId, $postIds);
+        $this->assertNotContains($closedId, $postIds);
+
+        wp_reset_postdata();
     }
 
     public function test_properties_for_sale_filter_by_status_taxonomy(): void


### PR DESCRIPTION
## Summary
- add a `job_status` select field to the Jobs blueprint, expose it to REST, and update preset descriptions to reference the meta
- update the `gm2_open_jobs` Elementor query filter to read the new meta key/value
- document the new status field and expand FiltersTest coverage to ensure closed roles are excluded from the preset

## Testing
- vendor/bin/phpunit *(fails: Fatal error: Constant expression contains invalid operations in src/SEO/Schema/Mapper/EventMapper.php)*

------
https://chatgpt.com/codex/tasks/task_b_68cc2234cbe08330a8ba740c89d86f91