### PR TITLE
Add REST visibility guidance to custom post tools

### DIFF
--- a/admin/Gm2_Custom_Posts_Admin.php
+++ b/admin/Gm2_Custom_Posts_Admin.php
@@ -1550,11 +1550,13 @@ class Gm2_Custom_Posts_Admin {
                 ];
             }
             wp_localize_script('gm2-custom-posts-admin', 'gm2CPTFields', [
-                'nonce'  => wp_create_nonce('gm2_save_cpt_fields'),
-                'ajax'   => admin_url('admin-ajax.php'),
-                'slug'   => $slug,
-                'fields' => $fields,
-                'args'   => $args,
+                'nonce'           => wp_create_nonce('gm2_save_cpt_fields'),
+                'ajax'            => admin_url('admin-ajax.php'),
+                'slug'            => $slug,
+                'fields'          => $fields,
+                'args'            => $args,
+                'restMetaHelp'    => __( 'Fields exposed through the REST API must belong to post types or taxonomies registered with "Show in REST" enabled.', 'gm2-wordpress-suite' ),
+                'restMetaShowHelp' => __( 'Enable "Show in REST" so any fields flagged for REST exposure are included in API responses.', 'gm2-wordpress-suite' ),
             ]);
 
             $admin_css = GM2_PLUGIN_DIR . 'admin/css/gm2-custom-posts-admin.css';

--- a/admin/js/gm2-custom-posts-admin.js
+++ b/admin/js/gm2-custom-posts-admin.js
@@ -2,6 +2,8 @@ jQuery(function($){
     var fields = gm2CPTFields.fields || [];
     var args   = gm2CPTFields.args || [];
     var flexTypes = [];
+    var restMetaHelp = gm2CPTFields.restMetaHelp || '';
+    var restMetaShowHelp = gm2CPTFields.restMetaShowHelp || restMetaHelp;
 
     // Ensure various field types are available in the selector.
     var typeSelect = $('#gm2-field-type');
@@ -151,6 +153,9 @@ jQuery(function($){
             var chk = $('<label><input type="checkbox" id="gm2-arg-value" value="1"/> '+key+'</label>');
             if(value){ chk.find('input').prop('checked', true); }
             wrap.append(chk);
+            if(key === 'show_in_rest' && restMetaShowHelp){
+                wrap.append('<p class="description gm2-rest-meta-hint">'+esc(restMetaShowHelp)+'</p>');
+            }
         }else if(key === 'supports'){
             var opts = ['title','editor','excerpt','author','thumbnail','page-attributes','custom-fields','revisions'];
             $.each(opts, function(i, sup){
@@ -431,6 +436,9 @@ jQuery(function($){
     });
 
     function applyEnhancements(){
+        if(restMetaHelp && !$('#gm2-field-form .gm2-rest-meta-help').length){
+            $('#gm2-field-form').prepend('<p class="description gm2-rest-meta-help">'+esc(restMetaHelp)+'</p>');
+        }
         $('.gm2-field[data-placeholder]').each(function(){
             var ph = $(this).data('placeholder');
             $(this).find('input, textarea, select').first().attr('placeholder', ph);

--- a/admin/js/gm2-fg-wizard.js
+++ b/admin/js/gm2-fg-wizard.js
@@ -235,6 +235,8 @@
             { label: __('Number', 'gm2-wordpress-suite'), value: 'number' },
             { label: __('Color', 'gm2-wordpress-suite'), value: 'color' }
         ];
+        const restExposureMessage = __('Fields exposed to the REST API require their post type or taxonomy to enable "Show in REST" in the model settings.', 'gm2-wordpress-suite');
+        const hasRestExposure = field.expose_in_rest || data.fields.some(f => f.expose_in_rest);
 
         const addField = () => {
             if(!field.slug){
@@ -292,6 +294,7 @@
                     ))
                 )
             ),
+            hasRestExposure && el('p', { className: 'gm2-fg-rest-notice', role: 'note' }, restExposureMessage),
             el(TextControl, {
                 label: __('Field Label', 'gm2-wordpress-suite'),
                 id: 'gm2-field-label',
@@ -316,7 +319,8 @@
                 label: __('Expose in REST API', 'gm2-wordpress-suite'),
                 id: 'gm2-field-expose',
                 checked: !!field.expose_in_rest,
-                onChange: v => setField({ ...field, expose_in_rest: v })
+                onChange: v => setField({ ...field, expose_in_rest: v }),
+                help: __('Requires the related post type or taxonomy to enable "Show in REST" for the field to appear in REST responses.', 'gm2-wordpress-suite')
             }),
             el(Button, { isPrimary: true, onClick: addField }, editIndex !== null ? __('Update Field', 'gm2-wordpress-suite') : __('Add Field', 'gm2-wordpress-suite'))
         );

--- a/admin/pages/post-types.php
+++ b/admin/pages/post-types.php
@@ -219,6 +219,7 @@
         echo '</fieldset>';
         echo '<fieldset><legend>' . esc_html__( 'REST API', 'gm2-wordpress-suite' ) . '</legend>';
         echo '<p><label><input type="checkbox" name="pt_show_in_rest" value="1" /> ' . esc_html__( 'Show in REST', 'gm2-wordpress-suite' ) . '</label></p>';
+        echo '<p class="description gm2-rest-visibility-help">' . esc_html__( 'Enable "Show in REST" so field metadata flagged to expose itself over the REST API can appear in responses.', 'gm2-wordpress-suite' ) . '</p>';
         echo '<p><label>' . esc_html__( 'REST Base', 'gm2-wordpress-suite' ) . '<br />';
         echo '<input type="text" name="pt_rest_base" class="regular-text" /></label></p>';
         echo '<p><label>' . esc_html__( 'REST Controller Class', 'gm2-wordpress-suite' ) . '<br />';
@@ -266,6 +267,7 @@
         echo '<input type="text" name="tax_post_types" class="regular-text" /></label></p>';
         echo '<p><label>' . esc_html__( 'Args (JSON)', 'gm2-wordpress-suite' ) . '<br />';
         echo '<textarea name="tax_args" class="large-text code" rows="5"></textarea></label></p>';
+        echo '<p class="description gm2-rest-visibility-help">' . esc_html__( 'When exposing taxonomy field metadata in REST responses, remember to include "show_in_rest": true in these arguments.', 'gm2-wordpress-suite' ) . '</p>';
         echo '<p><input type="submit" class="button button-primary" value="' . esc_attr__( 'Save Taxonomy', 'gm2-wordpress-suite' ) . '" /></p>';
         echo '</form>';
 


### PR DESCRIPTION
## Summary
- add admin form help text reminding users that REST meta exposure requires the Show in REST flag
- surface the same guidance inside the CPT field editor UI via localized copy
- enhance the field group wizard toggle with inline help and a contextual notice when exposing fields

## Testing
- npm test -- --watchAll=false *(fails: jest command not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68cc918044a483309597326f35d21d01