### PR TITLE
Preserve hyphenated preset slugs during import

### DIFF
--- a/admin/Gm2_Custom_Posts_Admin.php
+++ b/admin/Gm2_Custom_Posts_Admin.php
@@ -2326,7 +2326,7 @@ class Gm2_Custom_Posts_Admin {
             ]);
         }
 
-        $slug = sanitize_key($_POST['preset'] ?? '');
+        $slug = sanitize_title(wp_unslash($_POST['preset'] ?? ''));
         if ($slug === '') {
             wp_send_json_error([
                 'code'    => 'preset_missing',


### PR DESCRIPTION
## Summary
- switch the preset slug sanitization in the AJAX import handler to `sanitize_title()` so hyphenated directory names are preserved
- unslash the raw value before sanitization to match other AJAX handlers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68f7f90f47d48330b0134518576de9a3