### PR TITLE
Fix schema mapper required field initialization

### DIFF
--- a/src/SEO/Schema/Mapper/CourseMapper.php
+++ b/src/SEO/Schema/Mapper/CourseMapper.php
@@ -6,13 +6,15 @@ use WP_Post;
 
 class CourseMapper extends AbstractMapper
 {
-    protected array $requiredFields = [
-        'provider'    => __('Provider', 'gm2-wordpress-suite'),
-        'course_code' => __('Course code', 'gm2-wordpress-suite'),
-    ];
+    protected array $requiredFields = [];
 
     public function __construct()
     {
+        $this->requiredFields = [
+            'provider'    => __('Provider', 'gm2-wordpress-suite'),
+            'course_code' => __('Course code', 'gm2-wordpress-suite'),
+        ];
+
         parent::__construct(
             'course',
             'Course',

--- a/src/SEO/Schema/Mapper/EventMapper.php
+++ b/src/SEO/Schema/Mapper/EventMapper.php
@@ -6,14 +6,16 @@ use WP_Post;
 
 class EventMapper extends AbstractMapper
 {
-    protected array $requiredFields = [
-        'start_date' => __('Start date', 'gm2-wordpress-suite'),
-        'end_date'   => __('End date', 'gm2-wordpress-suite'),
-        'location'   => __('Location', 'gm2-wordpress-suite'),
-    ];
+    protected array $requiredFields = [];
 
     public function __construct()
     {
+        $this->requiredFields = [
+            'start_date' => __('Start date', 'gm2-wordpress-suite'),
+            'end_date'   => __('End date', 'gm2-wordpress-suite'),
+            'location'   => __('Location', 'gm2-wordpress-suite'),
+        ];
+
         parent::__construct(
             'event',
             'Event',

--- a/src/SEO/Schema/Mapper/JobMapper.php
+++ b/src/SEO/Schema/Mapper/JobMapper.php
@@ -6,14 +6,16 @@ use WP_Post;
 
 class JobMapper extends AbstractMapper
 {
-    protected array $requiredFields = [
-        'date_posted'     => __('Date posted', 'gm2-wordpress-suite'),
-        'employment_type' => __('Employment type', 'gm2-wordpress-suite'),
-        'company'         => __('Company name', 'gm2-wordpress-suite'),
-    ];
+    protected array $requiredFields = [];
 
     public function __construct()
     {
+        $this->requiredFields = [
+            'date_posted'     => __('Date posted', 'gm2-wordpress-suite'),
+            'employment_type' => __('Employment type', 'gm2-wordpress-suite'),
+            'company'         => __('Company name', 'gm2-wordpress-suite'),
+        ];
+
         parent::__construct(
             'job',
             'JobPosting',

--- a/src/SEO/Schema/Mapper/RealEstateMapper.php
+++ b/src/SEO/Schema/Mapper/RealEstateMapper.php
@@ -48,13 +48,15 @@ class RealEstateMapper extends AbstractMapper
         'offmarket'      => 'https://schema.org/OutOfStock',
     ];
 
-    protected array $requiredFields = [
-        'price'   => __('Price', 'gm2-wordpress-suite'),
-        'address' => __('Address', 'gm2-wordpress-suite'),
-    ];
+    protected array $requiredFields = [];
 
     public function __construct()
     {
+        $this->requiredFields = [
+            'price'   => __('Price', 'gm2-wordpress-suite'),
+            'address' => __('Address', 'gm2-wordpress-suite'),
+        ];
+
         parent::__construct(
             'property',
             'RealEstateListing',


### PR DESCRIPTION
## Summary
- move schema mapper required field label initialization into constructors to avoid fatal errors during plugin loading

## Testing
- find src/SEO/Schema/Mapper -name '*.php' -print0 | xargs -0 -n1 php -l

------
https://chatgpt.com/codex/tasks/task_b_68f7bf6749a883309184248a3dd7b1ed