### PR TITLE
Localize admin wizards

### DIFF
--- a/admin/js/gm2-cpt-wizard.js
+++ b/admin/js/gm2-cpt-wizard.js
@@ -2,6 +2,7 @@
     const { createElement: el, useState, useEffect } = wp.element;
     const { render } = wp.element;
     const { Button, TextControl, SelectControl, PanelBody, Panel, NoticeList, SnackbarList } = wp.components;
+    const { __, sprintf } = wp.i18n;
     const { dispatch, useSelect } = wp.data;
     const addPassive = !window.AE_PERF_DISABLE_PASSIVE && window.aePerf?.addPassive
         ? window.aePerf.addPassive
@@ -10,7 +11,7 @@
     const slugify = (str) => str.toLowerCase().replace(/[^a-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '');
 
     const StepOne = ({ existing, currentModel, setCurrentModel, loadModel, rawSlug, setRawSlug, stepOneErrors, data, setData, setStepOneErrors }) => {
-        const options = [ { label: 'New', value: '' } ];
+        const options = [ { label: __('New', 'gm2-wordpress-suite'), value: '' } ];
         Object.keys(existing).forEach(sl => {
             options.push({ label: existing[sl].label || sl, value: sl });
         });
@@ -45,23 +46,23 @@
         const validFieldTypes = [ 'text', 'textarea', 'number', 'select', 'checkbox', 'radio', 'email', 'url', 'date' ];
         const parsePreset = (raw) => {
             if(!raw){
-                throw new Error('Preset data missing.');
+                throw new Error(__('Preset data missing.', 'gm2-wordpress-suite'));
             }
             let blueprint = raw;
             if(typeof raw === 'string'){
                 try {
                     blueprint = JSON.parse(raw);
                 } catch (err) {
-                    throw new Error('Invalid preset JSON.');
+                    throw new Error(__('Invalid preset JSON.', 'gm2-wordpress-suite'));
                 }
             }
             if(!blueprint || typeof blueprint !== 'object'){
-                throw new Error('Invalid preset data.');
+                throw new Error(__('Invalid preset data.', 'gm2-wordpress-suite'));
             }
             const postTypes = blueprint.post_types || {};
             const slugs = Object.keys(postTypes);
             if(!slugs.length){
-                throw new Error('Preset is missing a post type.');
+                throw new Error(__('Preset is missing a post type.', 'gm2-wordpress-suite'));
             }
             const presetSlug = slugify(slugs[0]);
             const presetPT = postTypes[slugs[0]] || {};
@@ -105,12 +106,12 @@
         };
         const importPreset = () => {
             if(!selectedPreset){
-                notify('error', 'Please select a preset to import.');
+                notify('error', __('Please select a preset to import.', 'gm2-wordpress-suite'));
                 return;
             }
             const nonce = (window.gm2CPTWizard && (window.gm2CPTWizard.importNonce || window.gm2CPTWizard.presetNonce));
             if(!nonce){
-                notify('error', 'Preset import is not available.');
+                notify('error', __('Preset import is not available.', 'gm2-wordpress-suite'));
                 return;
             }
             const payload = new URLSearchParams();
@@ -132,32 +133,32 @@
                         setStepOneErrors({});
                         setData({ slug: parsed.slug, label: parsed.label, fields: parsed.fields, taxonomies: parsed.taxonomies });
                         setRawSlug(parsed.slug);
-                        notify('success', (resp.data && resp.data.message) || 'Preset applied.');
+                        notify('success', (resp.data && resp.data.message) || __('Preset applied.', 'gm2-wordpress-suite'));
                     } catch (err) {
-                        notify('error', err.message || 'Failed to apply preset.');
+                        notify('error', err.message || __('Failed to apply preset.', 'gm2-wordpress-suite'));
                     }
                 } else {
-                    const message = resp && resp.data && resp.data.message ? resp.data.message : 'Failed to import preset.';
+                    const message = resp && resp.data && resp.data.message ? resp.data.message : __('Failed to import preset.', 'gm2-wordpress-suite');
                     notify('error', message);
                 }
             }).catch(() => {
-                notify('error', 'Failed to import preset.');
+                notify('error', __('Failed to import preset.', 'gm2-wordpress-suite'));
             }).finally(() => {
                 setImportingPreset(false);
             });
         };
         return el('div', {},
             options.length > 1 && el(SelectControl, {
-                label: 'Existing Models',
+                label: __('Existing Models', 'gm2-wordpress-suite'),
                 value: currentModel,
                 options: options,
                 onChange: v => { setCurrentModel(v); loadModel(v); }
             }),
             el('div', { className: 'gm2-cpt-preset-import' },
                 el(SelectControl, {
-                    label: 'Blueprint Presets',
+                    label: __('Blueprint Presets', 'gm2-wordpress-suite'),
                     value: selectedPreset,
-                    options: [ { label: presetOptions.length ? 'Select a preset' : 'No presets available', value: '' }, ...presetOptions ],
+                    options: [ { label: presetOptions.length ? __('Select a preset', 'gm2-wordpress-suite') : __('No presets available', 'gm2-wordpress-suite'), value: '' }, ...presetOptions ],
                     onChange: v => setSelectedPreset(v),
                     disabled: !presetOptions.length
                 }),
@@ -166,17 +167,17 @@
                     onClick: importPreset,
                     disabled: !presetOptions.length || importingPreset,
                     isBusy: importingPreset
-                }, 'Add from Preset')
+                }, __('Add from Preset', 'gm2-wordpress-suite'))
             ),
             el(TextControl, {
-                label: 'Post Type Slug',
+                label: __('Post Type Slug', 'gm2-wordpress-suite'),
                 value: rawSlug,
                 onChange: v => { setRawSlug(v); setStepOneErrors(e => ({ ...e, slug: undefined })); },
                 onBlur: () => setRawSlug(slugify(rawSlug)),
                 help: stepOneErrors.slug
             }),
             el(TextControl, {
-                label: 'Label',
+                label: __('Label', 'gm2-wordpress-suite'),
                 value: data.label,
                 onChange: v => {
                     setData(d => ({ ...d, label: v }));
@@ -192,7 +193,12 @@
 
     const Wizard = () => {
         const [ existing, setExisting ] = useState((window.gm2CPTWizard && window.gm2CPTWizard.models) || {});
-        const steps = ['Post Type', 'Fields', 'Taxonomies', 'Review'];
+        const steps = [
+            __('Post Type', 'gm2-wordpress-suite'),
+            __('Fields', 'gm2-wordpress-suite'),
+            __('Taxonomies', 'gm2-wordpress-suite'),
+            __('Review', 'gm2-wordpress-suite')
+        ];
         const [ step, setStep ] = useState(1);
         const [ data, setData ] = useState({ slug: '', label: '', fields: [], taxonomies: [] });
         const [ rawSlug, setRawSlug ] = useState('');
@@ -201,9 +207,9 @@
         const [ showNewButton, setShowNewButton ] = useState(false);
         const [ saving, setSaving ] = useState(false);
         const errorMap = {
-            permission: 'You do not have permission to save models.',
-            nonce: 'Security check failed. Please refresh and try again.',
-            data: 'Invalid data provided. Please check your inputs and try again.'
+            permission: __('You do not have permission to save models.', 'gm2-wordpress-suite'),
+            nonce: __('Security check failed. Please refresh and try again.', 'gm2-wordpress-suite'),
+            data: __('Invalid data provided. Please check your inputs and try again.', 'gm2-wordpress-suite')
         };
         const notices = useSelect( select => select('core/notices').getNotices(), [] );
         const { removeNotice } = dispatch('core/notices');
@@ -213,14 +219,14 @@
         const validateStepOne = () => {
             const errs = {};
             if(!data.label.trim()){
-                errs.label = 'Label is required';
+                errs.label = __('Label is required', 'gm2-wordpress-suite');
             }
             if(!data.slug.trim()){
-                errs.slug = 'Slug is required';
+                errs.slug = __('Slug is required', 'gm2-wordpress-suite');
             } else if(!/^[a-z][a-z0-9_-]*$/.test(data.slug)){
-                errs.slug = 'Slug must start with a letter and contain only lowercase letters, numbers, hyphens, or underscores';
+                errs.slug = __('Slug must start with a letter and contain only lowercase letters, numbers, hyphens, or underscores', 'gm2-wordpress-suite');
             } else if(existing[data.slug] && data.slug !== currentModel){
-                errs.slug = 'Slug already exists';
+                errs.slug = __('Slug already exists', 'gm2-wordpress-suite');
             }
             setStepOneErrors(errs);
             return Object.keys(errs).length === 0;
@@ -260,15 +266,15 @@
             const [ dragIndex, setDragIndex ] = useState(null);
             const [ fieldError, setFieldError ] = useState('');
             const typeOptions = [
-                { label: 'Text', value: 'text' },
-                { label: 'Textarea', value: 'textarea' },
-                { label: 'Number', value: 'number' },
-                { label: 'Select', value: 'select' },
-                { label: 'Checkbox', value: 'checkbox' },
-                { label: 'Radio', value: 'radio' },
-                { label: 'Email', value: 'email' },
-                { label: 'URL', value: 'url' },
-                { label: 'Date', value: 'date' }
+                { label: __('Text', 'gm2-wordpress-suite'), value: 'text' },
+                { label: __('Textarea', 'gm2-wordpress-suite'), value: 'textarea' },
+                { label: __('Number', 'gm2-wordpress-suite'), value: 'number' },
+                { label: __('Select', 'gm2-wordpress-suite'), value: 'select' },
+                { label: __('Checkbox', 'gm2-wordpress-suite'), value: 'checkbox' },
+                { label: __('Radio', 'gm2-wordpress-suite'), value: 'radio' },
+                { label: __('Email', 'gm2-wordpress-suite'), value: 'email' },
+                { label: __('URL', 'gm2-wordpress-suite'), value: 'url' },
+                { label: __('Date', 'gm2-wordpress-suite'), value: 'date' }
             ];
             const validTypes = typeOptions.map(o => o.value);
             const addField = () => {
@@ -276,7 +282,7 @@
                 const copy = data.fields.slice();
                 const isDuplicate = copy.some((f,i) => f.slug === field.slug && i !== editIndex);
                 if(isDuplicate){
-                    setFieldError('Field slug must be unique');
+                    setFieldError(__('Field slug must be unique', 'gm2-wordpress-suite'));
                     return;
                 }
                 if(editIndex !== null){
@@ -319,29 +325,29 @@
                     onDragEnd,
                     className: 'gm2-sortable-item'
                 },
-                    `${f.label} (${f.slug})`,
-                    el(Button, { isLink: true, onClick: () => editField(i) }, 'Edit'),
-                    el(Button, { isLink: true, onClick: () => removeField(i) }, 'Delete')
+                    sprintf(__('%1$s (%2$s)', 'gm2-wordpress-suite'), f.label, f.slug),
+                    el(Button, { isLink: true, onClick: () => editField(i) }, __('Edit', 'gm2-wordpress-suite')),
+                    el(Button, { isLink: true, onClick: () => removeField(i) }, __('Delete', 'gm2-wordpress-suite'))
                 )),
                 el(TextControl, {
-                    label: 'Field Label',
+                    label: __('Field Label', 'gm2-wordpress-suite'),
                     value: field.label,
                     onChange: v => setField({ ...field, label: v })
                 }),
                 el(TextControl, {
-                    label: 'Field Slug',
+                    label: __('Field Slug', 'gm2-wordpress-suite'),
                     value: field.slug,
                     onChange: v => setField({ ...field, slug: slugify(v) }),
                     onBlur: () => setField({ ...field, slug: slugify(field.slug) }),
                     help: fieldError
                 }),
                 el(SelectControl, {
-                    label: 'Field Type',
+                    label: __('Field Type', 'gm2-wordpress-suite'),
                     value: field.type,
-                    options: [ { label: 'Select Type', value: '' }, ...typeOptions ],
+                    options: [ { label: __('Select Type', 'gm2-wordpress-suite'), value: '' }, ...typeOptions ],
                     onChange: v => setField({ ...field, type: v })
                 }),
-                el(Button, { isPrimary: true, onClick: addField }, editIndex !== null ? 'Update Field' : 'Add Field')
+                el(Button, { isPrimary: true, onClick: addField }, editIndex !== null ? __('Update Field', 'gm2-wordpress-suite') : __('Add Field', 'gm2-wordpress-suite'))
             );
         };
 
@@ -355,7 +361,7 @@
                 const copy = data.taxonomies.slice();
                 const isDuplicate = copy.some((t,i) => t.slug === tax.slug && i !== editIndex);
                 if(isDuplicate){
-                    setTaxError('Taxonomy slug must be unique');
+                    setTaxError(__('Taxonomy slug must be unique', 'gm2-wordpress-suite'));
                     return;
                 }
                 if(editIndex !== null){
@@ -398,49 +404,49 @@
                     onDragEnd,
                     className: 'gm2-sortable-item'
                 },
-                    `${t.label} (${t.slug})`,
-                    el(Button, { isLink: true, onClick: () => editTax(i) }, 'Edit'),
-                    el(Button, { isLink: true, onClick: () => removeTax(i) }, 'Delete')
+                    sprintf(__('%1$s (%2$s)', 'gm2-wordpress-suite'), t.label, t.slug),
+                    el(Button, { isLink: true, onClick: () => editTax(i) }, __('Edit', 'gm2-wordpress-suite')),
+                    el(Button, { isLink: true, onClick: () => removeTax(i) }, __('Delete', 'gm2-wordpress-suite'))
                 )),
                 el(TextControl, {
-                    label: 'Taxonomy Slug',
+                    label: __('Taxonomy Slug', 'gm2-wordpress-suite'),
                     value: tax.slug,
                     onChange: v => setTax({ ...tax, slug: slugify(v) }),
                     onBlur: () => setTax({ ...tax, slug: slugify(tax.slug) }),
                     help: taxError
                 }),
                 el(TextControl, {
-                    label: 'Taxonomy Label',
+                    label: __('Taxonomy Label', 'gm2-wordpress-suite'),
                     value: tax.label,
                     onChange: v => setTax({ ...tax, label: v })
                 }),
