### PR TITLE
docs: tabulate preset schema mappings

### DIFF
--- a/docs/presets/courses.md
+++ b/docs/presets/courses.md
@@ -25,10 +25,35 @@
 ## Schema Mapping
 
 - **Schema Type:** `Course`
-- **Mappings:**
-  - `provider` ← `provider`
-  - `courseCode` ← `course_code`
-  - `url` ← `course_url`
+- **Source:** [`presets/courses/blueprint.json`](../../presets/courses/blueprint.json) (`seo_mappings → course`)
+
+| Schema property | GM2 field slug |
+| --- | --- |
+| `provider.name` | `provider` |
+| `provider.alternateName` | `organization_name` |
+| `provider.department` | `department` |
+| `provider.url` | `website` |
+| `provider.email` | `contact_email` |
+| `provider.telephone` | `contact_phone` |
+| `courseCode` | `course_code` |
+| `url` | `course_url` |
+| `coursePrerequisites` | `prerequisites` |
+| `timeRequired` | `duration_iso` |
+| `courseInstance.courseMode` | `modality` |
+| `courseInstance.eventAttendanceMode` | `modality` |
+| `courseInstance.startDate` | `start_date_time` |
+| `courseInstance.endDate` | `end_date_time` |
+| `courseInstance.duration` | `duration_iso` |
+| `courseInstance.location.name` | `provider` |
+| `courseInstance.location.url` | `website` |
+| `courseInstance.location.email` | `contact_email` |
+| `courseInstance.location.telephone` | `contact_phone` |
+| `courseInstance.location.timeZone` | `start_time_zone` |
+| `courseInstance.offers.price` | `amount` |
+| `courseInstance.offers.priceCurrency` | `currency` |
+| `courseInstance.offers.url` | `course_url` |
+
+Shared fields like `modality`, `provider`, and `course_url` deliberately power both the parent `Course` object and nested `CourseInstance` data so schedule details stay in sync across schema consumers.
 
 ## Elementor Notes
 

--- a/docs/presets/directory.md
+++ b/docs/presets/directory.md
@@ -26,10 +26,24 @@
 ## Schema Mapping
 
 - **Schema Type:** `LocalBusiness`
-- **Mappings:**
-  - `telephone` ← `phone`
-  - `address.streetAddress` ← `address`
-  - `url` ← `website`
+- **Source:** [`presets/directory/blueprint.json`](../../presets/directory/blueprint.json) (`seo_mappings → listing`)
+
+| Schema property | GM2 field slug |
+| --- | --- |
+| `telephone` | `phone` |
+| `email` | `email` |
+| `address.streetAddress` | `address` |
+| `address.addressLocality` | `city` |
+| `address.addressRegion` | `region` |
+| `address.postalCode` | `postal_code` |
+| `address.addressCountry` | `country` |
+| `geo.latitude` | `latitude` |
+| `geo.longitude` | `longitude` |
+| `openingHoursSpecification` | `opening_hours` |
+| `sameAs` | `same_as` |
+| `priceRange` | `price_level` |
+| `image` | `logo` |
+| `url` | `website` |
 
 ## Elementor Notes
 

--- a/docs/presets/events.md
+++ b/docs/presets/events.md
@@ -26,17 +26,20 @@
 ## Schema Mapping
 
 - **Schema Type:** `Event`
-- **Mappings:**
-  - `startDate` ← `start_date`
-  - `endDate` ← `end_date`
-  - `eventStatus` ← `status`
-  - `eventAttendanceMode` ← `attendance_mode`
-  - `location.name` ← `location`
-  - `location.address.streetAddress` ← `location`
-  - `virtualLocation.url` ← `virtual_event_url`
-  - `onlineEventUrl` ← `virtual_event_url`
-  - `organizer` ← `organizer`
-  - `offers` ← `ticket_offers`
+- **Source:** [`presets/events/blueprint.json`](../../presets/events/blueprint.json) (`seo_mappings → event`)
+
+| Schema property | GM2 field slug |
+| --- | --- |
+| `startDate` | `start_date` |
+| `endDate` | `end_date` |
+| `eventStatus` | `status` |
+| `eventAttendanceMode` | `attendance_mode` |
+| `location.name` | `location` |
+| `location.address.streetAddress` | `location` |
+| `virtualLocation.url` | `virtual_event_url` |
+| `onlineEventUrl` | `virtual_event_url` |
+| `organizer` | `organizer` |
+| `offers` | `ticket_offers` |
 
 The `location` text feeds the `Place` name and street address, while linking an organizer post fills the `Organization` node. Adding rows to the `ticket_offers` repeater produces `Offer` objects with price, currency, and optional purchase URLs, and supplying a virtual event link populates a `VirtualLocation` alongside `onlineEventUrl` for all-online or hybrid sessions.
 

--- a/docs/presets/jobs.md
+++ b/docs/presets/jobs.md
@@ -27,11 +27,43 @@
 ## Schema Mapping
 
 - **Schema Type:** `JobPosting`
