### PR TITLE
Fix fatal errors from duplicate bootstrap and schema mapper

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -789,9 +789,11 @@ function gm2_initialize_guideline_rules() {
 }
 
 // Initialize plugin
-function gm2_init_plugin() {
-    $plugin = new Gm2_Loader();
-    $plugin->run();
+if (!function_exists('gm2_init_plugin')) {
+    function gm2_init_plugin() {
+        $plugin = new Gm2_Loader();
+        $plugin->run();
+    }
 }
 add_action('plugins_loaded', 'gm2_init_plugin');
 

--- a/src/SEO/Schema/Mapper/DirectoryMapper.php
+++ b/src/SEO/Schema/Mapper/DirectoryMapper.php
@@ -6,12 +6,14 @@ use WP_Post;
 
 class DirectoryMapper extends AbstractMapper
 {
-    protected array $requiredFields = [
-        'address' => __('Address', 'gm2-wordpress-suite'),
-    ];
+    protected array $requiredFields = [];
 
     public function __construct()
     {
+        $this->requiredFields = [
+            'address' => __('Address', 'gm2-wordpress-suite'),
+        ];
+
         parent::__construct(
             'listing',
             'LocalBusiness',


### PR DESCRIPTION
## Summary
- guard the gm2_init_plugin bootstrap function so duplicate plugin copies cannot redeclare it
- move the DirectoryMapper required field translation into the constructor to avoid invalid constant expressions during class loading

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68f7acc90cbc8330b8ae15df0bc2b2be