### PR TITLE
Add relationships management UI and blueprint support

### DIFF
--- a/admin/js/gm2-relationships.js
+++ b/admin/js/gm2-relationships.js
@@ -1,0 +1,243 @@
+jQuery(function($){
+    var config = window.gm2Relationships || {};
+    var strings = config.strings || {};
+    var ajaxUrl = config.ajax || (typeof window.ajaxurl !== 'undefined' ? window.ajaxurl : '');
+    var state = {
+        relationships: $.isArray(config.relationships) ? config.relationships.slice() : []
+    };
+
+    function t(key, fallback){
+        if (strings[key]) {
+            return strings[key];
+        }
+        return fallback;
+    }
+
+    function showMessage(message, type){
+        var container = $('#gm2-rel-messages');
+        if (!container.length) {
+            return;
+        }
+        if (!message) {
+            container.hide();
+            return;
+        }
+        container.removeClass('notice-error notice-success');
+        container.addClass(type === 'success' ? 'notice-success' : 'notice-error');
+        container.find('p').text(message);
+        container.show();
+    }
+
+    function resetForm(){
+        $('#gm2-rel-original').val('');
+        $('#gm2-rel-type').val('');
+        $('#gm2-rel-from').val('');
+        $('#gm2-rel-to').val('');
+        $('#gm2-rel-label').val('');
+        $('#gm2-rel-reverse-label').val('');
+        $('#gm2-rel-direction').val('');
+        $('#gm2-rel-cardinality').val('');
+        $('#gm2-rel-description').val('');
+    }
+
+    function openForm(rel){
+        if (rel) {
+            $('#gm2-rel-original').val(rel.type || '');
+            $('#gm2-rel-type').val(rel.type || '');
+            $('#gm2-rel-from').val(rel.from || '');
+            $('#gm2-rel-to').val(rel.to || '');
+            $('#gm2-rel-label').val(rel.label || '');
+            $('#gm2-rel-reverse-label').val(rel.reverse_label || '');
+            $('#gm2-rel-direction').val(rel.direction || '');
+            $('#gm2-rel-cardinality').val(rel.cardinality || '');
+            $('#gm2-rel-description').val(rel.description || '');
+        } else {
+            resetForm();
+        }
+        $('#gm2-relationship-form').stop(true, true).slideDown(200);
+    }
+
+    function hideForm(){
+        $('#gm2-relationship-form').stop(true, true).slideUp(200, function(){
+            resetForm();
+        });
+    }
+
+    function findRelationship(type){
+        var result = null;
+        $.each(state.relationships, function(i, rel){
+            if (rel && rel.type === type) {
+                result = rel;
+                return false;
+            }
+            return true;
+        });
+        return result;
+    }
+
+    function updateRelationships(list){
+        if ($.isArray(list)) {
+            state.relationships = list;
+        } else {
+            state.relationships = [];
+        }
+        renderList();
+    }
+
+    function renderList(){
+        var tbody = $('#gm2-relationships-table tbody');
+        if (!tbody.length) {
+            return;
+        }
+        tbody.empty();
+        if (!state.relationships.length) {
+            var emptyRow = $('<tr/>');
+            emptyRow.append(
+                $('<td/>').attr('colspan', 6).text(t('noRelationships', 'No relationships defined.'))
+            );
+            tbody.append(emptyRow);
+            return;
+        }
+        $.each(state.relationships, function(i, rel){
+            if (!rel) {
+                return;
+            }
+            var row = $('<tr/>');
+            row.append($('<td/>').text(rel.type || ''));
+            row.append($('<td/>').text(rel.from || ''));
+            row.append($('<td/>').text(rel.to || ''));
+            row.append($('<td/>').text(rel.label || ''));
+            row.append($('<td/>').text(rel.cardinality || ''));
+            var actions = $('<td/>');
+            var editBtn = $('<button type="button" class="button-link gm2-rel-edit"/>').text(t('edit', 'Edit'));
+            editBtn.data('rel', rel.type || '');
+            var deleteBtn = $('<button type="button" class="button-link delete-link gm2-rel-delete"/>').text(t('delete', 'Delete'));
+            deleteBtn.data('rel', rel.type || '');
+            actions.append(editBtn).append(' ').append(deleteBtn);
+            row.append(actions);
+            tbody.append(row);
+        });
+    }
+
+    $('#gm2-add-relationship').on('click', function(){
+        showMessage('');
+        openForm(null);
+    });
+
+    $(document).on('click', '.gm2-rel-edit', function(e){
+        e.preventDefault();
+        var type = $(this).data('rel');
+        if (!type) {
+            return;
+        }
+        var rel = findRelationship(type);
+        if (rel) {
+            showMessage('');
+            openForm(rel);
+        }
+    });
+
+    $('#gm2-rel-cancel').on('click', function(e){
+        e.preventDefault();
+        hideForm();
+        showMessage('');
+    });
+
+    $('#gm2-rel-save').on('click', function(e){
+        e.preventDefault();
+        if (!ajaxUrl) {
+            showMessage(t('errorSaving', 'Error saving relationship.'), 'error');
+            return;
+        }
+        var button = $(this);
+        if (button.prop('disabled')) {
+            return;
+        }
+        showMessage('');
+        var payload = {
+            action: 'gm2_save_relationship',
+            nonce: config.nonce || '',
+            original: $('#gm2-rel-original').val() || '',
+            type: $.trim($('#gm2-rel-type').val() || ''),
+            from: $.trim($('#gm2-rel-from').val() || ''),
+            to: $.trim($('#gm2-rel-to').val() || ''),
+            label: $.trim($('#gm2-rel-label').val() || ''),
+            reverse_label: $.trim($('#gm2-rel-reverse-label').val() || ''),
+            direction: $.trim($('#gm2-rel-direction').val() || ''),
+            cardinality: $('#gm2-rel-cardinality').val() || '',
+            description: $.trim($('#gm2-rel-description').val() || '')
+        };
+        if (!payload.type || !payload.from || !payload.to) {
+            showMessage(t('missingRequired', 'Relationship key, from, and to fields are required.'), 'error');
+            return;
+        }
+        button.prop('disabled', true);
+        $.post(ajaxUrl, payload)
+            .done(function(response){
+                if (response && response.success && response.data && $.isArray(response.data.relationships)) {
+                    updateRelationships(response.data.relationships);
+                    hideForm();
+                    showMessage(t('saved', 'Relationship saved.'), 'success');
+                } else {
+                    var message = response && response.data ? response.data : t('errorSaving', 'Error saving relationship.');
+                    if ($.isArray(message)) {
+                        message = message.join(', ');
+                    }
+                    showMessage(message || t('errorSaving', 'Error saving relationship.'), 'error');
+                }
+            })
+            .fail(function(){
+                showMessage(t('errorSaving', 'Error saving relationship.'), 'error');
+            })
+            .always(function(){
+                button.prop('disabled', false);
+            });
+    });
+
+    $(document).on('click', '.gm2-rel-delete', function(e){
+        e.preventDefault();
+        if (!ajaxUrl) {
+            showMessage(t('errorDeleting', 'Error deleting relationship.'), 'error');
+            return;
+        }
+        var button = $(this);
+        if (button.prop('disabled')) {
+            return;
+        }
+        var type = button.data('rel');
+        if (!type) {
+            return;
+        }
+        if (!window.confirm(t('confirmDelete', 'Delete this relationship?'))) {
+            return;
+        }
+        showMessage('');
+        button.prop('disabled', true);
+        $.post(ajaxUrl, {
+            action: 'gm2_delete_relationship',
+            nonce: config.deleteNonce || '',
+            type: type
+        })
+            .done(function(response){
+                if (response && response.success && response.data && $.isArray(response.data.relationships)) {
+                    updateRelationships(response.data.relationships);
+                    hideForm();
+                    showMessage(t('deleted', 'Relationship deleted.'), 'success');
+                } else {
+                    var message = response && response.data ? response.data : t('errorDeleting', 'Error deleting relationship.');
+                    if ($.isArray(message)) {
+                        message = message.join(', ');
+                    }
+                    showMessage(message || t('errorDeleting', 'Error deleting relationship.'), 'error');
+                }
+            })
+            .fail(function(){
+                showMessage(t('errorDeleting', 'Error deleting relationship.'), 'error');
+            })
+            .always(function(){
+                button.prop('disabled', false);
+            });
+    });
+
+    updateRelationships(state.relationships);
+});

