### PR TITLE
Improve GitHub updater upgrade diagnostics

### DIFF
--- a/assets/js/github-updater-admin.js
+++ b/assets/js/github-updater-admin.js
@@ -401,13 +401,37 @@
         });
     }
 
-    function renderMessage(type, message) {
+    function renderMessage(type, message, log) {
         var notice = $('<div/>', {
             'class': 'notice notice-' + type + ' is-dismissible',
             'role': 'alert',
             'tabindex': '-1'
         });
         $('<p/>').text(message).appendTo(notice);
+
+        if (Array.isArray(log) && log.length) {
+            var details = $('<details/>', {
+                'class': 'gm2-github-feedback-log'
+            });
+
+            if (type === 'error') {
+                details.attr('open', 'open');
+            }
+
+            $('<summary/>').text(gm2GitHubUpdaterAdmin.i18n.viewLog).appendTo(details);
+
+            var list = $('<ul/>', {
+                'class': 'gm2-github-feedback-log__list'
+            });
+
+            log.forEach(function (entry) {
+                $('<li/>').text(entry).appendTo(list);
+            });
+
+            details.append(list);
+            notice.append(details);
+        }
+
         $('<button/>', {
             'type': 'button',
             'class': 'notice-dismiss'
@@ -561,19 +585,29 @@
             dataType: 'json',
             data: requestData
         }).done(function (response) {
+            var payload = response && response.data ? response.data : {};
+            var logData = Array.isArray(payload.log) ? payload.log : [];
+
             if (response && response.success && typeof successHandler === 'function') {
-                successHandler(response.data || {});
-            } else if (response && response.data && response.data.message) {
-                renderMessage('error', response.data.message);
+                successHandler(payload, logData);
+            } else if (payload && payload.message) {
+                renderMessage('error', payload.message, logData);
             } else {
-                renderMessage('error', gm2GitHubUpdaterAdmin.i18n.unknownError);
+                renderMessage('error', gm2GitHubUpdaterAdmin.i18n.unknownError, logData);
             }
         }).fail(function (jqXHR) {
             var message = gm2GitHubUpdaterAdmin.i18n.unknownError;
-            if (jqXHR.responseJSON && jqXHR.responseJSON.data && jqXHR.responseJSON.data.message) {
-                message = jqXHR.responseJSON.data.message;
+            var logData = [];
+
+            if (jqXHR.responseJSON && jqXHR.responseJSON.data) {
+                if (jqXHR.responseJSON.data.message) {
+                    message = jqXHR.responseJSON.data.message;
+                }
+                if (Array.isArray(jqXHR.responseJSON.data.log)) {
+                    logData = jqXHR.responseJSON.data.log;
+                }
             }
-            renderMessage('error', message);
+            renderMessage('error', message, logData);
         }).always(function () {
             setButtonsDisabled(false);
         });
@@ -592,7 +626,7 @@
             return;
         }
 
-        handleAjax(testButton, testButton.data('action'), gm2GitHubUpdaterAdmin.i18n.testing, function (data) {
+        handleAjax(testButton, testButton.data('action'), gm2GitHubUpdaterAdmin.i18n.testing, function (data, log) {
             var message = gm2GitHubUpdaterAdmin.i18n.testSuccess;
             if (data.repository) {
                 var details = [];
@@ -615,7 +649,7 @@
             if (data.unsaved) {
                 message += ' ' + gm2GitHubUpdaterAdmin.i18n.unsavedTestNotice;
             }
-            renderMessage('success', message);
+            renderMessage('success', message, log);
         }, { settings: settings });
     });
 
@@ -636,7 +670,7 @@
             return;
         }
 
-        handleAjax(checkButton, checkButton.data('action'), gm2GitHubUpdaterAdmin.i18n.checking, function (data) {
+        handleAjax(checkButton, checkButton.data('action'), gm2GitHubUpdaterAdmin.i18n.checking, function (data, log) {
             var message = gm2GitHubUpdaterAdmin.i18n.checkSuccess;
             if (data.metadata) {
                 var parts = [];
@@ -650,7 +684,7 @@
                     message += ' ' + parts.join(' • ');
                 }
             }
-            renderMessage('success', message);
+            renderMessage('success', message, log);
         }, { settings: settings });
     });
 
@@ -672,7 +706,7 @@
                 return;
             }
 
