### PR TITLE
Fix schema event mapper initialization and guard shell exec usage

### DIFF
--- a/includes/class-ae-css-optimizer.php
+++ b/includes/class-ae-css-optimizer.php
@@ -523,6 +523,10 @@ final class AE_CSS_Optimizer {
         if ($cached !== false) {
             return $cached === '1';
         }
+        if (!\function_exists('shell_exec')) {
+            \set_transient('ae_css_has_node', '0', DAY_IN_SECONDS);
+            return false;
+        }
         $has = false;
         foreach (['node', 'npx'] as $cmd) {
             $out = \shell_exec($cmd . ' --version 2>&1');
@@ -585,6 +589,9 @@ final class AE_CSS_Optimizer {
         }
         $url = \esc_url_raw($url);
         if ($url === '' || empty($css_paths)) {
+            return;
+        }
+        if (!\function_exists('shell_exec')) {
             return;
         }
         $script = \escapeshellarg(\dirname(__DIR__) . '/tools/node/critical.js');

--- a/src/SEO/Schema/Mapper/EventMapper.php
+++ b/src/SEO/Schema/Mapper/EventMapper.php
@@ -6,7 +6,7 @@ use WP_Post;
 
 class EventMapper extends AbstractMapper
 {
-    protected array $requiredFields = [];
+    protected array $requiredFields;
 
     public function __construct()
     {


### PR DESCRIPTION
## Summary
- remove the default value from the Event schema mapper's required fields property to avoid PHP constant expression errors during plugin load
- guard shell_exec-dependent logic in the CSS optimizer so environments without the function degrade gracefully

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68f7c4c700808330a05101898b802691