### PR TITLE
Add Brain Monkey bootstrap for hook tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.6",
         "yoast/phpunit-polyfills": "^2.0",
-        "mikey179/vfsstream": "^1.6"
+        "mikey179/vfsstream": "^1.6",
+        "brain/monkey": "^2.6"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d8e90abb77bd5274a8d4077bfac6bbfb",
+    "content-hash": "f92e87dbf412212050511768556e5f1c",
     "packages": [
         {
             "name": "matthiasmullie/minify",
@@ -198,6 +198,124 @@
     ],
     "packages-dev": [
         {
+            "name": "antecedent/patchwork",
+            "version": "2.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/antecedent/patchwork.git",
+                "reference": "8b6b235f405af175259c8f56aea5fc23ab9f03ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/8b6b235f405af175259c8f56aea5fc23ab9f03ce",
+                "reference": "8b6b235f405af175259c8f56aea5fc23ab9f03ce",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=4"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignas Rudaitis",
+                    "email": "ignas.rudaitis@gmail.com"
+                }
+            ],
+            "description": "Method redefinition (monkey-patching) functionality for PHP.",
+            "homepage": "https://antecedent.github.io/patchwork/",
+            "keywords": [
+                "aop",
+                "aspect",
+                "interception",
+                "monkeypatching",
+                "redefinition",
+                "runkit",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/antecedent/patchwork/issues",
+                "source": "https://github.com/antecedent/patchwork/tree/2.2.3"
+            },
+            "time": "2025-09-17T09:00:56+00:00"
+        },
+        {
+            "name": "brain/monkey",
+            "version": "2.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Brain-WP/BrainMonkey.git",
+                "reference": "d95a9d895352c30f47604ad1b825ab8fa9d1a373"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Brain-WP/BrainMonkey/zipball/d95a9d895352c30f47604ad1b825ab8fa9d1a373",
+                "reference": "d95a9d895352c30f47604ad1b825ab8fa9d1a373",
+                "shasum": ""
+            },
+            "require": {
+                "antecedent/patchwork": "^2.1.17",
+                "mockery/mockery": "^1.3.5 || ^1.4.4",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
+                "phpcompatibility/php-compatibility": "^9.3.0",
+                "phpunit/phpunit": "^5.7.26 || ^6.0 || ^7.0 || >=8.0 <8.5.12 || ^8.5.14 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev",
+                    "dev-version/1": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "inc/api.php"
+                ],
+                "psr-4": {
+                    "Brain\\Monkey\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Giuseppe Mazzapica",
+                    "email": "giuseppe.mazzapica@gmail.com",
+                    "homepage": "https://gmazzap.me",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Mocking utility for PHP functions and WordPress plugin API",
+            "keywords": [
+                "Monkey Patching",
+                "interception",
+                "mock",
+                "mock functions",
+                "mockery",
+                "patchwork",
+                "redefinition",
+                "runkit",
+                "test",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Brain-WP/BrainMonkey/issues",
+                "source": "https://github.com/Brain-WP/BrainMonkey"
+            },
+            "time": "2024-08-29T20:15:04+00:00"
+        },
+        {
             "name": "doctrine/instantiator",
             "version": "2.0.0",
             "source": {
@@ -268,6 +386,57 @@
             "time": "2022-12-30T00:23:10+00:00"
         },
         {
+            "name": "hamcrest/hamcrest-php",
+            "version": "v2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hamcrest/hamcrest-php.git",
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "replace": {
+                "cordoval/hamcrest-php": "*",
+                "davedevelopment/hamcrest-php": "*",
+                "kodova/hamcrest-php": "*"
+            },
+            "require-dev": {
+                "phpunit/php-file-iterator": "^1.4 || ^2.0 || ^3.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "hamcrest"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "This is the PHP port of Hamcrest Matchers",
+            "keywords": [
+                "test"
+            ],
+            "support": {
+                "issues": "https://github.com/hamcrest/hamcrest-php/issues",
+                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.1.1"
+            },
+            "time": "2025-04-30T06:54:44+00:00"
+        },
+        {
             "name": "mikey179/vfsstream",
             "version": "v1.6.12",
             "source": {
@@ -318,6 +487,89 @@
                 "wiki": "https://github.com/bovigo/vfsStream/wiki"
             },
             "time": "2024-08-29T18:43:31+00:00"
+        },
+        {
+            "name": "mockery/mockery",
+            "version": "1.6.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mockery/mockery.git",
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/1f4efdd7d3beafe9807b08156dfcb176d18f1699",
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699",
+                "shasum": ""
+            },
+            "require": {
+                "hamcrest/hamcrest-php": "^2.0.1",
+                "lib-pcre": ">=7.0",
+                "php": ">=7.3"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5 || ^9.6.17",
+                "symplify/easy-coding-standard": "^12.1.14"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "library/helpers.php",
+                    "library/Mockery.php"
+                ],
+                "psr-4": {
+                    "Mockery\\": "library/Mockery"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "https://github.com/padraic",
+                    "role": "Author"
+                },
+                {
+                    "name": "Dave Marshall",
+                    "email": "dave.marshall@atstsolutions.co.uk",
+                    "homepage": "https://davedevelopment.co.uk",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Nathanael Esayeas",
+                    "email": "nathanael.esayeas@protonmail.com",
+                    "homepage": "https://github.com/ghostwriter",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "Mockery is a simple yet flexible PHP mock object framework",
+            "homepage": "https://github.com/mockery/mockery",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "library",
+                "mock",
+                "mock objects",
+                "mockery",
+                "stub",
+                "test",
+                "test double",
+                "testing"
+            ],
+            "support": {
+                "docs": "https://docs.mockery.io/",
+                "issues": "https://github.com/mockery/mockery/issues",
+                "rss": "https://github.com/mockery/mockery/releases.atom",
+                "security": "https://github.com/mockery/mockery/security/advisories",
+                "source": "https://github.com/mockery/mockery"
+            },
+            "time": "2024-05-16T03:13:13+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,6 +4,24 @@
         <testsuite name="Plugin Test Suite">
             <directory suffix=".php">./tests</directory>
             <exclude>./tests/test-cli</exclude>
+            <exclude>./tests/AbandonedCartProcessTest.php</exclude>
+            <exclude>./tests/AbandonedCartSessionTest.php</exclude>
+            <exclude>./tests/AbandonedCartSummaryTest.php</exclude>
+            <exclude>./tests/ActivityLogPagingTest.php</exclude>
+            <exclude>./tests/ActivityTableInstallTest.php</exclude>
+            <exclude>./tests/CaptureCartActivityTest.php</exclude>
+            <exclude>./tests/MaybeInstallActivityTableTest.php</exclude>
+            <exclude>./tests/test-abandoned-carts.php</exclude>
+        </testsuite>
+        <testsuite name="Brain Monkey Test Suite">
+            <file>./tests/AbandonedCartProcessTest.php</file>
+            <file>./tests/AbandonedCartSessionTest.php</file>
+            <file>./tests/AbandonedCartSummaryTest.php</file>
+            <file>./tests/ActivityLogPagingTest.php</file>
+            <file>./tests/ActivityTableInstallTest.php</file>
+            <file>./tests/CaptureCartActivityTest.php</file>
+            <file>./tests/MaybeInstallActivityTableTest.php</file>
+            <file>./tests/test-abandoned-carts.php</file>
         </testsuite>
         <testsuite name="CLI Test Suite">
             <directory suffix=".php">./tests/test-cli</directory>

--- a/tests/AbandonedCartProcessTest.php
+++ b/tests/AbandonedCartProcessTest.php
@@ -1,15 +1,21 @@
 <?php
 namespace Gm2 {
-    function current_user_can( $cap ) { return true; }
-    function check_ajax_referer( $action, $query_arg = false ) { return true; }
-    function wp_send_json_success( $data = null ) { $GLOBALS['gm2_ajax_success'] = true; return ['success'=>true]; }
-    function wp_send_json_error( $data = null ) { $GLOBALS['gm2_ajax_success'] = false; return ['success'=>false]; }
-    class Gm2_Abandoned_Carts {
-        public static $called = false;
-        public static function cron_mark_abandoned() { self::$called = true; }
+    if (!function_exists(__NAMESPACE__ . '\\current_user_can')) {
+        function current_user_can( $cap ) { return true; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\check_ajax_referer')) {
+        function check_ajax_referer( $action, $query_arg = false ) { return true; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\wp_send_json_success')) {
+        function wp_send_json_success( $data = null ) { $GLOBALS['gm2_ajax_success'] = true; return ['success'=>true]; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\wp_send_json_error')) {
+        function wp_send_json_error( $data = null ) { $GLOBALS['gm2_ajax_success'] = false; return ['success'=>false]; }
     }
 }
 namespace {
+    use Tests\Phpunit\BrainMonkeyTestCase;
+
     if ( ! defined( 'ABSPATH' ) ) {
         define( 'ABSPATH', __DIR__ . '/../' );
     }
@@ -25,12 +31,13 @@ namespace {
 
     require_once dirname( __DIR__ ) . '/admin/Gm2_Abandoned_Carts_Admin.php';
 
-    class AbandonedCartProcessTest extends \PHPUnit\Framework\TestCase {
+    class AbandonedCartProcessTest extends BrainMonkeyTestCase {
         public function test_ajax_process_triggers_cron() {
             $_POST['nonce'] = 'n';
+            $mock = \Mockery::mock('alias:Gm2\\Gm2_Abandoned_Carts');
+            $mock->shouldReceive('cron_mark_abandoned')->once();
             $admin = new \Gm2\Gm2_Abandoned_Carts_Admin();
             $admin->ajax_process();
-            $this->assertTrue( \Gm2\Gm2_Abandoned_Carts::$called );
             $this->assertTrue( $GLOBALS['gm2_ajax_success'] );
         }
     }

--- a/tests/AbandonedCartSessionTest.php
+++ b/tests/AbandonedCartSessionTest.php
@@ -1,11 +1,13 @@
 <?php
 
 namespace Gm2 {
-    function add_action($hook, $callback) {}
+    if (!function_exists(__NAMESPACE__ . '\\add_action')) {
+        function add_action($hook, $callback) {}
+    }
 }
 
 namespace {
-use PHPUnit\Framework\TestCase;
+use Tests\Phpunit\BrainMonkeyTestCase;
 
 if (!defined('ABSPATH')) {
     define('ABSPATH', __DIR__ . '/../');
@@ -44,7 +46,7 @@ if (!function_exists('WC')) {
 
 require_once __DIR__ . '/../includes/Gm2_Abandoned_Carts.php';
 
-final class AbandonedCartSessionTest extends TestCase {
+final class AbandonedCartSessionTest extends BrainMonkeyTestCase {
     public function test_capture_cart_handles_missing_session() {
         global $wc_obj;
         $product = new class {

--- a/tests/AbandonedCartSummaryTest.php
+++ b/tests/AbandonedCartSummaryTest.php
@@ -6,7 +6,8 @@ namespace Gm2 {
     }
 }
 namespace {
-use PHPUnit\Framework\TestCase;
+use Tests\Phpunit\BrainMonkeyTestCase;
+
 if (!defined('ABSPATH')) {
     define('ABSPATH', __DIR__ . '/../');
 }
@@ -57,7 +58,7 @@ class SummaryDB {
         return [];
     }
 }
-final class AbandonedCartSummaryTest extends TestCase {
+final class AbandonedCartSummaryTest extends BrainMonkeyTestCase {
     public function test_summary_calculations(){
         $db = new SummaryDB();
         $GLOBALS['wpdb'] = $db;

--- a/tests/ActivityLogPagingTest.php
+++ b/tests/ActivityLogPagingTest.php
@@ -1,31 +1,54 @@
 <?php
 namespace Gm2 {
-    function check_ajax_referer($action, $query_arg = false, $die = true) { return true; }
-    function wp_send_json_success($data = null) { $GLOBALS['gm2_ajax_data'] = ['success'=>true,'data'=>$data]; return $GLOBALS['gm2_ajax_data']; }
-    function wp_send_json_error($data = null) { $GLOBALS['gm2_ajax_data'] = ['success'=>false,'data'=>$data]; return $GLOBALS['gm2_ajax_data']; }
-    function current_user_can($cap = '') { return true; }
-    function sanitize_text_field($str) { return $str; }
-    function wp_unslash($v) { return $v; }
-    function absint($v) { return abs((int)$v); }
-    function mysql2date($f, $d) { return $d; }
-    function get_option($n) { return 'Y-m-d H:i:s'; }
-    function add_action($hook, $callback, $priority = 10, $args = 1) {}
+    if (!function_exists(__NAMESPACE__ . '\\check_ajax_referer')) {
+        function check_ajax_referer($action, $query_arg = false, $die = true) { return true; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\wp_send_json_success')) {
+        function wp_send_json_success($data = null) { $GLOBALS['gm2_ajax_data'] = ['success'=>true,'data'=>$data]; return $GLOBALS['gm2_ajax_data']; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\wp_send_json_error')) {
+        function wp_send_json_error($data = null) { $GLOBALS['gm2_ajax_data'] = ['success'=>false,'data'=>$data]; return $GLOBALS['gm2_ajax_data']; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\current_user_can')) {
+        function current_user_can($cap = '') { return true; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\sanitize_text_field')) {
+        function sanitize_text_field($str) { return $str; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\wp_unslash')) {
+        function wp_unslash($v) { return $v; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\absint')) {
+        function absint($v) { return abs((int)$v); }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\mysql2date')) {
+        function mysql2date($f, $d) { return $d; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\get_option')) {
+        function get_option($n) { return 'Y-m-d H:i:s'; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\add_action')) {
+        function add_action($hook, $callback, $priority = 10, $args = 1) {}
+    }
 }
 
 namespace {
+    use Tests\Phpunit\BrainMonkeyTestCase;
+
     if (!defined('ABSPATH')) { define('ABSPATH', __DIR__ . '/../'); }
     require_once __DIR__ . '/../includes/Gm2_Abandoned_Carts.php';
-    use PHPUnit\Framework\TestCase;
 
-    class ActivityLogPagingTest extends TestCase {
+    class ActivityLogPagingTest extends BrainMonkeyTestCase {
         private $orig_wpdb;
         protected function setUp(): void {
+            parent::setUp();
             $this->orig_wpdb = $GLOBALS['wpdb'] ?? null;
-            $GLOBALS['wpdb'] = new FakeDB();
+            $GLOBALS['wpdb'] = new ActivityLogFakeDB();
             $GLOBALS['gm2_ajax_data'] = null;
         }
         protected function tearDown(): void {
             $GLOBALS['wpdb'] = $this->orig_wpdb;
+            parent::tearDown();
         }
         public function test_returns_paged_activity_and_visits() {
             global $wpdb;
@@ -83,7 +106,7 @@ namespace {
         }
     }
 
-    class FakeDB {
+    class ActivityLogFakeDB {
         public $prefix = 'wp_';
         public $data = [];
         private $last_sql;

--- a/tests/ActivityTableInstallTest.php
+++ b/tests/ActivityTableInstallTest.php
@@ -1,9 +1,14 @@
 <?php
 namespace Gm2 {
-    function add_action($hook, $callback, $priority = 10, $accepted_args = 1) {}
+    if (!function_exists(__NAMESPACE__ . '\\add_action')) {
+        function add_action($hook, $callback, $priority = 10, $accepted_args = 1) {}
+    }
 }
 
 namespace {
+    use Gm2\Gm2_Abandoned_Carts;
+    use Tests\Phpunit\BrainMonkeyTestCase;
+
     if (!function_exists('dbDelta')) {
         function dbDelta($sql) {
             global $wpdb;
@@ -12,84 +17,84 @@ namespace {
             }
         }
     }
-    if (!class_exists('WP_UnitTestCase')) {
-        abstract class WP_UnitTestCase extends \PHPUnit\Framework\TestCase {}
-    }
     if (!defined('ABSPATH')) {
         define('ABSPATH', sys_get_temp_dir() . '/');
     }
     require_once dirname(__DIR__) . '/includes/Gm2_Abandoned_Carts.php';
 
-    use Gm2\Gm2_Abandoned_Carts;
+    class ActivityTableInstallTest extends BrainMonkeyTestCase {
+        private $orig_wpdb;
+        private $upgrade_file;
+        private $created_upgrade = false;
 
-    class ActivityTableInstallTest extends WP_UnitTestCase {
-    private $orig_wpdb;
-    private $upgrade_file;
-    private $created_upgrade = false;
+        protected function setUp(): void {
+            parent::setUp();
+            $this->orig_wpdb = $GLOBALS['wpdb'] ?? null;
+            $GLOBALS['wpdb'] = new FakeMaybeInstallDB();
+            $root = defined('ABSPATH') ? ABSPATH : dirname(__DIR__) . '/';
+            if (!defined('ABSPATH')) {
+                define('ABSPATH', $root);
+            }
+            $path = $root . 'wp-admin/includes';
+            if (!is_dir($path)) {
+                mkdir($path, 0777, true);
+                $this->created_upgrade = true;
+            }
+            $this->upgrade_file = $path . '/upgrade.php';
+            if (!file_exists($this->upgrade_file)) {
+                file_put_contents($this->upgrade_file, "<?php\n");
+                $this->created_upgrade = true;
+            }
+        }
 
-    protected function setUp(): void {
-        parent::setUp();
-        $this->orig_wpdb = $GLOBALS['wpdb'] ?? null;
-        $GLOBALS['wpdb'] = new FakeMaybeInstallDB();
-        $root = defined('ABSPATH') ? ABSPATH : dirname(__DIR__) . '/';
-        if (!defined('ABSPATH')) {
-            define('ABSPATH', $root);
+        protected function tearDown(): void {
+            if ($this->created_upgrade && file_exists($this->upgrade_file)) {
+                unlink($this->upgrade_file);
+                @rmdir(dirname($this->upgrade_file));
+                @rmdir(dirname(dirname($this->upgrade_file)));
+            }
+            $GLOBALS['wpdb'] = $this->orig_wpdb;
+            parent::tearDown();
         }
-        $path = $root . 'wp-admin/includes';
-        if (!is_dir($path)) {
-            mkdir($path, 0777, true);
-            $this->created_upgrade = true;
-        }
-        $this->upgrade_file = $path . '/upgrade.php';
-        if (!file_exists($this->upgrade_file)) {
-            file_put_contents($this->upgrade_file, "<?php\n");
-            $this->created_upgrade = true;
-        }
-    }
 
-    protected function tearDown(): void {
-        if ($this->created_upgrade && file_exists($this->upgrade_file)) {
-            unlink($this->upgrade_file);
-            @rmdir(dirname($this->upgrade_file));
-            @rmdir(dirname(dirname($this->upgrade_file)));
+        public function test_activity_table_created_when_missing() {
+            $ac = new Gm2_Abandoned_Carts();
+            $ref = new \ReflectionClass(Gm2_Abandoned_Carts::class);
+            $method = $ref->getMethod('maybe_install');
+            $method->setAccessible(true);
+            $method->invoke($ac);
+            $activity_table = $GLOBALS['wpdb']->prefix . 'wc_ac_cart_activity';
+            $this->assertContains($activity_table, $GLOBALS['wpdb']->tables);
         }
-        $GLOBALS['wpdb'] = $this->orig_wpdb;
-        parent::tearDown();
-    }
-
-    public function test_activity_table_created_when_missing() {
-        $ac = new Gm2_Abandoned_Carts();
-        $ref = new \ReflectionClass(Gm2_Abandoned_Carts::class);
-        $method = $ref->getMethod('maybe_install');
-        $method->setAccessible(true);
-        $method->invoke($ac);
-        $activity_table = $GLOBALS['wpdb']->prefix . 'wc_ac_cart_activity';
-        $this->assertContains($activity_table, $GLOBALS['wpdb']->tables);
-    }
     }
 
     class FakeMaybeInstallDB {
-    public $prefix = 'wp_';
-    public $tables;
-    public function __construct() {
-        $this->tables = [
-            $this->prefix . 'wc_ac_carts',
-            $this->prefix . 'wc_ac_email_queue',
-            $this->prefix . 'wc_ac_recovered'
-        ];
-    }
-    public function prepare($query, $arg) {
-        return str_replace('%s', "'" . $arg . "'", $query);
-    }
-    public function get_var($query) {
-        if (preg_match("/SHOW TABLES LIKE '([^']+)'/", $query, $m)) {
-            return in_array($m[1], $this->tables, true) ? $m[1] : null;
+        public $prefix = 'wp_';
+        public $tables;
+
+        public function __construct() {
+            $this->tables = [
+                $this->prefix . 'wc_ac_carts',
+                $this->prefix . 'wc_ac_email_queue',
+                $this->prefix . 'wc_ac_recovered'
+            ];
         }
-        return null;
-    }
-    public function get_charset_collate() {
-        return '';
-    }
+
+        public function prepare($query, $arg) {
+            return str_replace('%s', "'" . $arg . "'", $query);
+        }
+
+        public function get_var($query) {
+            if (preg_match("/SHOW TABLES LIKE '([^']+)'/", $query, $m)) {
+                return in_array($m[1], $this->tables, true) ? $m[1] : null;
+            }
+            return null;
+        }
+
+        public function get_charset_collate() {
+            return '';
+        }
+
         public function query($sql) {
             // not needed for this test
         }

--- a/tests/CaptureCartActivityTest.php
+++ b/tests/CaptureCartActivityTest.php
@@ -36,7 +36,7 @@ namespace Gm2 {
 }
 
 namespace {
-use PHPUnit\Framework\TestCase;
+use Tests\Phpunit\BrainMonkeyTestCase;
 
 if (!defined('ABSPATH')) {
     define('ABSPATH', __DIR__ . '/../');
@@ -99,7 +99,7 @@ if (!function_exists('wc_get_product')) {
     function wc_get_product($id) { return new FakeProduct($id); }
 }
 
-class FakeDB {
+class CaptureCartFakeDB {
     public $prefix = 'wp_';
     public $data = [];
     public $insert_id = 0;
@@ -134,10 +134,11 @@ class FakeDB {
 
 require_once __DIR__.'/../includes/Gm2_Abandoned_Carts.php';
 
-final class CaptureCartActivityTest extends TestCase {
+final class CaptureCartActivityTest extends BrainMonkeyTestCase {
     private $ac; private $db; private $cart;
     protected function setUp(): void {
-        $this->db = new FakeDB();
+        parent::setUp();
+        $this->db = new CaptureCartFakeDB();
         $GLOBALS['wpdb'] = $this->db;
         $this->cart = new WC_Cart([
             [ 'product_id'=>1, 'quantity'=>1, 'data'=>new FakeProduct(1) ],

--- a/tests/MaybeInstallActivityTableTest.php
+++ b/tests/MaybeInstallActivityTableTest.php
@@ -1,9 +1,14 @@
 <?php
 namespace Gm2 {
-    function add_action($hook, $callback, $priority = 10, $accepted_args = 1) {}
+    if (!function_exists(__NAMESPACE__ . '\\add_action')) {
+        function add_action($hook, $callback, $priority = 10, $accepted_args = 1) {}
+    }
 }
 
 namespace {
+    use Gm2\Gm2_Abandoned_Carts;
+    use Tests\Phpunit\BrainMonkeyTestCase;
+
     if (!function_exists('dbDelta')) {
         function dbDelta($sql) {
             global $wpdb;
@@ -12,17 +17,12 @@ namespace {
             }
         }
     }
-    if (!class_exists('WP_UnitTestCase')) {
-        abstract class WP_UnitTestCase extends \PHPUnit\Framework\TestCase {}
-    }
     if (!defined('ABSPATH')) {
         define('ABSPATH', sys_get_temp_dir() . '/');
     }
     require_once dirname(__DIR__) . '/includes/Gm2_Abandoned_Carts.php';
 
-    use Gm2\Gm2_Abandoned_Carts;
-
-    class MaybeInstallActivityTableTest extends WP_UnitTestCase {
+    class MaybeInstallActivityTableTest extends BrainMonkeyTestCase {
         private $orig_wpdb;
         private $upgrade_file;
         private $created_upgrade = false;
@@ -30,7 +30,7 @@ namespace {
         protected function setUp(): void {
             parent::setUp();
             $this->orig_wpdb = $GLOBALS['wpdb'] ?? null;
-            $GLOBALS['wpdb'] = new FakeDB();
+            $GLOBALS['wpdb'] = new MaybeInstallActivityFakeDB();
             $root = defined('ABSPATH') ? ABSPATH : dirname(__DIR__) . '/';
             $path = $root . 'wp-admin/includes';
             if (!is_dir($path)) {
@@ -69,7 +69,7 @@ namespace {
         }
     }
 
-    class FakeDB {
+    class MaybeInstallActivityFakeDB {
         public $prefix = 'wp_';
         public $tables;
         public function __construct() {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,9 @@
 <?php
+$brainMonkeySuite = getenv('GM2_BRAIN_MONKEY');
+if ($brainMonkeySuite) {
+    require_once __DIR__ . '/brain-monkey-bootstrap.php';
+    return;
+}
 $_tests_dir = getenv('WP_TESTS_DIR');
 if (!$_tests_dir) {
     $_tests_dir = '/tmp/wordpress-tests-lib';

--- a/tests/brain-monkey-bootstrap.php
+++ b/tests/brain-monkey-bootstrap.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+$autoload = dirname(__DIR__) . '/vendor/autoload.php';
+if (!is_file($autoload)) {
+    throw new RuntimeException('Composer autoload file is missing. Run "composer install" before executing the Brain Monkey suite.');
+}
+require_once $autoload;
+require_once __DIR__ . '/phpunit/BrainMonkeyTestCase.php';
+
+// Prime and reset Brain Monkey once so subsequent tests start from a clean slate.
+\Brain\Monkey\setUp();
+\Brain\Monkey\tearDown();

--- a/tests/phpunit/BrainMonkeyTestCase.php
+++ b/tests/phpunit/BrainMonkeyTestCase.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Phpunit;
+
+use Brain\Monkey;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Base test case that boots Brain Monkey for hook-focused unit tests.
+ */
+abstract class BrainMonkeyTestCase extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Monkey\setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        if (class_exists('Mockery')) {
+            \Mockery::close();
+        }
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+}

--- a/tests/test-abandoned-carts.php
+++ b/tests/test-abandoned-carts.php
@@ -1,49 +1,119 @@
 <?php
 namespace Gm2 {
-    function check_ajax_referer($action, $query_arg = false, $die = true) {
-        return $GLOBALS['gm2_nonce_ok'] ?? true;
-    }
-    function wp_send_json_success($data = null) { return ['success'=>true,'data'=>$data]; }
-    function wp_send_json_error($data = null) { return ['success'=>false,'data'=>$data]; }
-    function error_log($message) { $GLOBALS['gm2_error_log'][] = $message; }
-    function do_action($tag, ...$args) {}
-    function current_time($type) {
-        if ('timestamp' === $type) {
-            return time();
+    if (!function_exists(__NAMESPACE__ . '\\check_ajax_referer')) {
+        function check_ajax_referer($action, $query_arg = false, $die = true) {
+            return $GLOBALS['gm2_nonce_ok'] ?? true;
         }
-        return gmdate('Y-m-d H:i:s');
     }
-    function current_user_can($cap = '') { return $GLOBALS['gm2_is_admin'] ?? false; }
-    function esc_url_raw($url) { return $url; }
-    function sanitize_text_field($str) { return $str; }
-    function wp_unslash($value) { return $value; }
-    function sanitize_email($email) { return $email; }
-    function home_url($path = '') { return 'https://example.com' . $path; }
-    function admin_url($path = '') { return 'https://example.com' . $path; }
-    function wp_create_nonce($action = '') { return 'nonce'; }
-    function wp_json_encode($data) { return json_encode($data); }
-    function get_current_user_id() { return 1; }
-    function is_admin() { return false; }
-    function add_action($hook, $callback, $priority = 10, $accepted_args = 1) {}
-    function wp_schedule_event() {}
-    function wp_next_scheduled() { return false; }
-    function wp_clear_scheduled_hook() {}
-    function apply_filters($tag, $value) { return $value; }
-    function get_option($option, $default = false) { return $GLOBALS['gm2_options'][$option] ?? $default; }
-    function update_option($option, $value) { $GLOBALS['gm2_options'][$option] = $value; return true; }
-    function is_ssl() { return false; }
-    function wp_doing_ajax() { return $GLOBALS['wp_doing_ajax'] ?? false; }
-    function wp_doing_cron() { return $GLOBALS['wp_doing_cron'] ?? false; }
+    if (!function_exists(__NAMESPACE__ . '\\wp_send_json_success')) {
+        function wp_send_json_success($data = null) { return ['success'=>true,'data'=>$data]; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\wp_send_json_error')) {
+        function wp_send_json_error($data = null) { return ['success'=>false,'data'=>$data]; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\error_log')) {
+        function error_log($message) { $GLOBALS['gm2_error_log'][] = $message; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\do_action')) {
+        function do_action($tag, ...$args) {}
+    }
+    if (!function_exists(__NAMESPACE__ . '\\current_time')) {
+        function current_time($type) {
+            if ('timestamp' === $type) {
+                return time();
+            }
+            return gmdate('Y-m-d H:i:s');
+        }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\current_user_can')) {
+        function current_user_can($cap = '') { return $GLOBALS['gm2_is_admin'] ?? false; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\esc_url_raw')) {
+        function esc_url_raw($url) { return $url; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\sanitize_text_field')) {
+        function sanitize_text_field($str) { return $str; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\wp_unslash')) {
+        function wp_unslash($value) { return $value; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\sanitize_email')) {
+        function sanitize_email($email) { return $email; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\home_url')) {
+        function home_url($path = '') { return 'https://example.com' . $path; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\admin_url')) {
+        function admin_url($path = '') { return 'https://example.com' . $path; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\wp_create_nonce')) {
+        function wp_create_nonce($action = '') { return 'nonce'; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\wp_json_encode')) {
+        function wp_json_encode($data) { return json_encode($data); }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\get_current_user_id')) {
+        function get_current_user_id() { return 1; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\is_admin')) {
+        function is_admin() { return false; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\add_action')) {
+        function add_action($hook, $callback, $priority = 10, $accepted_args = 1) {}
+    }
+    if (!function_exists(__NAMESPACE__ . '\\wp_schedule_event')) {
+        function wp_schedule_event() {}
+    }
+    if (!function_exists(__NAMESPACE__ . '\\wp_next_scheduled')) {
+        function wp_next_scheduled() { return false; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\wp_clear_scheduled_hook')) {
+        function wp_clear_scheduled_hook() {}
+    }
+    if (!function_exists(__NAMESPACE__ . '\\apply_filters')) {
+        function apply_filters($tag, $value) { return $value; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\get_option')) {
+        function get_option($option, $default = false) { return $GLOBALS['gm2_options'][$option] ?? $default; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\update_option')) {
+        function update_option($option, $value) { $GLOBALS['gm2_options'][$option] = $value; return true; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\is_ssl')) {
+        function is_ssl() { return false; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\wp_doing_ajax')) {
+        function wp_doing_ajax() { return $GLOBALS['wp_doing_ajax'] ?? false; }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\wp_doing_cron')) {
+        function wp_doing_cron() { return $GLOBALS['wp_doing_cron'] ?? false; }
+    }
 }
 
 namespace {
-define('ABSPATH', __DIR__ . '/../');
-define('GM2_PLUGIN_DIR', dirname(__DIR__) . '/');
-define('GM2_PLUGIN_URL', '');
-define('GM2_VERSION', '1.0');
-define('HOUR_IN_SECONDS', 3600);
-define('COOKIEPATH', '/');
-define('COOKIE_DOMAIN', '');
+use Tests\Phpunit\BrainMonkeyTestCase;
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/../');
+}
+if (!defined('GM2_PLUGIN_DIR')) {
+    define('GM2_PLUGIN_DIR', dirname(__DIR__) . '/');
+}
+if (!defined('GM2_PLUGIN_URL')) {
+    define('GM2_PLUGIN_URL', '');
+}
+if (!defined('GM2_VERSION')) {
+    define('GM2_VERSION', '1.0');
+}
+if (!defined('HOUR_IN_SECONDS')) {
+    define('HOUR_IN_SECONDS', 3600);
+}
+if (!defined('COOKIEPATH')) {
+    define('COOKIEPATH', '/');
+}
+if (!defined('COOKIE_DOMAIN')) {
+    define('COOKIE_DOMAIN', '');
+}
 require_once dirname(__DIR__) . '/includes/Gm2_Abandoned_Carts.php';
 if (!class_exists('WC_Session')) {
     class WC_Session {
@@ -73,41 +143,37 @@ if (!function_exists('WC')) {
 
 if (!function_exists('wc_get_order')) {
     function wc_get_order($order_id) {
-        return new FakeOrder();
+        return new AbandonedCartFakeOrder();
     }
 }
 
-class FakeOrder {
+class AbandonedCartFakeOrder {
     public function get_billing_email() { return 'user@example.com'; }
     public function get_billing_country() { return 'US'; }
     public function get_billing_state() { return 'CA'; }
 }
 
-class FakeProduct {
+class AbandonedCartFakeProduct {
     public function get_name() { return 'Test Product'; }
     public function get_price() { return 10; }
     public function get_sku() { return 'SKU'; }
 }
 
-class FakeCart {
+class AbandonedCartFakeCart {
     public function is_empty() { return false; }
     public function get_cart() {
         return [
             [
                 'product_id' => 1,
                 'quantity'   => 1,
-                'data'       => new FakeProduct(),
+                'data'       => new AbandonedCartFakeProduct(),
             ],
         ];
     }
     public function get_cart_contents_total() { return 10; }
 }
 
-if (!class_exists('WP_UnitTestCase')) {
-    abstract class WP_UnitTestCase extends \PHPUnit\Framework\TestCase {}
-}
-
-class AbandonedCartsTest extends WP_UnitTestCase {
+class AbandonedCartsTest extends BrainMonkeyTestCase {
     private $orig_wpdb;
     private $token = 'tok123';
 
@@ -324,7 +390,7 @@ class AbandonedCartsTest extends WP_UnitTestCase {
         $table = $GLOBALS['wpdb']->prefix . 'wc_ac_carts';
         $GLOBALS['wpdb']->data[$table] = [];
         global $wc_session_obj;
-        $wc_session_obj->cart = new FakeCart();
+        $wc_session_obj->cart = new AbandonedCartFakeCart();
         WC()->session->set('gm2_entry_url', null);
         $_SERVER['HTTP_HOST'] = 'example.com';
         $_SERVER['REQUEST_URI'] = '/shop/landing';
@@ -370,7 +436,7 @@ class AbandonedCartsTest extends WP_UnitTestCase {
 
         $GLOBALS['wpdb']->data[$table] = [];
         global $wc_session_obj;
-        $wc_session_obj->cart = new FakeCart();
+        $wc_session_obj->cart = new AbandonedCartFakeCart();
         $ac = new \Gm2\Gm2_Abandoned_Carts();
         $ac->capture_cart();
         $this->assertCount(0, $GLOBALS['wpdb']->data[$table]);


### PR DESCRIPTION
## Summary
- add the brain/monkey dev dependency and provide a BrainMonkeyTestCase helper for hook-centric tests
- introduce a Brain Monkey bootstrap and environment toggle so hook suites can bypass the WordPress bootstrap
- migrate the abandoned-cart hook tests to the new base class and register them in a dedicated phpunit testsuite

## Testing
- GM2_BRAIN_MONKEY=1 ./vendor/bin/phpunit --testsuite "Brain Monkey Test Suite" *(fails: missing WordPress-style stubs for several WooCommerce helpers)*

------
https://chatgpt.com/codex/tasks/task_b_68cdb8df1f6083309bbb7355cc9b11e5