### PR TITLE
Fix GitHub updater upgrade error handling

### DIFF
--- a/includes/github-updater/class-gm2-github-updater-admin.php
+++ b/includes/github-updater/class-gm2-github-updater-admin.php
@@ -760,10 +760,10 @@ class Gm2_GitHub_Updater_Admin {
         $upgrader = new \Plugin_Upgrader($skin);
         $result   = $upgrader->upgrade($plugin_basename);
 
-        $skin_errors = $skin->get_errors();
-        if ($skin_errors instanceof WP_Error && $skin_errors->has_errors()) {
+        $skin_error = $this->get_skin_error($skin);
+        if ($skin_error instanceof WP_Error) {
             $reactivate_if_needed();
-            wp_send_json_error(['message' => $skin_errors->get_error_message()], 500);
+            wp_send_json_error(['message' => $skin_error->get_error_message()], 500);
         }
 
         if ($result instanceof WP_Error) {
@@ -790,6 +790,32 @@ class Gm2_GitHub_Updater_Admin {
         }
 
         wp_send_json_success(['update' => $response]);
+    }
+
+    /**
+     * Retrieve a WP_Error instance from the upgrader skin when available.
+     *
+     * @param object $skin Upgrader skin instance.
+     *
+     * @return WP_Error|null
+     */
+    protected function get_skin_error($skin) {
+        if (!is_object($skin)) {
+            return null;
+        }
+
+        if (method_exists($skin, 'get_errors')) {
+            $errors = $skin->get_errors();
+            if ($errors instanceof WP_Error && $errors->has_errors()) {
+                return $errors;
+            }
+        }
+
+        if (isset($skin->result) && $skin->result instanceof WP_Error && $skin->result->has_errors()) {
+            return $skin->result;
+        }
+
+        return null;
     }
 
     /**

--- a/tests/test-github-updater.php
+++ b/tests/test-github-updater.php
@@ -3,8 +3,10 @@
 declare(strict_types=1);
 
 use Gm2\Updater\Gm2_GitHub_Updater;
+use Gm2\Updater\Gm2_GitHub_Updater_Admin;
 use PHPUnit\Framework\AssertionFailedError;
 use ReflectionClass;
+use ReflectionMethod;
 
 /**
  * @group github-updater
@@ -556,6 +558,35 @@ class GithubUpdaterTest extends WP_UnitTestCase {
         $this->assertSame('{"ok":true}', wp_remote_retrieve_body($response));
 
         remove_filter('pre_http_request', $mock, 10);
+    }
+
+    public function test_get_skin_error_handles_various_skins(): void {
+        $admin  = new Gm2_GitHub_Updater_Admin();
+        $method = new ReflectionMethod($admin, 'get_skin_error');
+        $method->setAccessible(true);
+
+        $skinWithResult = new class {
+            /** @var WP_Error|null */
+            public $result;
+        };
+        $skinWithResult->result = new WP_Error('gm2_updater_failed', 'Upgrade failed via result.');
+
+        $error = $method->invoke($admin, $skinWithResult);
+        $this->assertInstanceOf(WP_Error::class, $error);
+        $this->assertSame('Upgrade failed via result.', $error->get_error_message());
+
+        $skinWithMethod = new class {
+            public function get_errors() {
+                return new WP_Error('gm2_updater_failed', 'Upgrade failed via method.');
+            }
+        };
+
+        $errorFromMethod = $method->invoke($admin, $skinWithMethod);
+        $this->assertInstanceOf(WP_Error::class, $errorFromMethod);
+        $this->assertSame('Upgrade failed via method.', $errorFromMethod->get_error_message());
+
+        $skinWithoutIssues = new class {};
+        $this->assertNull($method->invoke($admin, $skinWithoutIssues));
     }
 
     /**


### PR DESCRIPTION
## Summary
- guard the GitHub updater AJAX upgrade handler against skins without `get_errors()`
- centralize skin error extraction logic and cover it with a unit test

## Testing
- vendor/bin/phpunit tests/test-github-updater.php *(fails: WordPress test suite bootstrap missing /tmp/wordpress-tests-lib)*

------
https://chatgpt.com/codex/tasks/task_b_68f8e68cbb208330af044c14d7edcd7a