### PR TITLE
Add meta index manager and CLI tooling

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,8 @@ For front-end submission flows, review [frontend-submission.md](frontend-submiss
 the field references in [fields-and-validation.md](fields-and-validation.md) and
 [field-definition-schema.md](field-definition-schema.md), plus Elementor specifics in
 [elementor-dynamic-tags.md](elementor-dynamic-tags.md).
+For database tuning guidance on composite meta indexes see
+[performance-indexes.md](performance-indexes.md).
 For schema mapping and SEO integration examples, see [schema-mapping-and-seo.md](schema-mapping-and-seo.md).
 
 For font optimization checks, review [font-performance-test-plan.md](font-performance-test-plan.md).

--- a/docs/performance-indexes.md
+++ b/docs/performance-indexes.md
@@ -1,0 +1,68 @@
+# Composite meta indexes
+
+The suite can register composite indexes that combine `meta_key` with a typed
+representation of `meta_value`. These indexes speed up meta queries that filter
+by a key **and** perform comparisons on the stored value. Common examples are
+range checks on `_gm2_start_date`, numeric comparisons on `_gm2_price`, or
+geospatial lookups on `_gm2_latitude`/`_gm2_longitude`.
+
+## Why add composite indexes?
+
+WordPress stores meta data in the `wp_postmeta` table where the `meta_value`
+column is a `LONGTEXT`. Without an index MySQL has to scan the entire table for
+each query. Creating a composite index on `(meta_key, CAST(meta_value AS ...))`
+allows the database to seek directly to the matching rows and dramatically
+reduces response times for faceted searches, REST API filters and background
+jobs that sort or filter by course dates, job price ranges and similar values.
+
+The default manager registers indexes for:
+
+- `start_date` and `end_date` as `CAST(meta_value AS DATETIME)`
+- `price` as `CAST(meta_value AS DECIMAL(18,2))`
+- `latitude` and `longitude` as `CAST(meta_value AS DECIMAL(10,6))`
+- `course_status` and `job_status` using a shortened `meta_value(32)` prefix
+
+Sites can add or remove keys via the
+`gm2_performance_meta_index_keys` filter and can override the SQL definition for
+any key with the `gm2_performance_meta_index_definitions` filter. Use
+`gm2_performance_meta_index_table` to point the manager at a different meta
+table.
+
+## When to avoid or drop an index
+
+Indexes trade faster reads for slower writes. Each insert, update or delete of
+the indexed meta keys must also update the index tree. For sites with frequent
+writes or large import jobs you may wish to disable indexes temporarily:
+
+```php
+add_filter( 'gm2_performance_meta_index_keys', function ( $keys ) {
+    return array_diff( $keys, [ 'latitude', 'longitude' ] );
+} );
+```
+
+Alternatively drop the index before bulk imports and recreate it afterwards with
+the CLI commands below.
+
+## WP-CLI commands
+
+Use the new `gm2 perf indexes` namespace to inspect and manage indexes:
+
+```bash
+wp gm2 perf indexes list
+wp gm2 perf indexes list --key=price
+wp gm2 perf indexes create --key=start_date --yes
+wp gm2 perf indexes drop --key=latitude --yes
+```
+
+The commands return the current status, ask for confirmation before destructive
+changes and surface the filters listed above so you can audit site-specific
+configuration.
+
+## Testing index SQL
+
+If you add new keys or customise the SQL ensure the resulting `CREATE INDEX`
+statement matches what your MySQL version supports. The
+`Gm2\Performance\MetaIndexManager` class exposes helper methods like
+`generateCreateStatement()` and `generateDropStatement()` that you can call from
+unit tests or wp shell to verify the generated SQL before deploying to
+production.

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -921,6 +921,7 @@ if (defined('WP_CLI') && WP_CLI) {
     require_once GM2_PLUGIN_DIR . 'includes/cli/class-ae-seo-critical-cli.php';
     require_once GM2_PLUGIN_DIR . 'includes/cli/class-ae-seo-js-smoketest.php';
     require_once GM2_PLUGIN_DIR . 'includes/cli/class-ae-seo-js-map.php';
+    require_once GM2_PLUGIN_DIR . 'includes/cli/class-gm2-performance-cli.php';
     require_once GM2_PLUGIN_DIR . 'includes/cli/class-font-performance-cli.php';
 }
 

--- a/includes/cli/class-gm2-performance-cli.php
+++ b/includes/cli/class-gm2-performance-cli.php
@@ -1,0 +1,133 @@
+<?php
+namespace Gm2;
+
+use Gm2\Performance\MetaIndexManager;
+
+if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+    return;
+}
+
+class Gm2_Performance_CLI extends \WP_CLI_Command {
+    /**
+     * List registered composite meta indexes.
+     *
+     * ## OPTIONS
+     *
+     * [--key=<meta_key>]
+     * : Limit output to a single meta key.
+     */
+    public function list_( $args, $assoc_args ) {
+        $manager = $this->get_manager();
+        $key     = $assoc_args['key'] ?? null;
+        $rows    = $manager->describe();
+
+        if ( $key !== null ) {
+            if ( ! isset( $rows[ $key ] ) ) {
+                \WP_CLI::error( sprintf( __( 'Meta key "%s" is not registered for indexing.', 'gm2-wordpress-suite' ), $key ) );
+            }
+            $rows = [ $rows[ $key ] ];
+        }
+
+        foreach ( $rows as $row ) {
+            $status = $row['exists'] ? __( 'exists', 'gm2-wordpress-suite' ) : __( 'missing', 'gm2-wordpress-suite' );
+            \WP_CLI::line( sprintf( '%s: %s (%s %s)', $row['meta_key'], $status, __( 'index', 'gm2-wordpress-suite' ), $row['index_name'] ) );
+            \WP_CLI::line( sprintf( '  %s', $row['expression'] ) );
+        }
+
+        \WP_CLI::line( sprintf(
+            __( 'Filters: %1$s (meta keys), %2$s (index definitions).', 'gm2-wordpress-suite' ),
+            MetaIndexManager::FILTER_META_KEYS,
+            MetaIndexManager::FILTER_DEFINITIONS
+        ) );
+    }
+
+    /**
+     * Create a composite meta index.
+     *
+     * ## OPTIONS
+     *
+     * --key=<meta_key>
+     * : Meta key to index.
+     *
+     * [--yes]
+     * : Answer yes to the confirmation message.
+     */
+    public function create( $args, $assoc_args ) {
+        $manager = $this->get_manager();
+        $key     = $assoc_args['key'] ?? '';
+
+        if ( $key === '' ) {
+            \WP_CLI::error( __( 'Use --key=<meta_key> to select an index.', 'gm2-wordpress-suite' ) );
+        }
+
+        $definition = $manager->getDefinition( $key );
+        if ( $definition === null ) {
+            \WP_CLI::error( sprintf( __( 'Meta key "%s" is not registered for indexing.', 'gm2-wordpress-suite' ), $key ) );
+        }
+
+        \WP_CLI::confirm( sprintf( __( 'Create index %1$s on %2$s?', 'gm2-wordpress-suite' ), $definition['name'], $definition['table'] ), $assoc_args );
+
+        $result = $manager->create( $key );
+        switch ( $result['status'] ?? '' ) {
+            case 'created':
+                \WP_CLI::success( sprintf( __( 'Created index %1$s for meta key %2$s.', 'gm2-wordpress-suite' ), $definition['name'], $key ) );
+                return;
+            case 'exists':
+                \WP_CLI::warning( sprintf( __( 'Index %1$s already exists for meta key %2$s.', 'gm2-wordpress-suite' ), $definition['name'], $key ) );
+                return;
+            case 'error':
+                \WP_CLI::error( sprintf( __( 'Failed to create index: %s', 'gm2-wordpress-suite' ), $result['message'] ?? __( 'Unknown error.', 'gm2-wordpress-suite' ) ) );
+                return;
+        }
+
+        \WP_CLI::error( __( 'Meta index operation failed.', 'gm2-wordpress-suite' ) );
+    }
+
+    /**
+     * Drop a composite meta index.
+     *
+     * ## OPTIONS
+     *
+     * --key=<meta_key>
+     * : Meta key whose index should be dropped.
+     *
+     * [--yes]
+     * : Answer yes to the confirmation message.
+     */
+    public function drop( $args, $assoc_args ) {
+        $manager = $this->get_manager();
+        $key     = $assoc_args['key'] ?? '';
+
+        if ( $key === '' ) {
+            \WP_CLI::error( __( 'Use --key=<meta_key> to select an index.', 'gm2-wordpress-suite' ) );
+        }
+
+        $definition = $manager->getDefinition( $key );
+        if ( $definition === null ) {
+            \WP_CLI::error( sprintf( __( 'Meta key "%s" is not registered for indexing.', 'gm2-wordpress-suite' ), $key ) );
+        }
+
+        \WP_CLI::confirm( sprintf( __( 'Drop index %1$s on %2$s?', 'gm2-wordpress-suite' ), $definition['name'], $definition['table'] ), $assoc_args );
+
+        $result = $manager->drop( $key );
+        switch ( $result['status'] ?? '' ) {
+            case 'dropped':
+                \WP_CLI::success( sprintf( __( 'Dropped index %1$s for meta key %2$s.', 'gm2-wordpress-suite' ), $definition['name'], $key ) );
+                return;
+            case 'missing':
+                \WP_CLI::warning( sprintf( __( 'Index %1$s was not present on %2$s.', 'gm2-wordpress-suite' ), $definition['name'], $definition['table'] ) );
+                return;
+            case 'error':
+                \WP_CLI::error( sprintf( __( 'Failed to drop index: %s', 'gm2-wordpress-suite' ), $result['message'] ?? __( 'Unknown error.', 'gm2-wordpress-suite' ) ) );
+                return;
+        }
+
+        \WP_CLI::error( __( 'Meta index operation failed.', 'gm2-wordpress-suite' ) );
+    }
+
+    private function get_manager(): MetaIndexManager {
+        return new MetaIndexManager();
+    }
+}
+
+\WP_CLI::add_command( 'gm2 perf indexes', __NAMESPACE__ . '\\Gm2_Performance_CLI' );

