### PR TITLE
Fix namespace usage for is_apache in AE SEO server hints

### DIFF
--- a/admin/class-ae-seo-server-hints.php
+++ b/admin/class-ae-seo-server-hints.php
@@ -128,7 +128,7 @@ NGINX;
     }
 
     public function handle_notice_actions(): void {
-        if (is_apache() && isset($_POST['ae_seo_write_htaccess']) && check_admin_referer('ae_seo_write_htaccess')) {
+        if (\is_apache() && isset($_POST['ae_seo_write_htaccess']) && check_admin_referer('ae_seo_write_htaccess')) {
             $success = $this->write_htaccess_snippet();
             add_action('admin_notices', function () use ($success) {
                 if ($success) {
@@ -148,7 +148,7 @@ NGINX;
         echo '<div class="notice notice-warning"><p>' . esc_html__( 'Gzip or Brotli compression is not enabled. ', 'gm2-wordpress-suite' ) . '</p>';
         $link = admin_url('tools.php?page=ae-seo-server-hints');
 
-        if (is_apache() && $this->htaccess_writable()) {
+        if (\is_apache() && $this->htaccess_writable()) {
             echo '<form method="post" style="display:inline-block;margin-right:8px;">';
             wp_nonce_field('ae_seo_write_htaccess');
             echo '<input type="hidden" name="ae_seo_write_htaccess" value="1" />';
@@ -193,7 +193,7 @@ NGINX;
         echo '});';
         echo '</script>';
 
-        if (is_apache() && isset($_POST['ae_seo_restore_htaccess']) && check_admin_referer('ae_seo_restore_htaccess')) {
+        if (\is_apache() && isset($_POST['ae_seo_restore_htaccess']) && check_admin_referer('ae_seo_restore_htaccess')) {
             if (!empty($backups)) {
                 rsort($backups);
                 $restore = $backups[0];
@@ -212,7 +212,7 @@ NGINX;
             $backups = glob($backup_glob) ?: [];
         }
 
-        if (is_apache() && isset($_POST['ae_seo_write_htaccess']) && check_admin_referer('ae_seo_write_htaccess')) {
+        if (\is_apache() && isset($_POST['ae_seo_write_htaccess']) && check_admin_referer('ae_seo_write_htaccess')) {
             if ($this->write_htaccess_snippet($backups)) {
                 echo '<div class="updated"><p>' . esc_html__( '.htaccess updated.', 'gm2-wordpress-suite' ) . '</p></div>';
             } else {
@@ -222,7 +222,7 @@ NGINX;
 
         echo '<h2>' . esc_html__( 'Apache', 'gm2-wordpress-suite' ) . '</h2>';
         echo '<textarea rows="15" style="width:100%;">' . esc_textarea($apache) . '</textarea>';
-        if (is_apache() && $this->htaccess_writable()) {
+        if (\is_apache() && $this->htaccess_writable()) {
             echo '<form method="post">';
             wp_nonce_field('ae_seo_write_htaccess');
             echo '<p><input type="submit" name="ae_seo_write_htaccess" class="button button-primary" value="' . esc_attr__( 'Write .htaccess', 'gm2-wordpress-suite' ) . '"></p>';


### PR DESCRIPTION
## Summary
- prefix calls to `is_apache()` with the global namespace in the AE SEO Server Hints admin class to avoid fatal errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68f7cd0152a083308eed9e8dbfce4385