### PR TITLE
Cache script attributes option per request

### DIFF
--- a/includes/Gm2_Script_Attributes.php
+++ b/includes/Gm2_Script_Attributes.php
@@ -9,7 +9,7 @@ if (!defined('ABSPATH')) {
 }
 
 class Gm2_Script_Attributes {
-    private array $attributes = [];
+    private ?array $attributes = null;
     private array $resolved = [];
 
     public static function init(): self {
@@ -18,8 +18,8 @@ class Gm2_Script_Attributes {
 
     public function __construct() {
         add_option('gm2_script_attributes', [], '', AutoloadManager::get_autoload_flag('gm2_script_attributes'));
-        $this->attributes = get_option('gm2_script_attributes', []);
         add_filter('script_loader_tag', [$this, 'filter'], 10, 3);
+        add_action('update_option_gm2_script_attributes', [$this, 'handle_option_update'], 10, 2);
     }
 
     public function filter(string $tag, string $handle, string $src): string {
@@ -39,7 +39,8 @@ class Gm2_Script_Attributes {
         }
         $this->resolved[$handle] = 'none';
 
-        $attr = $this->attributes[$handle] ?? 'defer';
+        $attributes = $this->get_attributes();
+        $attr = $attributes[$handle] ?? 'defer';
         if ($attr === 'blocking') {
             return $this->resolved[$handle] = 'blocking';
         }
@@ -62,5 +63,22 @@ class Gm2_Script_Attributes {
         }
 
         return $this->resolved[$handle] = $attr;
+    }
+
+    private function get_attributes(): array {
+        if ($this->attributes === null) {
+            $this->attributes = get_option('gm2_script_attributes', []);
+        }
+
+        return $this->attributes;
+    }
+
+    /**
+     * @param mixed $old_value
+     * @param mixed $value
+     */
+    public function handle_option_update($old_value, $value): void {
+        $this->attributes = is_array($value) ? $value : [];
+        $this->resolved = [];
     }
 }

--- a/includes/Gm2_Script_Attributes.php
+++ b/includes/Gm2_Script_Attributes.php
@@ -18,12 +18,11 @@ class Gm2_Script_Attributes {
 
     public function __construct() {
         add_option('gm2_script_attributes', [], '', AutoloadManager::get_autoload_flag('gm2_script_attributes'));
+        $this->attributes = get_option('gm2_script_attributes', []);
         add_filter('script_loader_tag', [$this, 'filter'], 10, 3);
     }
 
     public function filter(string $tag, string $handle, string $src): string {
-        $this->attributes = get_option('gm2_script_attributes', []);
-        $this->resolved   = [];
         $attr = $this->determine_attribute($handle);
 
         if ($attr === 'async' || $attr === 'defer') {


### PR DESCRIPTION
## Summary
- load the gm2_script_attributes option during construction so it is only fetched once per request
- keep the resolved dependency cache across script_loader_tag invocations to reuse previous resolutions

## Testing
- php -l includes/Gm2_Script_Attributes.php

------
https://chatgpt.com/codex/tasks/task_b_68f5e918ae188330a953d3dfb33d808f