--- a/src/Performance/MetaIndexManager.php
+++ b/src/Performance/MetaIndexManager.php
@@ -1,0 +1,340 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gm2\Performance;
+
+use RuntimeException;
+
+use function addslashes;
+use function apply_filters;
+use function array_filter;
+use function array_map;
+use function array_unique;
+use function array_values;
+use function explode;
+use function implode;
+use function is_array;
+use function is_object;
+use function method_exists;
+use function preg_replace;
+use function sprintf;
+use function str_replace;
+use function strtolower;
+use function trim;
+
+final class MetaIndexManager
+{
+    public const FILTER_META_KEYS      = 'gm2_performance_meta_index_keys';
+    public const FILTER_DEFINITIONS    = 'gm2_performance_meta_index_definitions';
+    public const FILTER_META_TABLE     = 'gm2_performance_meta_index_table';
+
+    /**
+     * Database connection used to inspect and manipulate indexes.
+     *
+     * @var object
+     */
+    private object $wpdb;
+
+    public function __construct(?object $wpdb = null)
+    {
+        if ($wpdb !== null) {
+            $this->wpdb = $wpdb;
+
+            return;
+        }
+
+        global $wpdb as $globalWpdb;
+        if (!is_object($globalWpdb)) {
+            throw new RuntimeException('The global $wpdb instance is not available.');
+        }
+
+        $this->wpdb = $globalWpdb;
+    }
+
+    /**
+     * Retrieve the default set of meta keys that receive composite indexes.
+     */
+    public function getDefaultMetaKeys(): array
+    {
+        return [
+            'start_date',
+            'end_date',
+            'price',
+            'latitude',
+            'longitude',
+            'course_status',
+            'job_status',
+        ];
+    }
+
+    /**
+     * Determine which table should receive the indexes.
+     */
+    public function getMetaTable(): string
+    {
+        $table = '';
+        if (isset($this->wpdb->postmeta) && $this->wpdb->postmeta !== '') {
+            $table = (string) $this->wpdb->postmeta;
+        }
+
+        if ($table === '') {
+            $prefix = isset($this->wpdb->prefix) ? (string) $this->wpdb->prefix : 'wp_';
+            $table  = $prefix . 'postmeta';
+        }
+
+        $table = apply_filters(self::FILTER_META_TABLE, $table, $this->wpdb);
+
+        return (string) $table;
+    }
+
+    /**
+     * Retrieve the filtered list of meta keys slated for indexing.
+     */
+    public function getMetaKeys(): array
+    {
+        $keys = apply_filters(self::FILTER_META_KEYS, $this->getDefaultMetaKeys(), $this->wpdb);
+        if (!is_array($keys)) {
+            $keys = [];
+        }
+
+        $keys = array_map(static fn($key): string => (string) $key, $keys);
+        $keys = array_filter($keys, static fn(string $key): bool => $key !== '');
+
+        return array_values(array_unique($keys));
+    }
+
+    /**
+     * Retrieve the normalized index definitions.
+     */
+    public function getDefinitions(): array
+    {
+        $table       = $this->getMetaTable();
+        $definitions = [];
+
+        foreach ($this->getMetaKeys() as $metaKey) {
+            $definitions[$metaKey] = $this->buildDefinition($metaKey, $table);
+        }
+
+        $definitions = apply_filters(self::FILTER_DEFINITIONS, $definitions, $table, $this->wpdb);
+        if (!is_array($definitions)) {
+            return [];
+        }
+
+        return $definitions;
+    }
+
+    /**
+     * Retrieve a specific index definition for a meta key.
+     */
+    public function getDefinition(string $metaKey): ?array
+    {
+        $definitions = $this->getDefinitions();
+
+        return $definitions[$metaKey] ?? null;
+    }
+
+    /**
+     * Generate the CREATE INDEX statement for a meta key.
+     */
+    public function generateCreateStatement(string $metaKey): ?string
+    {
+        $definition = $this->getDefinition($metaKey);
+
+        return $definition['create_sql'] ?? null;
+    }
+
+    /**
+     * Generate the DROP INDEX statement for a meta key.
+     */
+    public function generateDropStatement(string $metaKey): ?string
+    {
+        $definition = $this->getDefinition($metaKey);
+
+        return $definition['drop_sql'] ?? null;
+    }
+
+    /**
+     * Provide a status overview of each registered index.
+     */
+    public function describe(): array
+    {
+        $rows = [];
+        foreach ($this->getDefinitions() as $metaKey => $definition) {
+            $rows[$metaKey] = [
+                'meta_key'   => $metaKey,
+                'index_name' => $definition['name'],
+                'table'      => $definition['table'],
+                'expression' => $definition['expression'],
+                'exists'     => $this->indexExists($definition),
+            ];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * Create the index for a meta key when it does not already exist.
+     */
+    public function create(string $metaKey): array
+    {
+        $definition = $this->getDefinition($metaKey);
+        if ($definition === null) {
+            return ['status' => 'unknown'];
+        }
+
+        if ($this->indexExists($definition)) {
+            return ['status' => 'exists'];
+        }
+
+        $result = $this->wpdbQuery($definition['create_sql']);
+        if ($result === false) {
+            return [
+                'status'  => 'error',
+                'message' => $this->getLastError() ?: 'Failed to create index.',
+            ];
+        }
+
+        return ['status' => 'created'];
+    }
+
+    /**
+     * Drop the index for a meta key when it exists.
+     */
+    public function drop(string $metaKey): array
+    {
+        $definition = $this->getDefinition($metaKey);
+        if ($definition === null) {
+            return ['status' => 'unknown'];
+        }
+
+        if (!$this->indexExists($definition)) {
+            return ['status' => 'missing'];
+        }
+
+        $result = $this->wpdbQuery($definition['drop_sql']);
+        if ($result === false) {
+            return [
+                'status'  => 'error',
+                'message' => $this->getLastError() ?: 'Failed to drop index.',
+            ];
+        }
+
+        return ['status' => 'dropped'];
+    }
+
+    private function buildDefinition(string $metaKey, string $table): array
+    {
+        $indexName  = $this->buildIndexName($metaKey);
+        $expression = $this->expressionForMetaKey($metaKey);
+
+        $create = sprintf(
+            'CREATE INDEX %s ON %s (meta_key, %s)',
+            $this->quoteIdentifier($indexName),
+            $this->quoteIdentifier($table),
+            $expression
+        );
+
+        $drop = sprintf(
+            'DROP INDEX %s ON %s',
+            $this->quoteIdentifier($indexName),
+            $this->quoteIdentifier($table)
+        );
+
+        return [
+            'key'        => $metaKey,
+            'name'       => $indexName,
+            'table'      => $table,
+            'expression' => $expression,
+            'create_sql' => $create,
+            'drop_sql'   => $drop,
+        ];
+    }
+
+    private function buildIndexName(string $metaKey): string
+    {
+        $sanitized = preg_replace('/[^a-z0-9_]+/', '_', strtolower($metaKey)) ?? '';
+        $sanitized = trim($sanitized, '_');
+
+        if ($sanitized === '') {
+            $sanitized = 'meta';
+        }
+
+        return 'gm2_meta_' . $sanitized . '_idx';
+    }
+
+    private function expressionForMetaKey(string $metaKey): string
+    {
+        switch ($metaKey) {
+            case 'start_date':
+            case 'end_date':
+                return '(CAST(meta_value AS DATETIME))';
+            case 'price':
+                return '(CAST(meta_value AS DECIMAL(18,2)))';
+            case 'latitude':
+            case 'longitude':
+                return '(CAST(meta_value AS DECIMAL(10,6)))';
+            case 'course_status':
+            case 'job_status':
+                return 'meta_value(32)';
+            default:
+                return 'meta_value(191)';
+        }
+    }
+
+    private function indexExists(array $definition): bool
+    {
+        if (!method_exists($this->wpdb, 'get_results')) {
+            return false;
+        }
+
+        $sql = sprintf(
+            'SHOW INDEX FROM %s WHERE Key_name = %%s',
+            $this->quoteIdentifier($definition['table'])
+        );
+        $prepared = $this->wpdbPrepare($sql, $definition['name']);
+        $results  = $this->wpdb->get_results($prepared, 'ARRAY_A');
+
+        return !empty($results);
+    }
+
+    private function wpdbPrepare(string $query, string ...$args): string
+    {
+        if (method_exists($this->wpdb, 'prepare')) {
+            return $this->wpdb->prepare($query, ...$args);
+        }
+
+        foreach ($args as $arg) {
+            $query = preg_replace('/%s/', "'" . addslashes($arg) . "'", $query, 1);
+        }
+
+        return $query;
+    }
+
+    /**
+     * @return mixed
+     */
+    private function wpdbQuery(string $query)
+    {
+        if (!method_exists($this->wpdb, 'query')) {
+            return false;
+        }
+
+        return $this->wpdb->query($query);
+    }
+
+    private function quoteIdentifier(string $identifier): string
+    {
+        $parts = explode('.', $identifier);
+        foreach ($parts as &$part) {
+            $part = '`' . str_replace('`', '``', $part) . '`';
+        }
+
+        return implode('.', $parts);
+    }
+
+    private function getLastError(): string
+    {
+        return (string) ($this->wpdb->last_error ?? '');
+    }
+}

--- a/tests/Performance/MetaIndexManagerTest.php
+++ b/tests/Performance/MetaIndexManagerTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+use Gm2\Performance\MetaIndexManager;
+
+final class MetaIndexManagerTest extends WP_UnitTestCase
+{
+    public function test_generate_sql_for_numeric_meta_keys(): void
+    {
+        global $wpdb;
+
+        $manager = new MetaIndexManager();
+        $create  = $manager->generateCreateStatement('price');
+        $drop    = $manager->generateDropStatement('price');
+
+        $expectedCreate = sprintf(
+            'CREATE INDEX `%s` ON `%s` (meta_key, (CAST(meta_value AS DECIMAL(18,2))))',
+            'gm2_meta_price_idx',
+            $wpdb->postmeta
+        );
+        $expectedDrop = sprintf(
+            'DROP INDEX `%s` ON `%s`',
+            'gm2_meta_price_idx',
+            $wpdb->postmeta
+        );
+
+        $this->assertSame($expectedCreate, $create);
+        $this->assertSame($expectedDrop, $drop);
+    }
+
+    public function test_filters_can_disable_meta_key(): void
+    {
+        $callback = static function (array $keys): array {
+            return array_diff($keys, ['job_status']);
+        };
+
+        add_filter(MetaIndexManager::FILTER_META_KEYS, $callback, 10, 1);
+
+        try {
+            $manager = new MetaIndexManager(new MetaIndexManagerTest_FakeWpdb());
+            $this->assertNull($manager->getDefinition('job_status'));
+        } finally {
+            remove_filter(MetaIndexManager::FILTER_META_KEYS, $callback, 10);
+        }
+    }
+
+    public function test_create_reports_existing_indexes(): void
+    {
+        $wpdb = new MetaIndexManagerTest_FakeWpdb(['gm2_meta_start_date_idx']);
+        $manager = new MetaIndexManager($wpdb);
+
+        $result = $manager->create('start_date');
+
+        $this->assertSame('exists', $result['status']);
+        $creates = array_filter(
+            $wpdb->queries,
+            static fn(string $query): bool => strpos($query, 'CREATE INDEX') === 0
+        );
+        $this->assertSame([], array_values($creates));
+    }
+
+    public function test_drop_reports_missing_indexes(): void
+    {
+        $wpdb = new MetaIndexManagerTest_FakeWpdb();
+        $manager = new MetaIndexManager($wpdb);
+
+        $result = $manager->drop('latitude');
+
+        $this->assertSame('missing', $result['status']);
+    }
+
+    public function test_create_returns_error_message_from_wpdb(): void
+    {
+        $wpdb = new MetaIndexManagerTest_FakeWpdb([], true);
+        $manager = new MetaIndexManager($wpdb);
+
+        $result = $manager->create('course_status');
+
+        $this->assertSame('error', $result['status']);
+        $this->assertSame('Simulated failure', $result['message']);
+    }
+}
+
+final class MetaIndexManagerTest_FakeWpdb
+{
+    public string $postmeta = 'wp_postmeta';
+    public string $prefix   = 'wp_';
+    public string $last_error = '';
+    public array $queries = [];
+
+    /** @var array<int, string> */
+    private array $existing;
+    private bool $failOnQuery;
+
+    public function __construct(array $existing = [], bool $failOnQuery = false)
+    {
+        $this->existing    = $existing;
+        $this->failOnQuery = $failOnQuery;
+    }
+
+    public function prepare(string $query, ...$args): string
+    {
+        foreach ($args as $arg) {
+            $query = preg_replace('/%s/', "'" . addslashes((string) $arg) . "'", $query, 1);
+        }
+
+        return $query;
+    }
+
+    public function get_results(string $query, $output = null): array
+    {
+        $this->queries[] = $query;
+
+        foreach ($this->existing as $name) {
+            if (strpos($query, $name) !== false) {
+                return [['Key_name' => $name]];
+            }
+        }
+
+        return [];
+    }
+
+    public function query(string $query)
+    {
+        $this->queries[] = $query;
+
+        if ($this->failOnQuery) {
+            $this->last_error = 'Simulated failure';
+
+            return false;
+        }
+
+        if (preg_match('/CREATE INDEX `([^`]+)`/', $query, $matches) === 1) {
+            if (!in_array($matches[1], $this->existing, true)) {
+                $this->existing[] = $matches[1];
+            }
+        } elseif (preg_match('/DROP INDEX `([^`]+)`/', $query, $matches) === 1) {
+            $this->existing = array_values(array_filter(
+                $this->existing,
+                static fn(string $name): bool => $name !== $matches[1]
+            ));
+        }
+
+        return 1;
+    }
+}

--- a/tests/test-cli/performance-indexes.php
+++ b/tests/test-cli/performance-indexes.php
@@ -1,0 +1,144 @@
+<?php
+namespace Gm2;
+
+class MetaIndexCliTestWpdb
+{
+    public string $postmeta = 'wp_postmeta';
+    public string $prefix   = 'wp_';
+    public string $last_error = '';
+    public array $queries = [];
+    public array $existing;
+
+    public function __construct(array $existing = [])
+    {
+        $this->existing = $existing;
+    }
+
+    public function prepare(string $query, ...$args): string
+    {
+        foreach ($args as $arg) {
+            $query = preg_replace('/%s/', "'" . addslashes((string) $arg) . "'", $query, 1);
+        }
+
+        return $query;
+    }
+
+    public function get_results(string $query, $output = null): array
+    {
+        $this->queries[] = $query;
+        foreach ($this->existing as $name) {
+            if (strpos($query, $name) !== false) {
+                return [['Key_name' => $name]];
+            }
+        }
+
+        return [];
+    }
+
+    public function query(string $query)
+    {
+        $this->queries[] = $query;
+
+        if (preg_match('/CREATE INDEX `([^`]+)`/', $query, $matches) === 1) {
+            if (!in_array($matches[1], $this->existing, true)) {
+                $this->existing[] = $matches[1];
+            }
+        } elseif (preg_match('/DROP INDEX `([^`]+)`/', $query, $matches) === 1) {
+            $this->existing = array_values(array_filter(
+                $this->existing,
+                static fn(string $name): bool => $name !== $matches[1]
+            ));
+        }
+
+        return 1;
+    }
+}
+?>
+<?php
+namespace {
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'WP_CLI' ) ) {
+    define( 'WP_CLI', true );
+}
+
+if ( ! class_exists( 'WP_CLI' ) ) {
+    class WP_CLI {
+        public static $lines = [];
+        public static $confirmations = [];
+        public static function error( $msg, $code = 1 ) { throw new \Exception( $msg, $code ); }
+        public static function success( $msg ) { self::$lines[] = $msg; }
+        public static function warning( $msg ) { self::$lines[] = $msg; }
+        public static function line( $msg ) { self::$lines[] = $msg; }
+        public static function confirm( $msg, $assoc_args = [] ) { self::$confirmations[] = $msg; }
+        public static function add_command( $name, $callable ) {}
+    }
+}
+
+if ( ! class_exists( 'WP_CLI_Command' ) ) {
+    class WP_CLI_Command {}
+}
+
+class PerformanceIndexesCliTest extends TestCase
+{
+    private \Gm2\MetaIndexCliTestWpdb $wpdb;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        WP_CLI::$lines         = [];
+        WP_CLI::$confirmations = [];
+        $this->setWpdb();
+
+        if ( ! class_exists( '\\Gm2\\Gm2_Performance_CLI' ) ) {
+            require __DIR__ . '/../../includes/cli/class-gm2-performance-cli.php';
+        }
+    }
+
+    private function setWpdb(array $existing = []): void
+    {
+        $this->wpdb       = new \Gm2\MetaIndexCliTestWpdb( $existing );
+        $GLOBALS['wpdb'] = $this->wpdb;
+    }
+
+    public function test_list_outputs_status(): void
+    {
+        $this->setWpdb( ['gm2_meta_price_idx'] );
+        $cli = new \Gm2\Gm2_Performance_CLI();
+        $cli->list_( [], [] );
+
+        $output = implode( "\n", WP_CLI::$lines );
+        $this->assertNotEmpty( $output );
+        $this->assertStringContainsString( 'price: exists', $output );
+        $this->assertStringContainsString( 'Filters:', end( WP_CLI::$lines ) );
+    }
+
+    public function test_create_creates_index_and_confirms(): void
+    {
+        $cli = new \Gm2\Gm2_Performance_CLI();
+        $cli->create( [], [ 'key' => 'start_date', 'yes' => true ] );
+
+        $this->assertContains( 'gm2_meta_start_date_idx', $this->wpdb->existing );
+        $this->assertContains( 'Create index gm2_meta_start_date_idx on wp_postmeta?', WP_CLI::$confirmations );
+        $this->assertContains( 'Created index gm2_meta_start_date_idx for meta key start_date.', WP_CLI::$lines );
+    }
+
+    public function test_drop_warns_when_missing(): void
+    {
+        $cli = new \Gm2\Gm2_Performance_CLI();
+        $cli->drop( [], [ 'key' => 'latitude', 'yes' => true ] );
+
+        $this->assertContains( 'was not present', implode( '\n', WP_CLI::$lines ) );
+    }
+
+    public function test_create_with_unknown_key_errors(): void
+    {
+        $cli = new \Gm2\Gm2_Performance_CLI();
+
+        $this->expectException( \Exception::class );
+        $this->expectExceptionMessage( 'Meta key "unknown" is not registered for indexing.' );
+        $cli->create( [], [ 'key' => 'unknown', 'yes' => true ] );
+    }
+}
+}

