### PR TITLE
Add dedicated gm2 CLI namespaces and field group command

### DIFF
--- a/docs/model-cli.md
+++ b/docs/model-cli.md
@@ -1,45 +1,62 @@
 # Model WP-CLI commands
 
-Manage custom post types, taxonomies, and field groups from the command line.
-All commands are run with the `wp gm2 model` prefix.
+Manage custom post types, taxonomies, and field groups from the command line. All commands share the `wp gm2` prefix.
 
-## Creating models
+## Custom post types (`wp gm2 cpt`)
 
-### Custom post type
-
-```bash
-wp gm2 model create cpt <slug> [--args=<json>]
-```
-
-### Taxonomy
+Dedicated shortcuts exist for creating, removing, and listing CPT definitions stored in the `gm2_models` option. Legacy `wp gm2 model cpt ...` subcommands continue to function, but the streamlined syntax below is preferred:
 
 ```bash
-wp gm2 model create taxonomy <cpt> <slug> [--args=<json>]
+wp gm2 cpt add <slug> [--args=<json>]
+wp gm2 model update cpt <slug> [--args=<json>] [--version=<version>]
+wp gm2 cpt remove <slug>
+wp gm2 cpt list [<slug>]
 ```
 
-### Field group
+The `list` subcommand prints a table including the CPT slug, label, version, and any attached taxonomies.
+
+## Taxonomies (`wp gm2 tax`)
+
+Taxonomies can be managed directly with the `gm2 tax` namespace:
+
+```bash
+wp gm2 tax add <cpt> <slug> [--args=<json>]
+wp gm2 model update taxonomy <cpt> <slug> [--args=<json>]
+wp gm2 tax remove <cpt> <slug>
+wp gm2 tax list [<cpt>]
+```
+
+`list` outputs a table with each taxonomy slug, its associated CPT, and label.
+
+## Field groups
+
+Field groups continue to use the nested `gm2 model field` subcommands:
 
 ```bash
 wp gm2 model create field <cpt> <key> [--args=<json>]
-```
-
-## Updating models
-
-```bash
-wp gm2 model update cpt <slug> [--args=<json>] [--version=<version>]
-wp gm2 model update taxonomy <cpt> <slug> [--args=<json>]
 wp gm2 model update field <cpt> <key> [--args=<json>]
-```
-
-`modify` is an alias for `update`.
-
-## Deleting models
-
-```bash
-wp gm2 model delete cpt <slug>
-wp gm2 model delete taxonomy <cpt> <slug>
 wp gm2 model delete field <cpt> <key>
 ```
+
+### Exporting and importing field groups
+
+Use the dedicated `gm2 fields` command when working solely with field group data:
+
+```bash
+wp gm2 fields export <file> [--format=<json|yaml>] [--slug=<slug>] [--slugs=<list>]
+wp gm2 fields import <file> [--format=<json|yaml>] [--replace]
+```
+
+`--slug` may be provided multiple times, and `--slugs` accepts a comma-separated list. Imports merge into existing groups unless `--replace` is supplied.
+
+## Exporting and importing models
+
+```bash
+wp gm2 model export <file> [--format=<json|yaml>] [--field-groups]
+wp gm2 model import <file> [--format=<json|yaml>] [--field-groups] [--replace]
+```
+
+The `--field-groups` flag retains its previous behaviour for backwards compatibility but `wp gm2 fields` provides a clearer entry point.
 
 ## Migrations
 
