### PR TITLE
Ensure GitHub downloads include auth headers

### DIFF
--- a/includes/github-updater/class-gm2-github-updater.php
+++ b/includes/github-updater/class-gm2-github-updater.php
@@ -734,7 +734,22 @@ class Gm2_GitHub_Updater {
      * @return bool
      */
     protected function is_github_host($url) {
-        return (bool) preg_match('~https?://([^/]+\.)?github\.com/~i', $url) || (bool) preg_match('~https?://api\.github\.com/~i', $url);
+        $host = wp_parse_url($url, PHP_URL_HOST);
+        if (!$host) {
+            return false;
+        }
+
+        $host = strtolower($host);
+
+        if ($host === 'github.com' || substr($host, -11) === '.github.com') {
+            return true;
+        }
+
+        if ($host === 'githubusercontent.com' || substr($host, -22) === '.githubusercontent.com') {
+            return true;
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
## Summary
- ensure the GitHub updater recognises githubusercontent download hosts so authentication headers are applied

## Testing
- composer lint

------
https://chatgpt.com/codex/tasks/task_b_68f8059d5590833093e7863f469aa3be