### PR TITLE
Guard Elementor field control when Elementor is inactive

### DIFF
--- a/includes/elementor/class-gm2-field-key-control.php
+++ b/includes/elementor/class-gm2-field-key-control.php
@@ -4,6 +4,11 @@ namespace Gm2\Elementor;
 use Elementor\Base_Data_Control;
 use Elementor\Controls_Manager;
 
+// Abort early if Elementor is not active.
+if (!class_exists('Elementor\\Base_Data_Control')) {
+    return;
+}
+
 if (!defined('ABSPATH')) {
     exit;
 }


### PR DESCRIPTION
## Summary
- prevent the GM2 Elementor field key control from loading when Elementor's Base_Data_Control is unavailable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68f7c6329e3c83309426760748dd2fec