--- a/tests/test-cli/seo-perf.php
+++ b/tests/test-cli/seo-perf.php
@@ -23,15 +23,21 @@ use PHPUnit\Framework\TestCase;
 
 define( 'WP_CLI', true );
 
-class WP_CLI {
-    public static $lines = [];
-    public static function error( $msg, $code = 1 ) { throw new \Exception( $msg, $code ); }
-    public static function success( $msg ) { self::$lines[] = $msg; }
-    public static function warning( $msg ) { self::$lines[] = $msg; }
-    public static function line( $msg ) { self::$lines[] = $msg; }
-    public static function add_command( $name, $callable ) {}
+if ( ! class_exists( 'WP_CLI' ) ) {
+    class WP_CLI {
+        public static $lines = [];
+        public static $confirmations = [];
+        public static function error( $msg, $code = 1 ) { throw new \Exception( $msg, $code ); }
+        public static function success( $msg ) { self::$lines[] = $msg; }
+        public static function warning( $msg ) { self::$lines[] = $msg; }
+        public static function line( $msg ) { self::$lines[] = $msg; }
+        public static function confirm( $msg, $assoc_args = [] ) { self::$confirmations[] = $msg; }
+        public static function add_command( $name, $callable ) {}
+    }
 }
-class WP_CLI_Command {}
+if ( ! class_exists( 'WP_CLI_Command' ) ) {
+    class WP_CLI_Command {}
+}
 
 class WP_Error {
     protected $code;
@@ -49,6 +55,9 @@ function gm2_ai_send_prompt( $prompt ) { return $GLOBALS['gm2_ai_response']; }
 class SeoPerfCliTest extends TestCase {
     protected function setUp(): void {
         WP_CLI::$lines = [];
+        if ( property_exists( WP_CLI::class, 'confirmations' ) ) {
+            WP_CLI::$confirmations = [];
+        }
         $GLOBALS['apache_result'] = [ 'status' => 'written' ];
         $GLOBALS['nginx_result']  = [ 'status' => 'written', 'file' => '/tmp/nginx.conf' ];
         $GLOBALS['gm2_ai_response'] = [ 'ok' => true ];


### PR DESCRIPTION
## Summary
- add a MetaIndexManager service for registering, checking and dropping composite meta indexes with opt-in filters
- expose `wp gm2 perf indexes` CLI commands with confirmation prompts for listing, creating and dropping the managed indexes
- document when to enable or remove composite indexes and add PHPUnit coverage for the manager plus CLI shims

## Testing
- `./vendor/bin/phpunit` *(fails: WordPress test suite not installed; mysqladmin unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_b_68cc6ec1219c8330bceead6c1de66450