-                el(Button, { isPrimary: true, onClick: addTax }, editIndex !== null ? 'Update Taxonomy' : 'Add Taxonomy')
+                el(Button, { isPrimary: true, onClick: addTax }, editIndex !== null ? __('Update Taxonomy', 'gm2-wordpress-suite') : __('Add Taxonomy', 'gm2-wordpress-suite'))
             );
         };
 
         const ReviewStep = () => el('div', { className: 'gm2-cpt-review' },
             el('div', { className: 'gm2-cpt-review-section' },
-                el('h3', {}, 'Post Type'),
-                el('p', {}, `${data.label} (${data.slug})`),
-                el(Button, { isLink: true, onClick: () => setStep(1) }, 'Edit')
+                el('h3', {}, __('Post Type', 'gm2-wordpress-suite')),
+                el('p', {}, sprintf(__('%1$s (%2$s)', 'gm2-wordpress-suite'), data.label, data.slug)),
+                el(Button, { isLink: true, onClick: () => setStep(1) }, __('Edit', 'gm2-wordpress-suite'))
             ),
             el('div', { className: 'gm2-cpt-review-section' },
-                el('h3', {}, 'Fields'),
+                el('h3', {}, __('Fields', 'gm2-wordpress-suite')),
                 data.fields.length
                     ? el('ul', {}, data.fields.map((f,i) =>
-                        el('li', { key: i }, `${f.label} (${f.slug}) - ${f.type}`)
+                        el('li', { key: i }, sprintf(__('%1$s (%2$s) - %3$s', 'gm2-wordpress-suite'), f.label, f.slug, f.type))
                     ))
-                    : el('p', {}, 'None'),
-                el(Button, { isLink: true, onClick: () => setStep(2) }, 'Edit')
+                    : el('p', {}, __('None', 'gm2-wordpress-suite')),
+                el(Button, { isLink: true, onClick: () => setStep(2) }, __('Edit', 'gm2-wordpress-suite'))
             ),
             el('div', { className: 'gm2-cpt-review-section' },
-                el('h3', {}, 'Taxonomies'),
+                el('h3', {}, __('Taxonomies', 'gm2-wordpress-suite')),
                 data.taxonomies.length
                     ? el('ul', {}, data.taxonomies.map((t,i) =>
-                        el('li', { key: i }, `${t.label} (${t.slug})`)
+                        el('li', { key: i }, sprintf(__('%1$s (%2$s)', 'gm2-wordpress-suite'), t.label, t.slug))
                     ))
-                    : el('p', {}, 'None'),
-                el(Button, { isLink: true, onClick: () => setStep(3) }, 'Edit')
+                    : el('p', {}, __('None', 'gm2-wordpress-suite')),
+                el(Button, { isLink: true, onClick: () => setStep(3) }, __('Edit', 'gm2-wordpress-suite'))
             )
         );
 
