### PR TITLE
Harden editorial comment permissions

### DIFF
--- a/includes/gm2-editorial-comments.php
+++ b/includes/gm2-editorial-comments.php
@@ -68,6 +68,10 @@ function gm2_editorial_notify_mentions($user_ids, $comment_id) {
  * @return int|false Comment ID on success, false on failure.
  */
 function gm2_add_editorial_comment($post_id, $message, $context = '') {
+    if (!current_user_can('edit_post', $post_id)) {
+        return false;
+    }
+
     $comment_id = wp_insert_comment([
         'comment_post_ID' => $post_id,
         'comment_content' => $message,
@@ -94,6 +98,10 @@ function gm2_add_editorial_comment($post_id, $message, $context = '') {
  * @return array Array of comment data.
  */
 function gm2_get_editorial_comments($post_id, $context = '') {
+    if (!current_user_can('edit_post', $post_id)) {
+        return [];
+    }
+
     $args = [
         'post_id' => $post_id,
         'type'    => 'gm2_editorial',
@@ -129,6 +137,11 @@ function gm2_ajax_add_editorial_comment() {
     if (!$post_id || $message === '') {
         wp_send_json_error();
     }
+    if (!current_user_can('edit_post', $post_id)) {
+        wp_send_json_error([
+            'message' => __('You are not allowed to edit this post.', 'gm2-wordpress-suite'),
+        ], 403);
+    }
     $comment_id = gm2_add_editorial_comment($post_id, $message, $context);
     $comments   = gm2_get_editorial_comments($post_id, $context);
     wp_send_json_success($comments);
@@ -144,6 +157,11 @@ function gm2_ajax_get_editorial_comments() {
     $context = isset($_GET['context']) ? sanitize_text_field($_GET['context']) : '';
     if (!$post_id) {
         wp_send_json_error();
+    }
+    if (!current_user_can('edit_post', $post_id)) {
+        wp_send_json_error([
+            'message' => __('You are not allowed to edit this post.', 'gm2-wordpress-suite'),
+        ], 403);
     }
     $comments = gm2_get_editorial_comments($post_id, $context);
     wp_send_json_success($comments);

--- a/tests/test-editorial-comments.php
+++ b/tests/test-editorial-comments.php
@@ -1,0 +1,157 @@
+<?php
+
+class EditorialCommentsAjaxTest extends WP_UnitTestCase {
+    private $post_id;
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->post_id = self::factory()->post->create([
+            'post_status' => 'draft',
+        ]);
+    }
+
+    protected function tearDown(): void {
+        $_POST    = [];
+        $_GET     = [];
+        $_REQUEST = [];
+        wp_set_current_user(0);
+        parent::tearDown();
+    }
+
+    public function test_add_comment_requires_edit_capability() {
+        $user_id = self::factory()->user->create(['role' => 'subscriber']);
+        wp_set_current_user($user_id);
+
+        $nonce = wp_create_nonce('gm2_editorial_comment');
+        $_POST = [
+            'post_id'     => $this->post_id,
+            'message'     => 'Unauthorized note',
+            'context'     => 'meta-box',
+            '_ajax_nonce' => $nonce,
+        ];
+        $_REQUEST = $_POST;
+
+        try {
+            gm2_ajax_add_editorial_comment();
+            $this->fail('Expected WPDieException not thrown');
+        } catch (\WPDieException $e) {
+            $response = json_decode($e->getMessage(), true);
+            $this->assertIsArray($response);
+            $this->assertFalse($response['success']);
+            $this->assertSame(
+                'You are not allowed to edit this post.',
+                $response['data']['message']
+            );
+        }
+
+        $comments = get_comments([
+            'post_id' => $this->post_id,
+            'type'    => 'gm2_editorial',
+        ]);
+        $this->assertCount(0, $comments);
+    }
+
+    public function test_add_comment_succeeds_for_authorized_user() {
+        $user_id = self::factory()->user->create(['role' => 'editor']);
+        wp_set_current_user($user_id);
+
+        $nonce = wp_create_nonce('gm2_editorial_comment');
+        $_POST = [
+            'post_id'     => $this->post_id,
+            'message'     => 'Authorized note',
+            'context'     => 'meta-box',
+            '_ajax_nonce' => $nonce,
+        ];
+        $_REQUEST = $_POST;
+
+        try {
+            gm2_ajax_add_editorial_comment();
+            $this->fail('Expected WPDieException not thrown');
+        } catch (\WPDieException $e) {
+            $response = json_decode($e->getMessage(), true);
+            $this->assertTrue($response['success']);
+            $this->assertCount(1, $response['data']);
+            $this->assertSame('Authorized note', $response['data'][0]['content']);
+        }
+
+        $comments = get_comments([
+            'post_id' => $this->post_id,
+            'type'    => 'gm2_editorial',
+        ]);
+        $this->assertCount(1, $comments);
+        $this->assertSame('Authorized note', $comments[0]->comment_content);
+    }
+
+    public function test_get_comments_requires_edit_capability() {
+        $editor_id = self::factory()->user->create(['role' => 'editor']);
+        wp_set_current_user($editor_id);
+        $comment_id = wp_insert_comment([
+            'comment_post_ID'      => $this->post_id,
+            'comment_content'      => 'Hidden note',
+            'user_id'              => $editor_id,
+            'comment_type'         => 'gm2_editorial',
+            'comment_approved'     => 1,
+            'comment_author'       => 'Editor',
+            'comment_author_email' => 'editor@example.com',
+        ]);
+        add_comment_meta($comment_id, 'gm2_context', 'meta-box');
+        wp_set_current_user(0);
+
+        $subscriber_id = self::factory()->user->create(['role' => 'subscriber']);
+        wp_set_current_user($subscriber_id);
+
+        $nonce = wp_create_nonce('gm2_editorial_comment');
+        $_GET = [
+            'post_id'     => $this->post_id,
+            'context'     => 'meta-box',
+            '_ajax_nonce' => $nonce,
+        ];
+        $_REQUEST = $_GET;
+
+        try {
+            gm2_ajax_get_editorial_comments();
+            $this->fail('Expected WPDieException not thrown');
+        } catch (\WPDieException $e) {
+            $response = json_decode($e->getMessage(), true);
+            $this->assertFalse($response['success']);
+            $this->assertSame(
+                'You are not allowed to edit this post.',
+                $response['data']['message']
+            );
+        }
+    }
+
+    public function test_get_comments_succeeds_for_authorized_user() {
+        $editor_id = self::factory()->user->create(['role' => 'editor']);
+        wp_set_current_user($editor_id);
+        $comment_id = wp_insert_comment([
+            'comment_post_ID'      => $this->post_id,
+            'comment_content'      => 'Visible note',
+            'user_id'              => $editor_id,
+            'comment_type'         => 'gm2_editorial',
+            'comment_approved'     => 1,
+            'comment_author'       => 'Editor',
+            'comment_author_email' => 'editor@example.com',
+        ]);
+        add_comment_meta($comment_id, 'gm2_context', 'meta-box');
+
+        $nonce = wp_create_nonce('gm2_editorial_comment');
+        $_GET = [
+            'post_id'     => $this->post_id,
+            'context'     => 'meta-box',
+            '_ajax_nonce' => $nonce,
+        ];
+        $_REQUEST = $_GET;
+
+        try {
+            gm2_ajax_get_editorial_comments();
+            $this->fail('Expected WPDieException not thrown');
+        } catch (\WPDieException $e) {
+            $response = json_decode($e->getMessage(), true);
+            $this->assertTrue($response['success']);
+            $this->assertCount(1, $response['data']);
+            $this->assertSame('Visible note', $response['data'][0]['content']);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- ensure editorial comment insert and fetch handlers enforce the `edit_post` capability
- short-circuit helper utilities when the current user lacks permission
- cover authorized and unauthorized AJAX flows with new PHPUnit tests

## Testing
- `vendor/bin/phpunit --testsuite "Plugin Test Suite"` *(fails: fatal error in existing DirectoryMapper property default)*

------
https://chatgpt.com/codex/tasks/task_b_68cc62f852188330ab5e15c80396e096