### PR TITLE
Fix MetaIndexManager global wpdb initialization

### DIFF
--- a/src/Performance/MetaIndexManager.php
+++ b/src/Performance/MetaIndexManager.php
@@ -44,7 +44,9 @@ final class MetaIndexManager
             return;
         }
 
-        global $wpdb as $globalWpdb;
+        global $wpdb;
+        $globalWpdb = $wpdb;
+
         if (!is_object($globalWpdb)) {
             throw new RuntimeException('The global $wpdb instance is not available.');
         }


### PR DESCRIPTION
## Summary
- update MetaIndexManager to load the global wpdb instance using standard PHP syntax
- retain validation to ensure the global wpdb object exists before assignment

## Testing
- php -l src/Performance/MetaIndexManager.php

------
https://chatgpt.com/codex/tasks/task_b_68f5daeb92608330ad81d01c9c5a4699