### PR TITLE
Add course status meta for active course filtering

### DIFF
--- a/presets/courses/blueprint.json
+++ b/presets/courses/blueprint.json
@@ -348,6 +348,38 @@
           }
         },
         {
+          "key": "field_course_status",
+          "label": "Course Status",
+          "name": "course_status",
+          "type": "select",
+          "default": "active",
+          "options": {
+            "active": "Active",
+            "upcoming": "Upcoming",
+            "archived": "Archived"
+          },
+          "validation": {
+            "required": true,
+            "enum": [
+              "active",
+              "upcoming",
+              "archived"
+            ]
+          },
+          "instructions": "Status value used by Elementor \"Active Courses\" queries.",
+          "expose_in_rest": true,
+          "show_in_rest": {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "active",
+                "upcoming",
+                "archived"
+              ]
+            }
+          }
+        },
+        {
           "key": "field_course_level",
           "label": "Course Level",
           "name": "course_level",
@@ -910,7 +942,7 @@
     }
   },
   "label": "Courses",
-  "description": "Course catalogue blueprint with provider metadata, subject and level taxonomies, and Elementor hero placeholder.",
+  "description": "Course catalogue blueprint with provider metadata, subject and level taxonomies, Elementor hero placeholder, and \"course_status\" meta powering active course listings.",
   "fields": {
     "groups": [
       {
@@ -1105,6 +1137,38 @@
               "schema": {
                 "type": "string",
                 "format": "uri"
+              }
+            }
+          },
+          {
+            "key": "field_course_status",
+            "label": "Course Status",
+            "name": "course_status",
+            "type": "select",
+            "default": "active",
+            "options": {
+              "active": "Active",
+              "upcoming": "Upcoming",
+              "archived": "Archived"
+            },
+            "validation": {
+              "required": true,
+              "enum": [
+                "active",
+                "upcoming",
+                "archived"
+              ]
+            },
+            "instructions": "Status value used by Elementor \"Active Courses\" queries.",
+            "expose_in_rest": true,
+            "show_in_rest": {
+              "schema": {
+                "type": "string",
+                "enum": [
+                  "active",
+                  "upcoming",
+                  "archived"
+                ]
               }
             }
           },

--- a/src/Elementor/Query/Filters.php
+++ b/src/Elementor/Query/Filters.php
@@ -252,7 +252,7 @@ class Filters
     }
 
     /**
-     * Active courses are published entries with an "active" status flag.
+     * Active courses are published entries with a "course_status" meta of "active".
      */
     public static function handleActiveCourses($query, $widget = null): void
     {
@@ -266,7 +266,7 @@ class Filters
         self::applySearch($query, ['gm2_course_search', 'gm2_search']);
 
         self::appendMetaQuery($query, [
-            'key'   => 'status',
+            'key'   => 'course_status',
             'value' => 'active',
         ]);
 

--- a/tests/Elementor/Query/FiltersTest.php
+++ b/tests/Elementor/Query/FiltersTest.php
@@ -241,7 +241,37 @@ class FiltersTest extends WP_UnitTestCase
         $this->assertSame('Design', $query->get('s'));
 
         $metaQuery = $query->get('meta_query');
-        $this->assertSame('status', $metaQuery[0]['key']);
+        $this->assertSame('course_status', $metaQuery[0]['key']);
         $this->assertSame('active', $metaQuery[0]['value']);
+    }
+
+    public function test_courses_active_returns_only_active_posts(): void
+    {
+        $activeId = self::factory()->post->create([
+            'post_type'   => 'course',
+            'post_status' => 'publish',
+            'post_title'  => 'Active Course',
+        ]);
+        add_post_meta($activeId, 'course_status', 'active');
+
+        $inactiveId = self::factory()->post->create([
+            'post_type'   => 'course',
+            'post_status' => 'publish',
+            'post_title'  => 'Inactive Course',
+        ]);
+        add_post_meta($inactiveId, 'course_status', 'archived');
+
+        $query = new WP_Query();
+
+        do_action('elementor/query/gm2_courses_active', $query);
+
+        $query->query($query->query_vars);
+
+        $postIds = wp_list_pluck($query->posts, 'ID');
+
+        $this->assertContains($activeId, $postIds);
+        $this->assertNotContains($inactiveId, $postIds);
+
+        wp_reset_postdata();
     }
 }


### PR DESCRIPTION
## Summary
- add a REST-exposed `course_status` field to the course preset and document the active-course meta requirement
- update the Elementor active courses filter to rely on the `course_status` meta flag
- expand the filter test suite to cover the new meta key and ensure inactive courses are excluded

## Testing
- ./vendor/bin/phpunit *(fails: WordPress test suite cannot connect to MySQL in the container)*

------
https://chatgpt.com/codex/tasks/task_b_68cc59391b048330938771286b527602