### PR TITLE
Preserve hyphenated preset slugs during import

### DIFF
--- a/admin/Gm2_Custom_Posts_Admin.php
+++ b/admin/Gm2_Custom_Posts_Admin.php
@@ -2326,7 +2326,7 @@ class Gm2_Custom_Posts_Admin {
             ]);
         }
 
-        $slug = sanitize_title(wp_unslash($_POST['preset'] ?? ''));
+        $slug = sanitize_key(wp_unslash($_POST['preset'] ?? ''));
         if ($slug === '') {
             wp_send_json_error([
                 'code'    => 'preset_missing',


### PR DESCRIPTION
## Summary
- restore underscore-safe sanitization for preset slugs by switching back to `sanitize_key()` while still unslashing the input

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68f802f7d1c883308859b52111b4a980