@@ -47,13 +64,6 @@ Run pending migrations for all models:
 
 ```bash
 wp gm2 model migrate
-```
-
-## Exporting and importing
-
-```bash
-wp gm2 model export <file> [--format=<json|yaml>]
-wp gm2 model import <file> [--format=<json|yaml>]
 ```
 
 ## Blueprints

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -925,6 +925,7 @@ if (defined('WP_CLI') && WP_CLI) {
     require_once GM2_PLUGIN_DIR . 'includes/cli/class-gm2-cli.php';
     require_once GM2_PLUGIN_DIR . 'includes/cli/class-gm2-migrate.php';
     require_once GM2_PLUGIN_DIR . 'includes/cli/class-gm2-model.php';
+    require_once GM2_PLUGIN_DIR . 'includes/cli/class-gm2-fields-cli.php';
     require_once GM2_PLUGIN_DIR . 'includes/cli/class-gm2-blueprint-cli.php';
     require_once GM2_PLUGIN_DIR . 'includes/cli/class-gm2-presets-cli.php';
     require_once GM2_PLUGIN_DIR . 'includes/cli/class-gm2-schema-audit.php';

--- a/includes/cli/class-gm2-fields-cli.php
+++ b/includes/cli/class-gm2-fields-cli.php
@@ -1,0 +1,107 @@
+<?php
+namespace Gm2;
+
+if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+    return;
+}
+
+require_once GM2_PLUGIN_DIR . 'includes/gm2-model-export.php';
+
+/**
+ * Manage field groups via WP-CLI.
+ */
+class Gm2_Fields_CLI extends \WP_CLI_Command {
+    /**
+     * Export field group definitions to a file.
+     *
+     * ## OPTIONS
+     *
+     * <file>
+     * : Destination file path.
+     *
+     * [--format=<format>]
+     * : Output format: json or yaml. Defaults to json.
+     *
+     * [--slug=<slug>]
+     * : Limit the export to specific group slugs. Repeat for multiple slugs.
+     *
+     * [--slugs=<list>]
+     * : Comma separated list of slugs to export.
+     */
+    public function export( $args, $assoc_args ) {
+        $file = $args[0] ?? '';
+        if ( '' === $file ) {
+            \WP_CLI::error( __( 'Missing file argument.', 'gm2-wordpress-suite' ) );
+        }
+
+        $format = $assoc_args['format'] ?? 'json';
+
+        $slugs = [];
+        if ( isset( $assoc_args['slug'] ) ) {
+            $slugs = array_merge( $slugs, (array) $assoc_args['slug'] );
+        }
+        if ( isset( $assoc_args['slugs'] ) ) {
+            if ( is_array( $assoc_args['slugs'] ) ) {
+                $slugs = array_merge( $slugs, $assoc_args['slugs'] );
+            } else {
+                $slugs = array_merge( $slugs, explode( ',', (string) $assoc_args['slugs'] ) );
+            }
+        }
+
+        $slugs = array_values( array_unique( array_filter( array_map( static function ( $slug ) {
+            $slug = is_string( $slug ) ? trim( $slug ) : '';
+            return $slug !== '' ? $slug : null;
+        }, $slugs ) ) ) );
+
+        $data = \gm2_field_groups_export( $format, $slugs ? $slugs : null );
+        if ( is_wp_error( $data ) ) {
+            \WP_CLI::error( $data->get_error_message() );
+        }
+
+        file_put_contents( $file, $data );
+
+        if ( $slugs ) {
+            \WP_CLI::success( sprintf( __( 'Field groups %s exported to %s', 'gm2-wordpress-suite' ), implode( ', ', $slugs ), $file ) );
+        } else {
+            \WP_CLI::success( sprintf( __( 'Field groups exported to %s', 'gm2-wordpress-suite' ), $file ) );
+        }
+    }
+
+    /**
+     * Import field group definitions from a file.
+     *
+     * ## OPTIONS
+     *
+     * <file>
+     * : Source file path.
+     *
+     * [--format=<format>]
+     * : Input format: json or yaml. Defaults to json or guessed from the extension.
+     *
+     * [--replace]
+     * : Replace existing field groups instead of merging.
+     */
+    public function import( $args, $assoc_args ) {
+        $file = $args[0] ?? '';
+        if ( '' === $file || ! file_exists( $file ) ) {
+            \WP_CLI::error( __( 'File not found.', 'gm2-wordpress-suite' ) );
+        }
+
+        $format = $assoc_args['format'] ?? '';
+        if ( ! $format ) {
+            $format = preg_match( '/\.ya?ml$/i', $file ) ? 'yaml' : 'json';
+        }
+
+        $replace  = ! empty( $assoc_args['replace'] );
+        $contents = file_get_contents( $file );
+        $result   = \gm2_field_groups_import( $contents, $format, ! $replace );
+
+        if ( is_wp_error( $result ) ) {
+            \WP_CLI::error( $result->get_error_message() );
+        }
+
+        \WP_CLI::success( sprintf( __( 'Field groups imported from %s', 'gm2-wordpress-suite' ), $file ) );
+    }
+}
+
+\WP_CLI::add_command( 'gm2 fields', __NAMESPACE__ . '\\Gm2_Fields_CLI' );

--- a/tests/test-cli/model-cli.php
+++ b/tests/test-cli/model-cli.php
@@ -59,6 +59,20 @@ if ( ! empty( $models[0]['fields'] ) ) {
     throw new Exception( 'Field delete failed.' );
 }
 
+ob_start();
+$cli->cpt_list( [], [] );
+$cpt_list_output = ob_get_clean();
+if ( strpos( $cpt_list_output, 'book' ) === false ) {
+    throw new Exception( 'CPT list did not include expected slug.' );
+}
+
+ob_start();
+$cli->taxonomy_list( [], [] );
+$tax_list_output = ob_get_clean();
+if ( strpos( $tax_list_output, 'genre' ) === false ) {
+    throw new Exception( 'Taxonomy list did not include expected slug.' );
+}
+
 // Seeding tests.
 $GLOBALS['gm2_seeded_posts'] = [];
 $GLOBALS['gm2_seeded_terms'] = [];


### PR DESCRIPTION
## Summary
- add `gm2 cpt` and `gm2 tax` wrappers with tabular list output built on the existing model helpers
- expose new table-rendering utilities and list methods within the model CLI for CPTs and taxonomies
- introduce a `gm2 fields` export/import command and document the updated CLI entry points
- extend the CLI smoke test to cover the new list helpers

## Testing
- php tests/test-cli/model-cli.php
- php -l includes/cli/class-gm2-model.php
- php -l includes/cli/class-gm2-fields-cli.php
- php -l gm2-wordpress-suite.php

------
https://chatgpt.com/codex/tasks/task_b_68cdb4b2313c833082315263c74122d4