### PR TITLE
Defer Elementor bootstrap until plugin loads

### DIFF
--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -95,12 +95,28 @@ require_once GM2_PLUGIN_DIR . 'includes/gm2-query-builder.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-theme-tools.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-open-in-code.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-field-renderers.php';
-require_once GM2_PLUGIN_DIR . 'includes/elementor/class-gm2-field-key-control.php';
-require_once GM2_PLUGIN_DIR . 'src/Elementor/bootstrap.php';
+
+$gm2_bootstrap_elementor = static function (): void {
+    if (!class_exists('Elementor\\Plugin') && (!defined('GM2_TESTING') || !GM2_TESTING)) {
+        return;
+    }
+
+    require_once GM2_PLUGIN_DIR . 'includes/elementor/class-gm2-field-key-control.php';
+    require_once GM2_PLUGIN_DIR . 'src/Elementor/bootstrap.php';
+    require_once GM2_PLUGIN_DIR . 'integrations/elementor/class-gm2-cp-elementor-tags.php';
+    require_once GM2_PLUGIN_DIR . 'integrations/elementor/class-gm2-cp-elementor-query.php';
+};
+
+if (defined('GM2_TESTING') && GM2_TESTING) {
+    $gm2_bootstrap_elementor();
+} elseif (did_action('elementor/loaded')) {
+    $gm2_bootstrap_elementor();
+} else {
+    add_action('elementor/loaded', $gm2_bootstrap_elementor, 0, 0);
+}
+
 require_once GM2_PLUGIN_DIR . 'src/SEO/bootstrap.php';
 require_once GM2_PLUGIN_DIR . 'src/Presets/bootstrap.php';
-require_once GM2_PLUGIN_DIR . 'integrations/elementor/class-gm2-cp-elementor-tags.php';
-require_once GM2_PLUGIN_DIR . 'integrations/elementor/class-gm2-cp-elementor-query.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-schema-tooltips.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-editorial-comments.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-model-export.php';


### PR DESCRIPTION
## Summary
- wrap Elementor-specific bootstrapping in a closure that runs only after Elementor loads
- ensure automated tests still load Elementor stubs without requiring the real plugin

## Testing
- composer lint *(fails: Could not open input file: vendor/bin/parallel-lint)*

------
https://chatgpt.com/codex/tasks/task_b_68f7c78e2b8483309806b15546f18b78