@@ -495,18 +501,18 @@
                     const model = { ...saved, taxonomies: data.taxonomies };
                     const updated = { ...existing, [slug]: model };
                     setExisting(updated);
-                    dispatch('core/notices').createNotice('success', 'Model saved', { isDismissible: true, type: 'snackbar' });
+                    dispatch('core/notices').createNotice('success', __('Model saved', 'gm2-wordpress-suite'), { isDismissible: true, type: 'snackbar' });
                     loadModel('');
                     setStep(1);
                     setShowNewButton(true);
                 } else {
                     const code = resp && resp.data && (resp.data.code || resp.data) || '';
-                    const message = (resp && resp.data && resp.data.message) || errorMap[code] || 'Error saving';
+                    const message = (resp && resp.data && resp.data.message) || errorMap[code] || __('Error saving', 'gm2-wordpress-suite');
                     dispatch('core/notices').createNotice('error', message, { isDismissible: true, type: 'snackbar' });
                 }
                 setSaving(false);
             }).catch(() => {
-                dispatch('core/notices').createNotice('error', 'Error saving', { isDismissible: true, type: 'snackbar' });
+                dispatch('core/notices').createNotice('error', __('Error saving', 'gm2-wordpress-suite'), { isDismissible: true, type: 'snackbar' });
                 setSaving(false);
             });
         };
@@ -516,8 +522,8 @@
                 el(NoticeList, { notices: inlineNotices, onRemove: removeNotice }),
                 el(SnackbarList, { notices: snackbarNotices, onRemove: removeNotice }),
                 el('div', { className: 'gm2-cpt-success-actions' },
-                    el(Button, { isPrimary: true, onClick: () => setShowNewButton(false) }, 'Create New Model'),
-                    el(Button, { onClick: () => window.location.reload() }, 'Reload Page')
+                    el(Button, { isPrimary: true, onClick: () => setShowNewButton(false) }, __('Create New Model', 'gm2-wordpress-suite')),
+                    el(Button, { onClick: () => window.location.reload() }, __('Reload Page', 'gm2-wordpress-suite'))
                 )
             );
         }
