### PR TITLE
Expose CPT meta to WPGraphQL automatically

### DIFF
--- a/tests/test-graphql.php
+++ b/tests/test-graphql.php
@@ -1,6 +1,5 @@
 <?php
 
-use Gm2\Gm2_REST_Visibility;
 use Gm2\GraphQL\Registry as GraphQLRegistry;
 
 if (!class_exists('WPGraphQL')) {
@@ -74,15 +73,6 @@ class GraphQLRegistrationTest extends WP_UnitTestCase {
             ],
         ]);
 
-        update_option(Gm2_REST_Visibility::OPTION, [
-            'post_types' => [ 'book' => true ],
-            'taxonomies' => [],
-            'fields' => [
-                'isbn' => true,
-                'profile' => true,
-            ],
-        ]);
-
         GraphQLRegistry::init();
     }
 
@@ -90,7 +80,6 @@ class GraphQLRegistrationTest extends WP_UnitTestCase {
         unregister_post_type('book');
         unregister_post_meta('book', 'isbn');
         unregister_post_meta('book', 'profile');
-        delete_option(Gm2_REST_Visibility::OPTION);
         delete_option('gm2_field_caps');
         wp_set_current_user(0);
         parent::tearDown();
@@ -143,5 +132,99 @@ class GraphQLRegistrationTest extends WP_UnitTestCase {
         ]);
 
         $this->assertNull($isbnResolver(get_post($postId), [], null, null));
+    }
+
+    public function test_publicly_queryable_post_types_are_respected(): void {
+        global $gm2_graphql_fields;
+
+        unregister_post_type('private_book');
+        register_post_type('private_book', [
+            'label' => 'Private Book',
+            'public' => false,
+            'publicly_queryable' => false,
+            'show_in_graphql' => true,
+            'graphql_single_name' => 'PrivateBook',
+        ]);
+
+        register_post_meta('private_book', 'secret', [
+            'single' => true,
+            'type' => 'string',
+            'show_in_rest' => [
+                'schema' => [
+                    'type' => 'string',
+                ],
+            ],
+        ]);
+
+        do_action('graphql_register_types');
+
+        $this->assertArrayNotHasKey('PrivateBook', $gm2_graphql_fields);
+
+        unregister_post_type('private_book');
+        unregister_post_meta('private_book', 'secret');
+    }
+
+    public function test_field_name_filter_allows_custom_names(): void {
+        global $gm2_graphql_fields;
+
+        $callback = function ($name, $metaKey, $objectType) {
+            if ($metaKey === 'isbn' && $objectType === 'post') {
+                return 'isbnCode';
+            }
+
+            return $name;
+        };
+
+        add_filter('gm2/graphql/field_name', $callback, 10, 5);
+
+        do_action('graphql_register_types');
+
+        remove_filter('gm2/graphql/field_name', $callback, 10);
+
+        $this->assertArrayHasKey('Book', $gm2_graphql_fields);
+        $this->assertArrayHasKey('isbnCode', $gm2_graphql_fields['Book']);
+        $this->assertArrayNotHasKey('isbn', $gm2_graphql_fields['Book']);
+    }
+
+    public function test_auth_callback_is_respected(): void {
+        global $gm2_graphql_fields;
+
+        register_post_meta('book', 'restricted', [
+            'single' => true,
+            'type' => 'string',
+            'show_in_rest' => [
+                'schema' => [
+                    'type' => 'string',
+                ],
+            ],
+            'auth_callback' => function ($allowed, $metaKey, $postId, $userId) {
+                if (!user_can($userId, 'manage_options')) {
+                    return false;
+                }
+
+                return $allowed;
+            },
+        ]);
+
+        do_action('graphql_register_types');
+
+        $this->assertArrayHasKey('Book', $gm2_graphql_fields);
+        $this->assertArrayHasKey('restricted', $gm2_graphql_fields['Book']);
+
+        $postId = self::factory()->post->create([ 'post_type' => 'book' ]);
+        update_post_meta($postId, 'restricted', 'secret');
+
+        $resolver = $gm2_graphql_fields['Book']['restricted']['resolve'];
+
+        $subscriber = self::factory()->user->create([ 'role' => 'subscriber' ]);
+        wp_set_current_user($subscriber);
+        $this->assertNull($resolver(get_post($postId), [], null, null));
+
+        $admin = self::factory()->user->create([ 'role' => 'administrator' ]);
+        wp_set_current_user($admin);
+        $this->assertSame('secret', $resolver(get_post($postId), [], null, null));
+
+        unregister_post_meta('book', 'restricted');
+        wp_set_current_user(0);
     }
 }


### PR DESCRIPTION
## Summary
- automatically register public custom post type and taxonomy meta with WPGraphQL when available
- honour publicly_queryable flags and meta auth callbacks when resolving GraphQL fields
- extend GraphQL unit tests to cover field-name filters and auth restrictions

## Testing
- php -l src/GraphQL/Registry.php
- php -l tests/test-graphql.php

------
https://chatgpt.com/codex/tasks/task_b_68cc86c7ddd0833081fc676769fc1070