--- a/admin/pages/relationships.php
+++ b/admin/pages/relationships.php
@@ -1,0 +1,94 @@
+<?php
+if ($this->is_locked()) {
+    $this->display_locked_page(esc_html__( 'Relationships', 'gm2-wordpress-suite' ));
+    return;
+}
+if (!$this->can_manage()) {
+    wp_die(esc_html__( 'Permission denied', 'gm2-wordpress-suite' ));
+}
+
+$config = $this->get_config();
+$relationships = $config['relationships'] ?? [];
+
+$objects = [];
+$post_types = get_post_types([], 'objects');
+foreach ($post_types as $slug => $pt_obj) {
+    $label = $pt_obj->labels->singular_name ?? $slug;
+    $objects[$slug] = sprintf('%1$s (%2$s)', $label, __( 'Post Type', 'gm2-wordpress-suite' ));
+}
+$taxonomies = get_taxonomies([], 'objects');
+foreach ($taxonomies as $slug => $tax_obj) {
+    $label = $tax_obj->labels->singular_name ?? $slug;
+    $objects[$slug] = sprintf('%1$s (%2$s)', $label, __( 'Taxonomy', 'gm2-wordpress-suite' ));
+}
+ksort($objects);
+
+$cardinalities = [
+    'one-to-one'   => __( 'One to one', 'gm2-wordpress-suite' ),
+    'one-to-many'  => __( 'One to many', 'gm2-wordpress-suite' ),
+    'many-to-one'  => __( 'Many to one', 'gm2-wordpress-suite' ),
+    'many-to-many' => __( 'Many to many', 'gm2-wordpress-suite' ),
+];
+?>
+<div class="wrap">
+    <h1><?php echo esc_html__( 'Relationships', 'gm2-wordpress-suite' ); ?></h1>
+    <p><?php echo esc_html__( 'Define how your post types and taxonomies relate to each other. These settings are included when exporting blueprints or applying presets.', 'gm2-wordpress-suite' ); ?></p>
+
+    <div id="gm2-rel-messages" class="notice notice-error" style="display:none;"><p></p></div>
+
+    <table class="widefat fixed" id="gm2-relationships-table">
+        <thead>
+            <tr>
+                <th><?php echo esc_html__( 'Key', 'gm2-wordpress-suite' ); ?></th>
+                <th><?php echo esc_html__( 'From', 'gm2-wordpress-suite' ); ?></th>
+                <th><?php echo esc_html__( 'To', 'gm2-wordpress-suite' ); ?></th>
+                <th><?php echo esc_html__( 'Label', 'gm2-wordpress-suite' ); ?></th>
+                <th><?php echo esc_html__( 'Cardinality', 'gm2-wordpress-suite' ); ?></th>
+                <th><?php echo esc_html__( 'Actions', 'gm2-wordpress-suite' ); ?></th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+
+    <p><button type="button" class="button button-primary" id="gm2-add-relationship"><?php echo esc_html__( 'Add Relationship', 'gm2-wordpress-suite' ); ?></button></p>
+
+    <div id="gm2-relationship-form" style="display:none;">
+        <h2><?php echo esc_html__( 'Relationship Details', 'gm2-wordpress-suite' ); ?></h2>
+        <input type="hidden" id="gm2-rel-original" />
+        <p><label><?php echo esc_html__( 'Relationship Key', 'gm2-wordpress-suite' ); ?><br />
+            <input type="text" id="gm2-rel-type" class="regular-text" /></label></p>
+        <p><label><?php echo esc_html__( 'From Object', 'gm2-wordpress-suite' ); ?><br />
+            <input type="text" id="gm2-rel-from" class="regular-text" list="gm2-rel-objects" /></label></p>
+        <p><label><?php echo esc_html__( 'To Object', 'gm2-wordpress-suite' ); ?><br />
+            <input type="text" id="gm2-rel-to" class="regular-text" list="gm2-rel-objects" /></label></p>
+        <p><label><?php echo esc_html__( 'Label', 'gm2-wordpress-suite' ); ?><br />
+            <input type="text" id="gm2-rel-label" class="regular-text" /></label></p>
+        <p><label><?php echo esc_html__( 'Reverse Label', 'gm2-wordpress-suite' ); ?><br />
+            <input type="text" id="gm2-rel-reverse-label" class="regular-text" /></label></p>
+        <p><label><?php echo esc_html__( 'Direction', 'gm2-wordpress-suite' ); ?><br />
+            <input type="text" id="gm2-rel-direction" class="regular-text" /></label></p>
+        <p><label><?php echo esc_html__( 'Cardinality', 'gm2-wordpress-suite' ); ?><br />
+            <select id="gm2-rel-cardinality">
+                <option value=""><?php echo esc_html__( 'Select', 'gm2-wordpress-suite' ); ?></option>
+                <?php foreach ($cardinalities as $value => $label) : ?>
+                    <option value="<?php echo esc_attr($value); ?>"><?php echo esc_html($label); ?></option>
+                <?php endforeach; ?>
+            </select>
+        </label></p>
+        <p><label><?php echo esc_html__( 'Description', 'gm2-wordpress-suite' ); ?><br />
+            <textarea id="gm2-rel-description" class="large-text" rows="3"></textarea></label></p>
+        <p>
+            <button type="button" class="button button-primary" id="gm2-rel-save"><?php echo esc_html__( 'Save Relationship', 'gm2-wordpress-suite' ); ?></button>
+            <button type="button" class="button" id="gm2-rel-cancel"><?php echo esc_html__( 'Cancel', 'gm2-wordpress-suite' ); ?></button>
+        </p>
+    </div>
+
+    <datalist id="gm2-rel-objects">
+        <?php foreach ($objects as $slug => $label) : ?>
+            <option value="<?php echo esc_attr($slug); ?>" label="<?php echo esc_attr($label); ?>"></option>
+        <?php endforeach; ?>
+        <?php if (empty($objects)) : ?>
+            <option value="post" label="<?php echo esc_attr__( 'Post (Post Type)', 'gm2-wordpress-suite' ); ?>"></option>
+        <?php endif; ?>
+    </datalist>
+</div>

