### PR TITLE
Handle parent relationships when seeding taxonomy terms (follow-up)

### DIFF
--- a/includes/gm2-custom-posts-functions.php
+++ b/includes/gm2-custom-posts-functions.php
@@ -573,6 +573,9 @@ function gm2_register_custom_posts() {
                     continue;
                 }
                 $term_slug = $term['slug'] ?? '';
+                if ($term_slug === '' && !empty($term['name'])) {
+                    $term_slug = sanitize_title($term['name']);
+                }
                 if ($term_slug === '') {
                     continue;
                 }


### PR DESCRIPTION
## Summary
- derive a slug from the default term name when presets omit an explicit slug so those terms are still seeded

## Testing
- php -l includes/gm2-custom-posts-functions.php

------
https://chatgpt.com/codex/tasks/task_b_68f7f9a92a6c8330b2e3ddd9206b3a64