@@ -525,13 +531,13 @@
             el(NoticeList, { notices: inlineNotices, onRemove: removeNotice }),
             el(SnackbarList, { notices: snackbarNotices, onRemove: removeNotice }),
             el(Panel, {},
-                el(PanelBody, { title: 'CPT Wizard', initialOpen: true },
+                el(PanelBody, { title: __('CPT Wizard', 'gm2-wordpress-suite'), initialOpen: true },
                     el(StepIndicator),
                     renderStep(),
                     el('div', { className: 'gm2-cpt-wizard-buttons' }, [
-                        step > 1 && el(Button, { onClick: back }, 'Back'),
-                        step < steps.length && el(Button, { isPrimary: true, onClick: next }, 'Next'),
-                        step === steps.length && el(Button, { isPrimary: true, onClick: save, isBusy: saving, disabled: saving }, 'Finish')
+                        step > 1 && el(Button, { onClick: back }, __('Back', 'gm2-wordpress-suite')),
+                        step < steps.length && el(Button, { isPrimary: true, onClick: next }, __('Next', 'gm2-wordpress-suite')),
+                        step === steps.length && el(Button, { isPrimary: true, onClick: save, isBusy: saving, disabled: saving }, __('Finish', 'gm2-wordpress-suite'))
                     ])
                 )
             )

--- a/admin/js/gm2-fg-wizard.js
+++ b/admin/js/gm2-fg-wizard.js
@@ -2,23 +2,24 @@
     const { createElement: el, useState, useEffect } = wp.element;
     const { render } = wp.element;
     const { Button, TextControl, SelectControl, FormTokenField, PanelBody, Panel, Card, CardBody, Sortable, ToggleControl, Modal, CheckboxControl } = wp.components;
+    const { __, sprintf } = wp.i18n;
     const { dispatch } = wp.data;
     const addPassive = !window.AE_PERF_DISABLE_PASSIVE && window.aePerf?.addPassive
         ? window.aePerf.addPassive
         : (el, type, handler, options) => el.addEventListener(type, handler, options);
 
     const StepOne = ({ data, setData, existing, loadGroup, setExisting }) => {
-        const options = [ { label: 'New', value: '' } ];
+        const options = [ { label: __('New', 'gm2-wordpress-suite'), value: '' } ];
         Object.keys(existing).forEach(sl => {
             options.push({ label: existing[sl].title || sl, value: sl });
         });
         const wizard = window.gm2FGWizard || {};
         const scopeOptions = [];
         if (wizard.postTypes && Object.keys(wizard.postTypes).length) {
-            scopeOptions.push({ label: 'Post Types', value: 'post_type' });
+            scopeOptions.push({ label: __('Post Types', 'gm2-wordpress-suite'), value: 'post_type' });
         }
         if (wizard.taxonomies && Object.keys(wizard.taxonomies).length) {
-            scopeOptions.push({ label: 'Taxonomies', value: 'taxonomy' });
+            scopeOptions.push({ label: __('Taxonomies', 'gm2-wordpress-suite'), value: 'taxonomy' });
         }
         const source = data.scope === 'taxonomy' ? wizard.taxonomies : wizard.postTypes;
         const suggestions = Object.keys(source || {});
@@ -30,9 +31,9 @@
         const onSlugChange = (v) => {
             const duplicate = existing[v] && v !== data.slug;
             if(!v){
-                setSlugError('Slug is required');
+                setSlugError(__('Slug is required', 'gm2-wordpress-suite'));
             } else if(duplicate){
-                setSlugError('Slug must be unique');
+                setSlugError(__('Slug must be unique', 'gm2-wordpress-suite'));
             } else {
                 setSlugError('');
             }
@@ -41,7 +42,7 @@
 
         const deleteGroup = () => {
             if(!data.slug) return;
-            if(!window.confirm('Delete this group?')) return;
+            if(!window.confirm(__('Delete this group?', 'gm2-wordpress-suite'))) return;
             const payload = new URLSearchParams();
             payload.append('action','gm2_delete_field_group');
             payload.append('nonce', window.gm2FGWizard.nonce);
@@ -55,18 +56,18 @@
                 if(resp && resp.success){
                     setExisting(resp.data.groups || {});
                     loadGroup('');
-                    dispatch('core/notices').createNotice('success', 'Field group deleted');
+                    dispatch('core/notices').createNotice('success', __('Field group deleted', 'gm2-wordpress-suite'));
                 } else {
-                    dispatch('core/notices').createNotice('error', 'Error deleting group');
+                    dispatch('core/notices').createNotice('error', __('Error deleting group', 'gm2-wordpress-suite'));
                 }
             }).catch(() => {
-                dispatch('core/notices').createNotice('error', 'Error deleting group');
+                dispatch('core/notices').createNotice('error', __('Error deleting group', 'gm2-wordpress-suite'));
             });
         };
 
         const renameGroup = () => {
             if(!data.slug) return;
-            const newSlug = window.prompt('Enter new slug', data.slug);
+            const newSlug = window.prompt(__('Enter new slug', 'gm2-wordpress-suite'), data.slug);
             if(!newSlug || newSlug === data.slug) return;
             const payload = new URLSearchParams();
             payload.append('action','gm2_rename_field_group');
@@ -82,12 +83,12 @@
                 if(resp && resp.success){
                     setExisting(resp.data.groups || {});
                     loadGroup(newSlug);
-                    dispatch('core/notices').createNotice('success', 'Field group renamed');
+                    dispatch('core/notices').createNotice('success', __('Field group renamed', 'gm2-wordpress-suite'));
                 } else {
-                    dispatch('core/notices').createNotice('error', 'Error renaming group');
+                    dispatch('core/notices').createNotice('error', __('Error renaming group', 'gm2-wordpress-suite'));
                 }
             }).catch(() => {
-                dispatch('core/notices').createNotice('error', 'Error renaming group');
+                dispatch('core/notices').createNotice('error', __('Error renaming group', 'gm2-wordpress-suite'));
             });
         };
 
