### PR TITLE
Add GitHub OAuth login for updater

### DIFF
--- a/admin/class-gm2-github-settings.php
+++ b/admin/class-gm2-github-settings.php
@@ -33,11 +33,30 @@ class Gm2_Github_Settings {
             ]
         );
 
+        register_setting(
+            'gm2_github',
+            'gm2_github_client_id',
+            [
+                'type'              => 'string',
+                'sanitize_callback' => [ $this, 'sanitize_client_id' ],
+                'default'           => '',
+                'capability'        => 'manage_options',
+            ]
+        );
+
         add_settings_section(
             'gm2_github_section',
             __('GitHub', 'gm2-wordpress-suite'),
             '__return_false',
             'gm2-github-settings'
+        );
+
+        add_settings_field(
+            'gm2_github_client_id',
+            __('OAuth Client ID', 'gm2-wordpress-suite'),
+            [ $this, 'client_id_field' ],
+            'gm2-github-settings',
+            'gm2_github_section'
         );
 
         add_settings_field(
@@ -51,6 +70,19 @@ class Gm2_Github_Settings {
 
     public function sanitize_token($token) {
         return sanitize_text_field($token);
+    }
+
+    public function sanitize_client_id($client_id) {
+        return sanitize_text_field($client_id);
+    }
+
+    public function client_id_field() {
+        $client_id = get_option('gm2_github_client_id', '');
+        printf(
+            '<input type="text" name="gm2_github_client_id" value="%s" class="regular-text" autocomplete="off" />',
+            esc_attr($client_id)
+        );
+        echo '<p class="description">' . esc_html__( 'Register a GitHub OAuth application and copy its client ID here. The updater uses this value to launch the device authorization flow.', 'gm2-wordpress-suite' ) . '</p>';
     }
 
     public function token_field() {

--- a/assets/js/github-updater-admin.js
+++ b/assets/js/github-updater-admin.js
@@ -15,6 +15,217 @@
     var feedback = $('#gm2-github-updater-feedback');
     var testButton = $('#gm2-github-test');
     var checkButton = $('#gm2-github-check');
+    var oauthConfig = gm2GitHubUpdaterAdmin.oauth || {};
+    var loginButton = $('#gm2-github-login-button');
+    var disconnectButton = $('#gm2-github-disconnect-button');
+    var loginInstructions = $('#gm2-github-login-instructions');
+    var loginCode = $('#gm2-github-login-code');
+    var loginUrl = $('#gm2-github-login-url');
+    var accountStatus = $('#gm2-github-account-status');
+    var oauthState = {
+        timer: null,
+        interval: 5,
+        expiresAt: 0
+    };
+
+    function clearOAuthTimer() {
+        if (oauthState.timer) {
+            window.clearTimeout(oauthState.timer);
+            oauthState.timer = null;
+        }
+    }
+
+    function isAccountConnected() {
+        if (!accountStatus.length) {
+            return false;
+        }
+        return accountStatus.attr('data-connected') === '1';
+    }
+
+    function setOauthBusy(isBusy) {
+        if (loginButton.length) {
+            loginButton.prop('disabled', !!isBusy || !oauthConfig.enabled);
+        }
+        if (disconnectButton.length) {
+            disconnectButton.prop('disabled', !!isBusy ? true : !isAccountConnected());
+        }
+    }
+
+    function updateAccountStatus(login) {
+        if (!accountStatus.length) {
+            return;
+        }
+
+        var hasLogin = typeof login === 'string' && login !== '';
+        accountStatus.attr('data-connected', hasLogin ? '1' : '0');
+
+        if (hasLogin) {
+            accountStatus.html($('<span/>', {
+                'class': 'gm2-github-account-connected',
+                'text': gm2GitHubUpdaterAdmin.i18n.oauthConnectedAs.replace('%s', login)
+            }));
+        } else {
+            accountStatus.html($('<span/>', {
+                'class': 'gm2-github-account-disconnected',
+                'text': gm2GitHubUpdaterAdmin.i18n.oauthNotConnected
+            }));
+        }
+
+        if (disconnectButton.length) {
+            disconnectButton.prop('disabled', !hasLogin);
+        }
+    }
+
+    function showOAuthInstructions(url, code) {
+        if (!loginInstructions.length) {
+            return;
+        }
+
+        var targetUrl = typeof url === 'string' && url !== '' ? url : '#';
+        loginUrl.attr('href', targetUrl);
+        loginUrl.text(gm2GitHubUpdaterAdmin.i18n.oauthOpenLink);
+        loginCode.text(typeof code === 'string' ? code : '');
+        loginInstructions.show().attr('aria-hidden', 'false');
+    }
+
+    function hideOAuthInstructions() {
+        if (!loginInstructions.length) {
+            return;
+        }
+
+        loginInstructions.hide().attr('aria-hidden', 'true');
+        loginUrl.attr('href', '#');
+        loginCode.text('');
+    }
+
+    function scheduleOAuthPoll(seconds) {
+        clearOAuthTimer();
+
+        if (typeof seconds === 'number' && !isNaN(seconds) && seconds > 0) {
+            oauthState.interval = seconds;
+        }
+
+        if (oauthState.expiresAt && Date.now() >= oauthState.expiresAt) {
+            handleOAuthError(gm2GitHubUpdaterAdmin.i18n.oauthExpired);
+            return;
+        }
+
+        oauthState.timer = window.setTimeout(pollOAuth, oauthState.interval * 1000);
+    }
+
+    function handleOAuthError(message) {
+        clearOAuthTimer();
+        setOauthBusy(false);
+        hideOAuthInstructions();
+        renderMessage('error', typeof message === 'string' && message ? message : gm2GitHubUpdaterAdmin.i18n.unknownError);
+    }
+
+    function handleOAuthSuccess(data) {
+        clearOAuthTimer();
+        setOauthBusy(false);
+        hideOAuthInstructions();
+
+        var message = gm2GitHubUpdaterAdmin.i18n.oauthSuccess;
+        var login = '';
+
+        if (data && data.user && typeof data.user.login === 'string' && data.user.login !== '') {
+            login = data.user.login;
+            message += ' ' + gm2GitHubUpdaterAdmin.i18n.oauthConnectedAs.replace('%s', login);
+        }
+
+        updateAccountStatus(login);
+        oauthConfig.connectedUser = login;
+
+        toggleTokenField(false);
+        renderMessage('success', message);
+    }
+
+    function startOAuth() {
+        if (!oauthConfig.startAction) {
+            renderMessage('error', gm2GitHubUpdaterAdmin.i18n.unknownError);
+            return;
+        }
+
+        clearOAuthTimer();
+        setOauthBusy(true);
+        renderMessage('info', gm2GitHubUpdaterAdmin.i18n.oauthPrompt);
+
+        $.ajax({
+            method: 'POST',
+            url: gm2GitHubUpdaterAdmin.ajaxUrl,
+            dataType: 'json',
+            data: {
+                action: oauthConfig.startAction,
+                nonce: gm2GitHubUpdaterAdmin.nonce
+            }
+        }).done(function (response) {
+            if (response && response.success && response.data) {
+                var data = response.data;
+                var verificationUrl = data.verification_uri_complete || data.verification_uri || '';
+                oauthState.interval = typeof data.interval === 'number' ? data.interval : parseInt(data.interval, 10) || 5;
+                oauthState.expiresAt = Date.now() + ((typeof data.expires_in === 'number' ? data.expires_in : parseInt(data.expires_in, 10) || 600) * 1000);
+                showOAuthInstructions(verificationUrl, data.user_code || '');
+                scheduleOAuthPoll(oauthState.interval);
+            } else if (response && response.data && response.data.message) {
+                handleOAuthError(response.data.message);
+            } else {
+                handleOAuthError(gm2GitHubUpdaterAdmin.i18n.unknownError);
+            }
+        }).fail(function (jqXHR) {
+            var message = gm2GitHubUpdaterAdmin.i18n.unknownError;
+            if (jqXHR.responseJSON && jqXHR.responseJSON.data && jqXHR.responseJSON.data.message) {
+                message = jqXHR.responseJSON.data.message;
+            }
+            handleOAuthError(message);
+        });
+    }
+
+    function pollOAuth() {
+        if (!oauthConfig.pollAction) {
+            handleOAuthError(gm2GitHubUpdaterAdmin.i18n.unknownError);
+            return;
+        }
+
+        $.ajax({
+            method: 'POST',
+            url: gm2GitHubUpdaterAdmin.ajaxUrl,
+            dataType: 'json',
+            data: {
+                action: oauthConfig.pollAction,
+                nonce: gm2GitHubUpdaterAdmin.nonce
+            }
+        }).done(function (response) {
+            if (response && response.success && response.data) {
+                var data = response.data;
+                if (data.status === 'pending') {
+                    renderMessage('info', gm2GitHubUpdaterAdmin.i18n.oauthPending);
+                    scheduleOAuthPoll(typeof data.interval === 'number' ? data.interval : parseInt(data.interval, 10) || oauthState.interval);
+                    return;
+                }
+                if (data.status === 'slow_down') {
+                    renderMessage('info', gm2GitHubUpdaterAdmin.i18n.oauthSlowDown);
+                    scheduleOAuthPoll(typeof data.interval === 'number' ? data.interval : parseInt(data.interval, 10) || oauthState.interval + 5);
+                    return;
+                }
+                if (data.status === 'success') {
+                    handleOAuthSuccess(data);
+                    return;
+                }
+            }
+
+            if (response && response.data && response.data.message) {
+                handleOAuthError(response.data.message);
+            } else {
+                handleOAuthError(gm2GitHubUpdaterAdmin.i18n.unknownError);
+            }
+        }).fail(function (jqXHR) {
+            var message = gm2GitHubUpdaterAdmin.i18n.unknownError;
+            if (jqXHR.responseJSON && jqXHR.responseJSON.data && jqXHR.responseJSON.data.message) {
+                message = jqXHR.responseJSON.data.message;
+            }
+            handleOAuthError(message);
+        });
+    }
 
     function renderMessage(type, message) {
         var notice = $('<div/>', {
@@ -57,6 +268,76 @@
         toggleTokenField(true);
     } else if (tokenFieldWrapper.is(':hidden')) {
         tokenToggle.text(gm2GitHubUpdaterAdmin.i18n.showToken);
+    }
+
+    updateAccountStatus(oauthConfig.connectedUser || '');
+    hideOAuthInstructions();
+    setOauthBusy(false);
+
+    if (loginButton.length) {
+        loginButton.on('click', function (event) {
+            event.preventDefault();
+            if (!oauthConfig.enabled) {
+                renderMessage('error', gm2GitHubUpdaterAdmin.i18n.oauthMissingClientId);
+                return;
+            }
+            startOAuth();
+        });
+    }
+
+    if (disconnectButton.length) {
+        disconnectButton.on('click', function (event) {
+            event.preventDefault();
+
+            if (!isAccountConnected()) {
+                return;
+            }
+
+            if (!window.confirm(gm2GitHubUpdaterAdmin.i18n.oauthDisconnectConfirm)) {
+                return;
+            }
+
+            setOauthBusy(true);
+
+            if (!oauthConfig.disconnectAction) {
+                setOauthBusy(false);
+                renderMessage('error', gm2GitHubUpdaterAdmin.i18n.unknownError);
+                return;
+            }
+
+            $.ajax({
+                method: 'POST',
+                url: gm2GitHubUpdaterAdmin.ajaxUrl,
+                dataType: 'json',
+                data: {
+                    action: oauthConfig.disconnectAction,
+                    nonce: gm2GitHubUpdaterAdmin.nonce
+                }
+            }).done(function (response) {
+                if (response && response.success) {
+                    renderMessage('success', gm2GitHubUpdaterAdmin.i18n.oauthDisconnected);
+                    oauthConfig.connectedUser = '';
+                    updateAccountStatus('');
+                    hideOAuthInstructions();
+                    tokenFieldWrapper.hide().attr('aria-hidden', 'true');
+                    tokenInput.prop('disabled', true).val('');
+                    tokenKeep.val('0');
+                    tokenToggle.text(gm2GitHubUpdaterAdmin.i18n.addToken || gm2GitHubUpdaterAdmin.i18n.showToken).attr('aria-expanded', 'false');
+                } else if (response && response.data && response.data.message) {
+                    renderMessage('error', response.data.message);
+                } else {
+                    renderMessage('error', gm2GitHubUpdaterAdmin.i18n.unknownError);
+                }
+            }).fail(function (jqXHR) {
+                var message = gm2GitHubUpdaterAdmin.i18n.unknownError;
+                if (jqXHR.responseJSON && jqXHR.responseJSON.data && jqXHR.responseJSON.data.message) {
+                    message = jqXHR.responseJSON.data.message;
+                }
+                renderMessage('error', message);
+            }).always(function () {
+                setOauthBusy(false);
+            });
+        });
     }
 
     function updateBranchVisibility() {

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -121,6 +121,7 @@ require_once GM2_PLUGIN_DIR . 'includes/gm2-schema-tooltips.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-editorial-comments.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-model-export.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_Github_Client.php';
+require_once GM2_PLUGIN_DIR . 'includes/github-updater/class-gm2-github-oauth.php';
 require_once GM2_PLUGIN_DIR . 'includes/github-updater/class-gm2-github-updater.php';
 require_once GM2_PLUGIN_DIR . 'includes/github-updater/class-gm2-github-updater-admin.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-apply-patch.php';

--- a/includes/github-updater/class-gm2-github-oauth.php
+++ b/includes/github-updater/class-gm2-github-oauth.php
@@ -1,0 +1,276 @@
+<?php
+namespace Gm2\Updater;
+
+use WP_Error;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Handle the GitHub device authorization flow for generating access tokens.
+ */
+class Gm2_GitHub_OAuth {
+    private const DEVICE_CODE_URL = 'https://github.com/login/device/code';
+    private const ACCESS_TOKEN_URL = 'https://github.com/login/oauth/access_token';
+    private const USER_ENDPOINT = 'https://api.github.com/user';
+    private const TRANSIENT_KEY = 'gm2_github_oauth_state_%d';
+
+    /**
+     * Get the configured GitHub OAuth client ID.
+     */
+    public static function get_client_id() {
+        $client_id = '';
+
+        if (defined('GM2_GITHUB_CLIENT_ID') && GM2_GITHUB_CLIENT_ID) {
+            $client_id = (string) GM2_GITHUB_CLIENT_ID;
+        }
+
+        if ($client_id === '') {
+            $client_id = (string) get_option('gm2_github_client_id', '');
+        }
+
+        /**
+         * Filter the GitHub OAuth client ID used for the device flow.
+         *
+         * @param string $client_id Client ID value.
+         */
+        $client_id = (string) apply_filters('gm2_github_oauth_client_id', $client_id);
+
+        return trim($client_id);
+    }
+
+    /**
+     * Get the scopes requested when generating a GitHub access token.
+     *
+     * @return string[]
+     */
+    public static function get_scopes() {
+        $scopes = ['repo'];
+
+        /**
+         * Filter the GitHub OAuth scopes requested during the device flow.
+         *
+         * @param string[] $scopes List of scopes.
+         */
+        $scopes = apply_filters('gm2_github_oauth_scopes', $scopes);
+
+        if (!is_array($scopes)) {
+            $scopes = ['repo'];
+        }
+
+        $sanitized = [];
+        foreach ($scopes as $scope) {
+            $scope = trim((string) $scope);
+            if ($scope !== '') {
+                $sanitized[$scope] = $scope;
+            }
+        }
+
+        if (empty($sanitized)) {
+            $sanitized['repo'] = 'repo';
+        }
+
+        return array_values($sanitized);
+    }
+
+    /**
+     * Begin the GitHub device flow for the current user.
+     *
+     * @param int $user_id WordPress user ID.
+     *
+     * @return array<string, mixed>|WP_Error
+     */
+    public static function begin_device_flow($user_id) {
+        $user_id = absint($user_id);
+        if ($user_id <= 0) {
+            return new WP_Error('github_oauth_user', __('Invalid user.', 'gm2-wordpress-suite'));
+        }
+
+        $client_id = self::get_client_id();
+        if ($client_id === '') {
+            return new WP_Error('github_oauth_client', __('GitHub OAuth client ID is not configured.', 'gm2-wordpress-suite'));
+        }
+
+        $response = wp_safe_remote_post(self::DEVICE_CODE_URL, [
+            'timeout' => 20,
+            'headers' => [
+                'Accept' => 'application/json',
+            ],
+            'body'    => [
+                'client_id' => $client_id,
+                'scope'     => implode(' ', self::get_scopes()),
+            ],
+        ]);
+
+        if (is_wp_error($response)) {
+            return $response;
+        }
+
+        $code = wp_remote_retrieve_response_code($response);
+        if ($code < 200 || $code >= 300) {
+            return new WP_Error('github_oauth_http', sprintf(__('GitHub returned HTTP %d while starting authorization.', 'gm2-wordpress-suite'), (int) $code));
+        }
+
+        $data = json_decode((string) wp_remote_retrieve_body($response), true);
+        if (!is_array($data) || empty($data['device_code']) || empty($data['user_code']) || empty($data['verification_uri'])) {
+            return new WP_Error('github_oauth_response', __('Unexpected response from GitHub when starting authorization.', 'gm2-wordpress-suite'));
+        }
+
+        $interval   = isset($data['interval']) ? max(5, absint($data['interval'])) : 5;
+        $expires_in = isset($data['expires_in']) ? max($interval, absint($data['expires_in'])) : 900;
+
+        $state = [
+            'device_code' => (string) $data['device_code'],
+            'interval'    => $interval,
+            'expires_at'  => time() + $expires_in,
+            'client_id'   => $client_id,
+        ];
+
+        set_transient(self::get_transient_key($user_id), $state, $expires_in);
+
+        return [
+            'device_code'               => $state['device_code'],
+            'user_code'                 => (string) $data['user_code'],
+            'verification_uri'          => (string) $data['verification_uri'],
+            'verification_uri_complete' => isset($data['verification_uri_complete']) ? (string) $data['verification_uri_complete'] : '',
+            'interval'                  => $interval,
+            'expires_in'                => $expires_in,
+        ];
+    }
+
+    /**
+     * Poll GitHub for a device flow access token.
+     *
+     * @param int $user_id WordPress user ID.
+     *
+     * @return array<string, mixed>|WP_Error
+     */
+    public static function poll_device_flow($user_id) {
+        $user_id = absint($user_id);
+        if ($user_id <= 0) {
+            return new WP_Error('github_oauth_user', __('Invalid user.', 'gm2-wordpress-suite'));
+        }
+
+        $state = get_transient(self::get_transient_key($user_id));
+        if (!is_array($state) || empty($state['device_code']) || empty($state['client_id'])) {
+            return new WP_Error('github_oauth_state', __('GitHub authorization session expired. Start again.', 'gm2-wordpress-suite'));
+        }
+
+        if (!empty($state['expires_at']) && time() >= (int) $state['expires_at']) {
+            delete_transient(self::get_transient_key($user_id));
+            return new WP_Error('github_oauth_expired', __('GitHub authorization expired. Please try again.', 'gm2-wordpress-suite'));
+        }
+
+        $response = wp_safe_remote_post(self::ACCESS_TOKEN_URL, [
+            'timeout' => 20,
+            'headers' => [
+                'Accept' => 'application/json',
+            ],
+            'body'    => [
+                'client_id'   => (string) $state['client_id'],
+                'device_code' => (string) $state['device_code'],
+                'grant_type'  => 'urn:ietf:params:oauth:grant-type:device_code',
+            ],
+        ]);
+
+        if (is_wp_error($response)) {
+            return $response;
+        }
+
+        $code = wp_remote_retrieve_response_code($response);
+        if ($code < 200 || $code >= 300) {
+            return new WP_Error('github_oauth_http', sprintf(__('GitHub returned HTTP %d while completing authorization.', 'gm2-wordpress-suite'), (int) $code));
+        }
+
+        $data = json_decode((string) wp_remote_retrieve_body($response), true);
+        if (!is_array($data)) {
+            return new WP_Error('github_oauth_response', __('Unexpected response from GitHub when completing authorization.', 'gm2-wordpress-suite'));
+        }
+
+        if (!empty($data['error'])) {
+            $error = (string) $data['error'];
+            if ($error === 'authorization_pending') {
+                return [
+                    'status'  => 'pending',
+                    'interval'=> isset($data['interval']) ? max(5, absint($data['interval'])) : (int) $state['interval'],
+                ];
+            }
+
+            if ($error === 'slow_down') {
+                $state['interval'] = isset($state['interval']) ? (int) $state['interval'] + 5 : 10;
+                set_transient(self::get_transient_key($user_id), $state, max(60, (int) ($state['expires_at'] - time())));
+
+                return [
+                    'status'   => 'slow_down',
+                    'interval' => $state['interval'],
+                ];
+            }
+
+            delete_transient(self::get_transient_key($user_id));
+
+            $message = isset($data['error_description']) ? (string) $data['error_description'] : __('GitHub authorization failed.', 'gm2-wordpress-suite');
+
+            return new WP_Error('github_oauth_error', $message);
+        }
+
+        if (empty($data['access_token'])) {
+            return new WP_Error('github_oauth_response', __('GitHub did not return an access token.', 'gm2-wordpress-suite'));
+        }
+
+        delete_transient(self::get_transient_key($user_id));
+
+        return [
+            'status'       => 'success',
+            'access_token' => (string) $data['access_token'],
+            'scope'        => isset($data['scope']) ? (string) $data['scope'] : '',
+            'token_type'   => isset($data['token_type']) ? (string) $data['token_type'] : 'bearer',
+        ];
+    }
+
+    /**
+     * Fetch the GitHub user associated with a token.
+     *
+     * @param string $token Access token string.
+     *
+     * @return array<string, mixed>|WP_Error
+     */
+    public static function fetch_user($token) {
+        $token = trim((string) $token);
+        if ($token === '') {
+            return new WP_Error('github_oauth_token', __('Missing GitHub token.', 'gm2-wordpress-suite'));
+        }
+
+        $response = wp_safe_remote_get(self::USER_ENDPOINT, [
+            'timeout' => 20,
+            'headers' => [
+                'Accept'        => 'application/vnd.github+json',
+                'Authorization' => 'Bearer ' . $token,
+                'User-Agent'    => 'Gm2-WordPress-Suite',
+            ],
+        ]);
+
+        if (is_wp_error($response)) {
+            return $response;
+        }
+
+        $code = wp_remote_retrieve_response_code($response);
+        if ($code < 200 || $code >= 300) {
+            return new WP_Error('github_oauth_http', sprintf(__('GitHub returned HTTP %d when fetching the user profile.', 'gm2-wordpress-suite'), (int) $code));
+        }
+
+        $data = json_decode((string) wp_remote_retrieve_body($response), true);
+        if (!is_array($data) || empty($data['login'])) {
+            return new WP_Error('github_oauth_response', __('Unable to determine the GitHub account for this token.', 'gm2-wordpress-suite'));
+        }
+
+        return $data;
+    }
+
+    /**
+     * Build the transient key for the supplied user ID.
+     */
+    protected static function get_transient_key($user_id) {
+        return sprintf(self::TRANSIENT_KEY, absint($user_id));
+    }
+}

--- a/includes/github-updater/class-gm2-github-updater-admin.php
+++ b/includes/github-updater/class-gm2-github-updater-admin.php
@@ -16,6 +16,9 @@ class Gm2_GitHub_Updater_Admin {
     protected const MENU_SLUG = 'gm2-github-updater';
     protected const AJAX_TEST = 'gm2_github_updater_test';
     protected const AJAX_CHECK = 'gm2_github_updater_check';
+    protected const AJAX_OAUTH_START = 'gm2_github_oauth_start';
+    protected const AJAX_OAUTH_POLL = 'gm2_github_oauth_poll';
+    protected const AJAX_OAUTH_DISCONNECT = 'gm2_github_oauth_disconnect';
     protected const NONCE_ACTION = 'gm2_github_updater_actions';
 
     /**
@@ -39,6 +42,9 @@ class Gm2_GitHub_Updater_Admin {
         add_action('admin_notices', [$this, 'render_settings_notices']);
         add_action('wp_ajax_' . self::AJAX_TEST, [$this, 'ajax_test_connection']);
         add_action('wp_ajax_' . self::AJAX_CHECK, [$this, 'ajax_check_now']);
+        add_action('wp_ajax_' . self::AJAX_OAUTH_START, [$this, 'ajax_oauth_start']);
+        add_action('wp_ajax_' . self::AJAX_OAUTH_POLL, [$this, 'ajax_oauth_poll']);
+        add_action('wp_ajax_' . self::AJAX_OAUTH_DISCONNECT, [$this, 'ajax_oauth_disconnect']);
         add_action('updated_option', [$this, 'handle_option_update'], 10, 3);
         add_action('added_option', [$this, 'handle_option_add'], 10, 2);
         add_filter('cron_schedules', [$this, 'filter_cron_schedules']);
@@ -172,6 +178,7 @@ class Gm2_GitHub_Updater_Admin {
                 'optionKey' => self::OPTION_KEY,
                 'ajaxUrl' => admin_url('admin-ajax.php'),
                 'nonce'   => wp_create_nonce(self::NONCE_ACTION),
+                'oauth'   => $this->get_oauth_localization(),
                 'i18n'    => [
                     'testing'      => esc_html__('Testing connection…', 'gm2-wordpress-suite'),
                     'checking'     => esc_html__('Checking for updates…', 'gm2-wordpress-suite'),
@@ -180,14 +187,61 @@ class Gm2_GitHub_Updater_Admin {
                     'unknownError' => esc_html__('An unexpected error occurred.', 'gm2-wordpress-suite'),
                     'showToken'    => esc_html__('Reveal Token Field', 'gm2-wordpress-suite'),
                     'hideToken'    => esc_html__('Hide Token Field', 'gm2-wordpress-suite'),
+                    'addToken'     => esc_html__('Add Token', 'gm2-wordpress-suite'),
                     'defaultBranch'=> esc_html__('Default branch: %s', 'gm2-wordpress-suite'),
                     'privateRepo'  => esc_html__('Private repository', 'gm2-wordpress-suite'),
                     'versionLabel' => esc_html__('Version: %s', 'gm2-wordpress-suite'),
                     'updatedLabel' => esc_html__('Published: %s', 'gm2-wordpress-suite'),
                     'dismiss'      => esc_html__('Dismiss this notice.', 'gm2-wordpress-suite'),
+                    'oauthPrompt'  => esc_html__('Authorize access to your GitHub account to automatically generate a token.', 'gm2-wordpress-suite'),
+                    'oauthPending' => esc_html__('Waiting for GitHub authorization…', 'gm2-wordpress-suite'),
+                    'oauthSlowDown'=> esc_html__('GitHub requested a slower polling interval. Retrying…', 'gm2-wordpress-suite'),
+                    'oauthSuccess' => esc_html__('GitHub access token saved.', 'gm2-wordpress-suite'),
+                    'oauthExpired' => esc_html__('GitHub authorization expired. Please start again.', 'gm2-wordpress-suite'),
+                    'oauthMissingClientId' => esc_html__('Configure the GitHub OAuth client ID before connecting.', 'gm2-wordpress-suite'),
+                    'oauthNotConnected' => esc_html__('Not connected.', 'gm2-wordpress-suite'),
+                    'oauthConnectedAs' => esc_html__('Connected as %s.', 'gm2-wordpress-suite'),
+                    'oauthOpenLink' => esc_html__('Open GitHub to continue', 'gm2-wordpress-suite'),
+                    'oauthEnterCode' => esc_html__('Enter this code on GitHub:', 'gm2-wordpress-suite'),
+                    'oauthDisconnectConfirm' => esc_html__('Disconnecting will remove the stored GitHub access token. Continue?', 'gm2-wordpress-suite'),
+                    'oauthDisconnected' => esc_html__('GitHub access token removed.', 'gm2-wordpress-suite'),
                 ],
             ]
         );
+    }
+
+    /**
+     * Build localized configuration for the GitHub OAuth helpers.
+     *
+     * @return array<string, mixed>
+     */
+    protected function get_oauth_localization() {
+        $client_id = Gm2_GitHub_OAuth::get_client_id();
+        $connected = $this->get_connected_github_account();
+
+        return [
+            'enabled'          => $client_id !== '',
+            'startAction'      => self::AJAX_OAUTH_START,
+            'pollAction'       => self::AJAX_OAUTH_POLL,
+            'disconnectAction' => self::AJAX_OAUTH_DISCONNECT,
+            'connectedUser'    => $connected,
+        ];
+    }
+
+    /**
+     * Retrieve the login for the currently connected GitHub account.
+     *
+     * @return string
+     */
+    protected function get_connected_github_account() {
+        $client = new \Gm2\Gm2_Github_Client();
+        $user   = $client->validate_token();
+
+        if (is_wp_error($user) || !is_array($user) || empty($user['login'])) {
+            return '';
+        }
+
+        return sanitize_text_field($user['login']);
     }
 
     /**
@@ -246,6 +300,8 @@ class Gm2_GitHub_Updater_Admin {
             $interval = 60;
         }
         $token_keep = $has_token ? '1' : '0';
+        $connected_account = $this->get_connected_github_account();
+        $is_connected      = $connected_account !== '';
         ?>
         <div class="wrap">
             <h1><?php esc_html_e('GitHub Updater', 'gm2-wordpress-suite'); ?></h1>
@@ -287,6 +343,33 @@ class Gm2_GitHub_Updater_Admin {
                             <td>
                                 <input type="text" id="gm2-github-branch" name="<?php echo esc_attr(self::OPTION_KEY); ?>[branch]" value="<?php echo esc_attr($branch); ?>" class="regular-text" autocomplete="off" />
                                 <p class="description"><?php esc_html_e('Used when the channel is set to Branch.', 'gm2-wordpress-suite'); ?></p>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th scope="row"><?php esc_html_e('GitHub Account', 'gm2-wordpress-suite'); ?></th>
+                            <td>
+                                <p id="gm2-github-account-status" class="gm2-github-account-status" data-connected="<?php echo $is_connected ? '1' : '0'; ?>">
+                                    <?php
+                                    if ($is_connected) {
+                                        printf(
+                                            '<span class="gm2-github-account-connected">%s</span>',
+                                            esc_html(sprintf(__('Connected as %s.', 'gm2-wordpress-suite'), $connected_account))
+                                        );
+                                    } else {
+                                        echo '<span class="gm2-github-account-disconnected">' . esc_html__('Not connected.', 'gm2-wordpress-suite') . '</span>';
+                                    }
+                                    ?>
+                                </p>
+                                <p class="description"><?php esc_html_e('Sign in to GitHub to automatically generate an access token for private repositories.', 'gm2-wordpress-suite'); ?></p>
+                                <div class="gm2-github-oauth-actions">
+                                    <button type="button" class="button button-secondary" id="gm2-github-login-button"><?php esc_html_e('Sign in with GitHub', 'gm2-wordpress-suite'); ?></button>
+                                    <button type="button" class="button" id="gm2-github-disconnect-button" <?php disabled(!$is_connected); ?>><?php esc_html_e('Disconnect', 'gm2-wordpress-suite'); ?></button>
+                                </div>
+                                <div id="gm2-github-login-instructions" class="gm2-github-login-instructions" aria-hidden="true" style="display:none;">
+                                    <p><?php esc_html_e('Authorize access to your GitHub account in the window that opens.', 'gm2-wordpress-suite'); ?></p>
+                                    <p><a href="#" target="_blank" rel="noopener noreferrer" id="gm2-github-login-url" class="button button-link"><?php esc_html_e('Open GitHub to continue', 'gm2-wordpress-suite'); ?></a></p>
+                                    <p><strong><?php esc_html_e('Enter this code on GitHub:', 'gm2-wordpress-suite'); ?></strong> <code id="gm2-github-login-code"></code></p>
+                                </div>
                             </td>
                         </tr>
                         <tr>
@@ -412,6 +495,109 @@ class Gm2_GitHub_Updater_Admin {
         ];
 
         wp_send_json_success(['metadata' => $response]);
+    }
+
+    /**
+     * Start the GitHub device authorization flow.
+     */
+    public function ajax_oauth_start() {
+        $this->verify_ajax_permissions();
+
+        $result = Gm2_GitHub_OAuth::begin_device_flow(get_current_user_id());
+        if (is_wp_error($result)) {
+            wp_send_json_error(['message' => $result->get_error_message()], 400);
+        }
+
+        wp_send_json_success([
+            'user_code'                 => $result['user_code'],
+            'verification_uri'          => $result['verification_uri'],
+            'verification_uri_complete' => $result['verification_uri_complete'],
+            'interval'                  => (int) $result['interval'],
+            'expires_in'                => (int) $result['expires_in'],
+        ]);
+    }
+
+    /**
+     * Poll for the GitHub device authorization result.
+     */
+    public function ajax_oauth_poll() {
+        $this->verify_ajax_permissions();
+
+        $result = Gm2_GitHub_OAuth::poll_device_flow(get_current_user_id());
+        if (is_wp_error($result)) {
+            wp_send_json_error(['message' => $result->get_error_message()], 400);
+        }
+
+        if (!is_array($result) || empty($result['status'])) {
+            wp_send_json_error(['message' => esc_html__('Unexpected response from GitHub.', 'gm2-wordpress-suite')], 400);
+        }
+
+        if ($result['status'] === 'pending' || $result['status'] === 'slow_down') {
+            wp_send_json_success([
+                'status'   => $result['status'],
+                'interval' => isset($result['interval']) ? (int) $result['interval'] : 5,
+            ]);
+        }
+
+        if ($result['status'] !== 'success' || empty($result['access_token'])) {
+            wp_send_json_error(['message' => esc_html__('GitHub authorization did not return a token.', 'gm2-wordpress-suite')], 400);
+        }
+
+        $token = (string) $result['access_token'];
+        $this->persist_github_token($token);
+
+        $user      = Gm2_GitHub_OAuth::fetch_user($token);
+        $user_data = ['login' => ''];
+        if (!is_wp_error($user) && is_array($user)) {
+            if (!empty($user['login'])) {
+                $user_data['login'] = sanitize_text_field($user['login']);
+            }
+            if (!empty($user['html_url'])) {
+                $user_data['html_url'] = esc_url_raw($user['html_url']);
+            }
+        }
+
+        wp_send_json_success([
+            'status' => 'success',
+            'user'   => $user_data,
+        ]);
+    }
+
+    /**
+     * Disconnect the stored GitHub token.
+     */
+    public function ajax_oauth_disconnect() {
+        $this->verify_ajax_permissions();
+
+        $this->persist_github_token('');
+
+        wp_send_json_success();
+    }
+
+    /**
+     * Persist the GitHub access token across the plugin settings.
+     *
+     * @param string $token Raw access token.
+     */
+    protected function persist_github_token($token) {
+        $token = trim((string) $token);
+
+        if ($token === '') {
+            update_option('gm2_github_token', '');
+        } else {
+            update_option('gm2_github_token', sanitize_text_field($token));
+        }
+
+        $settings = get_option(self::OPTION_KEY, []);
+        if (!is_array($settings)) {
+            $settings = [];
+        }
+
+        $settings['token'] = $token === '' ? '' : self::obfuscate_token($token);
+
+        update_option(self::OPTION_KEY, $settings);
+
+        \gm2_github_updater(true);
     }
 
     /**


### PR DESCRIPTION
## Summary
- add a GitHub device flow helper to automate token generation for the updater
- update the GitHub Updater admin UI to handle sign-in, polling, and disconnect actions
- expose a setting for the GitHub OAuth client ID so the flow can be configured

## Testing
- npx eslint assets/js/github-updater-admin.js *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_68f7d285b1f483309f92eb9f3e3e7421