### PR TITLE
Allow forcing GitHub updater installs

### DIFF
--- a/includes/github-updater/class-gm2-github-updater-admin.php
+++ b/includes/github-updater/class-gm2-github-updater-admin.php
@@ -521,7 +521,7 @@ class Gm2_GitHub_Updater_Admin {
             wp_send_json_error(['message' => esc_html__('The updater is not configured.', 'gm2-wordpress-suite')], 400);
         }
 
-        $meta = $updater->refresh();
+        $meta = $updater->refresh(true);
         if ($meta instanceof WP_Error) {
             wp_send_json_error(['message' => $meta->get_error_message()], 500);
         }

--- a/includes/github-updater/class-gm2-github-updater.php
+++ b/includes/github-updater/class-gm2-github-updater.php
@@ -157,7 +157,7 @@ class Gm2_GitHub_Updater {
             }
 
             public function update($args, $assoc_args) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
-                $meta = $this->updater->refresh();
+                $meta = $this->updater->refresh(true);
                 if (is_wp_error($meta)) {
                     WP_CLI::error($meta->get_error_message());
                 }
@@ -213,20 +213,32 @@ class Gm2_GitHub_Updater {
 
         $current_version = $this->get_local_version();
         if ($meta && version_compare($meta['version'], $current_version, '>')) {
-            $plugin              = new stdClass();
-            $plugin->slug        = dirname($this->plugin_basename);
-            $plugin->plugin      = $this->plugin_basename;
-            $plugin->new_version = $meta['version'];
-            $plugin->tested      = isset($meta['tested']) ? $meta['tested'] : '';
-            $plugin->url         = isset($meta['changelog_url']) ? $meta['changelog_url'] : '';
-            $plugin->package     = $meta['package'];
-            $plugin->icons       = [];
-            $transient->response[$this->plugin_basename] = $plugin;
+            $transient->response[$this->plugin_basename] = $this->prepare_update_payload($meta);
         } else {
             unset($transient->response[$this->plugin_basename]);
         }
 
         return $transient;
+    }
+
+    /**
+     * Build the update payload stored in the plugin update transient.
+     *
+     * @param array<string, mixed> $meta Normalised metadata.
+     *
+     * @return stdClass
+     */
+    protected function prepare_update_payload(array $meta) {
+        $plugin              = new stdClass();
+        $plugin->slug        = dirname($this->plugin_basename);
+        $plugin->plugin      = $this->plugin_basename;
+        $plugin->new_version = isset($meta['version']) ? $meta['version'] : '';
+        $plugin->tested      = isset($meta['tested']) ? $meta['tested'] : '';
+        $plugin->url         = isset($meta['changelog_url']) ? $meta['changelog_url'] : '';
+        $plugin->package     = isset($meta['package']) ? $meta['package'] : '';
+        $plugin->icons       = [];
+
+        return $plugin;
     }
 
     /**
@@ -710,9 +722,11 @@ class Gm2_GitHub_Updater {
     /**
      * Warmup helper exposed for AJAX/CLI.
      *
+     * @param bool $force_update Force the update transient to contain this plugin.
+     *
      * @return array<string, mixed>|WP_Error
      */
-    public function refresh() {
+    public function refresh($force_update = false) {
         $this->clear_cache();
         $meta = $this->get_remote_version(true);
         if (is_wp_error($meta)) {
@@ -725,6 +739,13 @@ class Gm2_GitHub_Updater {
         }
 
         $transient = $this->check_for_update($transient);
+        if ($force_update) {
+            if (!isset($transient->response)) {
+                $transient->response = [];
+            }
+
+            $transient->response[$this->plugin_basename] = $this->prepare_update_payload($meta);
+        }
         set_site_transient('update_plugins', $transient);
 
         return $meta;

--- a/tests/test-github-updater.php
+++ b/tests/test-github-updater.php
@@ -280,6 +280,69 @@ class GithubUpdaterTest extends WP_UnitTestCase {
         remove_filter('pre_http_request', $refreshMock, 10);
     }
 
+    public function test_force_refresh_injects_update_entry_even_when_versions_match(): void {
+        $updater         = $this->create_updater(['channel' => 'release']);
+        $pluginBasename  = plugin_basename($this->pluginFile);
+        $pluginData      = get_plugin_data($this->pluginFile, false, false);
+        $localVersion    = isset($pluginData['Version']) ? $pluginData['Version'] : '0.0.0';
+        $downloadPackage = 'https://example.com/force-update.zip';
+
+        add_filter(
+            'pre_http_request',
+            $forceMock = static function ($pre, $args, $url) use ($localVersion, $downloadPackage) {
+                if (str_contains($url, '/releases/latest')) {
+                    return [
+                        'headers'  => [],
+                        'body'     => wp_json_encode([
+                            'tag_name'    => 'v' . $localVersion,
+                            'zipball_url' => $downloadPackage,
+                            'body'        => '',
+                            'html_url'    => '',
+                            'published_at'=> '2024-05-01T00:00:00Z',
+                        ]),
+                        'response' => [
+                            'code'    => 200,
+                            'message' => 'OK',
+                        ],
+                    ];
+                }
+
+                if (str_contains($url, 'readme.txt')) {
+                    return [
+                        'headers'  => [],
+                        'body'     => '',
+                        'response' => [
+                            'code'    => 404,
+                            'message' => 'Not Found',
+                        ],
+                    ];
+                }
+
+                return false;
+            },
+            10,
+            3
+        );
+
+        $meta = $updater->refresh();
+        $this->assertSame($localVersion, $meta['version']);
+
+        $transient = get_site_transient('update_plugins');
+        $this->assertIsObject($transient);
+        $this->assertArrayHasKey('response', (array) $transient);
+        $this->assertArrayNotHasKey($pluginBasename, $transient->response);
+
+        $meta = $updater->refresh(true);
+        $this->assertSame($localVersion, $meta['version']);
+
+        $transient = get_site_transient('update_plugins');
+        $this->assertIsObject($transient);
+        $this->assertArrayHasKey($pluginBasename, $transient->response);
+        $this->assertSame($downloadPackage, $transient->response[$pluginBasename]->package);
+
+        remove_filter('pre_http_request', $forceMock, 10);
+    }
+
     public function test_run_registers_cron_schedule_and_event(): void {
         $updater = $this->create_updater([
             'check_interval' => 15,


### PR DESCRIPTION
## Summary
- allow the GitHub updater to force an entry into the plugin update transient so manual installs can run even when the version string is unchanged
- update the admin "Update Now" flow and CLI command to use the forced refresh payload
- cover the forced refresh behaviour with a unit test

## Testing
- vendor/bin/phpunit --group github-updater *(fails: WordPress test library not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68f7e68419688330a9f31a17105bc678