@@ -110,7 +111,7 @@
         const performExport = () => {
             if(exporting) return;
             if(exportSelection.length === 0){
-                setExportError('Select at least one field group to export.');
+                setExportError(__('Select at least one field group to export.', 'gm2-wordpress-suite'));
                 return;
             }
             setExportError('');
@@ -136,15 +137,15 @@
                     link.click();
                     document.body.removeChild(link);
                     URL.revokeObjectURL(url);
-                    dispatch('core/notices').createNotice('success', 'Field groups exported');
+                    dispatch('core/notices').createNotice('success', __('Field groups exported', 'gm2-wordpress-suite'));
                     setExportOpen(false);
                 } else {
-                    const msg = resp && resp.data && resp.data.message ? resp.data.message : 'Error exporting field groups';
+                    const msg = resp && resp.data && resp.data.message ? resp.data.message : __('Error exporting field groups', 'gm2-wordpress-suite');
                     setExportError(msg);
                     dispatch('core/notices').createNotice('error', msg);
                 }
             }).catch(() => {
-                const msg = 'Error exporting field groups';
+                const msg = __('Error exporting field groups', 'gm2-wordpress-suite');
                 setExportError(msg);
                 dispatch('core/notices').createNotice('error', msg);
             }).finally(() => {
@@ -154,53 +155,56 @@
 
         return el('div', {},
             options.length > 1 && el(SelectControl, {
-                label: 'Existing Groups',
+                label: __('Existing Groups', 'gm2-wordpress-suite'),
                 id: 'gm2-existing-groups',
                 value: data.slug && existing[data.slug] ? data.slug : '',
                 options: options,
                 onChange: v => loadGroup(v)
             }),
             el(TextControl, {
-                label: 'Group Slug',
+                label: __('Group Slug', 'gm2-wordpress-suite'),
                 id: 'gm2-group-slug',
                 value: data.slug,
                 onChange: onSlugChange,
                 help: slugError
             }),
             el(TextControl, {
-                label: 'Title',
+                label: __('Title', 'gm2-wordpress-suite'),
                 id: 'gm2-group-title',
                 value: data.title,
                 onChange: v => setData({ ...data, title: v })
             }),
             el(SelectControl, {
-                label: 'Scope',
+                label: __('Scope', 'gm2-wordpress-suite'),
                 id: 'gm2-group-scope',
                 value: data.scope,
                 options: scopeOptions,
                 onChange: v => setData({ ...data, scope: v, objects: [] }),
-                help: 'Scope determines the type of content (post types or taxonomies) this field group attaches to.'
+                help: __('Scope determines the type of content (post types or taxonomies) this field group attaches to.', 'gm2-wordpress-suite')
             }),
             el(FormTokenField, {
-                label: 'Objects',
+                label: __('Objects', 'gm2-wordpress-suite'),
                 id: 'gm2-group-objects',
                 value: data.objects,
                 suggestions: suggestions,
                 onChange: tokens => setData({ ...data, objects: tokens }),
-                help: 'Select the specific ' + (data.scope === 'taxonomy' ? 'taxonomies' : 'post types') + ' where this field group should appear.'
+                help: sprintf(
+                    __('Select the specific %s where this field group should appear.', 'gm2-wordpress-suite'),
+                    data.scope === 'taxonomy' ? __('taxonomies', 'gm2-wordpress-suite') : __('post types', 'gm2-wordpress-suite')
+                )
             }),
             existing[data.slug] && el('div', { className: 'gm2-fg-group-actions' },
-                el(Button, { isDestructive: true, onClick: deleteGroup }, 'Delete Group'),
-                el(Button, { onClick: renameGroup }, 'Rename'),
-                el(Button, { onClick: openExportModal }, 'Export JSON')
+                el(Button, { isDestructive: true, onClick: deleteGroup }, __('Delete Group', 'gm2-wordpress-suite')),
+                el(Button, { onClick: renameGroup }, __('Rename', 'gm2-wordpress-suite')),
+                el(Button, { onClick: openExportModal }, __('Export JSON', 'gm2-wordpress-suite'))
             ),
             exportOpen && el(Modal, {
-                title: 'Export Field Groups',
+                title: __('Export Field Groups', 'gm2-wordpress-suite'),
                 onRequestClose: () => { if(!exporting){ setExportOpen(false); } },
                 shouldCloseOnClickOutside: !exporting,
                 shouldCloseOnEsc: !exporting
             },
-                el('p', {}, 'Select the field groups to include in the JSON export.'),
+                el('p', {}, __('Select the field groups to include in the JSON export.', 'gm2-wordpress-suite')),
                 Object.keys(existing).length ? el('div', { className: 'gm2-fg-export-list' },
                     Object.keys(existing).sort().map(sl => el(CheckboxControl, {
                         key: sl,
@@ -208,11 +212,11 @@
                         checked: exportSelection.includes(sl),
                         onChange: () => toggleExportGroup(sl)
                     }))
-                ) : el('p', {}, 'No field groups available.'),
+                ) : el('p', {}, __('No field groups available.', 'gm2-wordpress-suite')),
                 exportError && el('p', { className: 'gm2-fg-error' }, exportError),
                 el('div', { className: 'gm2-fg-export-actions' },
-                    el(Button, { onClick: () => setExportOpen(false), disabled: exporting }, 'Cancel'),
-                    el(Button, { isPrimary: true, onClick: performExport, disabled: exporting || exportSelection.length === 0, isBusy: exporting }, 'Download JSON')
+                    el(Button, { onClick: () => setExportOpen(false), disabled: exporting }, __('Cancel', 'gm2-wordpress-suite')),
+                    el(Button, { isPrimary: true, onClick: performExport, disabled: exporting || exportSelection.length === 0, isBusy: exporting }, __('Download JSON', 'gm2-wordpress-suite'))
                 )
             )
         );
@@ -225,22 +229,22 @@
         const [ fieldsOpen, setFieldsOpen ] = useState(true);
 
         const fieldTypes = [
-            { label: 'Text', value: 'text' },
-            { label: 'Textarea', value: 'textarea' },
-            { label: 'Select', value: 'select' },
-            { label: 'Number', value: 'number' },
-            { label: 'Color', value: 'color' }
+            { label: __('Text', 'gm2-wordpress-suite'), value: 'text' },
+            { label: __('Textarea', 'gm2-wordpress-suite'), value: 'textarea' },
+            { label: __('Select', 'gm2-wordpress-suite'), value: 'select' },
+            { label: __('Number', 'gm2-wordpress-suite'), value: 'number' },
+            { label: __('Color', 'gm2-wordpress-suite'), value: 'color' }
         ];
 
         const addField = () => {
             if(!field.slug){
-                setError('Field slug is required');
-                dispatch('core/notices').createNotice('error', 'Field slug is required');
+                setError(__('Field slug is required', 'gm2-wordpress-suite'));
+                dispatch('core/notices').createNotice('error', __('Field slug is required', 'gm2-wordpress-suite'));
                 return;
             }
             if(data.fields.some((f,i) => f.slug === field.slug && i !== editIndex)){
-                setError('Field slug must be unique');
-                dispatch('core/notices').createNotice('error', 'Field slug must be unique');
+                setError(__('Field slug must be unique', 'gm2-wordpress-suite'));
+                dispatch('core/notices').createNotice('error', __('Field slug must be unique', 'gm2-wordpress-suite'));
                 return;
             }
             setError('');
@@ -273,48 +277,48 @@
         };
 
         return el('div', {},
-            data.fields.length > 0 && el(PanelBody, { title: 'Fields', opened: fieldsOpen, onToggle: () => setFieldsOpen(!fieldsOpen), 'aria-expanded': fieldsOpen, role: 'region' },
+            data.fields.length > 0 && el(PanelBody, { title: __('Fields', 'gm2-wordpress-suite'), opened: fieldsOpen, onToggle: () => setFieldsOpen(!fieldsOpen), 'aria-expanded': fieldsOpen, role: 'region' },
                 el(Sortable, { onSortEnd },
                     data.fields.map((f,i) => el(Sortable.Item, { key: f.slug || i },
                         el(Card, { className: 'gm2-field-item' },
                             el(CardBody, {},
-                                el('strong', {}, f.label || '(no label)'),
-                                el('div', {}, 'Slug: ' + f.slug),
-                                el('div', {}, 'Type: ' + f.type),
-                                el(Button, { isLink: true, onClick: () => editField(i) }, 'Edit'),
-                                el(Button, { isLink: true, onClick: () => removeField(i) }, 'Delete')
+                                el('strong', {}, f.label || __('(no label)', 'gm2-wordpress-suite')),
+                                el('div', {}, sprintf(__('Slug: %s', 'gm2-wordpress-suite'), f.slug)),
+                                el('div', {}, sprintf(__('Type: %s', 'gm2-wordpress-suite'), f.type)),
+                                el(Button, { isLink: true, onClick: () => editField(i) }, __('Edit', 'gm2-wordpress-suite')),
+                                el(Button, { isLink: true, onClick: () => removeField(i) }, __('Delete', 'gm2-wordpress-suite'))
                             )
                         )
                     ))
                 )
             ),
             el(TextControl, {
-                label: 'Field Label',
+                label: __('Field Label', 'gm2-wordpress-suite'),
                 id: 'gm2-field-label',
                 value: field.label,
                 onChange: v => setField({ ...field, label: v })
             }),
             el(TextControl, {
-                label: 'Field Slug',
+                label: __('Field Slug', 'gm2-wordpress-suite'),
                 id: 'gm2-field-slug',
                 value: field.slug,
                 onChange: v => setField({ ...field, slug: v }),
                 help: error
             }),
             el(SelectControl, {
-                label: 'Field Type',
+                label: __('Field Type', 'gm2-wordpress-suite'),
                 id: 'gm2-field-type',
                 value: field.type,
                 options: fieldTypes,
                 onChange: v => setField({ ...field, type: v })
             }),
             el(ToggleControl, {
-                label: 'Expose in REST API',
+                label: __('Expose in REST API', 'gm2-wordpress-suite'),
                 id: 'gm2-field-expose',
                 checked: !!field.expose_in_rest,
                 onChange: v => setField({ ...field, expose_in_rest: v })
             }),
-            el(Button, { isPrimary: true, onClick: addField }, editIndex !== null ? 'Update Field' : 'Add Field')
+            el(Button, { isPrimary: true, onClick: addField }, editIndex !== null ? __('Update Field', 'gm2-wordpress-suite') : __('Add Field', 'gm2-wordpress-suite'))
         );
     };
 
@@ -323,9 +327,9 @@
     const LocationStep = ({ data, setData }) => {
         const wizard = window.gm2FGWizard || {};
         const paramOptions = [
-            { label: 'Post Type', value: 'post_type' },
-            { label: 'Taxonomy', value: 'taxonomy' },
-            { label: 'Template', value: 'template' }
+            { label: __('Post Type', 'gm2-wordpress-suite'), value: 'post_type' },
+            { label: __('Taxonomy', 'gm2-wordpress-suite'), value: 'taxonomy' },
+            { label: __('Template', 'gm2-wordpress-suite'), value: 'template' }
         ];
         const operatorOptions = [
             { label: '==', value: '==' },
@@ -362,7 +366,7 @@
         const ValueControl = ({ rule, onChange, idBase }) => {
             if(rule.param === 'post_type'){
                 const options = Object.keys(wizard.postTypes || {}).map(slug => ({ label: wizard.postTypes[slug], value: slug }));
-                return el(SelectControl, { label: 'Value', id: idBase, value: rule.value, options, onChange });
+                return el(SelectControl, { label: __('Value', 'gm2-wordpress-suite'), id: idBase, value: rule.value, options, onChange });
             }
             if(rule.param === 'taxonomy'){
                 const taxOptions = Object.keys(wizard.taxonomies || {}).map(slug => ({ label: wizard.taxonomies[slug], value: slug }));
@@ -379,14 +383,14 @@
                 }, [selectedTax]);
                 return el('div', {},
                     el(SelectControl, {
-                        label: 'Taxonomy',
+                        label: __('Taxonomy', 'gm2-wordpress-suite'),
                         id: idBase + '-taxonomy',
                         value: selectedTax,
                         options: taxOptions,
                         onChange: v => { setSelectedTax(v); onChange(v + ':'); }
                     }),
                     selectedTax && el(SelectControl, {
-                        label: 'Term',
+                        label: __('Term', 'gm2-wordpress-suite'),
                         id: idBase + '-term',
                         value: term,
                         options: terms,
@@ -394,31 +398,31 @@
                     })
                 );
             }
-            return el(TextControl, { label: 'Value', id: idBase, value: rule.value, onChange });
+            return el(TextControl, { label: __('Value', 'gm2-wordpress-suite'), id: idBase, value: rule.value, onChange });
         };
         return el('div', {},
-            el('p', { className: 'gm2-location-help' }, 'Each group is evaluated separately. Rules inside a group use the selected relation, and the field group is displayed when any group matches.'),
-            data.location.map((g,gi) => el(Card, { key: gi, className: 'gm2-location-group', role: 'group', 'aria-label': 'Location group ' + (gi + 1) },
+            el('p', { className: 'gm2-location-help' }, __('Each group is evaluated separately. Rules inside a group use the selected relation, and the field group is displayed when any group matches.', 'gm2-wordpress-suite')),
+            data.location.map((g,gi) => el(Card, { key: gi, className: 'gm2-location-group', role: 'group', 'aria-label': sprintf(__('Location group %d', 'gm2-wordpress-suite'), gi + 1) },
                 el(CardBody, {},
                     el(SelectControl, {
-                        label: 'Group Relation',
+                        label: __('Group Relation', 'gm2-wordpress-suite'),
                         id: 'gm2-group-relation-' + gi,
                         value: g.relation || 'AND',
-                        options: [ { label: 'AND', value: 'AND' }, { label: 'OR', value: 'OR' } ],
+                        options: [ { label: __('AND', 'gm2-wordpress-suite'), value: 'AND' }, { label: __('OR', 'gm2-wordpress-suite'), value: 'OR' } ],
                         onChange: v => updateGroupRel(gi,v),
-                        help: 'Choose how rules in this group are combined.'
+                        help: __('Choose how rules in this group are combined.', 'gm2-wordpress-suite')
                     }),
-                    g.rules.map((r,ri) => el(Card, { key: ri, className: 'gm2-location-rule', role: 'group', 'aria-label': 'Rule ' + (ri + 1) },
+                    g.rules.map((r,ri) => el(Card, { key: ri, className: 'gm2-location-rule', role: 'group', 'aria-label': sprintf(__('Rule %d', 'gm2-wordpress-suite'), ri + 1) },
                         el(CardBody, {},
                             el(SelectControl, {
-                                label: 'Parameter',
+                                label: __('Parameter', 'gm2-wordpress-suite'),
                                 id: 'gm2-rule-param-' + gi + '-' + ri,
                                 value: r.param,
                                 options: paramOptions,
                                 onChange: v => updateRule(gi,ri,'param',v)
                             }),
                             el(SelectControl, {
-                                label: 'Operator',
+                                label: __('Operator', 'gm2-wordpress-suite'),
                                 id: 'gm2-rule-operator-' + gi + '-' + ri,
                                 value: r.operator,
                                 options: operatorOptions,
@@ -429,14 +433,14 @@
                                 idBase: 'gm2-rule-value-' + gi + '-' + ri,
                                 onChange: v => updateRule(gi,ri,'value',v)
                             }),
-                            el(Button, { isLink: true, onClick: () => removeRule(gi,ri) }, 'Delete Rule')
+                            el(Button, { isLink: true, onClick: () => removeRule(gi,ri) }, __('Delete Rule', 'gm2-wordpress-suite'))
                         )
                     )),
-                    el(Button, { isSecondary: true, onClick: () => addRule(gi) }, 'Add Rule'),
-                    el(Button, { isDestructive: true, onClick: () => removeGroup(gi) }, 'Remove Group')
+                    el(Button, { isSecondary: true, onClick: () => addRule(gi) }, __('Add Rule', 'gm2-wordpress-suite')),
+                    el(Button, { isDestructive: true, onClick: () => removeGroup(gi) }, __('Remove Group', 'gm2-wordpress-suite'))
                 )
             )),
-            el(Button, { isPrimary: true, onClick: addGroup }, 'Add Location Group')
+            el(Button, { isPrimary: true, onClick: addGroup }, __('Add Location Group', 'gm2-wordpress-suite'))
         );
     };
 
@@ -445,9 +449,9 @@
             el('table', { className: 'gm2-fg-review-fields' },
                 el('thead', {},
                     el('tr', {},
-                        el('th', {}, 'Label'),
-                        el('th', {}, 'Slug'),
-                        el('th', {}, 'Type')
+                        el('th', {}, __('Label', 'gm2-wordpress-suite')),
+                        el('th', {}, __('Slug', 'gm2-wordpress-suite')),
+                        el('th', {}, __('Type', 'gm2-wordpress-suite'))
                     )
                 ),
                 el('tbody', {},
@@ -457,29 +461,34 @@
                         el('td', {}, f.type)
                     ))
                 )
-            ) : el('p', {}, 'No fields defined.');
+            ) : el('p', {}, __('No fields defined.', 'gm2-wordpress-suite'));
 
         const locationSummary = data.location.length ?
-            data.location.map((g,gi) => el('div', { key: gi },
-                el('strong', {}, 'Group ' + (gi + 1) + ' (' + (g.relation || 'AND') + ')'),
-                el('ul', {},
-                    g.rules.map((r,ri) => el('li', { key: ri },
-                        r.param + ' ' + r.operator + ' ' + (Array.isArray(r.value) ? r.value.join(', ') : r.value)
-                    ))
-                )
-            )) : el('p', {}, 'No location rules.');
+            data.location.map((g,gi) => {
+                const relationLabel = g.relation === 'OR' ? __('OR', 'gm2-wordpress-suite') : __('AND', 'gm2-wordpress-suite');
+                return el('div', { key: gi },
+                    el('strong', {}, sprintf(__('Group %1$d (%2$s)', 'gm2-wordpress-suite'), gi + 1, relationLabel)),
+                    el('ul', {},
+                        g.rules.map((r,ri) => el('li', { key: ri },
+                            sprintf(__('%1$s %2$s %3$s', 'gm2-wordpress-suite'), r.param, r.operator, Array.isArray(r.value) ? r.value.join(', ') : r.value)
+                        ))
+                    )
+                );
+            }) : el('p', {}, __('No location rules.', 'gm2-wordpress-suite'));
+
+        const scopeLabel = data.scope === 'taxonomy' ? __('Taxonomy', 'gm2-wordpress-suite') : data.scope === 'template' ? __('Template', 'gm2-wordpress-suite') : __('Post Type', 'gm2-wordpress-suite');
 
         return el('div', {},
-            el('h3', {}, 'General ', el(Button, { isLink: true, onClick: () => onEdit(1) }, 'Edit')),
+            el('h3', {}, __('General', 'gm2-wordpress-suite'), ' ', el(Button, { isLink: true, onClick: () => onEdit(1) }, __('Edit', 'gm2-wordpress-suite'))),
             el('ul', {},
-                el('li', {}, 'Slug: ' + data.slug),
-                el('li', {}, 'Title: ' + data.title),
-                el('li', {}, 'Scope: ' + data.scope),
-                el('li', {}, 'Objects: ' + (data.objects.join(', ') || 'None'))
+                el('li', {}, sprintf(__('Slug: %s', 'gm2-wordpress-suite'), data.slug)),
+                el('li', {}, sprintf(__('Title: %s', 'gm2-wordpress-suite'), data.title)),
+                el('li', {}, sprintf(__('Scope: %s', 'gm2-wordpress-suite'), scopeLabel)),
+                el('li', {}, sprintf(__('Objects: %s', 'gm2-wordpress-suite'), data.objects.length ? data.objects.join(', ') : __('None', 'gm2-wordpress-suite')))
             ),
-            el('h3', {}, 'Fields ', el(Button, { isLink: true, onClick: () => onEdit(2) }, 'Edit')),
+            el('h3', {}, __('Fields', 'gm2-wordpress-suite'), ' ', el(Button, { isLink: true, onClick: () => onEdit(2) }, __('Edit', 'gm2-wordpress-suite'))),
             fieldsTable,
-            el('h3', {}, 'Location Rules ', el(Button, { isLink: true, onClick: () => onEdit(3) }, 'Edit')),
+            el('h3', {}, __('Location Rules', 'gm2-wordpress-suite'), ' ', el(Button, { isLink: true, onClick: () => onEdit(3) }, __('Edit', 'gm2-wordpress-suite'))),
             locationSummary
         );
     };