--- a/src/Presets/PresetManager.php
+++ b/src/Presets/PresetManager.php
@@ -561,6 +561,9 @@ class PresetManager
         if (!empty($config['post_types']) || !empty($config['taxonomies'])) {
             return true;
         }
+        if (!empty($config['relationships'])) {
+            return true;
+        }
 
         $fieldGroups = get_option('gm2_field_groups', []);
         if (is_array($fieldGroups) && !empty($fieldGroups)) {

--- a/tests/Presets/BlueprintIOTest.php
+++ b/tests/Presets/BlueprintIOTest.php
@@ -113,7 +113,18 @@ class BlueprintIOTest extends WP_UnitTestCase {
         $result = \gm2_model_import($export, 'array');
         $this->assertTrue($result);
 
-        $this->assertEquals($config, get_option('gm2_custom_posts_config'));
+        $importedConfig = get_option('gm2_custom_posts_config');
+        $this->assertEquals($config['post_types'], $importedConfig['post_types']);
+        $this->assertEquals($config['taxonomies'], $importedConfig['taxonomies']);
+        $expectedRelationships = [
+            'taxonomy' => [
+                'type' => 'taxonomy',
+                'from' => 'book',
+                'to'   => 'genre',
+            ],
+        ];
+        $this->assertEquals($expectedRelationships, $importedConfig['relationships']);
+
         $this->assertEquals($field_groups, get_option('gm2_field_groups'));
         $this->assertEquals($schema_map, get_option('gm2_cp_schema_map'));
         $this->assertEquals($meta, get_option('gm2_model_blueprint_meta'));

--- a/tests/Presets/PresetManagerTest.php
+++ b/tests/Presets/PresetManagerTest.php
@@ -58,6 +58,10 @@ class PresetManagerTest extends WP_UnitTestCase {
         $seoMappings = apply_filters('gm2/presets/seo/mappings', []);
         $this->assertArrayHasKey('directory', $seoMappings);
         $this->assertArrayHasKey('listing', $seoMappings['directory']);
+
+        $relationships = apply_filters('gm2/presets/relationships', []);
+        $this->assertArrayHasKey('directory', $relationships);
+        $this->assertIsArray($relationships['directory']);
     }
 
     public function test_invalid_blueprint_reports_error(): void {
@@ -76,6 +80,13 @@ class PresetManagerTest extends WP_UnitTestCase {
         update_option('gm2_custom_posts_config', [
             'post_types' => [ 'example' => [] ],
             'taxonomies' => [ 'genre' => [] ],
+            'relationships' => [
+                'example_to_genre' => [
+                    'type' => 'example_to_genre',
+                    'from' => 'example',
+                    'to'   => 'genre',
+                ],
+            ],
         ]);
         update_option('gm2_field_groups', [ 'group' => [ 'title' => 'Group', 'fields' => [] ] ]);
         update_option('gm2_cp_schema_map', [ 'map' => [ 'type' => 'Thing' ] ]);
@@ -97,6 +108,7 @@ class PresetManagerTest extends WP_UnitTestCase {
         $this->assertIsArray($config);
         $this->assertSame([], $config['post_types'] ?? []);
         $this->assertSame([], $config['taxonomies'] ?? []);
+        $this->assertSame([], $config['relationships'] ?? []);
 
         $this->assertSame([], get_option('gm2_field_groups'));
         $this->assertSame([], get_option('gm2_cp_schema_map'));


### PR DESCRIPTION
## Summary
- add a dedicated relationships admin screen with JavaScript controller and server-side CRUD endpoints
- fold relationship data into the custom posts configuration and blueprint import/export flows
- extend preset utilities and tests to cover stored relationship definitions

## Testing
- vendor/bin/phpunit *(fails: WordPress test suite bootstrap not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68cd96e149b8833097b684826f635f98