### PR TITLE
Fix GitHub OAuth sign-in flow and require client secret

### DIFF
--- a/admin/class-gm2-github-settings.php
+++ b/admin/class-gm2-github-settings.php
@@ -44,6 +44,17 @@ class Gm2_Github_Settings {
             ]
         );
 
+        register_setting(
+            'gm2_github',
+            'gm2_github_client_secret',
+            [
+                'type'              => 'string',
+                'sanitize_callback' => [ $this, 'sanitize_client_secret' ],
+                'default'           => '',
+                'capability'        => 'manage_options',
+            ]
+        );
+
         add_settings_section(
             'gm2_github_section',
             __('GitHub', 'gm2-wordpress-suite'),
@@ -55,6 +66,14 @@ class Gm2_Github_Settings {
             'gm2_github_client_id',
             __('OAuth Client ID', 'gm2-wordpress-suite'),
             [ $this, 'client_id_field' ],
+            'gm2-github-settings',
+            'gm2_github_section'
+        );
+
+        add_settings_field(
+            'gm2_github_client_secret',
+            __('OAuth Client Secret', 'gm2-wordpress-suite'),
+            [ $this, 'client_secret_field' ],
             'gm2-github-settings',
             'gm2_github_section'
         );
@@ -76,6 +95,10 @@ class Gm2_Github_Settings {
         return sanitize_text_field($client_id);
     }
 
+    public function sanitize_client_secret($client_secret) {
+        return sanitize_text_field($client_secret);
+    }
+
     public function client_id_field() {
         $client_id = get_option('gm2_github_client_id', '');
         printf(
@@ -83,6 +106,15 @@ class Gm2_Github_Settings {
             esc_attr($client_id)
         );
         echo '<p class="description">' . esc_html__( 'Register a GitHub OAuth application and copy its client ID here. The updater uses this value to launch the device authorization flow.', 'gm2-wordpress-suite' ) . '</p>';
+    }
+
+    public function client_secret_field() {
+        $client_secret = get_option('gm2_github_client_secret', '');
+        printf(
+            '<input type="password" name="gm2_github_client_secret" value="%s" class="regular-text" autocomplete="new-password" />',
+            esc_attr($client_secret)
+        );
+        echo '<p class="description">' . esc_html__( 'Copy the client secret from the same GitHub OAuth application. It is required to complete the sign-in process and store the generated access token automatically.', 'gm2-wordpress-suite' ) . '</p>';
     }
 
     public function token_field() {

--- a/includes/github-updater/class-gm2-github-oauth.php
+++ b/includes/github-updater/class-gm2-github-oauth.php
@@ -41,6 +41,32 @@ class Gm2_GitHub_OAuth {
     }
 
     /**
+     * Get the configured GitHub OAuth client secret.
+     *
+     * @return string
+     */
+    public static function get_client_secret() {
+        $client_secret = '';
+
+        if (defined('GM2_GITHUB_CLIENT_SECRET') && GM2_GITHUB_CLIENT_SECRET) {
+            $client_secret = (string) GM2_GITHUB_CLIENT_SECRET;
+        }
+
+        if ($client_secret === '') {
+            $client_secret = (string) get_option('gm2_github_client_secret', '');
+        }
+
+        /**
+         * Filter the GitHub OAuth client secret used for the device flow.
+         *
+         * @param string $client_secret Client secret value.
+         */
+        $client_secret = (string) apply_filters('gm2_github_oauth_client_secret', $client_secret);
+
+        return trim($client_secret);
+    }
+
+    /**
      * Get the scopes requested when generating a GitHub access token.
      *
      * @return string[]
@@ -92,6 +118,11 @@ class Gm2_GitHub_OAuth {
             return new WP_Error('github_oauth_client', __('GitHub OAuth client ID is not configured.', 'gm2-wordpress-suite'));
         }
 
+        $client_secret = self::get_client_secret();
+        if ($client_secret === '') {
+            return new WP_Error('github_oauth_client_secret', __('GitHub OAuth client secret is not configured.', 'gm2-wordpress-suite'));
+        }
+
         $response = wp_safe_remote_post(self::DEVICE_CODE_URL, [
             'timeout' => 20,
             'headers' => [
@@ -121,10 +152,11 @@ class Gm2_GitHub_OAuth {
         $expires_in = isset($data['expires_in']) ? max($interval, absint($data['expires_in'])) : 900;
 
         $state = [
-            'device_code' => (string) $data['device_code'],
-            'interval'    => $interval,
-            'expires_at'  => time() + $expires_in,
-            'client_id'   => $client_id,
+            'device_code'    => (string) $data['device_code'],
+            'interval'       => $interval,
+            'expires_at'     => time() + $expires_in,
+            'client_id'      => $client_id,
+            'client_secret'  => $client_secret,
         ];
 
         set_transient(self::get_transient_key($user_id), $state, $expires_in);
@@ -157,6 +189,18 @@ class Gm2_GitHub_OAuth {
             return new WP_Error('github_oauth_state', __('GitHub authorization session expired. Start again.', 'gm2-wordpress-suite'));
         }
 
+        if (empty($state['client_secret'])) {
+            $state['client_secret'] = self::get_client_secret();
+            if ($state['client_secret'] === '') {
+                delete_transient(self::get_transient_key($user_id));
+
+                return new WP_Error('github_oauth_client_secret', __('GitHub OAuth client secret is not configured.', 'gm2-wordpress-suite'));
+            }
+
+            $ttl = isset($state['expires_at']) ? max(60, (int) $state['expires_at'] - time()) : 600;
+            set_transient(self::get_transient_key($user_id), $state, $ttl);
+        }
+
         if (!empty($state['expires_at']) && time() >= (int) $state['expires_at']) {
             delete_transient(self::get_transient_key($user_id));
             return new WP_Error('github_oauth_expired', __('GitHub authorization expired. Please try again.', 'gm2-wordpress-suite'));
@@ -168,9 +212,10 @@ class Gm2_GitHub_OAuth {
                 'Accept' => 'application/json',
             ],
             'body'    => [
-                'client_id'   => (string) $state['client_id'],
-                'device_code' => (string) $state['device_code'],
-                'grant_type'  => 'urn:ietf:params:oauth:grant-type:device_code',
+                'client_id'     => (string) $state['client_id'],
+                'client_secret' => (string) $state['client_secret'],
+                'device_code'   => (string) $state['device_code'],
+                'grant_type'    => 'urn:ietf:params:oauth:grant-type:device_code',
             ],
         ]);
 

--- a/includes/github-updater/class-gm2-github-updater-admin.php
+++ b/includes/github-updater/class-gm2-github-updater-admin.php
@@ -198,7 +198,7 @@ class Gm2_GitHub_Updater_Admin {
                     'oauthSlowDown'=> esc_html__('GitHub requested a slower polling interval. Retrying…', 'gm2-wordpress-suite'),
                     'oauthSuccess' => esc_html__('GitHub access token saved.', 'gm2-wordpress-suite'),
                     'oauthExpired' => esc_html__('GitHub authorization expired. Please start again.', 'gm2-wordpress-suite'),
-                    'oauthMissingClientId' => esc_html__('Configure the GitHub OAuth client ID before connecting.', 'gm2-wordpress-suite'),
+                    'oauthMissingClientId' => esc_html__('Configure the GitHub OAuth client ID and secret before connecting.', 'gm2-wordpress-suite'),
                     'oauthNotConnected' => esc_html__('Not connected.', 'gm2-wordpress-suite'),
                     'oauthConnectedAs' => esc_html__('Connected as %s.', 'gm2-wordpress-suite'),
                     'oauthOpenLink' => esc_html__('Open GitHub to continue', 'gm2-wordpress-suite'),
@@ -216,11 +216,12 @@ class Gm2_GitHub_Updater_Admin {
      * @return array<string, mixed>
      */
     protected function get_oauth_localization() {
-        $client_id = Gm2_GitHub_OAuth::get_client_id();
-        $connected = $this->get_connected_github_account();
+        $client_id     = Gm2_GitHub_OAuth::get_client_id();
+        $client_secret = Gm2_GitHub_OAuth::get_client_secret();
+        $connected     = $this->get_connected_github_account();
 
         return [
-            'enabled'          => $client_id !== '',
+            'enabled'          => $client_id !== '' && $client_secret !== '',
             'startAction'      => self::AJAX_OAUTH_START,
             'pollAction'       => self::AJAX_OAUTH_POLL,
             'disconnectAction' => self::AJAX_OAUTH_DISCONNECT,


### PR DESCRIPTION
## Summary
- ensure the GitHub OAuth device flow exchanges include the client secret and gracefully require it before starting sign-in
- expose a GitHub OAuth client secret setting so admins can configure both credentials in the dashboard
- gate the “Sign in with GitHub” button until the OAuth client is fully configured and update the helper messaging

## Testing
- composer lint

------
https://chatgpt.com/codex/tasks/task_b_68f7d86a1f5483308a02d783ad230d57