@@ -490,15 +499,20 @@
         const [ data, setData ] = useState({ slug: '', title: '', scope: 'post_type', objects: [], fields: [], location: [] });
         const [ saving, setSaving ] = useState(false);
         const [ error, setError ] = useState('');
-        const steps = [ 'Details', 'Fields', 'Location', 'Review' ];
+        const steps = [
+            __('Details', 'gm2-wordpress-suite'),
+            __('Fields', 'gm2-wordpress-suite'),
+            __('Location', 'gm2-wordpress-suite'),
+            __('Review', 'gm2-wordpress-suite')
+        ];
 
         const next = () => {
             if(step === 1 && !data.slug){
-                setError('Slug is required');
+                setError(__('Slug is required', 'gm2-wordpress-suite'));
                 return;
             }
             if(step === 2 && data.fields.length === 0){
-                setError('At least one field is required');
+                setError(__('At least one field is required', 'gm2-wordpress-suite'));
                 return;
             }
             setError('');
@@ -533,7 +547,7 @@
         const save = () => {
             if(saving) return;
             if(!data.slug){
-                setError('Slug is required');
+                setError(__('Slug is required', 'gm2-wordpress-suite'));
                 setStep(1);
                 return;
             }
@@ -555,16 +569,16 @@
                 body: payload.toString()
             }).then(r => r.json()).then(resp => {
                 if(resp && resp.success){
-                    dispatch('core/notices').createNotice('success', 'Field group saved', { type: 'snackbar' });
+                    dispatch('core/notices').createNotice('success', __('Field group saved', 'gm2-wordpress-suite'), { type: 'snackbar' });
                     setTimeout(() => {
                         window.location.href = (window.gm2FGWizard && window.gm2FGWizard.listUrl) || 'admin.php?page=gm2-custom-posts';
                     }, 1500);
                 } else {
-                    const msg = resp && resp.data && resp.data.message ? resp.data.message : 'Error saving';
+                    const msg = resp && resp.data && resp.data.message ? resp.data.message : __('Error saving', 'gm2-wordpress-suite');
                     setError(msg);
                 }
             }).catch(() => {
-                setError('Error saving');
+                setError(__('Error saving', 'gm2-wordpress-suite'));
             }).finally(() => {
                 setSaving(false);
             });