-- **Mappings:**
-  - `datePosted` ← `date_posted`
-  - `employmentType` ← `employment_type`
-  - `hiringOrganization` ← `company`
-  - `url` ← `apply_url`
+- **Source:** [`presets/jobs/blueprint.json`](../../presets/jobs/blueprint.json) (`seo_mappings → job`)
+
+| Schema property | GM2 field slug |
+| --- | --- |
+| `datePosted` | `date_posted` |
+| `validThrough` | `valid_through` |
+| `employmentType` | `employment_type` |
+| `jobLocationType` | `job_location_type` |
+| `jobLocation.name` | `job_location_name` |
+| `jobLocation.address.streetAddress` | `job_street` |
+| `jobLocation.address.addressLocality` | `job_city` |
+| `jobLocation.address.addressRegion` | `job_region` |
+| `jobLocation.address.postalCode` | `job_postal_code` |
+| `jobLocation.address.addressCountry` | `job_country` |
+| `jobLocation.geo.latitude` | `job_latitude` |
+| `jobLocation.geo.longitude` | `job_longitude` |
+| `baseSalary.currency` | `salary_currency` |
+| `baseSalary.value.minValue` | `salary_min` |
+| `baseSalary.value.maxValue` | `salary_max` |
+| `baseSalary.value.unitText` | `salary_unit_text` |
+| `offers.0.priceCurrency` | `salary_currency` |
+| `offers.0.price` | `salary_min` |
+| `offers.0.priceSpecification.priceCurrency` | `salary_currency` |
+| `offers.0.priceSpecification.price` | `salary_min` |
+| `offers.0.priceSpecification.minPrice` | `salary_min` |
+| `offers.0.priceSpecification.maxPrice` | `salary_max` |
+| `offers.0.priceSpecification.unitText` | `salary_unit_text` |
+| `offers.0.url` | `apply_url` |
+| `jobBenefits` | `job_benefits` |
+| `educationRequirements` | `education_level` |
+| `experienceRequirements` | `experience_requirements` |
+| `applicationContact.email` | `apply_email` |
+| `applicationContact.url` | `apply_url` |
+| `hiringOrganization` | `company` |
+| `url` | `apply_url` |
+
+Salary values intentionally feed both the `baseSalary` object and the first `Offer` node to satisfy job board aggregators that prefer complete `Offer` pricing data alongside structured salary ranges.
 
 ## Elementor Notes
 

--- a/docs/presets/real-estate.md
+++ b/docs/presets/real-estate.md
@@ -25,10 +25,25 @@
 ## Schema Mapping
 
 - **Schema Type:** `RealEstateListing`
-- **Mappings:**
-  - `price` ← `price`
-  - `address.streetAddress` ← `address`
-  - `numberOfRooms` ← `bedrooms`
+- **Source:** [`presets/real-estate/blueprint.json`](../../presets/real-estate/blueprint.json) (`seo_mappings → property`)
+
+| Schema property | GM2 field slug |
+| --- | --- |
+| `price` | `price` |
+| `priceCurrency` | `price_currency` |
+| `address.streetAddress` | `address` |
+| `address.addressLocality` | `city` |
+| `address.addressRegion` | `region` |
+| `address.postalCode` | `postal_code` |
+| `address.addressCountry` | `country` |
+| `geo.latitude` | `latitude` |
+| `geo.longitude` | `longitude` |
+| `numberOfRooms` | `bedrooms` |
+| `numberOfBathroomsTotal` | `bathrooms` |
+| `floorSize.value` | `floor_size` |
+| `floorSize.unitText` | `floor_size_unit` |
+| `identifier` | `mls_id` |
+| `yearBuilt` | `year_built` |
 
 ## Elementor Notes
 

--- a/docs/schema-mapping-and-seo.md
+++ b/docs/schema-mapping-and-seo.md
@@ -15,13 +15,13 @@ Presets provide a quick starting point for popular verticals while still allowin
 
 ### Preset property reference
 
-| Preset | Key properties pre-filled |
-| --- | --- |
-| LocalBusiness | `name`, `image`, `address`, `geo`, `telephone`, `openingHoursSpecification`, `url`, `sameAs`, `priceRange` |
-| Event | `name`, `startDate`, `endDate`, `location`, `image`, `offers`, `organizer` |
-| RealEstateListing | `name`, `description`, `url`, `address`, `geo`, `price`, `offers` |
-| JobPosting | `title`, `description`, `datePosted`, `validThrough`, `employmentType`, `jobLocation`, `baseSalary`, `hiringOrganization` |
-| Course | `name`, `description`, `provider`, `url`, `courseCode`, `courseInstance.startDate`, `courseInstance.endDate`, `courseInstance.location.name`, `courseInstance.offers.price` |
+| Preset | Key properties pre-filled | Detailed mapping |
+| --- | --- | --- |
+| LocalBusiness | `name`, `image`, `address`, `geo`, `telephone`, `openingHoursSpecification`, `url`, `sameAs`, `priceRange` | [Directory schema mapping](presets/directory.md#schema-mapping) |
+| Event | `name`, `startDate`, `endDate`, `location`, `image`, `offers`, `organizer` | [Event schema mapping](presets/events.md#schema-mapping) |
+| RealEstateListing | `name`, `description`, `url`, `address`, `geo`, `price`, `offers` | [Real estate schema mapping](presets/real-estate.md#schema-mapping) |
+| JobPosting | `title`, `description`, `datePosted`, `validThrough`, `employmentType`, `jobLocation`, `baseSalary`, `hiringOrganization` | [Job schema mapping](presets/jobs.md#schema-mapping) |
+| Course | `name`, `description`, `provider`, `url`, `courseCode`, `courseInstance.startDate`, `courseInstance.endDate`, `courseInstance.location.name`, `courseInstance.offers.price` | [Course schema mapping](presets/courses.md#schema-mapping) |
 
 Use dotted paths (for example `courseInstance.startDate`) to target nested objects; the suite automatically infers the correct `@type` for nested structures such as `Place`, `Offer`, and `CourseInstance`.
 


### PR DESCRIPTION
## Summary
- replace schema mapping bullet lists in each preset guide with schema-to-field tables sourced from the corresponding blueprint JSON
- note the blueprint file for quick verification and add clarifying context where fields populate multiple schema paths
- link from the schema mapping overview to the detailed mapping sections for courses, directory, events, jobs, and real estate

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d1bfe6465483309351298300902d83