-            handleAjax(updateButton, updateButton.data('action'), gm2GitHubUpdaterAdmin.i18n.updating, function (data) {
+            handleAjax(updateButton, updateButton.data('action'), gm2GitHubUpdaterAdmin.i18n.updating, function (data, log) {
                 var message = gm2GitHubUpdaterAdmin.i18n.updateSuccess;
                 if (data.update && data.update.version) {
                     message += ' ' + gm2GitHubUpdaterAdmin.i18n.versionLabel.replace('%s', data.update.version);
@@ -680,7 +714,7 @@
                 if (data.update && Array.isArray(data.update.messages) && data.update.messages.length) {
                     message += ' ' + data.update.messages.join(' ');
                 }
-                renderMessage('success', message);
+                renderMessage('success', message, log);
             }, { settings: settings });
         });
     }

--- a/gm2-wordpress-suite.php
+++ b/gm2-wordpress-suite.php
@@ -122,6 +122,7 @@ require_once GM2_PLUGIN_DIR . 'includes/gm2-editorial-comments.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-model-export.php';
 require_once GM2_PLUGIN_DIR . 'includes/Gm2_Github_Client.php';
 require_once GM2_PLUGIN_DIR . 'includes/github-updater/class-gm2-github-oauth.php';
+require_once GM2_PLUGIN_DIR . 'includes/github-updater/class-gm2-github-upgrader-skin.php';
 require_once GM2_PLUGIN_DIR . 'includes/github-updater/class-gm2-github-updater.php';
 require_once GM2_PLUGIN_DIR . 'includes/github-updater/class-gm2-github-updater-admin.php';
 require_once GM2_PLUGIN_DIR . 'includes/gm2-apply-patch.php';

--- a/includes/github-updater/class-gm2-github-updater-admin.php
+++ b/includes/github-updater/class-gm2-github-updater-admin.php
@@ -335,6 +335,7 @@ class Gm2_GitHub_Updater_Admin {
                     'versionLabel' => esc_html__('Version: %s', 'gm2-wordpress-suite'),
                     'updatedLabel' => esc_html__('Published: %s', 'gm2-wordpress-suite'),
                     'dismiss'      => esc_html__('Dismiss this notice.', 'gm2-wordpress-suite'),
+                    'viewLog'      => esc_html__('View detailed log', 'gm2-wordpress-suite'),
                     'oauthPrompt'  => esc_html__('Authorize access to your GitHub account to automatically generate a token.', 'gm2-wordpress-suite'),
                     'oauthPending' => esc_html__('Waiting for GitHub authorization…', 'gm2-wordpress-suite'),
                     'oauthSlowDown'=> esc_html__('GitHub requested a slower polling interval. Retrying…', 'gm2-wordpress-suite'),
@@ -754,26 +755,36 @@ class Gm2_GitHub_Updater_Admin {
             }
         };
 