@@ -572,17 +586,17 @@
 
         return el('div', { className: 'gm2-fg-wizard' },
             el(Panel, {},
-                el(PanelBody, { title: 'Field Group Wizard', initialOpen: true },
+                el(PanelBody, { title: __('Field Group Wizard', 'gm2-wordpress-suite'), initialOpen: true },
                     el('div', { className: 'gm2-fg-stepper' },
-                        el('div', { className: 'gm2-fg-stepper-label' }, 'Step ' + step + ' of ' + steps.length),
+                        el('div', { className: 'gm2-fg-stepper-label' }, sprintf(__('Step %1$d of %2$d', 'gm2-wordpress-suite'), step, steps.length)),
                         el('progress', { max: steps.length, value: step })
                     ),
                     renderStep(),
                     error && el('p', { className: 'gm2-fg-error' }, error),
                     el('div', { className: 'gm2-fg-wizard-buttons' }, [
-                        step > 1 && el(Button, { onClick: back, disabled: saving }, 'Back'),
-                        step < steps.length && el(Button, { isPrimary: true, onClick: next, disabled: saving }, 'Next'),
-                        step === steps.length && el(Button, { isPrimary: true, onClick: save, isBusy: saving, disabled: saving }, 'Finish')
+                        step > 1 && el(Button, { onClick: back, disabled: saving }, __('Back', 'gm2-wordpress-suite')),
+                        step < steps.length && el(Button, { isPrimary: true, onClick: next, disabled: saving }, __('Next', 'gm2-wordpress-suite')),
+                        step === steps.length && el(Button, { isPrimary: true, onClick: save, isBusy: saving, disabled: saving }, __('Finish', 'gm2-wordpress-suite'))
                     ])
                 )
             )


### PR DESCRIPTION
## Summary
- import wp.i18n helpers in the CPT and Field Group wizards and wrap all user-facing text with translation calls
- update notices, button labels, helper text, and validation messages to use localized strings throughout both wizards

## Testing
- `npm test` *(fails: jest executable not found in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cc8f93c2ec8330a879ffc7253fe00f