### PR TITLE
Ensure GitHub updater refresh registers available update

### DIFF
--- a/includes/github-updater/class-gm2-github-updater.php
+++ b/includes/github-updater/class-gm2-github-updater.php
@@ -718,7 +718,15 @@ class Gm2_GitHub_Updater {
         if (is_wp_error($meta)) {
             return $meta;
         }
-        $this->check_for_update(new stdClass());
+
+        $transient = get_site_transient('update_plugins');
+        if (!is_object($transient)) {
+            $transient = new stdClass();
+        }
+
+        $transient = $this->check_for_update($transient);
+        set_site_transient('update_plugins', $transient);
+
         return $meta;
     }
 


### PR DESCRIPTION
## Summary
- update the GitHub updater refresh routine to persist the computed update transient
- ensure the manual "Update Now" flow can find the latest package information

## Testing
- composer run-script lint *(fails: missing vendor/bin/parallel-lint)*

------
https://chatgpt.com/codex/tasks/task_b_68f7e4b194bc8330998c700f53c151bd