-        $skin     = new \Automatic_Upgrader_Skin([
+        $skin     = new Gm2_GitHub_Upgrader_Skin([
             'plugin' => $plugin_basename,
         ]);
         $upgrader = new \Plugin_Upgrader($skin);
         $result   = $upgrader->upgrade($plugin_basename);
 
-        $skin_errors = $skin->get_errors();
-        if ($skin_errors instanceof WP_Error && $skin_errors->has_errors()) {
+        $log        = $skin->get_log();
+        $skin_error = $this->get_skin_error($skin);
+        if ($skin_error instanceof WP_Error) {
             $reactivate_if_needed();
-            wp_send_json_error(['message' => $skin_errors->get_error_message()], 500);
+            wp_send_json_error([
+                'message' => $skin_error->get_error_message(),
+                'log'     => $log,
+            ], 500);
         }
 
         if ($result instanceof WP_Error) {
             $reactivate_if_needed();
-            wp_send_json_error(['message' => $result->get_error_message()], 500);
+            wp_send_json_error([
+                'message' => $result->get_error_message(),
+                'log'     => $log,
+            ], 500);
         }
 
         if ($result === false || $result === null) {
             $reactivate_if_needed();
-            wp_send_json_error(['message' => esc_html__('Plugin upgrade did not complete.', 'gm2-wordpress-suite')], 500);
+            wp_send_json_error([
+                'message' => esc_html__('Plugin upgrade did not complete.', 'gm2-wordpress-suite'),
+                'log'     => $log,
+            ], 500);
         }
 
         $reactivate_if_needed();
@@ -789,7 +800,36 @@ class Gm2_GitHub_Updater_Admin {
             }, $messages);
         }
 
-        wp_send_json_success(['update' => $response]);
+        wp_send_json_success([
+            'update' => $response,
+            'log'    => $log,
+        ]);
+    }
+
+    /**
+     * Retrieve a WP_Error instance from the upgrader skin when available.
+     *
+     * @param object $skin Upgrader skin instance.
+     *
+     * @return WP_Error|null
+     */
+    protected function get_skin_error($skin) {
+        if (!is_object($skin)) {
+            return null;
+        }
+
+        if (method_exists($skin, 'get_errors')) {
+            $errors = $skin->get_errors();
+            if ($errors instanceof WP_Error && $errors->has_errors()) {
+                return $errors;
+            }
+        }
+
+        if (isset($skin->result) && $skin->result instanceof WP_Error && $skin->result->has_errors()) {
+            return $skin->result;
+        }
+
+        return null;
     }
 
     /**

--- a/includes/github-updater/class-gm2-github-upgrader-skin.php
+++ b/includes/github-updater/class-gm2-github-upgrader-skin.php
@@ -1,0 +1,137 @@
+<?php
+namespace Gm2\Updater;
+
+use WP_Error;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Custom upgrader skin used for AJAX-driven updates.
+ */
+class Gm2_GitHub_Upgrader_Skin extends \Automatic_Upgrader_Skin {
+    /**
+     * @var array<int, string>
+     */
+    protected $log = [];
+
+    /**
+     * @var array<int, string>
+     */
+    protected $error_messages = [];
+
+    /**
+     * Record upgrader feedback while keeping the parent behaviour intact.
+     *
+     * @param string $string Message key or text.
+     * @param mixed  ...$args Optional sprintf arguments.
+     */
+    public function feedback($string, ...$args) { // phpcs:ignore Squiz.Commenting.FunctionComment.ScalarTypeHintMissing
+        $formatted = $this->format_string($string, $args);
+        if ($formatted !== '') {
+            $this->log[] = $formatted;
+        }
+
+        // Maintain default behaviour (including printing the message when appropriate).
+        parent::feedback(...func_get_args());
+    }
+
+    /**
+     * Capture upgrader errors in an inspectable form.
+     *
+     * @param string|WP_Error $errors Error code or WP_Error instance.
+     */
+    public function error($errors) { // phpcs:ignore Squiz.Commenting.FunctionComment.ScalarTypeHintMissing
+        if ($errors instanceof WP_Error) {
+            foreach ($errors->get_error_messages() as $message) {
+                $message = $this->sanitize_message($message);
+                if ($message !== '') {
+                    $this->error_messages[] = $message;
+                }
+            }
+        } elseif (is_string($errors)) {
+            $message = $this->format_string($errors, []);
+            if ($message !== '') {
+                $this->error_messages[] = $message;
+            }
+        }
+
+        parent::error($errors);
+    }
+
+    /**
+     * Retrieve all captured log messages.
+     *
+     * @return array<int, string>
+     */
+    public function get_log() {
+        if (empty($this->log)) {
+            return [];
+        }
+
+        return array_values(array_unique($this->log));
+    }
+
+    /**
+     * Return a WP_Error containing all captured error messages.
+     *
+     * @return WP_Error
+     */
+    public function get_errors() {
+        $error = new WP_Error();
+
+        if (empty($this->error_messages)) {
+            return $error;
+        }
+
+        foreach ($this->error_messages as $message) {
+            $error->add('gm2_github_updater_upgrade', $message);
+        }
+
+        return $error;
+    }
+
+    /**
+     * Convert a message key and sprintf args into a plain string.
+     *
+     * @param string   $string Message key or text.
+     * @param string[] $args   Arguments for vsprintf.
+     *
+     * @return string
+     */
+    protected function format_string($string, array $args) {
+        if (isset($this->upgrader) && isset($this->upgrader->strings[$string])) {
+            $string = $this->upgrader->strings[$string];
+        }
+
+        if (!empty($args)) {
+            $formatted = @vsprintf($string, $args); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+            if (is_string($formatted)) {
+                $string = $formatted;
+            }
+        }
+
+        return $this->sanitize_message($string);
+    }
+
+    /**
+     * Sanitize a message prior to storing it.
+     *
+     * @param string $message Raw message.
+     *
+     * @return string
+     */
+    protected function sanitize_message($message) {
+        $message = (string) $message;
+        $message = \wp_strip_all_tags($message);
+        $message = html_entity_decode($message, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $message = preg_replace('/\s+/', ' ', $message);
+
+        if (!is_string($message)) {
+            return '';
+        }
+
+        return trim($message);
+    }
+}

--- a/tests/test-github-updater.php
+++ b/tests/test-github-updater.php
@@ -3,8 +3,11 @@
 declare(strict_types=1);
 
 use Gm2\Updater\Gm2_GitHub_Updater;
+use Gm2\Updater\Gm2_GitHub_Updater_Admin;
+use Gm2\Updater\Gm2_GitHub_Upgrader_Skin;
 use PHPUnit\Framework\AssertionFailedError;
 use ReflectionClass;
+use ReflectionMethod;
 
 /**
  * @group github-updater
@@ -556,6 +559,60 @@ class GithubUpdaterTest extends WP_UnitTestCase {
         $this->assertSame('{"ok":true}', wp_remote_retrieve_body($response));
 
         remove_filter('pre_http_request', $mock, 10);
+    }
+
+    public function test_get_skin_error_handles_various_skins(): void {
+        $admin  = new Gm2_GitHub_Updater_Admin();
+        $method = new ReflectionMethod($admin, 'get_skin_error');
+        $method->setAccessible(true);
+
+        $skinWithResult = new class {
+            /** @var WP_Error|null */
+            public $result;
+        };
+        $skinWithResult->result = new WP_Error('gm2_updater_failed', 'Upgrade failed via result.');
+
+        $error = $method->invoke($admin, $skinWithResult);
+        $this->assertInstanceOf(WP_Error::class, $error);
+        $this->assertSame('Upgrade failed via result.', $error->get_error_message());
+
+        $skinWithMethod = new class {
+            public function get_errors() {
+                return new WP_Error('gm2_updater_failed', 'Upgrade failed via method.');
+            }
+        };
+
+        $errorFromMethod = $method->invoke($admin, $skinWithMethod);
+        $this->assertInstanceOf(WP_Error::class, $errorFromMethod);
+        $this->assertSame('Upgrade failed via method.', $errorFromMethod->get_error_message());
+
+        $customSkin = new Gm2_GitHub_Upgrader_Skin();
+        $customSkin->error(new WP_Error('gm2_updater_failed', 'Upgrade failed via custom skin.'));
+
+        $customError = $method->invoke($admin, $customSkin);
+        $this->assertInstanceOf(WP_Error::class, $customError);
+        $this->assertSame('Upgrade failed via custom skin.', $customError->get_error_message());
+
+        $skinWithoutIssues = new class {};
+        $this->assertNull($method->invoke($admin, $skinWithoutIssues));
+    }
+
+    public function test_custom_upgrader_skin_collects_logs_and_errors(): void {
+        $skin = new Gm2_GitHub_Upgrader_Skin();
+
+        $skin->feedback('Downloading update from %s…', 'https://example.com/plugin.zip');
+        $skin->feedback('<strong>Installing</strong> update.');
+        $skin->error(new WP_Error('gm2_updater_failed', 'Install failed & needs attention.'));
+
+        $log = $skin->get_log();
+        $this->assertNotEmpty($log);
+        $this->assertSame('Downloading update from https://example.com/plugin.zip…', $log[0]);
+        $this->assertStringNotContainsString('<strong>', $log[1]);
+
+        $errors = $skin->get_errors();
+        $this->assertInstanceOf(WP_Error::class, $errors);
+        $this->assertTrue($errors->has_errors());
+        $this->assertSame('Install failed & needs attention.', $errors->get_error_message());
     }
 
     /**


### PR DESCRIPTION
## Summary
- add a custom upgrader skin that captures progress messages and errors for AJAX upgrades
- return the captured log from the update endpoint and display it in the GitHub updater admin UI
- expand the GitHub updater test suite to cover the new skin behaviour

## Testing
- vendor/bin/phpunit tests/test-github-updater.php *(fails: `vendor/bin/phpunit` is not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68f8e68cbb208330af044c14d7edcd7a