### PR TITLE
Fix GitHub updater POST mock expectation JSON string

### DIFF
--- a/tests/test-github-updater.php
+++ b/tests/test-github-updater.php
@@ -491,7 +491,7 @@ class GithubUpdaterTest extends WP_UnitTestCase {
         $response = wp_remote_post('https://api.github.com/repos/gm2/wordpress-suite/zipball');
         $this->assertSame(200, wp_remote_retrieve_response_code($response));
 
-        $expected_body = '{"ok":true}';
+        $expected_body = wp_json_encode(['ok' => true]);
 
         $this->assertSame(
             $expected_body,


### PR DESCRIPTION
## Summary
- update the POST request test to derive the expected JSON body using `wp_json_encode`

## Testing
- not run (WordPress core test library unavailable in container)

------
https://chatgpt.com/codex/tasks/task_b_68f7f31027f883309a73ee802b7edf31