### PR TITLE
Cache script attributes option per request

### DIFF
--- a/includes/Gm2_Script_Attributes.php
+++ b/includes/Gm2_Script_Attributes.php
@@ -18,12 +18,11 @@ class Gm2_Script_Attributes {
 
     public function __construct() {
         add_option('gm2_script_attributes', [], '', AutoloadManager::get_autoload_flag('gm2_script_attributes'));
+        $this->attributes = get_option('gm2_script_attributes', []);
         add_filter('script_loader_tag', [$this, 'filter'], 10, 3);
     }
 
     public function filter(string $tag, string $handle, string $src): string {
-        $this->attributes = get_option('gm2_script_attributes', []);
-        $this->resolved   = [];
         $attr = $this->determine_attribute($handle);
 
         if ($attr === 'async' || $attr === 'defer') {


### PR DESCRIPTION
## Summary
- load the gm2_script_attributes option during construction so it is only fetched once per request
- keep the resolved dependency cache across script_loader_tag invocations to reuse previous resolutions

## Testing
- php -l includes/Gm2_Script_Attributes.php

------
https://chatgpt.com/codex/tasks/task_b_68f5e918ae188330a953d3dfb33d808f