### PR TITLE
Fix local provider command quoting

### DIFF
--- a/includes/AI/LocalGemmaProvider.php
+++ b/includes/AI/LocalGemmaProvider.php
@@ -27,12 +27,12 @@ class LocalGemmaProvider implements ProviderInterface {
         }
         $temperature = isset($args['temperature']) ? floatval($args['temperature']) : 1.0;
         $max_tokens  = isset($args['max_tokens']) ? intval($args['max_tokens']) : (isset($args['number-of-words']) ? intval($args['number-of-words']) : 0);
-        $command = escapeshellcmd($binary)
+        $command = escapeshellarg($binary)
             . ' -m ' . escapeshellarg($model)
             . ' -p ' . escapeshellarg($prompt)
             . ' --temp ' . escapeshellarg((string)$temperature);
         if ($max_tokens > 0) {
-            $command .= ' -n ' . intval($max_tokens);
+            $command .= ' -n ' . escapeshellarg((string)intval($max_tokens));
         }
         $output = shell_exec($command);
         if ($output === null) {

--- a/includes/AI/LocalLlamaProvider.php
+++ b/includes/AI/LocalLlamaProvider.php
@@ -27,12 +27,12 @@ class LocalLlamaProvider implements ProviderInterface {
         }
         $temperature = isset($args['temperature']) ? floatval($args['temperature']) : 1.0;
         $max_tokens  = isset($args['max_tokens']) ? intval($args['max_tokens']) : (isset($args['number-of-words']) ? intval($args['number-of-words']) : 0);
-        $command = escapeshellcmd($binary)
+        $command = escapeshellarg($binary)
             . ' -m ' . escapeshellarg($model)
             . ' -p ' . escapeshellarg($prompt)
             . ' --temp ' . escapeshellarg((string)$temperature);
         if ($max_tokens > 0) {
-            $command .= ' -n ' . intval($max_tokens);
+            $command .= ' -n ' . escapeshellarg((string)intval($max_tokens));
         }
         $output = shell_exec($command);
         if ($output === null) {


### PR DESCRIPTION
## Summary
- update the local Gemma and Llama providers to escape the binary path with `escapeshellarg`
- ensure the `-n` argument is also escaped to avoid shell parsing issues

## Testing
- php tmp/test_gemma.php

------
https://chatgpt.com/codex/tasks/task_b_68f65511da8c8330b9a64d9b0af6b18f