### PR TITLE
Protect font performance AJAX handlers

### DIFF
--- a/modules/font-performance/admin/class-font-performance-admin.php
+++ b/modules/font-performance/admin/class-font-performance-admin.php
@@ -172,6 +172,11 @@ class Font_Performance_Admin {
 
     /** AJAX handler to detect variants. */
     public static function ajax_detect_variants(): void {
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error([
+                'message' => __('Insufficient permissions.', 'gm2-wordpress-suite'),
+            ], 403);
+        }
         check_ajax_referer('gm2_font_variants', 'nonce');
         $variants = \Gm2\Font_Performance\Font_Performance::detect_font_variants();
         wp_send_json_success($variants);
@@ -179,6 +184,11 @@ class Font_Performance_Admin {
 
     /** AJAX handler to compute font size savings. */
     public static function ajax_font_size_diff(): void {
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error([
+                'message' => __('Insufficient permissions.', 'gm2-wordpress-suite'),
+            ], 403);
+        }
         check_ajax_referer('gm2_font_variants', 'nonce');
         $selected = $_POST['variants'] ?? [];
         if (!is_array($selected)) {

--- a/tests/FontPerformanceAdminAjaxTest.php
+++ b/tests/FontPerformanceAdminAjaxTest.php
@@ -1,0 +1,99 @@
+<?php
+
+use Gm2\Font_Performance\Admin\Font_Performance_Admin;
+
+class FontPerformanceAdminAjaxTest extends WP_Ajax_UnitTestCase {
+    public static function set_up_before_class(): void {
+        parent::set_up_before_class();
+
+        // Ensure AJAX callbacks are registered for tests.
+        if (!class_exists(Font_Performance_Admin::class) && defined('GM2_PLUGIN_DIR')) {
+            require_once GM2_PLUGIN_DIR . 'modules/font-performance/admin/class-font-performance-admin.php';
+        }
+        Font_Performance_Admin::init();
+    }
+
+    public function test_detect_variants_denied_without_manage_options(): void {
+        $this->_setRole('subscriber');
+        $_POST['nonce'] = wp_create_nonce('gm2_font_variants');
+
+        $status = null;
+        $callback = static function ($status_header, $code, $description) use (&$status) {
+            $status = $code;
+            return $status_header;
+        };
+        add_filter('status_header', $callback, 10, 3);
+
+        try {
+            $this->_handleAjax('gm2_detect_font_variants');
+        } catch (WPAjaxDieContinueException $e) {
+            // Expected due to wp_die in wp_send_json_* functions.
+        }
+
+        remove_filter('status_header', $callback, 10);
+
+        $response = json_decode($this->_last_response, true);
+        $this->assertSame(403, $status);
+        $this->assertFalse($response['success']);
+        $this->assertSame('Insufficient permissions.', $response['data']['message']);
+    }
+
+    public function test_detect_variants_allowed_for_manage_options(): void {
+        $this->_setRole('administrator');
+        $_POST['nonce'] = wp_create_nonce('gm2_font_variants');
+
+        try {
+            $this->_handleAjax('gm2_detect_font_variants');
+        } catch (WPAjaxDieContinueException $e) {
+            // Expected due to wp_die in wp_send_json_* functions.
+        }
+
+        $response = json_decode($this->_last_response, true);
+        $this->assertTrue($response['success']);
+        $this->assertIsArray($response['data']);
+    }
+
+    public function test_font_size_diff_denied_without_manage_options(): void {
+        $this->_setRole('subscriber');
+        $_POST['nonce']    = wp_create_nonce('gm2_font_variants');
+        $_POST['variants'] = ['400 normal'];
+
+        $status = null;
+        $callback = static function ($status_header, $code, $description) use (&$status) {
+            $status = $code;
+            return $status_header;
+        };
+        add_filter('status_header', $callback, 10, 3);
+
+        try {
+            $this->_handleAjax('gm2_font_size_diff');
+        } catch (WPAjaxDieContinueException $e) {
+            // Expected due to wp_die in wp_send_json_* functions.
+        }
+
+        remove_filter('status_header', $callback, 10);
+
+        $response = json_decode($this->_last_response, true);
+        $this->assertSame(403, $status);
+        $this->assertFalse($response['success']);
+        $this->assertSame('Insufficient permissions.', $response['data']['message']);
+    }
+
+    public function test_font_size_diff_allowed_for_manage_options(): void {
+        $this->_setRole('administrator');
+        $_POST['nonce']    = wp_create_nonce('gm2_font_variants');
+        $_POST['variants'] = ['400 normal'];
+
+        try {
+            $this->_handleAjax('gm2_font_size_diff');
+        } catch (WPAjaxDieContinueException $e) {
+            // Expected due to wp_die in wp_send_json_* functions.
+        }
+
+        $response = json_decode($this->_last_response, true);
+        $this->assertTrue($response['success']);
+        $this->assertArrayHasKey('total', $response['data']);
+        $this->assertArrayHasKey('selected', $response['data']);
+        $this->assertArrayHasKey('reduction', $response['data']);
+    }
+}


### PR DESCRIPTION
## Summary
- enforce the font performance AJAX callbacks to require `manage_options` before verifying nonces
- return JSON 403 errors for unauthorized requests and cover both success/denial paths with new PHPUnit tests

## Testing
- `vendor/bin/phpunit --filter FontPerformanceAdminAjaxTest` *(fails: Fatal error from existing DirectoryMapper typed property default when loading plugin)*

------
https://chatgpt.com/codex/tasks/task_b_68cc66ae3e248330b942303c4c2e8717